### PR TITLE
Add CLI entry point for ASI world model demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 # The `alpha-factory` CLI also works when the package is installed:
 #   pip install -e .
 #   alpha-factory --list-agents
+#   alpha-asi-demo --demo   # launch the α‑ASI world‑model UI
 #
 # Or install directly from GitHub for a quick test:
 #   pip install git+https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -53,7 +53,8 @@ Success criteria ✓
 # ░ Local Python (CPU or GPU)
 pip install -r requirements.txt        # torch, fastapi, uvicorn…
 
-python -m alpha_asi_world_model_demo --demo
+# new CLI (after `pip install -e .` at repo root)
+alpha-asi-demo --demo        # same as `python -m alpha_asi_world_model_demo --demo`
 open http://localhost:7860             # dashboard & Swagger
 
 # ░ One-liner Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.9"
 alpha-factory = "alpha_factory_v1.run:run"
 governance-sim = "alpha_factory_v1.demos.solving_agi_governance.governance_sim:main"
 edge-runner = "alpha_factory_v1.edge_runner:main"
+alpha-asi-demo = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo:_main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- expose `alpha-asi-demo` console script
- document the new command in both READMEs

## Testing
- `pytest -q` *(fails: command not found)*