### PR TITLE
Improve Helm charts and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ like `--cycle`, `--loglevel` and `--version`.
 | Target | Command | Notes |
 |--------|---------|-------|
 | **Docker Compose** | `docker compose up -d` | Kafka, Prometheus, Grafana |
-| **Helm (K8s)** | `helm install af charts/alpha-factory` | SPIFFE, HPA |
+| **Helm (K8s)** | `helm install af helm/alpha-factory` | SPIFFE, HPA |
 | **AWS Fargate** | `./infra/deploy_fargate.sh` | SQS shim for Kafka |
 | **IoT Edge** | `python edge_runner.py --agents manufacturing,energy` | Jetson Nano |
 

--- a/alpha_factory_v1/helm/alpha-factory-remote/templates/_helpers.tpl
+++ b/alpha_factory_v1/helm/alpha-factory-remote/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "alpha-factory-remote.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alpha-factory-remote.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "alpha-factory-remote.labels" -}}
+app.kubernetes.io/name: {{ include "alpha-factory-remote.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/alpha_factory_v1/tests/test_helm_charts.py
+++ b/alpha_factory_v1/tests/test_helm_charts.py
@@ -1,0 +1,30 @@
+import unittest
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+HELM_DIR = ROOT / "helm"
+
+class HelmChartTests(unittest.TestCase):
+    def check_chart_file(self, chart_path: Path):
+        self.assertTrue(chart_path.is_file(), f"{chart_path} missing")
+        text = chart_path.read_text()
+        for key in ["apiVersion:", "name:", "version:", "appVersion:"]:
+            self.assertIn(key, text, f"{key} not found in {chart_path}")
+
+    def test_alpha_factory_chart(self):
+        chart = HELM_DIR / "alpha-factory" / "Chart.yaml"
+        values = HELM_DIR / "alpha-factory" / "values.yaml"
+        self.check_chart_file(chart)
+        self.assertTrue(values.is_file(), "values.yaml missing for alpha-factory")
+
+    def test_alpha_factory_remote_chart(self):
+        chart = HELM_DIR / "alpha-factory-remote" / "Chart.yaml"
+        values = HELM_DIR / "alpha-factory-remote" / "values.yaml"
+        helpers = HELM_DIR / "alpha-factory-remote" / "templates" / "_helpers.tpl"
+        self.check_chart_file(chart)
+        self.assertTrue(values.is_file(), "values.yaml missing for alpha-factory-remote")
+        self.assertTrue(helpers.is_file(), "_helpers.tpl missing for alpha-factory-remote")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix README Helm chart path
- add missing `_helpers.tpl` to `alpha-factory-remote` Helm chart
- create unit tests verifying Helm chart structure

## Testing
- `python -m unittest alpha_factory_v1.tests.test_helm_charts -v`