### PR TITLE
Fix free-energy calc and add test

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/core/physics/gibbs.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/core/physics/gibbs.py
@@ -1,7 +1,8 @@
 # core/physics/gibbs.py
-import numpy as np
+from math import exp, log
+from typing import Sequence
 
-def free_energy(logp: np.ndarray, temperature: float, task_cost: float) -> float:
+def free_energy(logp: Sequence[float], temperature: float, task_cost: float) -> float:
     """
     Gibbs / variational free energy (negative ELBO):
         F = E - T*S
@@ -9,7 +10,12 @@ def free_energy(logp: np.ndarray, temperature: float, task_cost: float) -> float
         E = expected task cost  (we treat task_cost as energy)
         S = -sum_i p_i * log p_i  (Shannon entropy from logits)
     """
-    probs = np.exp(logp)
-    entropy = -np.sum(probs * logp)
+    logp = [float(x) for x in logp]
+    max_log = max(logp)
+    probs = [exp(x - max_log) for x in logp]
+    total = sum(probs)
+    probs = [p / total for p in probs]
+
+    entropy = -sum(p * log(p + 1e-12) for p in probs)
     F = task_cost - temperature * entropy
     return float(F)

--- a/alpha_factory_v1/tests/test_gibbs.py
+++ b/alpha_factory_v1/tests/test_gibbs.py
@@ -1,0 +1,15 @@
+import unittest
+import math
+from alpha_factory_v1.demos.meta_agentic_agi_v3.core.physics import gibbs
+
+class TestGibbs(unittest.TestCase):
+    def test_free_energy(self):
+        logp = [math.log(0.7), math.log(0.3)]
+        fe = gibbs.free_energy(logp, temperature=1.0, task_cost=1.0)
+        probs = [0.7, 0.3]
+        entropy = -sum(p * math.log(p) for p in probs)
+        expected = 1.0 - entropy
+        self.assertAlmostEqual(fe, expected, places=6)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix Gibbs free-energy calculation for numerical stability
- drop numpy dependency from physics helper
- add unit test covering free_energy

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests -v`