### PR TITLE
Clean backend imports

### DIFF
--- a/alpha_factory_v1/backend/a2a_client.py
+++ b/alpha_factory_v1/backend/a2a_client.py
@@ -30,13 +30,10 @@ NOTE:  Proto stubs are lazily imported, so you only need to `pip install grpcio`
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import ssl
-import sys
 from dataclasses import asdict, dataclass
-from pathlib import Path
 from types import TracebackType
 from typing import Any, AsyncGenerator, Literal, Type
 
@@ -247,7 +244,6 @@ def _spiffe_ssl_context(spiffe_id: str | None) -> ssl.SSLContext:
 
         bundle_set = X509BundleSet.new_empty_set()
         bundle_set.add(bundle=source.x509_bundle())
-        validator = cert_validator.create_default_x509_validator(bundle_set)
         ctx.verify_flags |= ssl.VERIFY_X509_TRUSTED_FIRST  # type: ignore[attr-defined]
 
         def _verify(conn, x509, errnum, depth, ok):  # noqa: D401

--- a/alpha_factory_v1/backend/agent_factory.py
+++ b/alpha_factory_v1/backend/agent_factory.py
@@ -137,9 +137,10 @@ try:
     from .tools.local_pytest import run_pytest
 except Exception as exc:  # pragma: no cover
     LOGGER.error("local_pytest tool could not be imported: %s", exc)
+    _exc_msg = str(exc)
 
     def run_pytest(*_, **__) -> str:  # type: ignore
-        return f"[local_pytest unavailable: {exc}]"
+        return f"[local_pytest unavailable: {_exc_msg}]"
 
 # ╭──────────────────────────────────────────────────────────────────────╮
 # │ 3 ▸ Model auto-selection helpers                                    │

--- a/alpha_factory_v1/backend/agents/base.py
+++ b/alpha_factory_v1/backend/agents/base.py
@@ -48,7 +48,7 @@ import os
 import random
 import time
 import traceback
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+from typing import Any, List, Mapping, MutableMapping, Optional
 
 # ───────────────────────────────────────────────────────────────────────────────
 # ░░░ 2. Optional, best-effort 3rd-party imports ░░░

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -53,14 +53,12 @@ import asyncio
 import hashlib
 import json
 import logging
-import math
 import os
 import random
-import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Soft‑optional dependencies — IMPORT FAILURES ARE SILENT.

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -46,13 +46,9 @@ import hashlib
 import json
 import logging
 import os
-import re
-import signal
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -47,7 +47,6 @@ import logging
 import math
 import os
 import random
-import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path

--- a/alpha_factory_v1/backend/agents/finance_agent.py
+++ b/alpha_factory_v1/backend/agents/finance_agent.py
@@ -38,9 +38,7 @@ from typing import Any, Dict, List, MutableMapping, Sequence
 with contextlib.suppress(ModuleNotFoundError):
     import numpy as np  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
-    import pandas as pd  # type: ignore
-with contextlib.suppress(ModuleNotFoundError):
-    from scipy.stats import skew, kurtosis, norm  # type: ignore
+    from scipy.stats import skew, kurtosis  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
     from scipy.special import erfcinv  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
@@ -244,7 +242,7 @@ class _Planner:
 
     def __init__(self, depth: int = 5):
         self.depth = depth
-        if "torch" in globals():
+        if torch is not None:
             self.net = nn.Sequential(nn.Linear(10, 64), nn.ReLU(), nn.Linear(64, 1))  # type: ignore[attr-defined]
         elif "lgb" in globals():
             self.net = lgb.LGBMRegressor(n_estimators=32)
@@ -373,7 +371,7 @@ class FinanceAgent(AgentBase):
         # 5 · plan & execute trades
         orders = self.planner.rollout(self.portfolio, prices, targets)
         for o in orders:
-            fill = self.broker.market(o["side"], o["qty"], o["sym"])
+            self.broker.market(o["side"], o["qty"], o["sym"])
             self.portfolio.update(o["sym"], o["qty"] if o["side"] == "BUY" else -o["qty"])
             _log.info("Executed %s %s %.4f @ est %.2f USD", o["side"], o["sym"], o["qty"], o["est_fill_px"])
 

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -43,10 +43,8 @@ import json
 import logging
 import os
 import random
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove unused imports across backend agents
- fix run_pytest fallback closure
- define placeholder constants in drug design agent
- adjust planner actions and trade loop
- clear lint issues across backend

## Testing
- `ruff check alpha_factory_v1/backend/a2a_client.py alpha_factory_v1/backend/agents/base.py alpha_factory_v1/backend/agents/climate_risk_agent.py alpha_factory_v1/backend/agents/cyber_threat_agent.py alpha_factory_v1/backend/agents/drug_design_agent.py alpha_factory_v1/backend/agents/energy_agent.py alpha_factory_v1/backend/agents/finance_agent.py alpha_factory_v1/backend/agents/manufacturing_agent.py alpha_factory_v1/backend/agent_factory.py`
- `python3 -m py_compile $(git ls-files '*.py')`