### PR TITLE
Improve MuZero quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ sequenceDiagram
 |8|`era_of_experience`|🏛️|Streams of life events build autobiographical memory‑graph tutor.|Transforms tacit SME knowledge into tradable signals.|`docker compose -f demos/docker-compose.era.yml up`|
 |9|`finance_alpha`|💹|Live momentum + risk‑parity bot on Binance test‑net.|Generates real P&L; stress‑tested against CVaR.|`docker compose -f demos/docker-compose.finance.yml up`|
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|
-|11|`muzero_planning`|♟️|MuZero plans synthetic markets → optimal execution curves.|Validates world‑model planning in noisy domains.|`docker compose -f demos/docker-compose.muzero.yml up`|
+|11|`muzero_planning`|♟|MuZero plans synthetic markets → optimal execution curves.|Validates world-model planning in noisy domains.|`docker compose -f alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml up`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.
@@ -355,6 +355,9 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 # Or install directly from GitHub for a quick test:
 #   pip install git+https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 #   alpha-factory --list-agents
+# Launch the MuZero planning demo (optional)
+#   bash alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh \
+#     # opens http://localhost:7861
 ```
 
 No GPU → falls back to GGML Llama‑3‑8B‑Q4.

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -44,7 +44,7 @@ Opens **http://localhost:7860** with a Gradio portal to every demo. Works on ma
 |8|`era_of_experience`|🏛️|Streams of life events build autobiographical memory‑graph tutor.|Transforms tacit SME knowledge into tradable signals.|`docker compose -f demos/docker-compose.era.yml up`|
 |9|`finance_alpha`|💹|Live momentum + risk‑parity bot on Binance test‑net.|Generates real P&L; stress‑tested against CVaR.|`docker compose -f demos/docker-compose.finance.yml up`|
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|
-|11|`muzero_planning`|♟️|MuZero plans synthetic markets → optimal execution curves.|Validates world‑model planning in noisy domains.|`docker compose -f demos/docker-compose.muzero.yml up`|
+|11|`muzero_planning`|♟|MuZero plans synthetic markets → optimal execution curves.|Validates world-model planning in noisy domains.|`docker compose -f alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml up`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -22,9 +22,8 @@ and **stabilise CartPole** — all inside your browser. No GPU, no PhD required
 
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
-cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning
-chmod +x run_muzero_demo.sh
-./run_muzero_demo.sh
+cd AGI-Alpha-Agent-v0
+bash alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
 ```
 
 1. **Docker Desktop** compiles the container (≈ 45 s cold start).  


### PR DESCRIPTION
## Summary
- clarify MuZero demo invocation in the root quick-start block
- streamline MuZero README with single-command launch

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`