### PR TITLE
Improve requests fallback module

### DIFF
--- a/alpha_factory_v1/requests.py
+++ b/alpha_factory_v1/requests.py
@@ -1,64 +1,75 @@
-"""Minimal requests shim for offline test environment.
+"""Minimal ``requests``-like shim for offline environments.
 
-This module emulates the tiny subset of :mod:`requests` used across the
-repository so that the test-suite and demos run even when the real
-``requests`` package is unavailable.  Only ``get`` and ``post`` are
-implemented with very small feature sets.
+This module mirrors a very small portion of :mod:`requests` so that the
+repository works even when the real dependency is not installed.  It aims to
+remain lightweight while still offering a reasonably friendly API suitable for
+tests and demos.  Only the most common HTTP verbs and features are supported.
 """
 from __future__ import annotations
 
 import json as _json
-from urllib import request as _request, parse as _parse, error as _error
+from urllib import error as _error
+from urllib import parse as _parse
+from urllib import request as _request
 
 # Default User-Agent header mimicking the real requests library.  Helps with
 # servers that reject requests without a UA and aids debugging/logging.
 _UA = "alpha-factory-requests/1.0"
 
+class RequestException(Exception):
+    """Base exception raised for network errors."""
+
+
+class HTTPError(RequestException, RuntimeError):
+    """Error for non-successful HTTP status codes."""
+
+
+class Timeout(RequestException):
+    """Error for requests that timed out."""
+
 class Response:
     """Lightweight HTTP response container."""
 
-    def __init__(self, status_code: int, text: str, headers: dict | None = None) -> None:
+    def __init__(self, status_code: int, content: bytes, headers: dict | None = None, url: str = "") -> None:
         self.status_code = status_code
-        self.text = text
+        self.content = content
         self.headers = headers or {}
+        self.url = url
+
+    @property
+    def text(self) -> str:
+        try:
+            return self.content.decode()
+        except UnicodeDecodeError:
+            return self.content.decode("latin1", errors="replace")
 
     def json(self):
         return _json.loads(self.text)
 
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
     def raise_for_status(self) -> None:
-        """Raise :class:`RuntimeError` if the status code signals an error."""
-        if self.status_code >= 400:
-            raise RuntimeError(f"HTTP {self.status_code}")
+        """Raise :class:`HTTPError` if the status code signals an error."""
+        if not self.ok:
+            raise HTTPError(f"HTTP {self.status_code}")
 
-def get(
+def _call(
+    method: str,
     url: str,
     *,
-    timeout: float | None = None,
-    headers: dict | None = None,
-) -> Response:
-    """Perform a simple HTTP GET request."""
-    req = _request.Request(url, headers={"User-Agent": _UA, **(headers or {})})
-    try:
-        with _request.urlopen(req, timeout=timeout) as resp:
-            data = resp.read().decode()
-            resp_headers = dict(resp.headers.items())
-            return Response(resp.getcode(), data, resp_headers)
-    except _error.HTTPError as exc:
-        data = exc.read().decode()
-        resp_headers = dict(exc.headers.items()) if hasattr(exc, "headers") else {}
-        return Response(exc.code, data, resp_headers)
-
-
-def post(
-    url: str,
-    *,
+    params: dict | None = None,
     json: dict | None = None,
     data: dict | bytes | None = None,
     headers: dict | None = None,
     timeout: float | None = None,
 ) -> Response:
-    """Perform a minimal HTTP POST request."""
-    body = b""
+    if params:
+        query = _parse.urlencode(params, doseq=True)
+        url += ("&" if "?" in url else "?") + query
+
+    body = None
     req_headers = {"User-Agent": _UA, **(headers or {})}
     if json is not None:
         body = _json.dumps(json).encode()
@@ -68,20 +79,95 @@ def post(
             body = data
         else:
             body = _parse.urlencode(data).encode()
-            req_headers.setdefault(
-                "Content-Type", "application/x-www-form-urlencoded"
-            )
+            req_headers.setdefault("Content-Type", "application/x-www-form-urlencoded")
 
-    req = _request.Request(url, data=body, headers=req_headers, method="POST")
+    req = _request.Request(url, data=body, headers=req_headers, method=method)
     try:
         with _request.urlopen(req, timeout=timeout) as resp:
-            text = resp.read().decode()
-            headers = dict(resp.headers.items())
-            return Response(resp.getcode(), text, headers)
+            content = resp.read()
+            resp_headers = dict(resp.headers.items())
+            return Response(resp.getcode(), content, resp_headers, url)
     except _error.HTTPError as exc:
-        text = exc.read().decode()
-        headers = dict(exc.headers.items()) if hasattr(exc, "headers") else {}
-        return Response(exc.code, text, headers)
+        content = exc.read()
+        resp_headers = dict(exc.headers.items()) if hasattr(exc, "headers") else {}
+        return Response(exc.code, content, resp_headers, url)
+    except _error.URLError as exc:  # pragma: no cover - network issues
+        if isinstance(getattr(exc, "reason", None), TimeoutError):
+            raise Timeout(str(exc.reason))
+        raise RequestException(str(exc))
 
 
-__all__ = ["get", "post", "Response"]
+def get(
+    url: str,
+    *,
+    params: dict | None = None,
+    headers: dict | None = None,
+    timeout: float | None = None,
+) -> Response:
+    """Perform a simple HTTP GET request."""
+    return _call("GET", url, params=params, headers=headers, timeout=timeout)
+
+
+def post(
+    url: str,
+    *,
+    params: dict | None = None,
+    json: dict | None = None,
+    data: dict | bytes | None = None,
+    headers: dict | None = None,
+    timeout: float | None = None,
+) -> Response:
+    """Perform a minimal HTTP POST request."""
+    return _call(
+        "POST",
+        url,
+        params=params,
+        json=json,
+        data=data,
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+def put(
+    url: str,
+    *,
+    params: dict | None = None,
+    json: dict | None = None,
+    data: dict | bytes | None = None,
+    headers: dict | None = None,
+    timeout: float | None = None,
+) -> Response:
+    """HTTP PUT request."""
+    return _call(
+        "PUT",
+        url,
+        params=params,
+        json=json,
+        data=data,
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+def delete(
+    url: str,
+    *,
+    params: dict | None = None,
+    headers: dict | None = None,
+    timeout: float | None = None,
+) -> Response:
+    """HTTP DELETE request."""
+    return _call("DELETE", url, params=params, headers=headers, timeout=timeout)
+
+
+__all__ = [
+    "get",
+    "post",
+    "put",
+    "delete",
+    "Response",
+    "HTTPError",
+    "RequestException",
+    "Timeout",
+]

--- a/alpha_factory_v1/tests/README.md
+++ b/alpha_factory_v1/tests/README.md
@@ -52,7 +52,7 @@ This wrapper executes `pytest` with CPU and memory caps and strips credentials f
 | `test_memory.py` | Key‑value memory fabric |
 | `test_vector_memory.py` | Vector memory fabric |
 | `test_planner_agent.py` | Planner agent logic |
-| `test_requests_shim.py` | HTTP requests shim |
+| `test_requests_shim.py` | HTTP requests shim (minimal `requests` clone) |
 | `test_register_decorator.py` | Agent registration decorator |
 | `test_smoke.py` | Container build and API health check |
 | `redteam_prompts.json` | Prompts for security testing |

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -1,6 +1,7 @@
 """Fallback shim mapping to :mod:`alpha_factory_v1.requests`.
 
-This allows ``import requests`` in environments without the real
-``requests`` package installed.
+This small proxy enables ``import requests`` for demos and tests even when the
+real library is missing.  It exposes a minimal yet practical subset of the
+`requests` API implemented in :mod:`alpha_factory_v1.requests`.
 """
 from alpha_factory_v1.requests import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- enhance requests shim with additional HTTP verbs and better error handling
- document minimal requests clone in test README
- clarify requests shim purpose in proxy package

## Testing
- `python -m unittest alpha_factory_v1.tests.test_requests_shim -v`
- `python -m unittest discover -s alpha_factory_v1/tests -v`