### PR TITLE
Add CI coverage and root tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -18,11 +20,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install coverage
           pip install -r alpha_factory_v1/backend/requirements.txt
           pip install -e .
       - name: Run tests
         run: |
-          python -m alpha_factory_v1.scripts.run_tests
+          coverage run -m alpha_factory_v1.scripts.run_tests
+          coverage run -m pytest tests
+          coverage combine
+          coverage xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -400,8 +400,9 @@ python alpha_factory_v1/scripts/run_tests.py
 ```
 
 The helper validates the target directory, prefers `pytest` when
-available and otherwise falls back to `unittest`. Ensure all tests pass
-before deploying changes.
+available and otherwise falls back to `unittest`. Tests live under
+`alpha_factory_v1/tests` and the project root `tests/` directory.
+Ensure all tests pass before deploying changes.
 
 <a name="62-marketplace-demo-example"></a>
 ### 6.2 · Marketplace Demo Example 🛒

--- a/tests/test_edge_runner_wrapper.py
+++ b/tests/test_edge_runner_wrapper.py
@@ -1,0 +1,20 @@
+import unittest
+import subprocess
+import sys
+from pathlib import Path
+
+
+class EdgeRunnerWrapperTest(unittest.TestCase):
+    def test_edge_runner_help(self):
+        script = Path(__file__).resolve().parents[1] / "edge_runner.py"
+        result = subprocess.run(
+            [sys.executable, str(script), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Alpha-Factory Edge Runner", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,12 @@
+import unittest
+import alpha_factory_v1 as af
+
+
+class PackageTest(unittest.TestCase):
+    def test_get_version_consistency(self):
+        self.assertEqual(af.get_version(), af.__version__)
+        self.assertIsInstance(af.__version__, str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new Python matrix and OS matrix to GitHub Actions
- cache pip dependencies and collect coverage
- include simple root level tests
- document new test directory

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`
- `python -m unittest discover -s tests -v`
