### PR TITLE
Add edge runner CLI utility

### DIFF
--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Lightweight orchestrator launcher for offline / edge deployments.
+
+This utility wraps :mod:`alpha_factory_v1.run` with sensible defaults so that
+`python edge_runner.py --agents A,B` spins up the orchestrator in **DEV** mode
+using only built‑in fallbacks (SQLite memory, in‑proc queue).  No external
+services are required.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+from alpha_factory_v1 import run as af_run
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Alpha-Factory Edge Runner")
+    ap.add_argument(
+        "--agents",
+        help="Comma separated list of agents to enable",
+    )
+    ap.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="REST API port (default: 8000)",
+    )
+    ap.add_argument(
+        "--metrics-port",
+        type=int,
+        help="Prometheus metrics port",
+    )
+    ap.add_argument(
+        "--a2a-port",
+        type=int,
+        help="gRPC A2A port",
+    )
+    return ap.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    cli = ["--dev", f"--port", str(args.port)]
+    if args.metrics_port:
+        cli += ["--metrics-port", str(args.metrics_port)]
+    if args.a2a_port:
+        cli += ["--a2a-port", str(args.a2a_port)]
+    if args.agents:
+        cli += ["--enabled", args.agents]
+
+    ns = af_run.parse_args(cli)
+    af_run.apply_env(ns)
+
+    os.environ.setdefault("PGHOST", "sqlite")
+
+    af_run.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.9"
 [project.scripts]
 alpha-factory = "alpha_factory_v1.run:run"
 governance-sim = "alpha_factory_v1.demos.solving_agi_governance.governance_sim:main"
+edge-runner = "alpha_factory_v1.edge_runner:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add `edge_runner.py` for offline/edge deployments
- expose it via new `edge-runner` entry point

## Testing
- `python3 alpha_factory_v1/scripts/run_tests.py`