### PR TITLE
Improve gRPC server lifecycle

### DIFF
--- a/alpha_factory_v1/backend/README.md
+++ b/alpha_factory_v1/backend/README.md
@@ -38,5 +38,6 @@ This starts the orchestrator in development mode, using in-memory stubs for Kafk
 ## Notes
 
 - Optional dependencies are soft-imported; missing libraries will disable related features without crashing the service.
+- The gRPC server starts automatically when `A2A_PORT` is set and shuts down cleanly on exit.
 - See `../requirements.txt` for the full dependency list.
 


### PR DESCRIPTION
## Summary
- keep the async gRPC server running in the background
- ensure it is stopped on orchestrator shutdown
- document the behaviour in the backend README

## Testing
- `python -m py_compile backend/orchestrator.py`
- `pytest -q` *(fails: command not found)*