### PR TITLE
Enhance script robustness and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,9 @@ Unit tests can be executed with the bundled helper script:
 python alpha_factory_v1/scripts/run_tests.py
 ```
 
-The script prefers `pytest` when available and otherwise falls back to
-`unittest`. Ensure all tests pass before deploying changes.
+The helper validates the target directory, prefers `pytest` when
+available and otherwise falls back to `unittest`. Ensure all tests pass
+before deploying changes.
 
 <a name="62-marketplace-demo-example"></a>
 ### 6.2 · Marketplace Demo Example 🛒

--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -83,6 +83,9 @@ All steps are idempotent; re‑running the script is safe.
 | Follow live logs | `docker compose logs -f orchestrator ui` |
 | Clean up containers & volumes | `docker compose down -v --remove-orphans` |
 
+The ``import_dashboard.py`` helper requires ``GRAFANA_TOKEN`` and verifies the
+given JSON file exists before uploading.
+
 ---
 
 ## 🛡️ Security & Compliance

--- a/alpha_factory_v1/scripts/import_dashboard.py
+++ b/alpha_factory_v1/scripts/import_dashboard.py
@@ -28,11 +28,18 @@ else:
 
 
 def main() -> None:
-    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("alpha_factory_v1/dashboards/alpha_factory_overview.json")
+    path = (
+        Path(sys.argv[1])
+        if len(sys.argv) > 1
+        else Path("alpha_factory_v1/dashboards/alpha_factory_overview.json")
+    )
     host = os.environ.get("GRAFANA_HOST", "http://localhost:3000").rstrip("/")
     token = os.environ.get("GRAFANA_TOKEN")
     if not token:
         raise SystemExit("GRAFANA_TOKEN environment variable is required")
+
+    if not path.exists():
+        raise SystemExit(f"Dashboard file {path} not found")
 
     with path.open() as f:
         dashboard = json.load(f)

--- a/alpha_factory_v1/scripts/run_tests.py
+++ b/alpha_factory_v1/scripts/run_tests.py
@@ -1,24 +1,42 @@
 #!/usr/bin/env python3
 """Run Alpha-Factory unit tests.
 
-This helper prefers *pytest* if installed, falling back to
+This helper prefers :mod:`pytest` if installed, falling back to
 ``python -m unittest`` when necessary. A test path can be optionally
-specified.
+specified. The module also exposes :func:`run_tests` for programmatic
+use.
 """
 from __future__ import annotations
+
 import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
 
-def main() -> None:
-    target = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1] / "tests"
+def run_tests(target: Path) -> int:
+    """Execute tests under ``target``.
+
+    ``pytest`` is preferred when available; otherwise ``unittest`` is used.
+    The exit status of the invoked command is returned.
+    """
     if importlib.util.find_spec("pytest"):
         cmd = [sys.executable, "-m", "pytest", str(target)]
     else:
         cmd = [sys.executable, "-m", "unittest", "discover", str(target)]
-    raise SystemExit(subprocess.call(cmd))
+    return subprocess.call(cmd)
+
+
+def main() -> None:
+    target = (
+        Path(sys.argv[1])
+        if len(sys.argv) > 1
+        else Path(__file__).resolve().parents[1] / "tests"
+    )
+    if not target.exists():
+        raise SystemExit(f"Test path {target} not found")
+
+    raise SystemExit(run_tests(target))
 
 
 if __name__ == "__main__":

--- a/alpha_factory_v1/tests/test_scripts_import_dashboard.py
+++ b/alpha_factory_v1/tests/test_scripts_import_dashboard.py
@@ -1,0 +1,45 @@
+import os
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from alpha_factory_v1.scripts import import_dashboard
+
+
+class ImportDashboardScriptTest(unittest.TestCase):
+    def test_requires_token(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit):
+                with mock.patch.object(import_dashboard.sys, 'argv', ['imp.py']):
+                    import_dashboard.main()
+
+    def test_missing_file(self):
+        with mock.patch.dict(os.environ, {'GRAFANA_TOKEN': 'x'}):
+            with self.assertRaises(SystemExit):
+                with mock.patch.object(import_dashboard.sys, 'argv', ['imp.py', '/nope']):
+                    import_dashboard.main()
+
+    def test_happy_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / 'dash.json'
+            path.write_text(json.dumps({'title': 't'}))
+            called = {}
+
+            class Resp:
+                text = 'ok'
+
+                def raise_for_status(self):
+                    called['raised'] = True
+
+            with mock.patch.dict(os.environ, {'GRAFANA_TOKEN': 'x'}):
+                with mock.patch('alpha_factory_v1.scripts.import_dashboard.post', return_value=Resp()) as post:
+                    with mock.patch.object(import_dashboard.sys, 'argv', ['imp.py', str(path)]):
+                        import_dashboard.main()
+                    post.assert_called_once()
+                    self.assertTrue(called.get('raised'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/alpha_factory_v1/tests/test_scripts_run_tests.py
+++ b/alpha_factory_v1/tests/test_scripts_run_tests.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from alpha_factory_v1.scripts import run_tests
+
+
+class RunTestsScriptTest(unittest.TestCase):
+    def test_path_must_exist(self):
+        with self.assertRaises(SystemExit):
+            with mock.patch.object(sys, 'argv', ['run_tests.py', '/nope']):
+                run_tests.main()
+
+    def test_uses_pytest_when_available(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir)
+            with mock.patch('importlib.util.find_spec', return_value=object()):
+                with mock.patch('subprocess.call', return_value=0) as call:
+                    with mock.patch.object(sys, 'argv', ['run_tests.py', str(target)]):
+                        with self.assertRaises(SystemExit):
+                            run_tests.main()
+                    call.assert_called_once()
+                    self.assertIn('pytest', call.call_args[0][0])
+
+    def test_falls_back_to_unittest(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir)
+            with mock.patch('importlib.util.find_spec', return_value=None):
+                with mock.patch('subprocess.call', return_value=0) as call:
+                    with mock.patch.object(sys, 'argv', ['run_tests.py', str(target)]):
+                        with self.assertRaises(SystemExit):
+                            run_tests.main()
+                    call.assert_called_once()
+                    self.assertIn('unittest', call.call_args[0][0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve `run_tests.py` with a `run_tests()` helper and path validation
- ensure `import_dashboard.py` validates JSON path
- document updated behaviour in README files
- add unit tests covering both scripts

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests`