### PR TITLE
Fix missing import

### DIFF
--- a/alpha_factory_v1/backend/tools/local_pytest.py
+++ b/alpha_factory_v1/backend/tools/local_pytest.py
@@ -21,6 +21,7 @@ import platform
 import subprocess
 import sys
 import time
+import shutil
 from pathlib import Path
 from typing import Any, Dict
 


### PR DESCRIPTION
## Summary
- fix missing `shutil` import for local pytest helper

## Testing
- `python -m py_compile backend/tools/local_pytest.py`
- `PYTHONPATH=$(pwd)/.. python -m unittest -v tests.test_governance_sim`
