### PR TITLE
Improve alpha_model test coverage

### DIFF
--- a/alpha_factory_v1/tests/test_alpha_model.py
+++ b/alpha_factory_v1/tests/test_alpha_model.py
@@ -29,6 +29,20 @@ class AlphaModelTest(unittest.TestCase):
         lower, upper = am.bollinger_bands(prices, window=4, num_std=1)
         self.assertLess(lower, upper)
 
+    def test_invalid_params_raise(self):
+        with self.assertRaises(ValueError):
+            am.momentum([1, 2], lookback=0)
+        with self.assertRaises(ValueError):
+            am.sma_crossover([1]*5, fast=0, slow=1)
+        with self.assertRaises(ValueError):
+            am.sma_crossover([1]*5, fast=5, slow=3)
+        with self.assertRaises(ValueError):
+            am.ema([1], span=0)
+        with self.assertRaises(ValueError):
+            am.rsi([1, 2], period=0)
+        with self.assertRaises(ValueError):
+            am.bollinger_bands([1], window=0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- exercise ValueError branches in `alpha_model`

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests -v`