### PR TITLE
Improve requests shim with default UA

### DIFF
--- a/alpha_factory_v1/tests/test_requests_shim.py
+++ b/alpha_factory_v1/tests/test_requests_shim.py
@@ -46,6 +46,7 @@ class RequestsShimTest(unittest.TestCase):
         self.assertEqual(resp.text, "ok")
         self.assertIsNone(H.received_body)
         self.assertIn("Host", H.received_headers)
+        self.assertEqual(H.received_headers.get("User-Agent"), "alpha-factory-requests/1.0")
         self.assertIn("Server", resp.headers)
 
     def test_post_json(self):
@@ -55,6 +56,7 @@ class RequestsShimTest(unittest.TestCase):
         self.assertEqual(resp.json(), payload)
         self.assertEqual(H.received_body, json.dumps(payload).encode())
         self.assertEqual(H.received_headers.get("Content-Type"), "application/json")
+        self.assertEqual(H.received_headers.get("User-Agent"), "alpha-factory-requests/1.0")
         self.assertIn("Server", resp.headers)
 
     def test_post_bytes(self):
@@ -67,6 +69,7 @@ class RequestsShimTest(unittest.TestCase):
             H.received_headers.get("Content-Type"),
             "application/x-www-form-urlencoded",
         )
+        self.assertEqual(H.received_headers.get("User-Agent"), "alpha-factory-requests/1.0")
         self.assertIn("Server", resp.headers)
 
     def test_raise_for_status(self):


### PR DESCRIPTION
## Summary
- ensure requests shim sets a default User-Agent header
- validate new header in tests

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests -v`