### PR TITLE
Clean demo docs and remove placeholders

### DIFF
--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -9,10 +9,9 @@ weather forecasts and ISO/LMP price curves to surface *alpha* in short-
 term dispatch, virtual-power-plant (VPP) coordination and forward-curve
 hedging.  The control loop blends deterministic optimisation (unit-
 commitment MILP) with model-based RL planning (MuZero-style tree search
-over a learned surrogate world-model) following Schrittwieser et al.
-2020 :contentReference[oaicite:0]{index=0}&#8203;:contentReference[oaicite:1]{index=1} while embracing the *Era-of-Experience*
-paradigm :contentReference[oaicite:2]{index=2}&#8203;:contentReference[oaicite:3]{index=3} and Clune’s AI-GA principle of evolvable
-architecture :contentReference[oaicite:4]{index=4}&#8203;:contentReference[oaicite:5]{index=5}.
+over a learned surrogate world-model) following Schrittwieser et al. (2020),
+while embracing the *Era-of-Experience* paradigm and Clune’s AI-GA principle
+of evolvable architecture.
 
 Key pillars
 -----------

--- a/alpha_factory_v1/backend/world_model.py
+++ b/alpha_factory_v1/backend/world_model.py
@@ -34,9 +34,9 @@ from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple
 
 # ────────────────── Soft-Imports (all optional) ──────────────────────────────
 with contextlib.suppress(ModuleNotFoundError):
-    from muzero import muzero  # MuZero-general :contentReference[oaicite:0]{index=0}
+    from muzero import muzero  # MuZero-general
 with contextlib.suppress(ModuleNotFoundError):
-    import openai  # OpenAI SDK :contentReference[oaicite:1]{index=1}
+    import openai  # OpenAI SDK
 with contextlib.suppress(ModuleNotFoundError):
     from llama_cpp import Llama
 with contextlib.suppress(ModuleNotFoundError):

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -1,7 +1,7 @@
 # Alpha‑Factory v1 👁️✨ — **Interactive Demo & Agent Gallery**
 *Out‑learn | Out‑think | Out‑design | Out‑strategise | Out‑execute*
 
-> “Intelligence is **experience** distilled through relentless self‑play.” — inspired by Sutton & Silver’s *Era of Experience* citeturn32file3
+> “Intelligence is **experience** distilled through relentless self‑play.” — inspired by Sutton & Silver’s *Era of Experience* 
 
 ---
 
@@ -18,14 +18,16 @@
 
 ---
 
-## 1 • Welcome  
-**Alpha‑Factory v1** is the **cross‑industry agentic engine** that captures live α‑signals and turns them into value across all industries & beyond.  This gallery lets you *touch* that power:
+## 1 • Welcome 
+**Alpha‑Factory v1** is the **cross‑industry agentic engine** that captures live α‑signals and turns them into value across all industries & beyond. This gallery lets you *touch* that power:
 
 ```bash
 # one‑command immersive tour (CPU‑only)
 curl -sSL https://raw.githubusercontent.com/MontrealAI/AGI-Alpha-Agent-v0/main/alpha_factory_v1/demos/quick_start.sh | bash
 # or, if cloned locally (run from repo root):
 ./alpha_factory_v1/quickstart.sh
+# or via Docker (no install)
+docker run --pull=always -p 7860:7860 ghcr.io/montrealai/alpha-factory-demos:latest
 ```
 Opens **http://localhost:7860** with a Gradio portal to every demo. Works on macOS, Linux, WSL 2 & Colab.
 
@@ -52,7 +54,7 @@ Opens **http://localhost:7860** with a Gradio portal to every demo. Works on ma
 ---
 
 ## 3 • Agent Roster 🖼️
-Each backend agent is callable as an **OpenAI Agents SDK** tool *and* as a REST endpoint (`/v1/agents/<name>`).  
+Each backend agent is callable as an **OpenAI Agents SDK** tool *and* as a REST endpoint (`/v1/agents/<name>`). 
 
 | # | File | Emoji | Core Alpha Skill | Key Env |
 |---|------|-------|------------------|--------|
@@ -84,9 +86,9 @@ Each backend agent is callable as an **OpenAI Agents SDK** tool *and* as a RES
 ---
 
 ## 5 • Governance & Safety ⚖️
-* **Model Context Protocol** envelopes every artefact (SHA‑256 + ISO‑8601).  
-* **SPIFFE + mTLS** across the mesh → zero‑trust.  
-* **Cosign + Rekor** immutable supply chain.  
+* **Model Context Protocol** envelopes every artefact (SHA‑256 + ISO‑8601). 
+* **SPIFFE + mTLS** across the mesh → zero‑trust. 
+* **Cosign + Rekor** immutable supply chain. 
 * Live bias & harm evals via model‑graded tests each night.
 
 ---
@@ -96,8 +98,8 @@ Each backend agent is callable as an **OpenAI Agents SDK** tool *and* as a RES
 [project.entry-points."alpha_factory.demos"]
 my_demo = my_pkg.cool_demo:app
 ```
-1. Ship a Gradio or Streamlit `app` returning a FastAPI router.  
-2. Add Helm annotation `af.maturity=beta` → appears in UI.  
+1. Ship a Gradio or Streamlit `app` returning a FastAPI router. 
+2. Add Helm annotation `af.maturity=beta` → appears in UI. 
 3. Submit PR — CI auto‑runs red‑team prompts.
 
 ---

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -1,18 +1,18 @@
 <!--
-  AI‑GA Meta‑Evolution Demo
-  Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**
-  Out‑learn · Out‑think · Out‑strategise · Out‑evolve
-  © 2025 MONTREAL.AI   MIT License
-  -------------------------------------------------------------------------------
-  Exhaustive README: quick‑start, deep‑dive, SOC‑2 rails, CI/CD, K8s,
-  observability, SBOM notice. Rendered as GitHub‑flavoured Markdown.
+ AI‑GA Meta‑Evolution Demo
+ Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**
+ Out‑learn · Out‑think · Out‑strategise · Out‑evolve
+ © 2025 MONTREAL.AI   MIT License
+ -------------------------------------------------------------------------------
+ Exhaustive README: quick‑start, deep‑dive, SOC‑2 rails, CI/CD, K8s,
+ observability, SBOM notice. Rendered as GitHub‑flavoured Markdown.
 -->
 
 
 # 🌌 Algorithms That Invent Algorithms — <br>**AI‑GA Meta‑Evolution Demo**
 
-> *“Why hand‑craft intelligence when evolution can author it for you?”*  
-> — Jeff Clune, *AI‑GAs: AI‑Generating Algorithms* (2019) citeturn3file0
+> *“Why hand‑craft intelligence when evolution can author it for you?”* 
+> — Jeff Clune, *AI‑GAs: AI‑Generating Algorithms* (2019) 
 
 A single‑command, browser‑based showcase of Clune’s **Three Pillars**:
 
@@ -51,7 +51,7 @@ Within **&lt; 60 s** you’ll watch neural nets **rewrite their own blueprin
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/aiga_meta_evolution
 
-# optional: --pull (signed image)  --gpu (NVIDIA runtime)
+# optional: --pull (signed image) --gpu (NVIDIA runtime)
 ./run_aiga_demo.sh
 ```
 
@@ -93,23 +93,23 @@ LLMs supply *commentary & analysis* only – **core evolution is deterministic**
 
 ```text
 ┌── docker‑compose ─────────────┐
-│ orchestrator  (FastAPI + UI)  │◀─────────┐
-│ ollama  (Mixtral fallback)    │          │ WebSocket
-│ prometheus  (opt)             │          │
-└───────────────────────────────┘          │
-        ▲ REST / Ray RPC                   │
+│ orchestrator (FastAPI + UI) │◀─────────┐
+│ ollama (Mixtral fallback)  │     │ WebSocket
+│ prometheus (opt)       │     │
+└───────────────────────────────┘     │
+    ▲ REST / Ray RPC          │
 ┌────────────────────────────────────────┐ │
-│  MetaEvolver        checkpoint.json    │ │
-│    ├─ Ray / mp evaluation workers      │ │
-│    └─ EvoNet(nn.Module) ──┐            │ │ obs/reward
-│                           ▼            │ │
-│  CurriculumEnv (Gymnasium)             │◀┘
+│ MetaEvolver    checkpoint.json  │ │
+│  ├─ Ray / mp evaluation workers   │ │
+│  └─ EvoNet(nn.Module) ──┐      │ │ obs/reward
+│              ▼      │ │
+│ CurriculumEnv (Gymnasium)       │◀┘
 └────────────────────────────────────────┘
 ```
 
-* **MetaEvolver** – pop 24, tournament‑k 3, elitism 2, novelty bonus toggle  
-* **EvoNet** – arbitrary hidden layers, activation ∈ {relu,tanh,sigmoid}, optional Hebbian ΔW  
-* **CurriculumEnv** – 12 × 12 grid, DFS solvability check, energy budget, genome auto‑mutation  
+* **MetaEvolver** – pop 24, tournament‑k 3, elitism 2, novelty bonus toggle 
+* **EvoNet** – arbitrary hidden layers, activation ∈ {relu,tanh,sigmoid}, optional Hebbian ΔW 
+* **CurriculumEnv** – 12 × 12 grid, DFS solvability check, energy budget, genome auto‑mutation 
 
 ---
 
@@ -122,15 +122,15 @@ LLMs supply *commentary & analysis* only – **core evolution is deterministic**
 | `aiga_generations_total` | Counter |
 | `aiga_curriculum_stage` | 0–3 |
 
-Enable profile `telemetry` to autopush → Prometheus → Grafana.  
+Enable profile `telemetry` to autopush → Prometheus → Grafana. 
 `docker compose --profile telemetry up`.
 
 ---
 
 ## 🧪 Tests & CI
 
-* **Coverage ≥ 90 %** in < 0.5 s (`pytest -q`)  
-* GitHub Actions → lint → test → build → Cosign sign  
+* **Coverage ≥ 90 %** in < 0.5 s (`pytest -q`) 
+* GitHub Actions → lint → test → build → Cosign sign 
 * **SBOM** via *Syft* (SPDX v3) per release
 
 ---
@@ -142,20 +142,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: { name: aiga-demo }
 spec:
-  replicas: 1
-  selector: { matchLabels: { app: aiga-demo } }
-  template:
-    metadata: { labels: { app: aiga-demo } }
-    spec:
-      containers:
-      - name: orchestrator
-        image: ghcr.io/montrealai/alpha-aiga:latest@sha256:<signed>
-        ports:
-        - { containerPort: 8000 }   # API
-        - { containerPort: 7862 }   # UI
-        readinessProbe:
-          httpGet: { path: /health, port: 8000 }
-        envFrom: [{ secretRef: { name: aiga-secrets } }]
+ replicas: 1
+ selector: { matchLabels: { app: aiga-demo } }
+ template:
+  metadata: { labels: { app: aiga-demo } }
+  spec:
+   containers:
+   - name: orchestrator
+    image: ghcr.io/montrealai/alpha-aiga:latest@sha256:<signed>
+    ports:
+    - { containerPort: 8000 }  # API
+    - { containerPort: 7862 }  # UI
+    readinessProbe:
+     httpGet: { path: /health, port: 8000 }
+    envFrom: [{ secretRef: { name: aiga-secrets } }]
 ```
 
 *Helm chart* → `infra/helm/aiga-demo/`.
@@ -164,10 +164,10 @@ spec:
 
 ## 🛡 SOC‑2 & supply‑chain
 
-* Cosign‑signed images (`cosign verify …`)  
-* Runs **non‑root UID 1001**, read‑only code volume  
-* Secrets via K8s / Docker *secrets* (never baked into layers)  
-* Dependencies hashed (Poetry lock) & validated at runtime  
+* Cosign‑signed images (`cosign verify …`) 
+* Runs **non‑root UID 1001**, read‑only code volume 
+* Secrets via K8s / Docker *secrets* (never baked into layers) 
+* Dependencies hashed (Poetry lock) & validated at runtime 
 * SBOM exported; SLSA level 2 pipeline
 
 ---
@@ -198,11 +198,11 @@ spec:
 
 ## ⚖️ License & credits
 
-*Source & assets* © 2025 Montreal.AI, released under the **MIT License**.  
+*Source & assets* © 2025 Montreal.AI, released under the **MIT License**. 
 Huge thanks to:
 
-* **Jeff Clune** – visionary behind AI‑GAs  
-* **OpenAI, Anthropic, Google** – open‑sourcing crucial agent tooling  
+* **Jeff Clune** – visionary behind AI‑GAs 
+* **OpenAI, Anthropic, Google** – open‑sourcing crucial agent tooling 
 * OSS maintainers – you make this possible ♥
 
 > **Alpha‑Factory** — forging intelligence that *invents* intelligence.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -1,27 +1,27 @@
 <!-- README.md — Large‑Scale α‑AGI Business Demo (v1.0‑production) -->
 <h1 align="center">
-  Large‑Scale α‑AGI Business 👁️✨ <sup><code>$AGIALPHA</code></sup>
+ Large‑Scale α‑AGI Business 👁️✨ <sup><code>$AGIALPHA</code></sup>
 </h1>
 
 <p align="center">
-  <b>Proof‑of‑Alpha 🚀 — an autonomous business entity that finds, exploits & compounds live market alpha<br/>
-  using <em>Alpha‑Factory v1</em> multi‑agent stack, on‑chain incentives & antifragile safety‑loops.</b>
+ <b>Proof‑of‑Alpha 🚀 — an autonomous business entity that finds, exploits & compounds live market alpha<br/>
+ using <em>Alpha‑Factory v1</em> multi‑agent stack, on‑chain incentives & antifragile safety‑loops.</b>
 </p>
 
 <p align="center">
-  <img alt="build"  src="https://img.shields.io/badge/build-passing-brightgreen">
-  <img alt="coverage" src="https://img.shields.io/badge/coverage-100%25-success">
-  <img alt="license"  src="https://img.shields.io/badge/license-Apache--2.0-blue">
-  <img alt="status"   src="https://img.shields.io/badge/status-production-green">
+ <img alt="build" src="https://img.shields.io/badge/build-passing-brightgreen">
+ <img alt="coverage" src="https://img.shields.io/badge/coverage-100%25-success">
+ <img alt="license" src="https://img.shields.io/badge/license-Apache--2.0-blue">
+ <img alt="status"  src="https://img.shields.io/badge/status-production-green">
 </p>
 
 ---
 
-## ✨ Executive Summary  
-* **Mission 🎯** Continuously harvest <code>alpha</code> across <kbd>equities • commodities • crypto • supply‑chains • life‑sciences</kbd> and convert it into compounding value — automatically, transparently, safely.  
-* **Engine ⚙️** *Alpha‑Factory v1 👁️✨* → six specialised agents orchestrated via **A2A** message‑bus (see §4).  
-* **Vehicle 🏛️** A legally‑shielded **α‑AGI Business** (`x.a.agi.eth`) governed & financed by scarce utility token **`$AGIALPHA`**.  
-* **Result 📈** A self‑reinforcing fly‑wheel that **Out‑learn • Out‑think • Out‑design • Out‑strategise • Out‑execute** the market, round‑after‑round.citeturn6file1
+## ✨ Executive Summary 
+* **Mission 🎯** Continuously harvest <code>alpha</code> across <kbd>equities • commodities • crypto • supply‑chains • life‑sciences</kbd> and convert it into compounding value — automatically, transparently, safely. 
+* **Engine ⚙️** *Alpha‑Factory v1 👁️✨* → six specialised agents orchestrated via **A2A** message‑bus (see §4). 
+* **Vehicle 🏛️** A legally‑shielded **α‑AGI Business** (`x.a.agi.eth`) governed & financed by scarce utility token **`$AGIALPHA`**. 
+* **Result 📈** A self‑reinforcing fly‑wheel that **Out‑learn • Out‑think • Out‑design • Out‑strategise • Out‑execute** the market, round‑after‑round.
 
 ---
 
@@ -46,12 +46,12 @@
 ## 1 An α‑AGI Business? 🌐
 Open financial & industrial alpha is shrinking 📉 — yet trillions in inefficiencies remain:
 
-* Mis‑priced risk in frontier markets  
-* Latent capacity in global logistics  
-* Undiscovered IP in public patent corpora  
-* Cross‑asset statistical edges invisible to siloed desks  
+* Mis‑priced risk in frontier markets 
+* Latent capacity in global logistics 
+* Undiscovered IP in public patent corpora 
+* Cross‑asset statistical edges invisible to siloed desks 
 
-> **Hypothesis 🧩**  *Alpha‑Factory v1* already demonstrates general skill‑acquisition & real‑time orchestration. Pointed at live, multi‑modal data it surfaces & arbitrages real‑world inefficiencies continuously.citeturn6file0
+> **Hypothesis 🧩**  *Alpha‑Factory v1* already demonstrates general skill‑acquisition & real‑time orchestration. Pointed at live, multi‑modal data it surfaces & arbitrages real‑world inefficiencies continuously.
 
 > **On-chain** as `<name>.a.agi.eth`, an *α-AGI Business* 👁️✨ unleashes a self-improving *α-AGI Agent* 👁️✨ (`<name>.a.agent.agi.eth`) swarm to hunt inefficiencies and transmute them into **$AGIALPHA**.
 
@@ -62,34 +62,34 @@ Open financial & industrial alpha is shrinking 📉 — yet trillions in ineffi
 
 ```mermaid
 flowchart LR
-    subgraph "α‑AGI Business (x.a.agi.eth) 👁️✨"
-        direction LR
-        P(PlanningAgent)
-        R(ResearchAgent)
-        S(StrategyAgent)
-        M(MarketAnalysisAgent)
-        T(MemoryAgent)
-        F(SafetyAgent)
-        P --> S
-        R --> S
-        S --> M
-        M -->|PnL + risk| F
-        S --> T
-        R --> T
-    end
+  subgraph "α‑AGI Business (x.a.agi.eth) 👁️✨"
+    direction LR
+    P(PlanningAgent)
+    R(ResearchAgent)
+    S(StrategyAgent)
+    M(MarketAnalysisAgent)
+    T(MemoryAgent)
+    F(SafetyAgent)
+    P --> S
+    R --> S
+    S --> M
+    M -->|PnL + risk| F
+    S --> T
+    R --> T
+  end
 
-    subgraph Broker["Exchange / DeFi DEX 🏦"]
-        E[Order Router]
-    end
+  subgraph Broker["Exchange / DeFi DEX 🏦"]
+    E[Order Router]
+  end
 
-    Client((Problem Owner))
-    Treasury(($AGIALPHA\nTreasury))
+  Client((Problem Owner))
+  Treasury(($AGIALPHA\nTreasury))
 
-    Client -. post α‑job .-> P
-    S -->|Orders| E
-    E -->|Fills & Market Data| M
-    F -->|Audit hash| Treasury
-    Treasury -->|Reward release| Client
+  Client -. post α‑job .-> P
+  S -->|Orders| E
+  E -->|Fills & Market Data| M
+  F -->|Audit hash| Treasury
+  Treasury -->|Reward release| Client
 ```
 
 ---
@@ -102,8 +102,8 @@ flowchart LR
 | **α‑AGI Business** | `<sub>.a.agi.eth` | Wallet holds **$AGIALPHA**; can issue bounties | Curate **α‑Job Portfolios**, pool data/IP, enforce domain constraints | Aggregates high‑value challenges, captures upside from solved portfolios, reinvests in new quests |
 | **α‑AGI Agent** | `<sub>.a.agent.agi.eth` | Personal stake (reputation + escrow) | Detect, plan & execute α‑jobs published by any Business | Earns **$AGIALPHA** rewards, boosts reputation, stores reusable alpha templates |
 
-> **Legal & Conceptual Shield 🛡️**  
-> Both layers inherit the **2017 Multi‑Agent AI DAO** prior‑art — a publicly timestamped blueprint for on‑chain, autonomous, self‑learning agent swarms, blocking trivial patents and providing a DAO‑native wrapper for fractional ownership.citeturn6file0
+> **Legal & Conceptual Shield 🛡️** 
+> Both layers inherit the **2017 Multi‑Agent AI DAO** prior‑art — a publicly timestamped blueprint for on‑chain, autonomous, self‑learning agent swarms, blocking trivial patents and providing a DAO‑native wrapper for fractional ownership.
 
 ---
 
@@ -126,11 +126,11 @@ All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google AD
 <a id="story"></a>
 ## 5 End‑to‑End Alpha Walk‑through 📖
 
-1. **ResearchAgent** scrapes SEC 13‑F deltas, maritime AIS pings & macro calendars.  
-2. **MarketAnalysisAgent** detects anomalous spread widening in copper vs renewable‑ETF flows.  
-3. **PlanningAgent** forks tasks → **StrategyAgent** crafts hedged LME‑COMEX pair‑trade + FX overlay.  
-4. **SafetyAgent** signs‑off compliance pack (Dodd‑Frank §716, EMIR RTS 6).  
-5. Orders hit venue; fills + k‑sigs hashed on‑chain; escrow releases **$AGIALPHA**; live PnL feeds Grafana.  
+1. **ResearchAgent** scrapes SEC 13‑F deltas, maritime AIS pings & macro calendars. 
+2. **MarketAnalysisAgent** detects anomalous spread widening in copper vs renewable‑ETF flows. 
+3. **PlanningAgent** forks tasks → **StrategyAgent** crafts hedged LME‑COMEX pair‑trade + FX overlay. 
+4. **SafetyAgent** signs‑off compliance pack (Dodd‑Frank §716, EMIR RTS 6). 
+5. Orders hit venue; fills + k‑sigs hashed on‑chain; escrow releases **$AGIALPHA**; live PnL feeds Grafana. 
 *Wall clock: 4 min 18 s on a CPU‑only laptop.*
 
 ---
@@ -145,11 +145,11 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 # launch full business stack (GPU optional)
 docker compose --profile business up -d
 
-open http://localhost:7878            # Dashboard SPA
+open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_copper_spread.json
 ```
 
-*No Docker?*  
+*No Docker?* 
 `bash <(curl -sL https://get.alpha-factory.ai/business_demo.sh)` boots an ephemeral VM (CPU‑only mode).
 
 ---
@@ -202,19 +202,19 @@ Full econ model → `docs/tokenomics_business_v1.pdf`.
 <a id="antifragility"></a>
 ## 10 Antifragility & Self‑Improvement 💪
 
-Alpha‑Factory injects stochastic **stressors** (latency spikes, reward flips, gradient dropouts) at random intervals.  
-The **SafetyAgent** & **PlanningAgent** collaborate to absorb shocks; metrics show ↑ robustness over time (see Grafana *Antifragility* panel).  
+Alpha‑Factory injects stochastic **stressors** (latency spikes, reward flips, gradient dropouts) at random intervals. 
+The **SafetyAgent** & **PlanningAgent** collaborate to absorb shocks; metrics show ↑ robustness over time (see Grafana *Antifragility* panel). 
 
-*Outcome:* the Business *benefits* from volatility — the more chaos, the sharper its edge.citeturn6file1
+*Outcome:* the Business *benefits* from volatility — the more chaos, the sharper its edge.
 
 ---
 
 <a id="roadmap"></a>
 ## 11 Roadmap 🛣️
-* **Q2‑25** — Auto‑generated MiFID II & CFTC reports  
-* **Q3‑25** — Secure MPC plug‑in for dark‑pool nets  
-* **Q4‑25** — Industry‑agnostic “Alpha‑as‑API” gateway  
-* **2026+** — Autonomous DAO treasury & community forks  
+* **Q2‑25** — Auto‑generated MiFID II & CFTC reports 
+* **Q3‑25** — Secure MPC plug‑in for dark‑pool nets 
+* **Q4‑25** — Industry‑agnostic “Alpha‑as‑API” gateway 
+* **2026+** — Autonomous DAO treasury & community forks 
 
 ---
 
@@ -236,7 +236,7 @@ The **SafetyAgent** & **PlanningAgent** collaborate to absorb shocks; metrics sh
 ---
 
 <a id="license"></a>
-## 13 License 📜  
+## 13 License 📜 
 Apache 2.0 © 2025 **MONTREAL.AI**
 
 <p align="center"><sub>Made with ❤️, ☕ and <b>real</b> GPUs by the Alpha‑Factory core team.</sub></p>

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -5,17 +5,17 @@
 
 ### 1 · Why we built this
 Alpha-Factory stitches together **five flagship agents** (Finance, Biotech, Climate, Manufacturing, Policy) under a
-zero-trust, policy-guarded orchestrator.  
+zero-trust, policy-guarded orchestrator. 
 It closes the full loop:
 
 > **alpha discovery → uniform real-world execution → continuous self-improvement**
 
 and ships with:
 
-* **Automated curriculum** (Ray PPO trainer + reward rubric)  
-* **Uniform adapters** (market data, PubMed, Carbon-API, OPC-UA, GovTrack)  
-* **DevSecOps hardening** — SBOM + _cosign_, MCP guard-rails, ed25519 prompt signing  
-* Runs **online (OpenAI)** or **offline** via bundled Mixtral-8×7B local-LLM  
+* **Automated curriculum** (Ray PPO trainer + reward rubric) 
+* **Uniform adapters** (market data, PubMed, Carbon-API, OPC-UA, GovTrack) 
+* **DevSecOps hardening** — SBOM + _cosign_, MCP guard-rails, ed25519 prompt signing 
+* Runs **online (OpenAI)** or **offline** via bundled Mixtral-8×7B local-LLM 
 * One-command Docker installer **_or_** one-click Colab notebook for non-technical users
 
 The design follows the “AI-GAs” recipe for open-ended systems, 
@@ -54,19 +54,19 @@ installer.
 ### 4 · Architecture at a glance
 ```
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ docker-compose (network: alpha_factory)                                      │
-│                                                                              │
-│   Grafana ◄── Prometheus ◄── metrics ───────┐                                │
-│          ▲                                 │                                │
-│  Trace-Graph ◄─ A2A spans ─ Orchestrator ──┴─► Knowledge-Hub (RAG + vec-DB)  │
-│                     ▲            ▲                                            │
-│                     │ ADK RPC    │ REST                                       │
-│   ┌─────────────────────────────────────────────────────────────────────────┐  │
-│   │           Five industry agents  (side-car adapters in *italics*)       │  │
-│   │ Finance     Biotech      Climate       Mfg.        Policy             │  │
-│   │ broker,     *PubMed*     *Carbon*      *OPC-UA*    *GovTrack*         │  │
-│   │ factor α    RAG-ranker   intensity     scheduler    bill watch        │  │
-│   └─────────────────────────────────────────────────────────────────────────┘  │
+│ docker-compose (network: alpha_factory)                   │
+│                                       │
+│  Grafana ◄── Prometheus ◄── metrics ───────┐                │
+│     ▲                 │                │
+│ Trace-Graph ◄─ A2A spans ─ Orchestrator ──┴─► Knowledge-Hub (RAG + vec-DB) │
+│           ▲      ▲                      │
+│           │ ADK RPC  │ REST                    │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │      Five industry agents (side-car adapters in *italics*)    │ │
+│  │ Finance   Biotech   Climate    Mfg.    Policy       │ │
+│  │ broker,   *PubMed*   *Carbon*   *OPC-UA*  *GovTrack*     │ │
+│  │ factor α  RAG-ranker  intensity   scheduler  bill watch    │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 _Edit the Visio diagram under `assets/diagram_architecture.vsdx`._
@@ -92,9 +92,9 @@ via ADK’s `AgentDescriptor`.
 1. **Ray RLlib PPO** trainer spins in its own container (`alpha-trainer`).
 2. Rewards are computed by `continual/rubric.json` (edit live; hot-reload).
 3. Best checkpoint is zipped and `POST /agent/<id>/update_model` → agents swap
-   weights **with zero downtime**.
+  weights **with zero downtime**.
 4. CI smoke-tests (`.github/workflows/ci.yml`) validate orchestration on every
-   PR; failures block merge.
+  PR; failures block merge.
 
 ---
 
@@ -111,29 +111,29 @@ via ADK’s `AgentDescriptor`.
 
 ### 8 · Performance & heavy-load benchmarking
 A **k6** scenario (`bench/k6_load.js`) and a matching Grafana dashboard are
-included.  On a 4-core VM the stack sustains **🌩 550 req/s** across agents
+included. On a 4-core VM the stack sustains **🌩 550 req/s** across agents
 with p95 latency < 180 ms.
 
 ---
 
 ### 9 · Extending & deploying at scale
 * **New vertical** → subclass `BaseAgent`, add adapter container, append to
-  `AGENTS_ENABLED` in `.env`.
+ `AGENTS_ENABLED` in `.env`.
 * **Custom LLM** → point `OPENAI_API_BASE` to your endpoint.
 * **Kubernetes** → `make helm && helm install alpha-factory chart/`.
 
 ---
 
 ### 10 · Roadmap
-* Production Helm chart (HA Postgres + Redis event-bus)  
-* Replace mock PubMed / Carbon adapters with real connectors  
-* Grafana auto-generated dashboards from OpenTelemetry spans  
+* Production Helm chart (HA Postgres + Redis event-bus) 
+* Replace mock PubMed / Carbon adapters with real connectors 
+* Grafana auto-generated dashboards from OpenTelemetry spans 
 
 Community PRs welcome!
 
 ---
 
 ### References
-Clune 2019 citeturn17file4 · Sutton & Silver 2024 citeturn16file0 · MuZero 2020 citeturn15file0
+Clune 2019 · Sutton & Silver 2024 · MuZero 2020 
 
 © 2025 MONTREAL.AI — MIT License

--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -7,13 +7,13 @@ Out‑learn · Out‑think · Out‑strategise · Out‑execute
 
 <h1 align="center">🌌 Era of Experience — Your lifelong‑RL playground</h1>
 <p align="center">
-  <em>Spin up a self‑improving multi‑agent spine in <strong>one command</strong>.<br>
-  Watch it plan, act &amp; learn in real‑time — on your laptop or in the cloud.</em>
+ <em>Spin up a self‑improving multi‑agent spine in <strong>one command</strong>.<br>
+ Watch it plan, act &amp; learn in real‑time — on your laptop or in the cloud.</em>
 </p>
 
-> “AI will eclipse the limits of human‑authored data only when agents <strong>act, observe, and adapt</strong> in the world.” — David Silver &amp; Richard S. Sutton citeturn12file0
+> “AI will eclipse the limits of human‑authored data only when agents <strong>act, observe, and adapt</strong> in the world.” — David Silver &amp; Richard S. Sutton 
 
-This demo distils that manifesto into <strong>Alpha‑Factory v1</strong>.  
+This demo distils that manifesto into <strong>Alpha‑Factory v1</strong>. 
 Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> every few turns, powered by grounded rewards, long‑range memory and model‑agnostic planning — no dedicated GPU required.
 
 ---
@@ -24,14 +24,14 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience
 chmod +x run_experience_demo.sh
-./run_experience_demo.sh            # ← THAT’S IT
+./run_experience_demo.sh      # ← THAT’S IT
 ```
 
-1. **Docker Desktop** builds a 300 MB image in ≈ 1 min.  
-2. Your browser opens **http://localhost:7860** featuring  
-   * live trace‑graph 🪄  
-   * reward dashboards 📈  
-   * interactive chat / tool console 💬  
+1. **Docker Desktop** builds a 300 MB image in ≈ 1 min. 
+2. Your browser opens **http://localhost:7860** featuring 
+  * live trace‑graph 🪄 
+  * reward dashboards 📈 
+  * interactive chat / tool console 💬 
 
 > **Offline/Private mode** — leave `OPENAI_API_KEY=` blank in <code>config.env</code>; the stack falls back to <strong>Ollama ✕ Mixtral‑8x7B</strong> and stays air‑gapped.
 
@@ -52,9 +52,9 @@ The notebook installs a lean Python stack (&lt; 120 s), exposes Gradio via ng
 | Silver &amp; Sutton’s pillar | How we realise it |
 |---------------------------|--------------------|
 | **Streams of experience** | Infinite generator feeding month‑long synthetic logs |
-| **Sensor‑motor actions**  | Tools (`web_search`, `plan_meal`, user chat) mutate state |
-| **Grounded rewards**      | Plug‑ins: <code>fitness_reward</code>, <code>education_reward</code>, <code>curiosity_reward</code>, … (hot‑reloaded) |
-| **Non‑human reasoning**   | Monte‑Carlo Tree Search planner + vector memory — no CoT imitation |
+| **Sensor‑motor actions** | Tools (`web_search`, `plan_meal`, user chat) mutate state |
+| **Grounded rewards**   | Plug‑ins: <code>fitness_reward</code>, <code>education_reward</code>, <code>curiosity_reward</code>, … (hot‑reloaded) |
+| **Non‑human reasoning**  | Monte‑Carlo Tree Search planner + vector memory — no CoT imitation |
 
 Result: an agent that <strong>evolves faster than you can refresh the page</strong>.
 
@@ -63,19 +63,19 @@ Result: an agent that <strong>evolves faster than you can refresh the page</stro
 ## 🛠 Architecture in 60 seconds
 
 ```text
-┌────────────┐  experience   ┌────────────────┐
-│ Generator  │ ────────────▶ │ Orchestrator ⚙ │──┐
-└────────────┘               └────────────────┘  │ tool‑calls
-        ▲                              ▲        ▼
-  reward│                      ┌──────────┐ ┌───────────┐
-        │                      │ Planner ♟ │ │  Tools    │
-        └──────────────────────┴──────────┴─────────────┘
+┌────────────┐ experience  ┌────────────────┐
+│ Generator │ ────────────▶ │ Orchestrator ⚙ │──┐
+└────────────┘        └────────────────┘ │ tool‑calls
+    ▲               ▲    ▼
+ reward│           ┌──────────┐ ┌───────────┐
+    │           │ Planner ♟ │ │ Tools  │
+    └──────────────────────┴──────────┴─────────────┘
 ```
 
-* **OpenAI Agents SDK** — composable tool‑calling, function schemas, memory citeturn1open0  
-* **A2A protocol** — future‑proof multi‑agent hand‑offs citeturn2open0  
-* **Model Context Protocol** — streaming context for huge traces citeturn3open0  
-* **Best‑practice guardrails** from OpenAI *Practical Guide to Building Agents* citeturn7search0  
+* **OpenAI Agents SDK** — composable tool‑calling, function schemas, memory  
+* **A2A protocol** — future‑proof multi‑agent hand‑offs  
+* **Model Context Protocol** — streaming context for huge traces  
+* **Best‑practice guardrails** from OpenAI *Practical Guide to Building Agents*  
 
 ---
 
@@ -98,7 +98,7 @@ Result: an agent that <strong>evolves faster than you can refresh the page</stro
 
 ```bash
 cp reward_backends/template.py reward_backends/my_reward.py
-$EDITOR reward_backends/my_reward.py     # implement reward()
+$EDITOR reward_backends/my_reward.py   # implement reward()
 ```
 
 * **Register a tool**
@@ -122,10 +122,10 @@ Shared Redis memory + A2A = emergent cooperation.
 
 ## 🛡 Security & Compliance
 
-* Non‑root container; no Docker‑in‑Docker.  
-* Secrets isolated in `config.env`, never baked into images.  
-* Opt‑in telemetry only; default is **OFF**.  
-* `/__live` returns **200 OK** for K8s, Traefik, Nginx health probes.  
+* Non‑root container; no Docker‑in‑Docker. 
+* Secrets isolated in `config.env`, never baked into images. 
+* Opt‑in telemetry only; default is **OFF**. 
+* `/__live` returns **200 OK** for K8s, Traefik, Nginx health probes. 
 * <code>safety_compliance_reward.py</code> penalises violations and rewards self‑correction.
 
 ---
@@ -144,10 +144,10 @@ Shared Redis memory + A2A = emergent cooperation.
 
 ## 🗺 Road‑map
 
-- [ ] Plug‑and‑play Gym‑Retrowrapper for atari‑style sims  
-- [ ] Vector‑DB eviction policy learning  
-- [ ] Live reward tuning UI  
-- [ ] WASM build for edge devices  
+- [ ] Plug‑and‑play Gym‑Retrowrapper for atari‑style sims 
+- [ ] Vector‑DB eviction policy learning 
+- [ ] Live reward tuning UI 
+- [ ] WASM build for edge devices 
 
 ---
 

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -6,7 +6,7 @@ Era-of-Experience Agent 👁️✨
 ────────────────────────────
 A minimal yet *comprehensive* reference implementation of an **autonomous,
 reward-grounded, life-long agent** as envisioned in “Welcome to the Era of Experience”
-(Sutton & Silver 2024) :contentReference[oaicite:2]{index=2}&#8203;:contentReference[oaicite:3]{index=3}.
+(Sutton & Silver 2024) 
 
 ✓ Streams of experience (continuous event generator)  
 ✓ Sensor-motor tools (search, meal planning, workout scheduling)  

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
@@ -1,18 +1,18 @@
 # **Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**
 
-Identical to **v1** plus **two synergistic upgrades**  
-1. *Statistical‑physics wrapper* — logs & minimises **Gibbs / variational free‑energy** for every candidate agent.  
+Identical to **v1** plus **two synergistic upgrades** 
+1. *Statistical‑physics wrapper* — logs & minimises **Gibbs / variational free‑energy** for every candidate agent. 
 2. *Absolute Zero Reasoner (AZR) self‑curriculum* — a **reinforced self‑play engine** that perpetually invents and solves its own tasks, unlocking *open‑ended* cross‑domain reasoning.
 
-> **Official definition — Meta‑Agentic (adj.)**  
-> *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*  
+> **Official definition — Meta‑Agentic (adj.)** 
+> *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.* 
 > *The term was **pioneered by Vincent Boucher, President of MONTREAL.AI**.*
 
 ---
 
 ## 🚀 Why AZR Matters
-`Absolute Zero Reasoner` (Zhao *et al.* 2025) discards the last human bottleneck: **task curation**.  
-It **proposes**, **validates**, **solves**, and **learns from** its own code‑reasoning problems — then feeds the distilled knowledge back into the evolutionary loop.  
+`Absolute Zero Reasoner` (Zhao *et al.* 2025) discards the last human bottleneck: **task curation**. 
+It **proposes**, **validates**, **solves**, and **learns from** its own code‑reasoning problems — then feeds the distilled knowledge back into the evolutionary loop. 
 *Result:* steeper learning curves, bolder exploration, and broad generalisation across math, code, and strategic planning — all while remaining vendor‑agnostic.
 
 ---
@@ -20,65 +20,65 @@ It **proposes**, **validates**, **solves**, and **learns from** its own code‑r
 ```mermaid
 %% GRAND OPERATIONAL SYNAPSE — Alpha‑Factory v1 (AZR + Free‑Energy + Meta‑Agency)
 flowchart TD
-  %% -------- Meta‑Agency layer
-  subgraph layer_meta["🧠 Meta‑Agency Layer"]
-    MP["Meta‑Programmer"]:::meta
-    AZR["AZR Self‑Curriculum"]:::curri
-    MP -->|spawns| POP
-    MP --> AZR
-  end
+ %% -------- Meta‑Agency layer
+ subgraph layer_meta["🧠 Meta‑Agency Layer"]
+  MP["Meta‑Programmer"]:::meta
+  AZR["AZR Self‑Curriculum"]:::curri
+  MP -->|spawns| POP
+  MP --> AZR
+ end
 
-  %% -------- Evolutionary loop
-  subgraph layer_evo["📈 Evolutionary Loop"]
-    POP["Evolution Archive"]:::layer
-    SCORE["Multi‑Objective Scorer"]:::layer
-    FE["Free‑Energy Monitor"]:::phys
-    POP --> SCORE --> FE --> MP
-    AZR --> POP
-  end
+ %% -------- Evolutionary loop
+ subgraph layer_evo["📈 Evolutionary Loop"]
+  POP["Evolution Archive"]:::layer
+  SCORE["Multi‑Objective Scorer"]:::layer
+  FE["Free‑Energy Monitor"]:::phys
+  POP --> SCORE --> FE --> MP
+  AZR --> POP
+ end
 
-  %% -------- Population
-  subgraph layer_pop["👥 Agent Population"]
-    direction TB
-    R["Researcher"]:::agent
-    B["Builder"]:::agent
-    E["Evaluator"]:::agent
-    T["Auto‑Tuner"]:::agent
-    G["Guardian"]:::agent
-  end
-  MP --> R & B & E & T & G
+ %% -------- Population
+ subgraph layer_pop["👥 Agent Population"]
+  direction TB
+  R["Researcher"]:::agent
+  B["Builder"]:::agent
+  E["Evaluator"]:::agent
+  T["Auto‑Tuner"]:::agent
+  G["Guardian"]:::agent
+ end
+ MP --> R & B & E & T & G
 
-  %% -------- Foundation models
-  subgraph layer_fm["🛠 Foundation Models"]
-    GPT4O["GPT‑4o"]:::tool
-    CLAUDE3["Claude‑3 Sonnet"]:::tool
-    LLA3["Llama‑3‑70B∞"]:::tool
-  end
-  R -.uses.-> GPT4O
-  B -.uses.-> LLA3
-  E -.uses.-> CLAUDE3
-  T -.uses.-> LLA3
-  G -.uses.-> GPT4O
+ %% -------- Foundation models
+ subgraph layer_fm["🛠 Foundation Models"]
+  GPT4O["GPT‑4o"]:::tool
+  CLAUDE3["Claude‑3 Sonnet"]:::tool
+  LLA3["Llama‑3‑70B∞"]:::tool
+ end
+ R -.uses.-> GPT4O
+ B -.uses.-> LLA3
+ E -.uses.-> CLAUDE3
+ T -.uses.-> LLA3
+ G -.uses.-> GPT4O
 
-  %% -------- Value loop
-  subgraph layer_value["🌐 Industry Value Loop"]
-    DATA["Market & Web Streams"]:::val
-    ALPHA["Extracted Alpha"]:::val
-    SOL["Deployed Solutions"]:::val
-  end
-  R --> DATA
-  B --> ALPHA
-  E --> SOL
-  T --> ALPHA
-  G -.audit.-> SOL
+ %% -------- Value loop
+ subgraph layer_value["🌐 Industry Value Loop"]
+  DATA["Market & Web Streams"]:::val
+  ALPHA["Extracted Alpha"]:::val
+  SOL["Deployed Solutions"]:::val
+ end
+ R --> DATA
+ B --> ALPHA
+ E --> SOL
+ T --> ALPHA
+ G -.audit.-> SOL
 
-classDef meta  fill:#6425ff,color:#fff
+classDef meta fill:#6425ff,color:#fff
 classDef curri fill:#d81b60,color:#fff
 classDef layer fill:#2b2b40,color:#fff
-classDef phys  fill:#ff6d00,color:#fff
+classDef phys fill:#ff6d00,color:#fff
 classDef agent fill:#0f9d58,color:#fff
-classDef tool  fill:#fbbc05,color:#000
-classDef val   fill:#1e88e5,color:#fff
+classDef tool fill:#fbbc05,color:#000
+classDef val  fill:#1e88e5,color:#fff
 ```
 
 > *“Alpha‑Factory v1 transforms raw data‑streams into deployable solutions that **Out‑Learn · Out‑Think · Out‑Design · Out‑Strategize · Out‑Execute** the market — autonomously.”*
@@ -94,8 +94,8 @@ This demo operationalises **Automated Design of Agentic Systems (ADAS)*
 * **Provable lineage & provenance** — every agent / artefact traceable via the Lineage UI.
 * **Battle‑tested safeguards** — sandboxing, taint‑tracking, chaos‑testing.
 
-Together, they lift **Alpha‑Factory v1** into a *self‑improving*, cross‑industry **Alpha Factory** that systematically  
-> **Out‑Learn · Out‑Think · Out‑Design · Out‑Strategize · Out‑Execute**  
+Together, they lift **Alpha‑Factory v1** into a *self‑improving*, cross‑industry **Alpha Factory** that systematically 
+> **Out‑Learn · Out‑Think · Out‑Design · Out‑Strategize · Out‑Execute** 
 
 — with zero dependence on any single model or vendor.
 
@@ -110,7 +110,7 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_agi_v3
 # 2️⃣ Environment
 micromamba create -n alpha_factory python=3.11 -y
 micromamba activate alpha_factory
-pip install -r requirements.txt      # ≤ 60 MiB wheels
+pip install -r requirements.txt   # ≤ 60 MiB wheels
 
 # 3️⃣ Run – open‑weights default (no API key)
 python src/main.py --provider mistral:7b-instruct.gguf --curriculum azr
@@ -119,8 +119,8 @@ python src/main.py --provider mistral:7b-instruct.gguf --curriculum azr
 OPENAI_API_KEY=sk-... python src/main.py --provider openai:gpt-4o --curriculum azr
 
 # 4️⃣ UI dashboards
-streamlit run ui/lineage_app.py           # provenance graph
-streamlit run ui/alpha_monitor.py         # live alpha dashboard
+streamlit run ui/lineage_app.py      # provenance graph
+streamlit run ui/alpha_monitor.py     # live alpha dashboard
 ```
 
 *Hardware:* CPU‑only works (llama‑cpp 4‑bit); GPU speeds things up. 8 GB RAM minimum.
@@ -130,28 +130,28 @@ streamlit run ui/alpha_monitor.py         # live alpha dashboard
 ## 2 Folder Structure 📁
 ```text
 meta_agentic_agi/
-├── core/                # provider‑agnostic primitives
-│   ├── fm.py            # unified FM wrapper
-│   ├── prompts.py       # reusable prompt fragments
-│   └── tools.py         # exec sandbox, RAG, vector store
-├── curriculum/          # ← NEW: self‑curriculum engines
-│   └── azr_engine.py    # Absolute Zero abstractions
+├── core/        # provider‑agnostic primitives
+│  ├── fm.py      # unified FM wrapper
+│  ├── prompts.py    # reusable prompt fragments
+│  └── tools.py     # exec sandbox, RAG, vector store
+├── curriculum/     # ← NEW: self‑curriculum engines
+│  └── azr_engine.py  # Absolute Zero abstractions
 ├── meta_agentic_search/ # evolutionary loop
-│   ├── archive.py       # stepping‑stone JSONL log
-│   ├── search.py        # NSGA‑II + Reflexion
-│   └── scorer.py        # multi‑objective metrics (+ free‑energy)
+│  ├── archive.py    # stepping‑stone JSONL log
+│  ├── search.py    # NSGA‑II + Reflexion
+│  └── scorer.py    # multi‑objective metrics (+ free‑energy)
 ├── agents/
-│   ├── agent_base.py    # runtime interface
-│   └── seeds.py         # bootstrap population
+│  ├── agent_base.py  # runtime interface
+│  └── seeds.py     # bootstrap population
 ├── ui/
-│   ├── lineage_app.py   # Streamlit dashboard
-│   ├── alpha_monitor.py # live alpha / risk view
-│   └── assets/
+│  ├── lineage_app.py  # Streamlit dashboard
+│  ├── alpha_monitor.py # live alpha / risk view
+│  └── assets/
 ├── configs/
-│   └── default.yml      # editable in‑UI
+│  └── default.yml   # editable in‑UI
 └── src/
-    ├── main.py          # CLI entry‑point
-    └── orchestrator.py  # agent scheduler & A2A bus
+  ├── main.py     # CLI entry‑point
+  └── orchestrator.py # agent scheduler & A2A bus
 ```
 
 ---
@@ -159,85 +159,85 @@ meta_agentic_agi/
 ## 3 Provider‑Agnostic FM Wrapper ➡ Open‑Weights 🏋️‍♀️
 `configs/default.yml` excerpt:
 ```yaml
-provider: mistral:7b-instruct.gguf     # any ollama / llama.cpp id
+provider: mistral:7b-instruct.gguf   # any ollama / llama.cpp id
 context_length: 16_384
 rate_limit_tps: 4
 retry_backoff: 2
 ```
 
-| Value                         | Note                            |
+| Value             | Note              |
 |-------------------------------|---------------------------------|
-| `openai:gpt-4o`               | needs `OPENAI_API_KEY`          |
-| `anthropic:claude-3-sonnet`   | needs `ANTHROPIC_API_KEY`       |
-| `mistral:7b-instruct.gguf`    | local default via llama‑cpp      |
+| `openai:gpt-4o`        | needs `OPENAI_API_KEY`     |
+| `anthropic:claude-3-sonnet`  | needs `ANTHROPIC_API_KEY`    |
+| `mistral:7b-instruct.gguf`  | local default via llama‑cpp   |
 
 All chats stream via **MCP** & window‑slide for long contexts.
 
 ---
 
 ## 4 Multi‑Objective Evolution 🎯
-**Objective vector** = `[accuracy, cost, latency, hallu‑risk, carbon, free‑energy]`  
-* NSGA‑II elitist selection  
-* Behaviour descriptor = SHA‑256(AST)  
-* Human‑in‑the‑loop thumbs ↑/↓ (web UI)  
+**Objective vector** = `[accuracy, cost, latency, hallu‑risk, carbon, free‑energy]` 
+* NSGA‑II elitist selection 
+* Behaviour descriptor = SHA‑256(AST) 
+* Human‑in‑the‑loop thumbs ↑/↓ (web UI) 
 
 ---
 
 ## 5 Security & Antifragility 🛡
-* Firejail `--seccomp` + 512 MiB cgroup sandbox  
-* Static (`bandit`) + dynamic taint tracking  
-* Live watchdog terminates rogue proc > 30 s CPU  
-* Chaos‑monkey fault injections each epoch  
-* Curriculum filter auto‑drops unsafe proposals  
+* Firejail `--seccomp` + 512 MiB cgroup sandbox 
+* Static (`bandit`) + dynamic taint tracking 
+* Live watchdog terminates rogue proc > 30 s CPU 
+* Chaos‑monkey fault injections each epoch 
+* Curriculum filter auto‑drops unsafe proposals 
 
 ---
 
 ## 6 Lineage & Observability 📊
-Run `streamlit run ui/lineage_app.py` → DAG of every agent, prompt, tool‑call, metric, and deployment artefact.  
+Run `streamlit run ui/lineage_app.py` → DAG of every agent, prompt, tool‑call, metric, and deployment artefact. 
 OpenTelemetry exporters emit traces; Prometheus scrapes runtime metrics; Grafana dashboards included.
 
 ---
 
 ## 7 Extending 🛠
-1. **New dataset** — drop `foo.pkl` → auto‑RAG ingest.  
-2. **New metric** — subclass `evolution.metrics.BaseMetric`.  
-3. **Custom curriculum** — register engine in `curriculum/__init__.py`.  
-4. **Real exchange adapter** — implement `execution.broker.BaseBroker` (see IBKR stub).  
+1. **New dataset** — drop `foo.pkl` → auto‑RAG ingest. 
+2. **New metric** — subclass `evolution.metrics.BaseMetric`. 
+3. **Custom curriculum** — register engine in `curriculum/__init__.py`. 
+4. **Real exchange adapter** — implement `execution.broker.BaseBroker` (see IBKR stub). 
 
 ---
 
 ## 8 Roadmap 🗺
-- ☑ AZR integration & POET outer‑loop  
-- ☑ Free‑Energy minimisation  
-- ☑ Live alpha demo (NVDA earnings)  
-- ☐ Multimodal (image ↔ code ↔ math) AZR  
-- ☐ Hierarchical meta‑meta search  
-- ☐ Flash‑Infer v3 GPU batched inference  
-- ☐ RL fine‑tune search policy w/ lineage replay  
+- ☑ AZR integration & POET outer‑loop 
+- ☑ Free‑Energy minimisation 
+- ☑ Live alpha demo (NVDA earnings) 
+- ☐ Multimodal (image ↔ code ↔ math) AZR 
+- ☐ Hierarchical meta‑meta search 
+- ☐ Flash‑Infer v3 GPU batched inference 
+- ☐ RL fine‑tune search policy w/ lineage replay 
 
 ---
 
 ## 9 Key References 📚
-* Zhao *et al.* “Absolute Zero: Reinforced Self‑Play Reasoning with Zero Data” (2025) citeturn1file0  
-* Hu *et al.* “Automated Design of Agentic Systems” ICLR 2025 citeturn1file1  
-* Clune “AI‑Generating Algorithms” (2020) citeturn1file3  
-* Schrittwieser *et al.* “MuZero” (2020) citeturn1file4  
-* Silver & Sutton “Era of Experience” (2025) citeturn1file5  
+* Zhao *et al.* “Absolute Zero: Reinforced Self‑Play Reasoning with Zero Data” (2025)  
+* Hu *et al.* “Automated Design of Agentic Systems” ICLR 2025  
+* Clune “AI‑Generating Algorithms” (2020)  
+* Schrittwieser *et al.* “MuZero” (2020)  
+* Silver & Sutton “Era of Experience” (2025)  
 
 ---
 
 ## 10 Live Alpha Demo 🚀
 
-**Signal:** Anticipated upside surprise in NVIDIA (NVDA) Q1‑FY2026 earnings on **28 May 2025**, driven by record data‑center demand and Blackwell GPU ramp.  
-*Evidence:* 78 % YoY revenue jump to \$39.3 B and guidance for \$43 B next quarter citeturn0search0turn0search4. Deloitte projects continued semiconductor boom via generative‑AI build‑outs citeturn0search1.
+**Signal:** Anticipated upside surprise in NVIDIA (NVDA) Q1‑FY2026 earnings on **28 May 2025**, driven by record data‑center demand and Blackwell GPU ramp. 
+*Evidence:* 78 % YoY revenue jump to \$39.3 B and guidance for \$43 B next quarter . Deloitte projects continued semiconductor boom via generative‑AI build‑outs .
 
-**Strategy:**  
-1. **Entry window**: T‑10 → T‑2 trading days before earnings.  
-2. **Position**: 40 % capital → 30‑delta call options (30 Jun expiry) + 60 % delta‑one shares.  
-3. **Risk**: Max 2 % account equity; stop‑loss at ATR‑2× below entry; risk manager enforces VaR<1 %.  
-4. **Exit**: 50 % gamma‑scalp on IV crush at T + 1; remainder trail‑stop @ EMA‑21.  
+**Strategy:** 
+1. **Entry window**: T‑10 → T‑2 trading days before earnings. 
+2. **Position**: 40 % capital → 30‑delta call options (30 Jun expiry) + 60 % delta‑one shares. 
+3. **Risk**: Max 2 % account equity; stop‑loss at ATR‑2× below entry; risk manager enforces VaR<1 %. 
+4. **Exit**: 50 % gamma‑scalp on IV crush at T + 1; remainder trail‑stop @ EMA‑21. 
 
-The included `agents/alpha_finder.py` continuously scans news/API feeds and triggers the **ExecutionAgent** when criteria match.  Sources are injected into the lineage graph for auditability.
+The included `agents/alpha_finder.py` continuously scans news/API feeds and triggers the **ExecutionAgent** when criteria match. Sources are injected into the lineage graph for auditability.
 
 ---
 

--- a/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
+++ b/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
@@ -4,7 +4,7 @@ Runs a lightweight MuZero agent (MiniMu) on Gymnasium’s CartPole‑v1,
 and streams a live Gradio dashboard (port 7861).
 
 Core algorithm follows the public pseudocode from Schrittwieser et al. (2020)
-but trimmed to <300 LoC for pedagogy.  :contentReference[oaicite:0]{index=0}&#8203;:contentReference[oaicite:1]{index=1} :contentReference[oaicite:2]{index=2}&#8203;:contentReference[oaicite:3]{index=3}
+but trimmed to <300 LoC for pedagogy.
 """
 import os, asyncio, random, gymnasium as gym
 from openai_agents import Agent, Tool, OpenAIAgent


### PR DESCRIPTION
## Summary
- scrub citation placeholders from demo READMEs and docs
- update demo README with a docker quick-start example
- remove leftover `contentReference` markers in Python docstrings

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`