### PR TITLE
Add unified launcher CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1
 pip install -r requirements.txt
 
 export ALPHA_KAFKA_BROKER=localhost:9092
-python -m backend.orchestrator
+python -m alpha_factory_v1.run --preflight
+python -m alpha_factory_v1.run
 open http://localhost:8000/docs
 ```
 

--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -334,11 +334,12 @@ Cells with \(Δ\mathcal F < 0\) glow 🔵 on Grafana; Ω‑Agents race to harves
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1
+
 pip install -r requirements.txt
-python scripts/preflight.py
+python -m alpha_factory_v1.run --preflight
 
 export ALPHA_KAFKA_BROKER=localhost:9092
-python -m backend.orchestrator
+python -m alpha_factory_v1.run
 open http://localhost:8000/docs
 ```
 

--- a/alpha_factory_v1/__init__.py
+++ b/alpha_factory_v1/__init__.py
@@ -1,4 +1,4 @@
 """Alpha-Factory v1 package root."""
 
-__all__ = ["backend", "demos", "ui"]
+__all__ = ["backend", "demos", "ui", "run"]
 __version__ = "1.0.0"

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -1,0 +1,44 @@
+import os
+import argparse
+from .scripts.preflight import main as preflight_main
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Alpha-Factory launcher")
+    ap.add_argument("--dev", action="store_true", help="Enable dev mode")
+    ap.add_argument("--preflight", action="store_true", help="Run environment checks and exit")
+    ap.add_argument("--port", type=int, help="REST API port")
+    ap.add_argument("--metrics-port", type=int, help="Prometheus metrics port")
+    ap.add_argument("--a2a-port", type=int, help="A2A gRPC port")
+    ap.add_argument("--enabled", help="Comma separated list of enabled agents")
+    ap.add_argument("--loglevel", default="INFO", help="Log level")
+    return ap.parse_args()
+
+
+def apply_env(args: argparse.Namespace) -> None:
+    if args.dev:
+        os.environ["DEV_MODE"] = "true"
+    if args.port is not None:
+        os.environ["PORT"] = str(args.port)
+    if args.metrics_port is not None:
+        os.environ["METRICS_PORT"] = str(args.metrics_port)
+    if args.a2a_port is not None:
+        os.environ["A2A_PORT"] = str(args.a2a_port)
+    if args.enabled is not None:
+        os.environ["ALPHA_ENABLED_AGENTS"] = args.enabled
+    if args.loglevel:
+        os.environ["LOGLEVEL"] = args.loglevel.upper()
+
+
+def run() -> None:
+    args = parse_args()
+    if args.preflight:
+        preflight_main()
+        return
+    apply_env(args)
+    from .backend.orchestrator import Orchestrator
+    Orchestrator().run_forever()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add `alpha_factory_v1.run` CLI wrapper
- expose the new launcher in package exports
- document usage with `alpha_factory_v1.run` in the quick start guides

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m alpha_factory_v1.run --help`
- `python -m alpha_factory_v1.run --preflight`
