### PR TITLE
Enhance agent registry exports and coverage

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -523,3 +523,14 @@ logger.info(
     len(AGENT_REGISTRY),
     len(CAPABILITY_GRAPH),
 )
+
+__all__ = [
+    "AGENT_REGISTRY",
+    "CAPABILITY_GRAPH",
+    "AgentMetadata",
+    "register_agent",
+    "register",
+    "list_agents",
+    "capability_agents",
+    "get_agent",
+]

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -52,6 +52,27 @@ class TestAgentRegistryFunctions(unittest.TestCase):
         agent = get_agent(DummyAgent.NAME)
         self.assertIsInstance(agent, DummyAgent)
 
+    def test_list_agents_detail(self):
+        class DAgent(AgentBase):
+            NAME = "detail"
+            CAPABILITIES = ["bar"]
+
+            async def step(self):
+                return None
+
+        meta = AgentMetadata(
+            name=DAgent.NAME,
+            cls=DAgent,
+            version="1.2",
+            capabilities=DAgent.CAPABILITIES,
+            compliance_tags=["x"],
+        )
+        register_agent(meta)
+        detail = list_agents(detail=True)
+        self.assertEqual(detail[0]["name"], DAgent.NAME)
+        self.assertEqual(detail[0]["version"], "1.2")
+        self.assertIn("bar", detail[0]["capabilities"])
+
 class TestPingAgentDisabled(unittest.TestCase):
     def test_ping_agent_skipped_when_env_set(self):
         code = "import alpha_factory_v1.backend.agents as mod; print('ping' in mod.AGENT_REGISTRY)"
@@ -59,6 +80,71 @@ class TestPingAgentDisabled(unittest.TestCase):
         env["AF_DISABLE_PING_AGENT"] = "true"
         result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
         self.assertEqual(result.stdout.strip(), "False")
+
+
+class TestRegisterDecorator(unittest.TestCase):
+    def setUp(self):
+        self._registry_backup = AGENT_REGISTRY.copy()
+        AGENT_REGISTRY.clear()
+
+    def tearDown(self):
+        AGENT_REGISTRY.clear()
+        AGENT_REGISTRY.update(self._registry_backup)
+
+    def test_condition_false(self):
+        from alpha_factory_v1.backend.agents import register, _agent_base
+        Base = _agent_base()
+
+        @register(condition=False)
+        class SkipAgent(Base):
+            NAME = "skip"
+
+            async def step(self):
+                return None
+
+        self.assertNotIn("skip", AGENT_REGISTRY)
+
+    def test_condition_true(self):
+        from alpha_factory_v1.backend.agents import register, _agent_base
+        Base = _agent_base()
+
+        @register
+        class OkAgent(Base):
+            NAME = "ok"
+
+            async def step(self):
+                return None
+
+        self.assertIn("ok", AGENT_REGISTRY)
+
+
+class TestHealthQuarantine(unittest.TestCase):
+    def setUp(self):
+        self._registry_backup = AGENT_REGISTRY.copy()
+        AGENT_REGISTRY.clear()
+
+    def tearDown(self):
+        AGENT_REGISTRY.clear()
+        AGENT_REGISTRY.update(self._registry_backup)
+
+    def test_stub_after_errors(self):
+        from alpha_factory_v1.backend.agents import _HEALTH_Q, StubAgent, _ERR_THRESHOLD
+
+        class FailingAgent(AgentBase):
+            NAME = "fail"
+
+            async def step(self):
+                raise RuntimeError("boom")
+
+        meta = AgentMetadata(name="fail", cls=FailingAgent, version="0", capabilities=[])  # type: ignore[list-item]
+        register_agent(meta)
+        # Pre-set error count to threshold -1
+        object.__setattr__(AGENT_REGISTRY["fail"], "err_count", _ERR_THRESHOLD - 1)
+        _HEALTH_Q.put(("fail", 0.0, False))
+        # give the background thread a moment
+        import time
+        time.sleep(0.05)
+        self.assertIs(AGENT_REGISTRY["fail"].cls, StubAgent)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- export public API via `__all__` in `agents` package
- extend registry tests for detailed listing, decorator conditions and quarantine logic

## Testing
- `python -m unittest tests.test_agents_registry`
- `python -m alpha_factory_v1.scripts.run_tests`