### PR TITLE
Enhance run_tests usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ No `OPENAI_API_KEY` → switches to local SBERT + heuristics.
 Unit tests can be executed with the bundled helper script:
 
 ```bash
-python alpha_factory_v1/scripts/run_tests.py
+python -m alpha_factory_v1.scripts.run_tests
 ```
 
 The helper validates the target directory, prefers `pytest` when

--- a/alpha_factory_v1/scripts/run_tests.py
+++ b/alpha_factory_v1/scripts/run_tests.py
@@ -29,10 +29,14 @@ def run_tests(target: Path) -> int:
 
 def main() -> None:
     script_dir = Path(__file__).resolve().parents[1]
+    repo_root = script_dir.parent
     if len(sys.argv) > 1:
         target = Path(sys.argv[1])
         if not target.is_absolute():
-            target = script_dir / target
+            guess = script_dir / target
+            if not guess.exists():
+                guess = repo_root / target
+            target = guess
     else:
         target = script_dir / "tests"
     if not target.exists():


### PR DESCRIPTION
## Summary
- improve `run_tests` script to resolve paths relative to repo root
- update README instructions to use module invocation

## Testing
- `python tests/test_imports.py && python tests/test_edge_runner_cli.py`
- `python -m alpha_factory_v1.scripts.run_tests`
- `python -m alpha_factory_v1.scripts.run_tests alpha_factory_v1/tests`
- `python -m alpha_factory_v1.scripts.run_tests tests`
