### PR TITLE
Add backend fallback tests

### DIFF
--- a/alpha_factory_v1/tests/test_memory_provider.py
+++ b/alpha_factory_v1/tests/test_memory_provider.py
@@ -1,0 +1,48 @@
+import unittest
+import os
+import logging
+
+# Disable noisy logs during import
+logging.disable(logging.CRITICAL)
+
+import alpha_factory_v1.backend.memory_fabric as memf
+from alpha_factory_v1.backend.model_provider import ModelProvider
+
+class ModelProviderStubTest(unittest.TestCase):
+    def setUp(self):
+        for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "LOCAL_LLM_BASE"):
+            os.environ.pop(key, None)
+
+    def test_stub_backend(self):
+        provider = ModelProvider()
+        self.assertEqual(provider.backend[0], "stub")
+        out = provider.complete("hello")
+        self.assertIsInstance(out, str)
+        self.assertTrue(out)
+
+class MemoryFabricFallbackTest(unittest.TestCase):
+    def setUp(self):
+        self.fabric = memf.MemoryFabric()
+        # Avoid metrics context when Prometheus is absent
+        memf._MET_V_SRCH = None
+
+    def test_vector_ram_mode(self):
+        self.assertEqual(self.fabric.vector._mode, "ram")
+        self.fabric.add_memory("X", "data")
+        self.assertEqual(self.fabric.search("data"), [])
+
+    def test_graph_list_mode(self):
+        self.assertEqual(self.fabric.graph._mode, "list")
+        self.fabric.add_relation("A", "rel", "B")
+        self.fabric.add_relation("B", "rel", "C")
+        self.assertEqual(self.fabric.find_path("A", "C"), ["A", "B", "C"])
+
+class EmbedderFallbackTest(unittest.TestCase):
+    def test_hash_embedder(self):
+        emb = memf._load_embedder()
+        vec = emb("test")
+        self.assertEqual(len(vec), memf.CFG.VECTOR_DIM)
+        self.assertTrue(all(isinstance(x, (float, int)) for x in vec))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests covering ModelProvider stub fallback
- cover MemoryFabric vector and graph fallbacks
- validate hash embedder

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests -v`