### PR TITLE
Improve CI coverage and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r alpha_factory_v1/backend/requirements.txt
           pip install -e .
+          pip install pytest-cov coverage
       - name: Run tests
         run: |
-          python -m alpha_factory_v1.scripts.run_tests
+          pytest -q --cov=alpha_factory_v1 --cov-report=xml --cov-report=term-missing
+      - name: Upload coverage (Codecov optional)
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml

--- a/alpha_factory_v1/tests/test_scripts_run_tests.py
+++ b/alpha_factory_v1/tests/test_scripts_run_tests.py
@@ -36,6 +36,15 @@ class RunTestsScriptTest(unittest.TestCase):
                     call.assert_called_once()
                     self.assertIn('unittest', call.call_args[0][0])
 
+    def test_defaults_to_tests_directory(self):
+        with mock.patch('importlib.util.find_spec', return_value=object()):
+            with mock.patch('subprocess.call', return_value=0) as call:
+                with mock.patch.object(sys, 'argv', ['run_tests.py']):
+                    with self.assertRaises(SystemExit):
+                        run_tests.main()
+                call.assert_called_once()
+                self.assertTrue(str(call.call_args[0][0][-1]).endswith('tests'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- collect code coverage in CI
- upload coverage to codecov when token available
- test default path of run_tests script

## Testing
- `python -m pytest alpha_factory_v1/tests/test_scripts_run_tests.py::RunTestsScriptTest::test_defaults_to_tests_directory -q` *(fails: No module named pytest)*