### PR TITLE
Fix ping_agent registration

### DIFF
--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -52,8 +52,10 @@ from typing import Any, Mapping, Optional
 # ──────────────────────────────────────────────────────────────────────────────
 # Alpha-Factory internal imports
 # ──────────────────────────────────────────────────────────────────────────────
-from backend.agents.base import AgentBase
-from backend.agents import register
+from backend.agents import register, _agent_base
+
+# Ensure compatibility with both legacy and new AgentBase locations
+AgentBase = _agent_base()
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Resilient, colourised logger (inherits project-wide JSON formatter)


### PR DESCRIPTION
## Summary
- ensure ping agent uses whichever AgentBase implementation is active
- unit test suite passes

## Testing
- `python -m unittest discover -v alpha_factory_v1/tests`