### PR TITLE
Harden runtime Dockerfile

### DIFF
--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -37,6 +37,8 @@ RUN if [ "$INSTALL_UI" = "1" ]; then npm run build; fi             # → dist/
 #  Stage 1 — Python Runtime                                           #
 #######################################################################
 FROM ${BASE_IMAGE} AS runtime
+LABEL org.opencontainers.image.title="Alpha-Factory Runtime" \
+      org.opencontainers.image.source="https://github.com/MontrealAI/AGI-Alpha-Agent-v0"
 
 #############################
 # 1) Environment variables   #
@@ -85,12 +87,14 @@ RUN if [ -f /tmp/requirements-lock.txt ]; then \
         openai-agents~=0.5 \   # OpenAI Agents SDK (beta)
         "google-adk @ git+https://github.com/google/adk-python@main#egg=google-adk" \
         anthropic~=0.19 \
-        gunicorn rocketry prometheus-client
+        gunicorn rocketry prometheus-client && \
+    rm -rf /tmp/requirements-lock.txt /tmp/requirements.txt
 
 #############################
 # 4) Copy project source     #
 #############################
 COPY backend/        /app/backend/
+COPY ui/             /app/ui/
 COPY entrypoint.sh   /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
@@ -101,12 +105,20 @@ ARG INSTALL_UI
 COPY --from=ui-build /ui/dist/ /app/static/trace/
 
 #############################
-# 6) Health‑check           #
+# 6) Non-root user           #
+#############################
+RUN addgroup --system alphafactory && \
+    adduser --system --ingroup alphafactory --home /app alphafactory && \
+    chown -R alphafactory:alphafactory /app
+USER alphafactory
+
+#############################
+# 7) Health‑check           #
 #############################
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8000/health || exit 1
 
 #############################
-# 7) Ports & Entrypoint      #
+# 8) Ports & Entrypoint      #
 #############################
 EXPOSE 8000 3000
 CMD ["/app/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- ship UI python code in runtime image
- remove temporary requirement files after install
- run container as unprivileged user
- label runtime image for clarity

## Testing
- `python3 alpha_factory_v1/scripts/run_tests.py alpha_factory_v1/tests`