### PR TITLE
Add coverage for manufacturing and supply-chain agents

### DIFF
--- a/tests/test_manufacturing_agent.py
+++ b/tests/test_manufacturing_agent.py
@@ -1,0 +1,34 @@
+import unittest
+import asyncio
+import json
+
+from alpha_factory_v1.backend.agents.manufacturing_agent import ManufacturingAgent
+
+
+class TestManufacturingAgent(unittest.TestCase):
+    def setUp(self):
+        self.agent = ManufacturingAgent()
+
+    def test_build_async_returns_ops(self):
+        jobs = [[{"machine": "m1", "proc": 2}, {"machine": "m2", "proc": 3}]]
+        req = {"jobs": jobs, "horizon": 10}
+        result = asyncio.run(self.agent._build_async(req))
+        payload = json.loads(result)["payload"]
+        self.assertIn("ops", payload)
+        self.assertIsInstance(payload["ops"], list)
+        self.assertGreaterEqual(payload["horizon"], 5)
+
+    def test_energy_calc(self):
+        ops = [
+            {"machine": "m1", "start": 0, "end": 5},
+            {"machine": "m1", "start": 5, "end": 15},
+        ]
+        rate = {"m1": 2.0}
+        payload = self.agent._energy_calc(ops, rate)
+        self.assertAlmostEqual(payload["kwh"], 30.0)
+        expected_co2 = 30.0 * self.agent.cfg.energy_rate_co2
+        self.assertAlmostEqual(payload["co2_kg"], expected_co2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_supply_chain_agent.py
+++ b/tests/test_supply_chain_agent.py
@@ -1,0 +1,32 @@
+import unittest
+import json
+import asyncio
+from alpha_factory_v1.backend.agents.supply_chain_agent import SupplyChainAgent
+
+
+class TestSupplyChainAgent(unittest.TestCase):
+    def setUp(self):
+        self.agent = SupplyChainAgent()
+
+    def test_build_network(self):
+        g = self.agent._build_network()
+        self.assertEqual(len(g.nodes), 4)
+        self.assertEqual(len(g.edges), 3)
+
+    def test_wrap_mcp_digest(self):
+        payload = {"a": 1}
+        mcp = self.agent._wrap_mcp(payload)
+        self.assertEqual(mcp["payload"], payload)
+        raw = json.dumps(payload, separators=(",", ":"))
+        import hashlib
+        self.assertEqual(mcp["digest"], hashlib.sha256(raw.encode()).hexdigest())
+
+    def test_plan_cycle_structure(self):
+        data = json.loads(asyncio.run(self.agent._plan_cycle()))
+        self.assertEqual(data["agent"], self.agent.NAME)
+        self.assertIn("payload", data)
+        self.assertIsInstance(data["payload"], list)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for ManufacturingAgent
- add unit tests for SupplyChainAgent

## Testing
- `python -m alpha_factory_v1.scripts.run_tests tests`