### PR TITLE
Fix strategy toggle message

### DIFF
--- a/alpha_factory_v1/install_alpha_factory_pro.sh
+++ b/alpha_factory_v1/install_alpha_factory_pro.sh
@@ -113,7 +113,7 @@ if [[ -n $ALPHA_TOGGLE ]]; then
   if command -v yq >/dev/null; then
     yq -i ".finance.strategy = \"$ALPHA_TOGGLE\"" config/alpha_factory.yml
   else
-    echo "⚠️  yq not found; falling back to sed"
+    echo "WARNING: yq not installed; using sed fallback"
     sed -i "s/^strategy: .*$/strategy: $ALPHA_TOGGLE/" config/alpha_factory.yml
   fi
 fi


### PR DESCRIPTION
## Summary
- fix fallback message for strategy toggle in install script

## Testing
- `bash -n alpha_factory_v1/install_alpha_factory_pro.sh`
- `pytest -q` *(fails: command not found)*