### PR TITLE
chore: clean up orchestrator import

### DIFF
--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 # ────────────────────────────── std-lib ───────────────────────────────
 import asyncio
 import contextlib
-import importlib
 import json
 import logging
 import os


### PR DESCRIPTION
## Summary
- remove unused `importlib` from orchestrator

## Testing
- `ruff check alpha_factory_v1/backend/orchestrator.py`
- `pytest -q` *(fails: `pytest: command not found`)*