### PR TITLE
Add packaging metadata and CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,13 +336,13 @@ Cells with \(Δ\mathcal F < 0\) glow 🔵 on Grafana; Ω‑Agents race to harves
 ## 6 · 5‑Minute Quick‑Start 🚀
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
-cd AGI-Alpha-Agent-v0/alpha_factory_v1
-pip install -r requirements.txt
+cd AGI-Alpha-Agent-v0
+pip install -e .
 
 export ALPHA_KAFKA_BROKER=localhost:9092
-python -m alpha_factory_v1.run --preflight
-python -m alpha_factory_v1.run
-python -m alpha_factory_v1.run --version  # display package version
+alpha-factory --preflight
+alpha-factory
+alpha-factory --version  # display package version
 open http://localhost:8000/docs
 ```
 

--- a/alpha_factory_v1/__main__.py
+++ b/alpha_factory_v1/__main__.py
@@ -1,0 +1,4 @@
+from .run import run
+
+if __name__ == "__main__":
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "alpha-factory-v1"
+version = "1.0.0"
+description = "Alpha-Factory v1"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[project.scripts]
+alpha-factory = "alpha_factory_v1.run:run"
+
+[project.entry-points."alpha_factory.agents"]
+# custom agents can be registered here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Root dependencies
+-r alpha_factory_v1/requirements.txt


### PR DESCRIPTION
## Summary
- add basic `pyproject.toml` with CLI and plugin entrypoints
- expose module entry via `alpha_factory_v1/__main__.py`
- provide root `requirements.txt`
- update quick-start instructions for new `alpha-factory` command

## Testing
- `python -m py_compile alpha_factory_v1/__main__.py`
- `python -m compileall -q alpha_factory_v1 requests`
- `pip install -e .` *(fails: Could not find build dependencies)*