### PR TITLE
Restrict Python version <3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Built atop **OpenAI Agents SDK**, **Google ADK**, **A2A protocol**, and Ant
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
+# Requires Python 3.9–3.11 (<3.12)
 ./quickstart.sh
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs
 ```

--- a/alpha_factory_v1/backend/requirements-lock.txt
+++ b/alpha_factory_v1/backend/requirements-lock.txt
@@ -69,7 +69,7 @@ psycopg2-binary==2.9.9
 networkx==3.3
 
 # ────────── Scientific / domain-specific libs ──────────────────────────
-rdkit-pypi==2024.3.1
+rdkit-pypi==2023.3.1b1
 noaa-sdk==1.17.3
 
 # ────────── Local-model fallbacks (no-API-key mode) ────────────────────

--- a/alpha_factory_v1/backend/requirements.txt
+++ b/alpha_factory_v1/backend/requirements.txt
@@ -70,7 +70,7 @@ psycopg2-binary>=2.9
 networkx>=3.3           # in-process fallback graph
 
 # ─────────── Scientific / domain-specific libs ─────────────────────────
-rdkit-pypi>=2024.3      # molecule ops for DrugDesignAgent
+rdkit-pypi>=2023.3.1b1  # molecule ops for DrugDesignAgent
 noaa-sdk>=1.17          # climate data for ClimateRiskAgent
 
 # ─────────── Local model fallbacks (no API-key mode) ───────────────────

--- a/alpha_factory_v1/quickstart.sh
+++ b/alpha_factory_v1/quickstart.sh
@@ -44,9 +44,10 @@ header
 # check python version
 python3 - <<'PY'
 import sys
-req = (3,9)
-if sys.version_info < req:
-    sys.exit(f"Python {req[0]}.{req[1]}+ required")
+req = (3, 9)
+max_py = (3, 12)
+if sys.version_info < req or sys.version_info >= max_py:
+    sys.exit(f"Python {req[0]}.{req[1]}+ and <{max_py[0]}.{max_py[1]} required")
 PY
 
 VENV_DIR=".venv"

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 
 MIN_PY = (3, 9)
+MAX_PY = (3, 12)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
 
 COLORS = {
@@ -22,8 +23,11 @@ def banner(msg: str, color: str = 'GREEN') -> None:
 
 
 def check_python() -> bool:
-    if sys.version_info < MIN_PY:
-        banner(f"Python {MIN_PY[0]}.{MIN_PY[1]}+ required", 'RED')
+    if sys.version_info < MIN_PY or sys.version_info >= MAX_PY:
+        banner(
+            f"Python {MIN_PY[0]}.{MIN_PY[1]}+ and <{MAX_PY[0]}.{MAX_PY[1]} required",
+            'RED',
+        )
         return False
     banner(f"Python {sys.version.split()[0]} detected", 'GREEN')
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "alpha-factory-v1"
 version = "1.0.0"
 description = "Alpha-Factory v1"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.12"
 
 [project.scripts]
 alpha-factory = "alpha_factory_v1.run:run"


### PR DESCRIPTION
## Summary
- restrict supported Python versions to <3.12
- enforce version range in quickstart and preflight checks
- document the requirement in README
- trim CI matrix to Python 3.10 and 3.11
- pin RDKit to latest available release

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`
