### PR TITLE
Fix Macro-Sentinel health check path

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
@@ -12,7 +12,7 @@
 #  • Event bus       – Redis Streams for pub/sub between agents
 #  • Risk cache      – Qdrant vector store (optional) for similarity RAG
 #  • Metrics         – Prometheus + Grafana dashboards (port 3001)
-#  • Health checks   – every service exposes /__live or container HC
+#  • Health checks   – every service exposes /healthz or container HC
 #  • GPU optional    – set ENABLE_CUDA=1 to build CUDA stage
 #
 #  Bring-up
@@ -139,7 +139,7 @@ services:
         condition: service_started
         required: false
     healthcheck:
-      test: ["CMD-SHELL","curl -f http://localhost:7864/__live || exit 1"]
+      test: ["CMD-SHELL","curl -f http://localhost:7864/healthz || exit 1"]
       <<: *hc
     restart: unless-stopped
 

--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -11,7 +11,7 @@
 #  ▸ `--live` flag starts real-time collectors (FRED, Etherscan, X/Twitter)
 #  ▸ `--reset` stops & purges any previous stack before fresh start
 #  ▸ Deterministic image tags, pre-pulls cache layers
-#  ▸ Health-gates the orchestrator on /__live (40 × 2 s)
+#  ▸ Health-gates the orchestrator on /healthz (40 × 2 s)
 #  ▸ Prints helper commands (logs, stop, purge) on success
 #
 #  Usage:
@@ -134,7 +134,7 @@ docker compose --project-name alpha_macro -f "$compose_file" $profile_arg up -d
 # ─────────────────────── health gate & trap ───────────────────
 trap 'docker compose -p alpha_macro stop; exit 0' INT
 say "⏳ Waiting for orchestrator health"
-health_wait "http://localhost:7864/__live" 40
+health_wait "http://localhost:7864/healthz" 40
 
 # ───────────────────────── success banner ─────────────────────
 printf '\n\033[1;32m🎉 Dashboard → http://localhost:7864\033[0m\n'


### PR DESCRIPTION
## Summary
- align Macro-Sentinel health endpoint with orchestrator
- update docs/comments referring to `/__live`

## Testing
- `pytest -q` *(fails: `pytest: command not found` due to missing dependencies)*