### PR TITLE
Improve edge runner usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,8 +353,10 @@ No `OPENAI_API_KEY` → switches to local SBERT + heuristics.
 
 <a name="7-deployment-recipes"></a>
 ## 7 · Deployment Recipes 🍳
-The repository now bundles a lightweight `edge_runner.py` helper for running
-Alpha‑Factory on air‑gapped or resource‑constrained devices.
+The repository bundles a lightweight `edge_runner.py` helper for running
+Alpha‑Factory on air‑gapped or resource‑constrained devices. The script
+forwards to `alpha_factory_v1.edge_runner` and exposes additional flags
+like `--cycle`, `--loglevel` and `--version`.
 
 | Target | Command | Notes |
 |--------|---------|-------|

--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -352,7 +352,8 @@ No `OPENAI_API_KEY` → switches to local SBERT + heuristics.
 <a name="7-deployment-recipes"></a>
 ## 7 · Deployment Recipes 🍳
 The repository ships with an `edge_runner.py` script for portable,
-offline deployments.
+offline deployments. It forwards to the Python module and supports
+extra flags such as `--cycle`, `--loglevel` and `--version`.
 
 | Target | Command | Notes |
 |--------|---------|-------|

--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import argparse
 import os
 
-from alpha_factory_v1 import run as af_run
+from alpha_factory_v1 import run as af_run, __version__
 
 
 def parse_args() -> argparse.Namespace:
@@ -27,6 +27,16 @@ def parse_args() -> argparse.Namespace:
         help="REST API port (default: 8000)",
     )
     ap.add_argument(
+        "--cycle",
+        type=int,
+        help="Override agent cycle seconds",
+    )
+    ap.add_argument(
+        "--loglevel",
+        default="INFO",
+        help="Logging verbosity",
+    )
+    ap.add_argument(
         "--metrics-port",
         type=int,
         help="Prometheus metrics port",
@@ -36,11 +46,20 @@ def parse_args() -> argparse.Namespace:
         type=int,
         help="gRPC A2A port",
     )
+    ap.add_argument(
+        "--version",
+        action="store_true",
+        help="Print version and exit",
+    )
     return ap.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+
+    if args.version:
+        print(__version__)
+        return
 
     cli = ["--dev", f"--port", str(args.port)]
     if args.metrics_port:
@@ -49,6 +68,10 @@ def main() -> None:
         cli += ["--a2a-port", str(args.a2a_port)]
     if args.agents:
         cli += ["--enabled", args.agents]
+    if args.cycle:
+        cli += ["--cycle", str(args.cycle)]
+    if args.loglevel:
+        cli += ["--loglevel", args.loglevel]
 
     ns = af_run.parse_args(cli)
     af_run.apply_env(ns)

--- a/alpha_factory_v1/tests/test_edge_runner.py
+++ b/alpha_factory_v1/tests/test_edge_runner.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+from alpha_factory_v1 import edge_runner
+
+
+class EdgeRunnerParseTest(unittest.TestCase):
+    def _parse(self, args):
+        old = sys.argv
+        sys.argv = ["edge_runner.py"] + args
+        try:
+            return edge_runner.parse_args()
+        finally:
+            sys.argv = old
+
+    def test_parse_defaults(self):
+        args = self._parse([])
+        self.assertEqual(args.port, 8000)
+        self.assertIsNone(args.agents)
+        self.assertIsNone(args.metrics_port)
+        self.assertIsNone(args.a2a_port)
+        self.assertIsNone(args.cycle)
+        self.assertEqual(args.loglevel, "INFO")
+
+    def test_version_flag(self):
+        args = self._parse(["--version"])
+        self.assertTrue(args.version)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/edge_runner.py
+++ b/edge_runner.py
@@ -1,44 +1,6 @@
 #!/usr/bin/env python3
-"""Alpha-Factory Edge Runner.
-
-This lightweight wrapper starts the orchestrator with edge-friendly defaults
-so the stack can operate without external services or GPU acceleration.
-"""
-from __future__ import annotations
-
-import argparse
-import os
-
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Run Alpha-Factory on edge devices")
-    parser.add_argument(
-        "--agents",
-        default="manufacturing,energy",
-        help="Comma separated list of agents to enable",
-    )
-    parser.add_argument(
-        "--cycle",
-        type=int,
-        help="Override agent cycle seconds",
-    )
-    parser.add_argument(
-        "--loglevel",
-        default="INFO",
-        help="Logging verbosity",
-    )
-    args = parser.parse_args()
-
-    os.environ.setdefault("DEV_MODE", "true")
-    os.environ["ALPHA_ENABLED_AGENTS"] = args.agents
-    os.environ["LOGLEVEL"] = args.loglevel.upper()
-    if args.cycle:
-        os.environ["ALPHA_CYCLE_SECONDS"] = str(args.cycle)
-
-    from alpha_factory_v1.backend.orchestrator import Orchestrator
-    Orchestrator().run_forever()
-
+"""Wrapper script forwarding to :mod:`alpha_factory_v1.edge_runner`."""
+from alpha_factory_v1.edge_runner import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- expand edge runner CLI with `--cycle`, `--loglevel` and `--version`
- forward top-level `edge_runner.py` to packaged module
- document new options in READMEs
- add tests for edge runner argument parsing

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests`