### PR TITLE
Add edge runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ No `OPENAI_API_KEY` → switches to local SBERT + heuristics.
 
 <a name="7-deployment-recipes"></a>
 ## 7 · Deployment Recipes 🍳
+The repository now bundles a lightweight `edge_runner.py` helper for running
+Alpha‑Factory on air‑gapped or resource‑constrained devices.
 
 | Target | Command | Notes |
 |--------|---------|-------|

--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -351,6 +351,8 @@ No `OPENAI_API_KEY` → switches to local SBERT + heuristics.
 
 <a name="7-deployment-recipes"></a>
 ## 7 · Deployment Recipes 🍳
+The repository ships with an `edge_runner.py` script for portable,
+offline deployments.
 
 | Target | Command | Notes |
 |--------|---------|-------|

--- a/alpha_factory_v1/backend/agents/README.md
+++ b/alpha_factory_v1/backend/agents/README.md
@@ -243,7 +243,8 @@ crispr = bio.design_guides("ACGT...")
 ---
 
 <a name="7"></a>
-## 7 · Deployment Recipes 🍳  
+## 7 · Deployment Recipes 🍳
+Use the bundled `edge_runner.py` utility for minimal, offline-capable setups.
 
 | Target | Command | Highlights |
 |--------|---------|------------|

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -79,7 +79,7 @@ Each backend agent is callable as an **OpenAI Agents SDK** tool *and* as a RES
 |Docker Compose|`docker compose up -d orchestrator`|Spins Kafka, Prometheus, Grafana, agents, demos.|
 |Kubernetes|`helm repo add alpha-factory https://montrealai.github.io/helm && helm install af alpha-factory/full`|mTLS via SPIFFE, HPA auto‑scales.|
 |Colab|Launch notebook ⇒ click *“Run on Colab”* badge.|GPU‑accelerated demos.|
-|Bare‑metal Edge|`python edge_runner.py --agents manufacturing,energy`|Zero external deps; SQLite state.|
+|Bare‑metal Edge|`python edge_runner.py --agents manufacturing,energy`|Zero external deps; SQLite state. The helper script is included in the repo.|
 
 ---
 

--- a/edge_runner.py
+++ b/edge_runner.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Alpha-Factory Edge Runner.
+
+This lightweight wrapper starts the orchestrator with edge-friendly defaults
+so the stack can operate without external services or GPU acceleration.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Alpha-Factory on edge devices")
+    parser.add_argument(
+        "--agents",
+        default="manufacturing,energy",
+        help="Comma separated list of agents to enable",
+    )
+    parser.add_argument(
+        "--cycle",
+        type=int,
+        help="Override agent cycle seconds",
+    )
+    parser.add_argument(
+        "--loglevel",
+        default="INFO",
+        help="Logging verbosity",
+    )
+    args = parser.parse_args()
+
+    os.environ.setdefault("DEV_MODE", "true")
+    os.environ["ALPHA_ENABLED_AGENTS"] = args.agents
+    os.environ["LOGLEVEL"] = args.loglevel.upper()
+    if args.cycle:
+        os.environ["ALPHA_CYCLE_SECONDS"] = str(args.cycle)
+
+    from alpha_factory_v1.backend.orchestrator import Orchestrator
+    Orchestrator().run_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `edge_runner.py` utility for offline/edge deployments
- mention the helper in deployment docs

## Testing
- `python3 -m py_compile edge_runner.py`
- `./edge_runner.py --help`