### PR TITLE
Fix backend agents alias and add regression test

### DIFF
--- a/alpha_factory_v1/backend/__init__.py
+++ b/alpha_factory_v1/backend/__init__.py
@@ -66,6 +66,14 @@ sys.modules.setdefault(
     __name__ + ".finance_agent",
     importlib.import_module(".agents.finance_agent", __name__),
 )
+sys.modules.setdefault(
+    "backend.agents",
+    importlib.import_module(".agents", __name__),
+)
+sys.modules.setdefault(
+    __name__ + ".agents",
+    importlib.import_module(".agents", __name__),
+)
 
 # ────────────────────────── standard library deps ─────────────────────────
 import json

--- a/tests/test_agents_alias.py
+++ b/tests/test_agents_alias.py
@@ -1,0 +1,12 @@
+import unittest
+import importlib
+
+class TestAgentsAlias(unittest.TestCase):
+    def test_backend_alias(self):
+        a = importlib.import_module("alpha_factory_v1.backend.agents")
+        b = importlib.import_module("backend.agents")
+        self.assertIs(a, b)
+        self.assertGreater(len(a.AGENT_REGISTRY), 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `backend.agents` refers to the main agents package
- add regression test verifying alias and agent registry count

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*