### PR TITLE
Improve AI‑GA meta-evolution demo resiliency

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -55,6 +55,9 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/aiga_meta_evolution
 ./run_aiga_demo.sh
 ```
 
+The service automatically resumes from the latest checkpoint if one exists,
+so you can stop and restart the container without losing progress.
+
 | Endpoint | URL | Purpose |
 | --- | --- | --- |
 | **Gradio** UI | <http://localhost:7862> | Click **Evolve 5 Generations** |


### PR DESCRIPTION
## Summary
- track best genome and fitness in `MetaEvolver`
- expose `save()`, `best_fitness` and `best_architecture`
- load latest checkpoint automatically
- update README with note on auto-resume

## Testing
- `python -m py_compile alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py`
- `python -m py_compile alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py`
- `python -m py_compile alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py`
- `python -m py_compile alpha_factory_v1/demos/aiga_meta_evolution/*.py`