### PR TITLE
Improve CI matrix and add CLI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
       - name: Ensure lock file up to date
         run: |

--- a/tests/test_edge_runner_cli.py
+++ b/tests/test_edge_runner_cli.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+
+def test_edge_runner_help():
+    result = subprocess.run(
+        [sys.executable, '-m', 'alpha_factory_v1.edge_runner', '--help'],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert 'usage' in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add a simple CLI smoke test
- test Python 3.12 in GitHub Actions

## Testing
- `python -m pytest -q tests/test_imports.py tests/test_edge_runner_cli.py` *(fails: No module named pytest)*
- `sudo apt-get update` *(fails: Could not resolve 'archive.ubuntu.com')*