### PR TITLE
Enhance demo validation and tests

### DIFF
--- a/alpha_factory_v1/demos/__init__.py
+++ b/alpha_factory_v1/demos/__init__.py
@@ -1,1 +1,5 @@
-# Demo package
+"""Demo package utilities and CLI helpers."""
+
+from . import validate_demos
+
+__all__ = ["validate_demos"]

--- a/alpha_factory_v1/demos/validate_demos.py
+++ b/alpha_factory_v1/demos/validate_demos.py
@@ -6,7 +6,15 @@ DEFAULT_DIR = os.path.dirname(__file__)
 
 
 def main(base_dir: str = DEFAULT_DIR, min_lines: int = 3) -> int:
-    """Validate each demo directory for basic production readiness."""
+    """Validate each demo directory for basic production readiness.
+
+    Parameters
+    ----------
+    base_dir:
+        Directory containing all demo sub-packages.
+    min_lines:
+        Minimum number of lines required in each ``README.md``.
+    """
     failures = []
     for entry in os.listdir(base_dir):
         path = os.path.join(base_dir, entry)
@@ -28,6 +36,15 @@ def main(base_dir: str = DEFAULT_DIR, min_lines: int = 3) -> int:
             init_file = os.path.join(path, "__init__.py")
             if not os.path.isfile(init_file):
                 failures.append(f"Missing __init__.py in {entry}")
+
+            # Ensure demo contains additional production assets
+            visible_files = [
+                f
+                for f in os.listdir(path)
+                if not f.startswith(".") and f not in {"README.md", "__init__.py"}
+            ]
+            if not visible_files:
+                failures.append(f"{entry} contains no demo code or assets")
     if failures:
         for msg in failures:
             print(f"ERROR: {msg}", file=sys.stderr)

--- a/alpha_factory_v1/tests/test_validate_demos.py
+++ b/alpha_factory_v1/tests/test_validate_demos.py
@@ -17,6 +17,15 @@ class TestValidateDemos(unittest.TestCase):
             ret = validate_demos.main(str(tmpdir))
             self.assertEqual(ret, 1)
 
+    def test_empty_demo_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            demo_dir = Path(tmpdir) / "demo"
+            demo_dir.mkdir()
+            (demo_dir / "README.md").write_text("""# Title\nMore than ten lines\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n""")
+            (demo_dir / "__init__.py").write_text("# package\n")
+            ret = validate_demos.main(str(tmpdir), min_lines=10)
+            self.assertEqual(ret, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ alpha-factory = "alpha_factory_v1.run:run"
 governance-sim = "alpha_factory_v1.demos.solving_agi_governance.governance_sim:main"
 edge-runner = "alpha_factory_v1.edge_runner:main"
 alpha-asi-demo = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo:_main"
+validate-demos = "alpha_factory_v1.demos.validate_demos:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -42,3 +42,16 @@ class TestDemos(unittest.TestCase):
                 content = script.read_text(errors="ignore")
                 self.assertTrue(content.startswith("#!/"), f"{script} missing shebang")
                 self.assertTrue(script.stat().st_mode & 0o111, f"{script} not executable")
+
+    def test_validate_demos_cli(self) -> None:
+        """Running the module as a CLI should succeed."""
+        import sys
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-m", "alpha_factory_v1.demos.validate_demos"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("validated", result.stdout.lower())


### PR DESCRIPTION
## Summary
- export `validate_demos` from demos package
- extend `validate_demos` to ensure demo content exists
- register `validate-demos` CLI entry point
- cover module CLI via new tests
- mark empty-demo case in unit tests
- make demo shell scripts executable for reliability

## Testing
- `python -m unittest discover -s tests`
- `python -m unittest discover -s alpha_factory_v1/tests`
