### PR TITLE
Add alpha-factory Helm chart

### DIFF
--- a/alpha_factory_v1/helm/alpha-factory/Chart.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: alpha-factory
+description: Core Alpha Factory orchestrator (API, UI and gRPC)
+type: application
+version: 0.1.0
+appVersion: "v2"
+dependencies:
+  - name: kube-prometheus-stack
+    version: "^56.0.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+maintainers:
+  - name: MontrealAI
+    url: https://github.com/MontrealAI

--- a/alpha_factory_v1/helm/alpha-factory/README.md
+++ b/alpha_factory_v1/helm/alpha-factory/README.md
@@ -1,0 +1,26 @@
+# alpha-factory Helm Chart
+
+This chart deploys the core **Alpha Factory** service including the API, UI and optional monitoring stack. It mirrors the provided Docker Compose setup while remaining easy to customise.
+
+## Installation
+```bash
+helm upgrade --install alphafactory ./helm/alpha-factory \
+  --set env.OPENAI_API_KEY=<key>
+```
+
+The service exposes:
+- REST + gRPC on port `8000`
+- Web UI on port `3000`
+
+## Values
+- `image.repository` – container image (default `ghcr.io/montrealai/alpha-factory`)
+- `image.tag` – image tag (default `v2`)
+- `env` – key/value environment variables passed to the container
+- `replicaCount` – number of pods
+- `service.type` – Service type (`ClusterIP`, `LoadBalancer`…)
+- `existingSecret` – use a pre-created Secret instead of the generated one
+- `spiffe.enabled` – enable SPIFFE sidecar
+- `grafanaService` – NodePort configuration for Grafana when Prometheus stack is enabled
+
+## Monitoring
+When `prometheus.enabled` is true, a `ServiceMonitor` matching label `app.kubernetes.io/name=alpha-factory` is created by the dependency. Grafana is provisioned with a finance dashboard.

--- a/alpha_factory_v1/helm/alpha-factory/dashboards/finance_agent.json
+++ b/alpha_factory_v1/helm/alpha-factory/dashboards/finance_agent.json
@@ -1,0 +1,87 @@
+{
+  "uid": "alpha-finance",
+  "title": "Alpha‑Factory – FinanceAgent",
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Un‑realised P&L (USD) per Symbol",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "af_pnl_usd",
+          "legendFormat": "{{symbol}}",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "color": { "mode": "palette-classic" } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "type": "stat",
+      "title": "99 % VaR (USD)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "af_var99_usd",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": { "mode": "thresholds", "fixedColor": "red" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 25000 },
+              { "color": "red", "value": 50000 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 8 }
+    },
+    {
+      "type": "stat",
+      "title": "Max Draw‑down (%)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "af_max_drawdown_pct * 100",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds",
+            "fixedColor": "red"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 10 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 8 }
+    }
+  ]
+}

--- a/alpha_factory_v1/helm/alpha-factory/templates/_helpers.tpl
+++ b/alpha_factory_v1/helm/alpha-factory/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "alpha-factory.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alpha-factory.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "alpha-factory.labels" -}}
+app.kubernetes.io/name: {{ include "alpha-factory.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/alpha_factory_v1/helm/alpha-factory/templates/_spiffe.tpl
+++ b/alpha_factory_v1/helm/alpha-factory/templates/_spiffe.tpl
@@ -1,0 +1,19 @@
+{{/* _spiffe.tpl – helper that renders a SPIRE agent side‑car when enabled */}}
+{{- define "af.spiffeSidecar" -}}
+{{- if .Values.spiffe.enabled }}
+- name: spire-agent
+  image: ghcr.io/spiffe/spire-agent:1.8
+  imagePullPolicy: IfNotPresent
+  securityContext:
+    runAsUser: 1337
+    runAsGroup: 1337
+    privileged: false
+    allowPrivilegeEscalation: false
+  volumeMounts:
+    - name: spire-socket
+      mountPath: /run/spire
+  env:
+    - name: SPIFFE_ENDPOINT_SOCKET
+      value: /run/spire/sock
+{{- end }}
+{{- end }}

--- a/alpha_factory_v1/helm/alpha-factory/templates/deployment.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alpha-factory.fullname" . }}
+  labels:
+    {{- include "alpha-factory.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ include "alpha-factory.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "alpha-factory.name" . }}
+    spec:
+      volumes:
+        - name: spire-socket
+          emptyDir: {}
+      containers:
+        - name: orchestrator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- range $k, $v := .Values.env }}
+          - name: {{ $k }}
+            value: "{{ $v }}"
+          {{- end }}
+          args: ["/app/entrypoint.sh"]
+          ports:
+            - containerPort: {{ .Values.service.port }}   # REST + gRPC
+            - containerPort: {{ .Values.service.uiPort }}  # UI
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+{{ include "af.spiffeSidecar" . | indent 8 }}

--- a/alpha_factory_v1/helm/alpha-factory/templates/service.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alpha-factory.fullname" . }}
+  labels:
+    {{- include "alpha-factory.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: api
+    - port: {{ .Values.service.uiPort }}
+      targetPort: {{ .Values.service.uiPort }}
+      protocol: TCP
+      name: ui
+  selector:
+    app: {{ include "alpha-factory.name" . }}

--- a/alpha_factory_v1/helm/alpha-factory/values.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/values.yaml
@@ -1,0 +1,79 @@
+image:
+  repository: ghcr.io/montrealai/alpha-factory
+  tag: v2
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# Environment variables (merged into the Secret)
+env:
+  OPENAI_API_KEY: ""
+  OPENAI_ORG_ID: ""
+  ANTHROPIC_API_KEY: ""
+  MISTRAL_API_KEY: ""
+  TOGETHER_API_KEY: ""
+  GOOGLE_API_KEY: ""
+  POLYGON_API_KEY: ""
+  ALPACA_KEY_ID: ""
+  ALPACA_SECRET_KEY: ""
+  BINANCE_API_KEY: ""
+  BINANCE_API_SECRET: ""
+  IBKR_CLIENT_ID: ""
+  IBKR_CLIENT_SECRET: ""
+  FRED_API_KEY: ""
+  NEWSAPI_KEY: ""
+  NEO4J_URI: bolt://neo4j:7687
+  NEO4J_USER: neo4j
+  NEO4J_PASSWORD: password
+  LLM_PROVIDER: openai
+  MODEL_NAME: gpt-4-turbo
+  PORT: "8000"
+  METRICS_PORT: "9090"
+  A2A_PORT: "8000"
+  TRACE_WS_PORT: "8088"
+  LOGLEVEL: INFO
+  ALPHA_KAFKA_BROKER: ""
+  ALPHA_DATA_DIR: /data
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
+
+existingSecret: ""
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 512Mi
+
+spiffe:
+  enabled: false
+
+service:
+  type: ClusterIP
+  port: 8000
+  uiPort: 3000
+
+prometheus:
+  enabled: true
+  prometheusSpec:
+    serviceMonitorSelector:
+      matchLabels:
+        app.kubernetes.io/name: alpha-factory
+
+grafana:
+  enabled: true
+  adminPassword: changeme
+  defaultDashboardsEnabled: false
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+  dashboards:
+    finance-agent:
+      json: |
+        {{ .Files.Get "dashboards/finance_agent.json" | indent 8 }}
+
+grafanaService:
+  type: NodePort
+  nodePort: 30030


### PR DESCRIPTION
## Summary
- add production-grade Helm chart for main alpha-factory service
- include deployment, service, monitoring, and SPIFFE helper
- document usage and provide default values

## Testing
- `pytest -q` *(fails: command not found)*