### PR TITLE
Add agent listing CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ echo "OPENAI_API_KEY=sk-..." > .env
 alpha-factory --preflight
 alpha-factory
 alpha-factory --version  # display package version
+alpha-factory --list-agents  # view available agents
 # the CLI auto-loads environment variables from .env if present
 open http://localhost:8000/docs
 ```

--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -83,6 +83,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Print version and exit",
     )
+    ap.add_argument(
+        "--list-agents",
+        action="store_true",
+        help="List available agents and exit",
+    )
     return ap.parse_args(argv)
 
 
@@ -91,6 +96,11 @@ def main() -> None:
 
     if args.version:
         print(__version__)
+        return
+    if args.list_agents:
+        from .backend import agents
+        for name in agents.list_agents():
+            print(name)
         return
 
     cli = ["--dev", f"--port", str(args.port)]

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -18,6 +18,11 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--enabled", help="Comma separated list of enabled agents")
     ap.add_argument("--loglevel", default="INFO", help="Log level")
     ap.add_argument("--version", action="store_true", help="Print version and exit")
+    ap.add_argument(
+        "--list-agents",
+        action="store_true",
+        help="List available agents and exit",
+    )
     return ap.parse_args()
 
 
@@ -50,6 +55,11 @@ def run() -> None:
     args = parse_args()
     if args.version:
         print(__version__)
+        return
+    if args.list_agents:
+        from .backend.agents import list_agents
+        for name in list_agents():
+            print(name)
         return
     if args.preflight:
         preflight_main()

--- a/alpha_factory_v1/tests/test_cli.py
+++ b/alpha_factory_v1/tests/test_cli.py
@@ -25,6 +25,7 @@ class CliParseTest(unittest.TestCase):
         self.assertIsNone(args.a2a_port)
         self.assertIsNone(args.enabled)
         self.assertEqual(args.loglevel, 'INFO')
+        self.assertFalse(args.list_agents)
 
     def test_apply_env(self):
         args = _parse_with([
@@ -48,6 +49,10 @@ class CliParseTest(unittest.TestCase):
     def test_version_flag(self):
         args = _parse_with(['--version'])
         self.assertTrue(args.version)
+
+    def test_list_agents_flag(self):
+        args = _parse_with(['--list-agents'])
+        self.assertTrue(args.list_agents)
 
     def test_env_file(self):
         with tempfile.NamedTemporaryFile('w', delete=False) as fh:

--- a/alpha_factory_v1/tests/test_edge_runner.py
+++ b/alpha_factory_v1/tests/test_edge_runner.py
@@ -24,6 +24,7 @@ class EdgeRunnerParseTest(unittest.TestCase):
         self.assertIsNone(args.a2a_port)
         self.assertIsNone(args.cycle)
         self.assertEqual(args.loglevel, "INFO")
+        self.assertFalse(args.list_agents)
 
     def test_env_defaults(self):
         os.environ["PORT"] = "9000"
@@ -41,6 +42,10 @@ class EdgeRunnerParseTest(unittest.TestCase):
     def test_version_flag(self):
         args = self._parse(["--version"])
         self.assertTrue(args.version)
+
+    def test_list_agents_flag(self):
+        args = self._parse(["--list-agents"])
+        self.assertTrue(args.list_agents)
 
     def test_invalid_port(self):
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
## Summary
- add `--list-agents` option to main CLI and edge runner
- expose the flag in Quick Start guide
- test new CLI argument handling

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`