### PR TITLE
Fix PlannerAgent async dispatch

### DIFF
--- a/alpha_factory_v1/backend/planner_agent.py
+++ b/alpha_factory_v1/backend/planner_agent.py
@@ -1,18 +1,30 @@
 import json
 import logging
 import random
-from typing import List, Dict, Any
+import re
+from typing import Any, Dict, List
+
+
+_JSON_RE = re.compile(r"\{.*?\}", re.DOTALL)
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    """Return the first JSON object found inside *text*."""
+    match = _JSON_RE.search(text)
+    if not match:
+        raise ValueError("no JSON object found")
+    return json.loads(match.group(0))
 
 from .agent_base import AgentBase
 
 
 class PlannerAgent(AgentBase):
-    """
-    LLM‑driven scheduler that decides which domain agent should run next.
+    """LLM‑driven scheduler deciding which domain agent runs next.
 
-    • Uses ModelProvider.complete() to ask an LLM for a JSON decision.
-    • Falls back to a random agent if no LLM backend or the response is invalid.
-    • Writes a “dispatch” record to memory, then triggers the chosen agent.
+    The planner queries an LLM for JSON instructions and gracefully falls back
+    to heuristics when the response is malformed.  Every dispatch is persisted
+    to :class:`~backend.memory.Memory` for auditability.  The chosen agent is
+    executed asynchronously via its :py:meth:`run_cycle` method.
     """
 
     def __init__(self, *args, domain_agents, **kwargs):
@@ -39,10 +51,10 @@ class PlannerAgent(AgentBase):
         # Ask the LLM; handle any backend / JSON issues gracefully
         try:
             resp = self.model.complete(prompt)
-            data = json.loads(resp)
+            data = _extract_json(resp)
             if data.get("agent") not in agent_names:
                 raise ValueError("unknown agent")
-        except Exception as err:
+        except Exception as err:  # pragma: no cover - planner safety net
             self.log.warning("Planner fallback due to %s", err)
             data = {
                 "agent": random.choice(agent_names),
@@ -51,7 +63,8 @@ class PlannerAgent(AgentBase):
 
         return [data]
 
-    def act(self, tasks: List[Dict[str, Any]]) -> None:
+    async def act(self, tasks: List[Dict[str, Any]]) -> None:
+        """Execute the next agent's cycle based on *tasks*."""
         target_name = tasks[0]["agent"]
         target = next((a for a in self.domain_agents if a.name == target_name), None)
         if not target:
@@ -61,6 +74,6 @@ class PlannerAgent(AgentBase):
         # Log the dispatch for auditability
         self.memory.write(self.name, "dispatch", tasks[0])
 
-        # Run the selected agent’s cycle (synchronously; could be threaded)
-        target.run_cycle()
+        # Run the selected agent's cycle
+        await target.run_cycle()
 

--- a/alpha_factory_v1/tests/test_planner_agent.py
+++ b/alpha_factory_v1/tests/test_planner_agent.py
@@ -1,0 +1,73 @@
+import unittest
+import asyncio
+import tempfile
+
+from alpha_factory_v1.backend.planner_agent import PlannerAgent, _extract_json
+from alpha_factory_v1.backend.memory import Memory
+
+
+class DummyModel:
+    def __init__(self, resp: str):
+        self.resp = resp
+
+    def complete(self, prompt: str) -> str:  # noqa: D401
+        return self.resp
+
+
+class DummyAgent:
+    def __init__(self, name: str = "dummy"):
+        self.name = name
+        self.ran = False
+
+    async def run_cycle(self):  # noqa: D401
+        self.ran = True
+
+
+class DummyGov:
+    def vet_plans(self, agent, plans):  # noqa: D401
+        return plans
+
+
+class PlannerAgentTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.memory = Memory(self.tmpdir.name)
+        self.gov = DummyGov()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_extract_json(self):
+        text = "noise {\"agent\": \"x\", \"reason\": \"ok\"} trailing"
+        self.assertEqual(_extract_json(text)["agent"], "x")
+
+    def test_fallback_logic(self):
+        agent = DummyAgent()
+        model = DummyModel("not json")
+        planner = PlannerAgent(
+            name="planner",
+            model=model,
+            memory=self.memory,
+            gov=self.gov,
+            domain_agents=[agent],
+        )
+        random_result = planner.think([])[0]
+        self.assertEqual(random_result["agent"], agent.name)
+        self.assertIn("fallback", random_result["reason"])
+
+    def test_act_runs_cycle(self):
+        agent = DummyAgent()
+        model = DummyModel('{"agent":"dummy","reason":"ok"}')
+        planner = PlannerAgent(
+            name="planner",
+            model=model,
+            memory=self.memory,
+            gov=self.gov,
+            domain_agents=[agent],
+        )
+        asyncio.run(planner.act([{"agent": "dummy"}]))
+        self.assertTrue(agent.ran)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make PlannerAgent.act async and properly await the selected agent
- add resilient JSON extraction for LLM replies
- document PlannerAgent and provide helper
- add tests for PlannerAgent behaviour

## Testing
- `python -m unittest discover -v alpha_factory_v1/tests`