### PR TITLE
Improve Helm chart

### DIFF
--- a/alpha_factory_v1/helm/alpha-factory-remote/Chart.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/Chart.yaml
@@ -1,6 +1,14 @@
 apiVersion: v2
 name: alpha-factory-remote
 description: Remote worker pod for Alpha Factory swarm (A2A)
+type: application
 version: 0.1.0
 appVersion: "v2"
+dependencies:
+  - name: kube-prometheus-stack
+    version: "^56.0.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+maintainers:
+  - name: MontrealAI
+    url: https://github.com/MontrealAI
 

--- a/alpha_factory_v1/helm/alpha-factory-remote/README.md
+++ b/alpha_factory_v1/helm/alpha-factory-remote/README.md
@@ -1,0 +1,22 @@
+# alpha-factory-remote Helm Chart
+
+This chart deploys a remote worker pod for the **Alpha‑Factory** swarm. It packages a single worker container alongside optional Prometheus/Grafana monitoring via the `kube-prometheus-stack` dependency.
+
+## Installation
+```bash
+helm upgrade --install af-remote ./helm/alpha-factory-remote \
+  --set env.OPENAI_API_KEY=<key>
+```
+The worker exposes gRPC + metrics on port `8000`.
+
+## Values
+- `image.repository` – container image (default `ghcr.io/montrealai/alpha-factory`)
+- `image.tag` – image tag (default `v2`)
+- `env` – key/value environment variables passed to the container
+- `replicaCount` – number of worker pods
+- `workerService` – type and port of the Service exposing the worker
+- `spiffe.enabled` – enable SPIFFE sidecar
+- `grafanaService` – NodePort configuration for Grafana when Prometheus stack is enabled
+
+## Metrics & Dashboards
+When `prometheus.enabled` is true, a `ServiceMonitor` matching label `app.kubernetes.io/name=alpha-factory` is created by the dependency. Grafana is provisioned with a finance dashboard.

--- a/alpha_factory_v1/helm/alpha-factory-remote/templates/deployment.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "alpha-factory-remote.fullname" . }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
       app: {{ include "alpha-factory-remote.name" . }}

--- a/alpha_factory_v1/helm/alpha-factory-remote/templates/service.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alpha-factory-remote.fullname" . }}
+  labels:
+    app.kubernetes.io/name: alpha-factory
+spec:
+  type: {{ .Values.workerService.type }}
+  ports:
+    - port: {{ .Values.workerService.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: rpc
+  selector:
+    app: {{ include "alpha-factory-remote.name" . }}

--- a/alpha_factory_v1/helm/alpha-factory-remote/values.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/values.yaml
@@ -1,3 +1,32 @@
+
+image:
+  repository: ghcr.io/montrealai/alpha-factory
+  tag: v2
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+env:
+  OPENAI_API_KEY: ""
+  ALPHA_MARKET_PROVIDER: sim
+  ALPHA_BROKER: sim
+  A2A_PORT: "8000"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 512Mi
+
+spiffe:
+  enabled: false
+
+workerService:
+  type: ClusterIP
+  port: 8000
+
 # ---------------------------------------------------------------------
 # Grafana & Prometheus – “kube‑prometheus‑stack” sub‑chart values
 # ---------------------------------------------------------------------
@@ -26,6 +55,6 @@ grafana:
 {{ .Files.Get "dashboards/finance_agent.json" | indent 8 }}
 
 # Expose Grafana (NodePort 30030 by default)
-service:
+grafanaService:
   type: NodePort
   nodePort: 30030


### PR DESCRIPTION
## Summary
- enhance `alpha-factory-remote` chart metadata
- provide sensible defaults in `values.yaml`
- allow replica count configuration
- add Kubernetes Service manifest
- document chart usage

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*