### PR TITLE
Improve quick-start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ open http://localhost:8000/docs
 # The `alpha-factory` CLI also works when the package is installed:
 #   pip install -e .
 #   alpha-factory --list-agents
+#
+# Or install directly from GitHub for a quick test:
+#   pip install git+https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
+#   alpha-factory --list-agents
 ```
 
 No GPU → falls back to GGML Llama‑3‑8B‑Q4.


### PR DESCRIPTION
## Summary
- refine README with instructions to install directly from GitHub

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`