### PR TITLE
Improve packaging and offline tests

### DIFF
--- a/alpha_factory_v1/__init__.py
+++ b/alpha_factory_v1/__init__.py
@@ -1,0 +1,4 @@
+"""Alpha-Factory v1 package root."""
+
+__all__ = ["backend", "demos", "ui"]
+__version__ = "1.0.0"

--- a/alpha_factory_v1/requests.py
+++ b/alpha_factory_v1/requests.py
@@ -1,0 +1,16 @@
+"""Minimal requests shim for offline test environment."""
+from urllib import request as _request
+import json
+
+class Response:
+    def __init__(self, status_code: int, text: str):
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return json.loads(self.text)
+
+def get(url: str, **kwargs):
+    with _request.urlopen(url) as resp:
+        data = resp.read().decode()
+        return Response(resp.getcode(), data)


### PR DESCRIPTION
## Summary
- make `alpha_factory_v1` an importable package
- provide minimal `requests` shim so smoke tests run offline

## Testing
- `PYTHONPATH=..:. python -m unittest discover -v tests` *(governance_sim passes; other tests require pytest/requests)*