### PR TITLE
Fix CI Python 3.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Built atop **OpenAI Agents SDK**, **Google ADK**, **A2A protocol**, and Ant
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
-# Requires Python 3.9–3.11 (<3.12)
+# Requires Python 3.9–3.12 (<3.13)
 ./quickstart.sh
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs
 ```

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 
 MIN_PY = (3, 9)
-MAX_PY = (3, 12)
+MAX_PY = (3, 13)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
 
 COLORS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "alpha-factory-v1"
 version = "1.0.0"
 description = "Alpha-Factory v1"
 readme = "README.md"
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 
 [tool.setuptools]
 packages = ["alpha_factory_v1", "requests"]


### PR DESCRIPTION
## Summary
- extend supported Python versions to 3.12
- update quickstart instructions
- relax version check in preflight script

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`