### PR TITLE
Enhance setup scripts

### DIFF
--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -12,6 +12,9 @@ and offline fallback — **in ≈ 60 seconds.**
 ## 🚀 Quick start (default profile)
 
 ```bash
+# 0 · validate prerequisites
+python3 scripts/preflight.py
+
 # 1 · make the installer executable
 chmod +x scripts/install_alpha_factory_pro.sh
 

--- a/alpha_factory_v1/scripts/install_alpha_factory_pro.sh
+++ b/alpha_factory_v1/scripts/install_alpha_factory_pro.sh
@@ -113,7 +113,7 @@ if [[ -n $ALPHA_TOGGLE ]]; then
   if command -v yq >/dev/null; then
     yq -i ".finance.strategy = \"$ALPHA_TOGGLE\"" config/alpha_factory.yml
   else
-    echo "⚠️  yq not found; falling back to sed"
+    echo "Warning: yq not found; falling back to sed"
     sed -i "s/^strategy: .*$/strategy: $ALPHA_TOGGLE/" config/alpha_factory.yml
   fi
 fi

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -49,6 +49,24 @@ def check_docker_daemon() -> bool:
         return False
 
 
+def check_docker_compose() -> bool:
+    if not shutil.which('docker'):
+        banner('docker compose missing', 'RED')
+        return False
+    try:
+        subprocess.run(
+            ['docker', 'compose', 'version'],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        banner('docker compose available', 'GREEN')
+        return True
+    except Exception:  # noqa: BLE001
+        banner('docker compose missing', 'RED')
+        return False
+
+
 def check_pkg(pkg: str) -> bool:
     """Return True if *pkg* is importable."""
     try:
@@ -74,6 +92,7 @@ def main() -> None:
     ok &= check_python()
     ok &= check_cmd('docker')
     ok &= check_docker_daemon()
+    ok &= check_docker_compose()
     ok &= check_pkg('openai')
     ok &= check_pkg('openai_agents')
     ensure_dir(MEM_DIR)


### PR DESCRIPTION
## Summary
- check docker compose availability in `preflight.py`
- mention `preflight.py` in quick-start guide
- simplify fallback message in installer script

## Testing
- `python3 alpha_factory_v1/scripts/run_tests.py`
