### PR TITLE
Fix Orchestrator API entry

### DIFF
--- a/alpha_factory_v1/backend/main.py
+++ b/alpha_factory_v1/backend/main.py
@@ -1,7 +1,10 @@
-
 from .orchestrator import Orchestrator
-def main():
-    orch=Orchestrator()
+
+def main() -> None:
+    """Run the Alpha‑Factory orchestrator indefinitely."""
+    orch = Orchestrator()
     orch.run_forever()
-if __name__=='__main__':
+
+
+if __name__ == "__main__":
     main()

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -379,9 +379,18 @@ async def _main() -> None:
     await asyncio.gather(*(r.task for r in runners.values() if r.task), return_exceptions=True)
     log.info("Orchestrator shutdown complete")
 
+# ───────────────────────── public API ───────────────────────────────
+class Orchestrator:
+    """Programmatic entry-point wrapping :func:`_main`."""
+
+    def run_forever(self) -> None:
+        """Start the orchestrator and block until interrupted."""
+        asyncio.run(_main())
+
+
 # ───────────────────────── CLI entry-point ──────────────────────────
 if __name__ == "__main__":
     try:
-        asyncio.run(_main())
+        Orchestrator().run_forever()
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
## Summary
- expose `Orchestrator` class for programmatic use
- update CLI entry point accordingly
- clean up `backend/main.py`

## Testing
- `pip install pytest` *(fails: no route to host)*