### PR TITLE
Add demo README validation

### DIFF
--- a/alpha_factory_v1/demos/__init__.py
+++ b/alpha_factory_v1/demos/__init__.py
@@ -1,0 +1,1 @@
+# Demo package

--- a/alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md
+++ b/alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md
@@ -1,0 +1,3 @@
+# MuZero MCTS LLM Agent Demo
+
+This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run `install_and_launch.sh` to build the environment and start the demo in your browser.

--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
@@ -1,0 +1,3 @@
+# Sovereign Agentic AGI Alpha Agent Demo
+
+Early prototype demonstrating a self-directed agent framework. Execute `deploy_sovereign_agentic_agialpha_agent_v0.sh` to launch the demo environment.

--- a/alpha_factory_v1/demos/validate_demos.py
+++ b/alpha_factory_v1/demos/validate_demos.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+
+DEFAULT_DIR = os.path.dirname(__file__)
+
+
+def main(base_dir: str = DEFAULT_DIR) -> int:
+    failures = []
+    for entry in os.listdir(base_dir):
+        path = os.path.join(base_dir, entry)
+        if os.path.isdir(path):
+            if entry.startswith('.') or entry.startswith('__'):
+                continue
+            readme = os.path.join(path, "README.md")
+            if not os.path.isfile(readme):
+                failures.append(f"Missing README.md in {entry}")
+    if failures:
+        for msg in failures:
+            print(f"ERROR: {msg}", file=sys.stderr)
+        return 1
+    print("All demo directories contain README.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alpha_factory_v1/tests/test_validate_demos.py
+++ b/alpha_factory_v1/tests/test_validate_demos.py
@@ -1,0 +1,12 @@
+import unittest
+
+from alpha_factory_v1.demos import validate_demos
+
+
+class TestValidateDemos(unittest.TestCase):
+    def test_all_demos_have_readme(self):
+        self.assertEqual(validate_demos.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- package demos folder for easier imports
- ensure every demo has a README
- provide a validation script and unit test

## Testing
- `python -m unittest alpha_factory_v1.tests.test_validate_demos`