### PR TITLE
Enhance genetic tests module

### DIFF
--- a/alpha_factory_v1/backend/genetic_tests.py
+++ b/alpha_factory_v1/backend/genetic_tests.py
@@ -1,17 +1,56 @@
 
 """Genetic test functions (fitness proxies) for the AI‑GA demo.
 
-Each fitness function must accept a candidate *gene dict* and return a
-**scalar float** – higher is better.  They are deliberately lightweight so
-that the demo can run on a laptop without network access or long runtimes.
-
-You are encouraged to replace these with domain‑specific benchmarks
-(financial P&L, manufacturing throughput, policy‑compliance score, etc.).
+Each fitness function must accept a candidate *gene dict* and return a scalar
+float – higher is better. They are deliberately lightweight so that the demo can
+run on a laptop without network access or long runtimes. You are encouraged to
+replace these with domain‑specific benchmarks (financial P&L, manufacturing
+throughput, policy‑compliance score, etc.).
 """
 
-import math
+from __future__ import annotations
+
 import random
-from typing import Dict
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+
+@dataclass(slots=True)
+class GeneConfig:
+    """Minimal schema describing a candidate genome.
+
+    This mirrors the parameters typically passed to a language model.  It can be
+    serialised to a plain dictionary for compatibility with the rest of the
+    optimisation stack.
+    """
+
+    temperature: float = 0.7
+    top_p: float = 0.9
+    max_tokens: int = 128
+
+    def as_dict(self) -> Dict[str, float]:
+        """Return a ``dict`` representation suitable for ``toy_fitness``."""
+
+        return {
+            "temperature": float(self.temperature),
+            "top_p": float(self.top_p),
+            "max_tokens": int(self.max_tokens),
+        }
+
+
+def _sanitise_genes(genes: Mapping[str, float]) -> Dict[str, float]:
+    """Ensure required keys exist and cast values to the correct types."""
+
+    required = ("temperature", "top_p", "max_tokens")
+    if not all(k in genes for k in required):
+        missing = [k for k in required if k not in genes]
+        raise KeyError(f"Missing gene(s): {', '.join(missing)}")
+
+    return {
+        "temperature": float(genes["temperature"]),
+        "top_p": float(genes["top_p"]),
+        "max_tokens": int(genes["max_tokens"]),
+    }
 
 
 def _score_temperature(t: float) -> float:
@@ -33,21 +72,27 @@ def _score_max_tokens(n: int) -> float:
 def toy_fitness(genes: Dict[str, float]) -> float:
     """Deterministic, fast, CI‑friendly fitness function.
 
-    Scores are between 0 and 3, higher is better.
+    The input mapping is first validated via :func:`_sanitise_genes`.  Scores are
+    between ``0`` and ``3`` – higher is better.
     """
-    t_score = _score_temperature(float(genes["temperature"]))
-    p_score = _score_top_p(float(genes["top_p"]))
-    tok_score = _score_max_tokens(int(genes["max_tokens"]))
+    genes = _sanitise_genes(genes)
+    t_score = _score_temperature(genes["temperature"])
+    p_score = _score_top_p(genes["top_p"])
+    tok_score = _score_max_tokens(genes["max_tokens"])
     return t_score + p_score + tok_score
 
 
 def stochastic_fitness(genes: Dict[str, float], noise: float = 0.05) -> float:
-    """Same as *toy_fitness* but with Gaussian noise added.
+    """Same as :func:`toy_fitness` but with Gaussian noise added.
 
-    Useful for testing the GA's robustness under noisy objectives.
+    Useful for testing the GA's robustness under noisy objectives. ``noise`` must
+    be non‑negative.
     """
+    genes = _sanitise_genes(genes)
+    if noise < 0:
+        raise ValueError("noise must be non-negative")
     base = toy_fitness(genes)
     return base + random.gauss(0.0, noise)
 
 
-__all__ = ["toy_fitness", "stochastic_fitness"]
+__all__ = ["GeneConfig", "toy_fitness", "stochastic_fitness"]

--- a/alpha_factory_v1/tests/test_genetic_tests.py
+++ b/alpha_factory_v1/tests/test_genetic_tests.py
@@ -1,0 +1,29 @@
+import unittest
+from alpha_factory_v1.backend import genetic_tests as gt
+
+
+class GeneticTestsTest(unittest.TestCase):
+    def test_toy_optimal(self):
+        genes = {"temperature": 0.7, "top_p": 0.9, "max_tokens": 128}
+        self.assertAlmostEqual(gt.toy_fitness(genes), 3.0, places=2)
+
+    def test_stochastic_zero_noise(self):
+        genes = {"temperature": 0.7, "top_p": 0.9, "max_tokens": 128}
+        self.assertAlmostEqual(
+            gt.stochastic_fitness(genes, noise=0.0), gt.toy_fitness(genes), places=6
+        )
+
+    def test_missing_gene_raises(self):
+        with self.assertRaises(KeyError):
+            gt.toy_fitness({"temperature": 0.7})
+
+    def test_geneconfig_roundtrip(self):
+        cfg = gt.GeneConfig(0.8, 0.95, 256)
+        d = cfg.as_dict()
+        self.assertEqual(d["temperature"], 0.8)
+        self.assertEqual(d["top_p"], 0.95)
+        self.assertEqual(d["max_tokens"], 256)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `GeneConfig` dataclass and input sanitisation
- validate inputs and noise range
- expose new utilities via `__all__`
- add unit tests covering genetic tests module

## Testing
- `python3 -m unittest discover alpha_factory_v1/tests`