### PR TITLE
Add one-click installer

### DIFF
--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -11,6 +11,16 @@ and offline fallback — **in ≈ 60 seconds.**
 
 ## 🚀 Quick start (default profile)
 
+For an all‑in‑one setup run:
+
+```bash
+./scripts/one_click_install.sh
+```
+
+This performs the preflight checks and deploys the full stack.
+
+If you prefer to execute the steps manually:
+
 ```bash
 # 0 · validate prerequisites
 python3 scripts/preflight.py

--- a/alpha_factory_v1/scripts/one_click_install.sh
+++ b/alpha_factory_v1/scripts/one_click_install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# one_click_install.sh -- Instant Alpha-Factory deploy
+# Usage: ./one_click_install.sh [installer flags]
+# Runs preflight checks then invokes install_alpha_factory_pro.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+
+python3 preflight.py
+chmod +x install_alpha_factory_pro.sh
+
+exec ./install_alpha_factory_pro.sh --bootstrap --deploy "$@"


### PR DESCRIPTION
## Summary
- add a helper script `one_click_install.sh` for instant deployment
- document the new script in the scripts README

## Testing
- `bash -n alpha_factory_v1/scripts/one_click_install.sh`
- `python -m py_compile alpha_factory_v1/scripts/preflight.py`
