### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -403,6 +403,11 @@ The helper validates the target directory, prefers `pytest` when
 available and otherwise falls back to `unittest`. Ensure all tests pass
 before deploying changes.
 
+Continuous integration runs the same suite on GitHub Actions across
+Python 3.10 and 3.11.  The workflow lives under
+`.github/workflows/ci.yml` and installs dependencies from
+`requirements.txt` before invoking `pytest`.
+
 <a name="62-marketplace-demo-example"></a>
 ### 6.2 · Marketplace Demo Example 🛒
 A minimal snippet queues the sample job once the orchestrator is running:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run unit tests on Python 3.10 and 3.11
- document new CI workflow in README

## Testing
- `python alpha_factory_v1/scripts/run_tests.py` *(fails: AssertionError in test_run_tests_script)*
