### PR TITLE
Fix meta_agentic_agi_v2 README paths

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
@@ -103,7 +103,7 @@ into the existing **Alpha‑Factory v1** (multi‑agent AGENTIC α‑AGI) pipe
 ```bash
 # 1️⃣ Clone & enter demo
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
-cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_agi
+cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_agi_v2
 
 # 2️⃣ Environment (CPU‑only default)
 micromamba create -n metaagi python=3.11 -y
@@ -111,10 +111,10 @@ micromamba activate metaagi
 pip install -r requirements.txt        # ≤ 40 MiB wheels
 
 # 3️⃣ Run – zero‑API mode (pulls a gguf via Ollama)
-python meta_agentic_agi_demo.py --provider mistral:7b-instruct.gguf
+python meta_agentic_agi_demo_v2.py --provider mistral:7b-instruct.gguf
 
 #   …or point to any provider
-OPENAI_API_KEY=sk‑… python meta_agentic_agi_demo.py --provider openai:gpt-4o
+OPENAI_API_KEY=sk‑… python meta_agentic_agi_demo_v2.py --provider openai:gpt-4o
 
 # 4️⃣ Launch the lineage UI
 streamlit run ui/lineage_app.py
@@ -125,7 +125,7 @@ streamlit run ui/lineage_app.py
 
 ## 2 Folder Structure 📁
 ```
-meta_agentic_agi/
+meta_agentic_agi_v2/
 ├── core/                # provider‑agnostic primitives
 │   ├── fm.py            # unified FM wrapper
 │   ├── prompts.py       # reusable prompt fragments
@@ -142,7 +142,7 @@ meta_agentic_agi/
 │   └── assets/
 ├── configs/
 │   └── default.yml      # editable in‑UI
-└── meta_agentic_agi_demo.py
+└── meta_agentic_agi_demo_v2.py
 ```
 
 ---

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/lineage_app.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/lineage_app.py
@@ -7,7 +7,7 @@ Streamlit dashboard for **Meta-Agentic α-AGI** lineage tracking.
 Key features
 ------------
 • Zero-config launch – `streamlit run lineage_app.py` (or add to Procfile).  
-• Works with *any* SQLite DB produced by `meta_agentic_agi_demo.py`.  
+• Works with *any* SQLite DB produced by `meta_agentic_agi_demo_v2.py`.
 • Auto-refresh & reactive controls (no manual reloads).  
 • Interactive Altair charts for **multi-objective** metrics.  
 • Toggle code snippets, filter generations, export to CSV.  
@@ -40,7 +40,7 @@ THEME    = os.getenv("METAAGI_THEME", "light")  # Streamlit theme override
 DB_PATH = (
     Path(DB_ENV).expanduser().resolve()
     if DB_ENV else
-    (Path(__file__).parent / ".." / "meta_agentic_agi_demo.sqlite").resolve()
+    (Path(__file__).parent / ".." / "meta_agentic_agi_demo_v2.sqlite").resolve()
 )
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -52,7 +52,7 @@ def connect(db_path: Path) -> sqlite3.Connection:
     if not db_path.exists():
         raise FileNotFoundError(
             f"[lineage_app] SQLite database not found at: {db_path}\n"
-            "‣ Make sure you have run `meta_agentic_agi_demo.py` at least once, or\n"
+            "‣ Make sure you have run `meta_agentic_agi_demo_v2.py` at least once, or\n"
             "‣ Set METAAGI_DB env-var to the correct .sqlite path."
         )
     conn = sqlite3.connect(str(db_path), check_same_thread=False)


### PR DESCRIPTION
## Summary
- point quick-start to the proper meta_agentic_agi_v2 directory
- reference correct demo script in README and UI

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`