### PR TITLE
Enhance governance sim CLI

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -84,14 +84,13 @@ This demo has **no third‑party dependencies**.  Any Python ≥ 3.9 works.
 Clone the repository and launch the Monte‑Carlo simulator:
 
 ```bash
-python -m alpha_factory_v1.demos.solving_agi_governance.governance_sim \
-    --agents 1000 --rounds 6000 --delta 0.8 --seed 42
+governance-sim --agents 1000 --rounds 6000 --delta 0.8 --seed 42 --verbose
 ```
 
 The script prints the mean cooperation rate after the simulated rounds,
 illustrating convergence toward the cooperative fixed point when the
-discount factor `δ` is at least 0.8.  The optional `--seed` flag makes
-the run deterministic.
+discount factor `δ` is at least 0.8. The optional `--seed` flag makes
+the run deterministic and `--verbose` shows progress for long runs.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.9"
 
 [project.scripts]
 alpha-factory = "alpha_factory_v1.run:run"
+governance-sim = "alpha_factory_v1.demos.solving_agi_governance.governance_sim:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add a `governance-sim` entry point
- support verbose mode and local RNG for reproducibility
- document updated usage in the demo README

## Testing
- `python -m pytest -q alpha_factory_v1/tests/test_governance_sim.py` *(fails: No module named pytest)*