### PR TITLE
Improve governance demo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Built atop **OpenAI Agents SDK**, **Google ADK**, **A2A protocol**, and Ant
 1. [System Topology 🗺️](#1-system-topology)  
 2. [World‑Model & Planner 🌌](#2-world-model--planner)  
 3. [Agent Gallery 🖼️ (12 agents)](#3-agent-gallery)  
-4. [Demo Showcase 🎬 (12 demos)](#4-demo-showcase)  
+4. [Demo Showcase 🎬 (13 demos)](#4-demo-showcase)
 5. [Memory & Knowledge Fabric 🧠](#5-memory--knowledge-fabric)
 6. [5‑Minute Quick‑Start 🚀](#6-5-minute-quick-start)
 6.1. [Running Tests 🧪](#61-running-tests)
@@ -260,6 +260,7 @@ sequenceDiagram
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|
 |11|`muzero_planning`|♟️|MuZero plans synthetic markets → optimal execution curves.|Validates world‑model planning in noisy domains.|`docker compose -f demos/docker-compose.muzero.yml up`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
+|13|`solving_agi_governance`|⚖️|Token‑staked Prisoner's Dilemma yielding cooperative equilibrium.|Validates minimal safe incentives.|`governance-sim --agents 100 --rounds 1000`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.
 
@@ -351,10 +352,12 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 # The `alpha-factory` CLI also works when the package is installed:
 #   pip install -e .
 #   alpha-factory --list-agents
+#   governance-sim --help
 #
 # Or install directly from GitHub for a quick test:
 #   pip install git+https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 #   alpha-factory --list-agents
+#   governance-sim --agents 500 --rounds 2000
 ```
 
 No GPU → falls back to GGML Llama‑3‑8B‑Q4.

--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -79,12 +79,19 @@ The protocol behaves as a **self-refining alpha-field**: every inefficiency touc
 ---
 
 ### 9 · Running the Demo
-This demo has **no third‑party dependencies**.  Any Python ≥ 3.9 works.
+This demo has **no third‑party dependencies** and works with any Python ≥ 3.9.
 
-Clone the repository and launch the Monte‑Carlo simulator:
+Install the package in editable mode and launch the Monte‑Carlo simulator:
 
 ```bash
+pip install -e .
 governance-sim --agents 1000 --rounds 6000 --delta 0.8 --seed 42 --verbose
+```
+
+You can also invoke the module directly:
+
+```bash
+python -m alpha_factory_v1.demos.solving_agi_governance.governance_sim --help
 ```
 
 The script prints the mean cooperation rate after the simulated rounds,


### PR DESCRIPTION
## Summary
- update Demo Showcase table to mention governance simulation demo
- document `governance-sim` CLI usage in the root quick‑start
- expand demo README with installation and module invocation tips

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`