### PR TITLE
Ensure consistent memory dir handling

### DIFF
--- a/alpha_factory_v1/install_alpha_factory.sh
+++ b/alpha_factory_v1/install_alpha_factory.sh
@@ -29,6 +29,7 @@ docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
 docker run -d $GPU_ARGS --name "$CONTAINER_NAME" \
   -p "$PORT":"$PORT" \
   -v alphafactory_data:/var/alphafactory \
+  -e AF_MEMORY_DIR=/var/alphafactory \
   -e OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
   -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
   "$IMAGE"

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -2,10 +2,11 @@ import os
 import shutil
 import sys
 import subprocess
+import tempfile
 from pathlib import Path
 
 MIN_PY = (3, 9)
-MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", "/var/alphafactory"))
+MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
 
 COLORS = {
     'RED': '\033[31m',

--- a/alpha_factory_v1/tests/test_finance_agent.py
+++ b/alpha_factory_v1/tests/test_finance_agent.py
@@ -1,9 +1,10 @@
-import json, pathlib
+import json, os, tempfile, pathlib
 
 REDTEAM = json.loads(open("tests/redteam_prompts.json").read())
 
 def load_memory():
-    db = pathlib.Path("/var/alphafactory/memory.db")
+    base = pathlib.Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
+    db = base / "memory.db"
     assert db.exists()
     return db.read_bytes()  # smoke check
 


### PR DESCRIPTION
## Summary
- update preflight to default AF_MEMORY_DIR to tmp
- set AF_MEMORY_DIR when launching docker container
- make finance agent tests honor AF_MEMORY_DIR

## Testing
- `python -m py_compile alpha_factory_v1/scripts/preflight.py alpha_factory_v1/tests/test_finance_agent.py`
- `python -m alpha_factory_v1.scripts.preflight`