### PR TITLE
Improve tests to run offline

### DIFF
--- a/alpha_factory_v1/tests/test_finance_agent.py
+++ b/alpha_factory_v1/tests/test_finance_agent.py
@@ -1,6 +1,10 @@
-import json, os, tempfile, pathlib
+import json
+import os
+import tempfile
+import pathlib
 
-REDTEAM = json.loads(open("tests/redteam_prompts.json").read())
+DATA_DIR = pathlib.Path(__file__).resolve().parent
+REDTEAM = json.loads((DATA_DIR / "redteam_prompts.json").read_text())
 
 def load_memory():
     base = pathlib.Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))

--- a/alpha_factory_v1/tests/test_smoke.py
+++ b/alpha_factory_v1/tests/test_smoke.py
@@ -7,7 +7,19 @@ import shutil
 import socket
 import requests
 import pathlib
-import pytest
+try:
+    import pytest
+except ModuleNotFoundError:  # pragma: no cover - allow unittest fallback
+    class _DummyMark:
+        def skipif(self, *_, **__):
+            def wrapper(func):
+                return func
+            return wrapper
+
+    class _DummyPytest:
+        mark = _DummyMark()
+
+    pytest = _DummyPytest()  # type: ignore
 
 
 def _docker_available() -> bool:

--- a/alpha_factory_v1/tests/test_vector_memory.py
+++ b/alpha_factory_v1/tests/test_vector_memory.py
@@ -1,0 +1,32 @@
+import unittest
+
+try:
+    import numpy as np
+    import alpha_factory_v1.backend.memory_vector as mv
+except ModuleNotFoundError:  # pragma: no cover
+    np = None  # type: ignore
+    mv = None  # type: ignore
+
+@unittest.skipIf(np is None, "numpy not available")
+class VectorMemoryTest(unittest.TestCase):
+    def setUp(self):
+        self._orig_embed = mv._embed
+        mv._embed = lambda texts: np.array(
+            [[len(t), sum(t.encode())] for t in texts], dtype="float32"
+        )
+
+    def tearDown(self):
+        mv._embed = self._orig_embed
+
+    def test_add_and_search(self):
+        mem = mv.VectorMemory(dsn=None)
+        mem.add("agent", ["hello world", "foo"])
+        self.assertEqual(len(mem), 2)
+        hits = mem.search("hello world", k=1)
+        self.assertTrue(hits)
+        agent, text, score = hits[0]
+        self.assertEqual(agent, "agent")
+        self.assertEqual(text, "hello world")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix relative path usage in finance agent tests
- make smoke test robust when pytest is missing
- add VectorMemory unit test with fallback when numpy unavailable

## Testing
- `python3 -m unittest discover -s alpha_factory_v1/tests -v`
