### PR TITLE
Enhance Helm charts with health checks and metrics

### DIFF
--- a/alpha_factory_v1/helm/alpha-factory-remote/README.md
+++ b/alpha_factory_v1/helm/alpha-factory-remote/README.md
@@ -7,7 +7,9 @@ This chart deploys a remote worker pod for the **Alpha‑Factory** swarm. It pac
 helm upgrade --install af-remote ./helm/alpha-factory-remote \
   --set env.OPENAI_API_KEY=<key>
 ```
-The worker exposes gRPC + metrics on port `8000`.
+The worker exposes gRPC on port `8000` and publishes Prometheus metrics on the
+port defined by `env.METRICS_PORT` (default `9090`). Liveness and readiness
+probes query `/healthz` for reliable orchestration.
 
 ## Values
 - `image.repository` – container image (default `ghcr.io/montrealai/alpha-factory`)

--- a/alpha_factory_v1/helm/alpha-factory-remote/templates/deployment.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/templates/deployment.yaml
@@ -28,6 +28,19 @@ spec:
           ports:
             - containerPort: 8000   # A2A RPC
             - containerPort: 3000   # UI (optional)
+            - containerPort: {{ .Values.env.METRICS_PORT | default 9090 }}  # metrics
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources: {{- toYaml .Values.resources | nindent 12 }}
 
 {{ include "af.spiffeSidecar" . | indent 8 }}   # ② inject side‑car when enabled

--- a/alpha_factory_v1/helm/alpha-factory-remote/templates/service.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: 8000
       protocol: TCP
       name: rpc
+    - port: {{ .Values.env.METRICS_PORT | default 9090 }}
+      targetPort: {{ .Values.env.METRICS_PORT | default 9090 }}
+      protocol: TCP
+      name: metrics
   selector:
     app: {{ include "alpha-factory-remote.name" . }}

--- a/alpha_factory_v1/helm/alpha-factory-remote/values.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/values.yaml
@@ -11,6 +11,7 @@ env:
   ALPHA_MARKET_PROVIDER: sim
   ALPHA_BROKER: sim
   A2A_PORT: "8000"
+  METRICS_PORT: "9090"
 
 resources:
   limits:

--- a/alpha_factory_v1/helm/alpha-factory/README.md
+++ b/alpha_factory_v1/helm/alpha-factory/README.md
@@ -11,6 +11,10 @@ helm upgrade --install alphafactory ./helm/alpha-factory \
 The service exposes:
 - REST + gRPC on port `8000`
 - Web UI on port `3000`
+- Prometheus metrics on port defined by `env.METRICS_PORT` (default `9090`)
+
+Liveness and readiness probes hit `/healthz` to ensure Kubernetes can reliably
+restart unhealthy pods.
 
 ## Values
 - `image.repository` – container image (default `ghcr.io/montrealai/alpha-factory`)

--- a/alpha_factory_v1/helm/alpha-factory/templates/deployment.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/templates/deployment.yaml
@@ -30,5 +30,18 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port }}   # REST + gRPC
             - containerPort: {{ .Values.service.uiPort }}  # UI
+            - containerPort: {{ .Values.env.METRICS_PORT | default 9090 }}  # metrics
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources: {{- toYaml .Values.resources | nindent 12 }}
 {{ include "af.spiffeSidecar" . | indent 8 }}

--- a/alpha_factory_v1/helm/alpha-factory/templates/service.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/templates/service.yaml
@@ -15,5 +15,9 @@ spec:
       targetPort: {{ .Values.service.uiPort }}
       protocol: TCP
       name: ui
+    - port: {{ .Values.env.METRICS_PORT | default 9090 }}
+      targetPort: {{ .Values.env.METRICS_PORT | default 9090 }}
+      protocol: TCP
+      name: metrics
   selector:
     app: {{ include "alpha-factory.name" . }}


### PR DESCRIPTION
## Summary
- expose metrics port and add health checks in `alpha-factory` chart
- expose metrics port and add health checks in `alpha-factory-remote` chart
- document new ports and probes in chart READMEs

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*