### PR TITLE
Improve CLI: add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ pip install -r requirements.txt
 export ALPHA_KAFKA_BROKER=localhost:9092
 python -m alpha_factory_v1.run --preflight
 python -m alpha_factory_v1.run
+python -m alpha_factory_v1.run --version  # display package version
 open http://localhost:8000/docs
 ```
 

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -1,6 +1,9 @@
+"""Command line launcher for Alpha‑Factory v1."""
+
 import os
 import argparse
 from .scripts.preflight import main as preflight_main
+from . import __version__
 
 
 def parse_args() -> argparse.Namespace:
@@ -12,6 +15,7 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--a2a-port", type=int, help="A2A gRPC port")
     ap.add_argument("--enabled", help="Comma separated list of enabled agents")
     ap.add_argument("--loglevel", default="INFO", help="Log level")
+    ap.add_argument("--version", action="store_true", help="Print version and exit")
     return ap.parse_args()
 
 
@@ -32,6 +36,9 @@ def apply_env(args: argparse.Namespace) -> None:
 
 def run() -> None:
     args = parse_args()
+    if args.version:
+        print(__version__)
+        return
     if args.preflight:
         preflight_main()
         return

--- a/alpha_factory_v1/tests/test_cli.py
+++ b/alpha_factory_v1/tests/test_cli.py
@@ -43,6 +43,11 @@ class CliParseTest(unittest.TestCase):
         self.assertEqual(os.environ['ALPHA_ENABLED_AGENTS'], 'foo,bar')
         self.assertEqual(os.environ['LOGLEVEL'], 'DEBUG')
 
+    def test_version_flag(self):
+        args = _parse_with(['--version'])
+        self.assertTrue(args.version)
+
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
## Summary
- document quickstart version command
- add `--version` flag to CLI
- unit tests for new flag

## Testing
- `python -m unittest discover -v alpha_factory_v1/tests`