### PR TITLE
Add test runner helper

### DIFF
--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -415,6 +415,17 @@ super = my_pkg.super_agent:MySuperAgent
 
 ---
 
+### Running Tests
+
+Use the helper script below to execute the full test-suite. It automatically
+falls back to Python's built-in `unittest` discovery when `pytest` is not
+available.
+
+```bash
+./scripts/run_tests.py
+```
+---
+
 <a name="12-roadmap"></a>
 ## 12 · Roadmap 🛣️
 

--- a/alpha_factory_v1/scripts/run_tests.py
+++ b/alpha_factory_v1/scripts/run_tests.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Run Alpha-Factory unit tests.
+
+This helper prefers *pytest* if installed, falling back to
+``python -m unittest`` when necessary. A test path can be optionally
+specified.
+"""
+from __future__ import annotations
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1] / "tests"
+    if importlib.util.find_spec("pytest"):
+        cmd = [sys.executable, "-m", "pytest", str(target)]
+    else:
+        cmd = [sys.executable, "-m", "unittest", "discover", str(target)]
+    raise SystemExit(subprocess.call(cmd))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_tests.py` helper to run test suite with pytest or unittest fallback
- document the helper script in the README

## Testing
- `PYTHONPATH=$PWD alpha_factory_v1/scripts/run_tests.py alpha_factory_v1/tests`
