### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: 🚀 CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-cov
+      - name: Run tests
+        run: |
+          pytest -q --cov=alpha_factory_v1 --cov-report=xml
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-py${{ matrix.python-version }}
+          path: coverage.xml
+

--- a/README.md
+++ b/README.md
@@ -403,8 +403,15 @@ The helper validates the target directory, prefers `pytest` when
 available and otherwise falls back to `unittest`. Ensure all tests pass
 before deploying changes.
 
+### 6.2 · Continuous Integration ⚙️
+
+Every push and pull request automatically triggers the **CI pipeline** via
+[GitHub Actions](.github/workflows/ci.yml). The workflow runs the unit tests
+across multiple Python versions and uploads coverage reports as build
+artifacts.  No additional configuration is required.
+
 <a name="62-marketplace-demo-example"></a>
-### 6.2 · Marketplace Demo Example 🛒
+### 6.3 · Marketplace Demo Example 🛒
 A minimal snippet queues the sample job once the orchestrator is running:
 
 ```bash


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running tests on Python 3.9–3.11
- document the CI pipeline in README

## Testing
- `git status --short`
