### PR TITLE
Enhance agent base and add PingAgent tests

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -247,15 +247,17 @@ def register(cls=None, *, condition=True):  # type: ignore
 #               internal — utility to import the master AgentBase            #
 ##############################################################################
 def _agent_base():
-    """
-    We accept both historic path `backend.agent_base.AgentBase`
-    *and* the new location `backend.agents.base.AgentBase`.
+    """Return the canonical AgentBase implementation.
+
+    The lightweight ``backend.agents.base`` module is preferred.  We
+    fall back to the legacy ``backend.agent_base`` variant when the new
+    path is unavailable for full backward compatibility.
     """
     try:
-        from backend.agent_base import AgentBase  # type: ignore
-        return AgentBase
-    except ModuleNotFoundError:                   # fallback to new path
         from backend.agents.base import AgentBase  # type: ignore
+        return AgentBase
+    except ModuleNotFoundError:  # pragma: no cover - legacy only
+        from backend.agent_base import AgentBase  # type: ignore
         return AgentBase
 
 ##############################################################################

--- a/alpha_factory_v1/backend/agents/base.py
+++ b/alpha_factory_v1/backend/agents/base.py
@@ -154,6 +154,11 @@ class AgentBase(abc.ABC):
         """The agent's main unit of work.  MUST be overridden."""
         raise NotImplementedError
 
+    # ------------------------------------------------------------------
+    async def run_cycle(self) -> None:  # pragma: no cover - default wrapper
+        """Single orchestrator cycle – runs :meth:`step` once."""
+        await self.step()
+
     async def teardown(self) -> None:  # noqa: D401
         """Optional async clean-up (closing DB handles etc.)."""
         return None

--- a/tests/test_ping_agent.py
+++ b/tests/test_ping_agent.py
@@ -1,0 +1,29 @@
+import asyncio
+import unittest
+
+from alpha_factory_v1.backend.agents.ping_agent import PingAgent
+
+class DummyOrch:
+    def __init__(self):
+        self.published = []
+    async def publish(self, topic, msg):
+        self.published.append((topic, msg))
+    async def subscribe(self, topic):
+        if False:
+            yield
+
+class TestPingAgent(unittest.TestCase):
+    def test_run_cycle_publishes(self):
+        agent = PingAgent()
+        agent.orchestrator = DummyOrch()
+        asyncio.run(agent.setup())
+        asyncio.run(agent.run_cycle())
+        asyncio.run(agent.teardown())
+        self.assertEqual(len(agent.orchestrator.published), 1)
+        topic, payload = agent.orchestrator.published[0]
+        self.assertEqual(topic, "agent.ping")
+        self.assertIn("agent", payload)
+        self.assertEqual(payload["agent"], agent.NAME)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add default `run_cycle` implementation to agent base
- prefer lightweight base class in agent registry helper
- fix PingAgent standalone runner
- test PingAgent publishes heartbeat

## Testing
- `python -m unittest discover -s tests -v`