### PR TITLE
Fix meta AGI demo quickstart

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
@@ -110,7 +110,7 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_agi_v3
 # 2️⃣ Environment
 micromamba create -n alpha_factory python=3.11 -y
 micromamba activate alpha_factory
-pip install -r requirements.txt      # ≤ 60 MiB wheels
+pip install -r ../../requirements.txt      # ≤ 60 MiB wheels
 
 # 3️⃣ Run – open‑weights default (no API key)
 python src/main.py --provider mistral:7b-instruct.gguf --curriculum azr

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/meta_agentic_agi_demo_v3.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/meta_agentic_agi_demo_v3.py
@@ -11,7 +11,7 @@ A *single* entry-point that can launch as:
 
 (Model provider & curriculum engine are runtime-selectable).
 
-Dependencies (auto-install via `pip install -r requirements.txt`):
+Dependencies (auto-install via `pip install -r ../../requirements.txt`):
 
     openai>=1.0.0
     anthropic>=0.25


### PR DESCRIPTION
## Summary
- fix path to requirements in meta_agentic_agi_v3 README quick-start
- adjust demo docstring to point to same requirements file

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`