### PR TITLE
Improve Grafana dashboard defaults

### DIFF
--- a/alpha_factory_v1/dashboards/README.md
+++ b/alpha_factory_v1/dashboards/README.md
@@ -1,0 +1,14 @@
+# Alpha Factory Dashboards
+
+This directory contains Grafana dashboards used for monitoring the Alpha Factory
+stack. The JSON files can be imported directly into Grafana or automatically
+loaded using the provided Docker Compose configuration.
+
+## Usage
+
+1. Ensure [Grafana](https://grafana.com/) is running (see `docker-compose.yml`).
+2. Open Grafana in your browser and log in.
+3. Navigate to **Dashboards → Import** and upload `alpha_factory_overview.json`.
+
+The default Prometheus data source is expected to be named **Prometheus**.
+

--- a/alpha_factory_v1/dashboards/alpha_factory_overview.json
+++ b/alpha_factory_v1/dashboards/alpha_factory_overview.json
@@ -14,7 +14,7 @@
       "id": 1,
       "type": "timeseries",
       "title": "HTTP Latency (p95)",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[1m])) by (le))",
@@ -27,7 +27,7 @@
       "id": 2,
       "type": "timeseries",
       "title": "HTTP Request Rate",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "sum(rate(http_server_requests_total[1m]))",
@@ -40,7 +40,7 @@
       "id": 3,
       "type": "timeseries",
       "title": "Finance P&L",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "finance_agent_pnl",
@@ -53,7 +53,7 @@
       "id": 4,
       "type": "gauge",
       "title": "Value‑at‑Risk (1‑day, 95%)",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": { "unit": "currencyUSD", "max": 0, "min": -100000 }
       },
@@ -69,7 +69,7 @@
       "id": 5,
       "type": "gauge",
       "title": "Current Draw‑down",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": { "unit": "percent", "max": 0, "min": -50 }
       },
@@ -85,7 +85,7 @@
       "id": 6,
       "type": "barchart",
       "title": "Manufacturing Makespan (s)",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "options": { "orientation": "horizontal" },
       "targets": [
         {
@@ -99,7 +99,7 @@
       "id": 7,
       "type": "timeseries",
       "title": "Manufacturing CPU Utilisation",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "rate(process_cpu_seconds_total{app=\"manufacturing\"}[1m])",
@@ -112,7 +112,7 @@
       "id": 8,
       "type": "stat",
       "title": "Biotech Optimisation Throughput",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": { "unit": "ops", "max": 100 }
       },
@@ -128,7 +128,7 @@
       "id": 9,
       "type": "timeseries",
       "title": "LLM Tokens per Minute",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "sum(rate(llm_tokens_total[1m]))",
@@ -141,7 +141,7 @@
       "id": 10,
       "type": "timeseries",
       "title": "OpenTelemetry Spans",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "sum(rate(otel_spans_total[1m]))",

--- a/alpha_factory_v1/docs/grafana/dashboards/alpha_factory_overview.json
+++ b/alpha_factory_v1/docs/grafana/dashboards/alpha_factory_overview.json
@@ -14,7 +14,7 @@
       "id": 1,
       "type": "timeseries",
       "title": "HTTP Latency (p95)",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[1m])) by (le))",
@@ -27,7 +27,7 @@
       "id": 2,
       "type": "timeseries",
       "title": "HTTP Request Rate",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "sum(rate(http_server_requests_total[1m]))",
@@ -40,7 +40,7 @@
       "id": 3,
       "type": "timeseries",
       "title": "Finance P&L",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "finance_agent_pnl",
@@ -53,7 +53,7 @@
       "id": 4,
       "type": "gauge",
       "title": "Value‑at‑Risk (1‑day, 95%)",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": { "unit": "currencyUSD", "max": 0, "min": -100000 }
       },
@@ -69,7 +69,7 @@
       "id": 5,
       "type": "gauge",
       "title": "Current Draw‑down",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": { "unit": "percent", "max": 0, "min": -50 }
       },
@@ -85,7 +85,7 @@
       "id": 6,
       "type": "barchart",
       "title": "Manufacturing Makespan (s)",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "options": { "orientation": "horizontal" },
       "targets": [
         {
@@ -99,7 +99,7 @@
       "id": 7,
       "type": "timeseries",
       "title": "Manufacturing CPU Utilisation",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "rate(process_cpu_seconds_total{app=\"manufacturing\"}[1m])",
@@ -112,7 +112,7 @@
       "id": 8,
       "type": "stat",
       "title": "Biotech Optimisation Throughput",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": { "unit": "ops", "max": 100 }
       },
@@ -128,7 +128,7 @@
       "id": 9,
       "type": "timeseries",
       "title": "LLM Tokens per Minute",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "sum(rate(llm_tokens_total[1m]))",
@@ -141,7 +141,7 @@
       "id": 10,
       "type": "timeseries",
       "title": "OpenTelemetry Spans",
-      "datasource": "${PROM}",
+      "datasource": "Prometheus",
       "targets": [
         {
           "expr": "sum(rate(otel_spans_total[1m]))",


### PR DESCRIPTION
## Summary
- fix Prometheus datasource references in default dashboard
- document how to import dashboards in Grafana

## Testing
- `git status --short`
