### PR TITLE
Improve tests for edge runner

### DIFF
--- a/tests/test_edge_runner_cli.py
+++ b/tests/test_edge_runner_cli.py
@@ -1,11 +1,20 @@
 import subprocess
 import sys
+import unittest
 
-def test_edge_runner_help():
-    result = subprocess.run(
-        [sys.executable, '-m', 'alpha_factory_v1.edge_runner', '--help'],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
-    assert 'usage' in result.stdout.lower()
+
+class TestEdgeRunnerCLI(unittest.TestCase):
+    """CLI regression tests for :mod:`alpha_factory_v1.edge_runner`."""
+
+    def test_edge_runner_help(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "alpha_factory_v1.edge_runner", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("usage", result.stdout.lower())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()

--- a/tests/test_edge_runner_parse.py
+++ b/tests/test_edge_runner_parse.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+from alpha_factory_v1 import edge_runner
+
+
+class TestPositiveInt(unittest.TestCase):
+    def test_valid(self) -> None:
+        self.assertEqual(edge_runner._positive_int("p")("1"), 1)
+
+    def test_invalid(self) -> None:
+        parser = edge_runner._positive_int("val")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parser("0")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parser("-5")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parser("foo")
+
+
+class TestParseArgs(unittest.TestCase):
+    def test_env_defaults(self) -> None:
+        env = {"PORT": "1234", "CYCLE": "5", "METRICS_PORT": "9000", "A2A_PORT": "7000"}
+        with patch.dict(os.environ, env, clear=True):
+            args = edge_runner.parse_args([])
+        self.assertEqual(args.port, 1234)
+        self.assertEqual(args.cycle, 5)
+        self.assertEqual(args.metrics_port, 9000)
+        self.assertEqual(args.a2a_port, 7000)
+
+    def test_version_flag(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "alpha_factory_v1.edge_runner", "--version"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), edge_runner.__version__)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,6 +1,15 @@
 import importlib
+import unittest
 
-def test_alpha_factory_import():
-    mod = importlib.import_module('alpha_factory_v1')
-    assert hasattr(mod, '__version__')
+
+class TestImports(unittest.TestCase):
+    """Verify that the package can be imported."""
+
+    def test_alpha_factory_import(self) -> None:
+        mod = importlib.import_module("alpha_factory_v1")
+        self.assertTrue(hasattr(mod, "__version__"))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()
 


### PR DESCRIPTION
## Summary
- rewrite tests using `unittest` to avoid external dependencies
- add coverage for edge runner argument parsing

## Testing
- `python -m unittest discover -s tests -v`