### PR TITLE
Fix demo quickstart

### DIFF
--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -24,8 +24,10 @@
 ```bash
 # one‑command immersive tour (CPU‑only)
 curl -sSL https://raw.githubusercontent.com/MontrealAI/AGI-Alpha-Agent-v0/main/alpha_factory_v1/demos/quick_start.sh | bash
+# or, if cloned locally (run from repo root):
+./alpha_factory_v1/quickstart.sh
 ```
-Opens **http://localhost:7860** with a Gradio portal to every demo. Works on macOS, Linux, WSL 2 & Colab.
+Opens **http://localhost:7860** with a Gradio portal to every demo. Works on macOS, Linux, WSL 2 & Colab.
 
 ---
 

--- a/alpha_factory_v1/demos/quick_start.sh
+++ b/alpha_factory_v1/demos/quick_start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Wrapper to maintain backwards compatibility with README instructions
+# Delegates to the main quickstart script located one directory up
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/../quickstart.sh" "$@"


### PR DESCRIPTION
## Summary
- add wrapper `quick_start.sh` for legacy README path
- update demo README to mention the correct local script

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests`