### PR TITLE
Enhance AI‑GA demo CLI and service

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
@@ -334,3 +334,28 @@ class MetaEvolver:
     @property
     def best_architecture(self) -> str:
         return self.best_genome.to_json() if self.best_genome else ""
+
+
+def cli() -> None:
+    """Run a short evolutionary loop and print the champion genome."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="AI-GA Meta-Evolver demo")
+    parser.add_argument("--gens", type=int, default=5, help="Generations to run")
+    args = parser.parse_args()
+
+    from curriculum_env import CurriculumEnv
+
+    evolver = MetaEvolver(env_cls=CurriculumEnv)
+    evolver.run_generations(args.gens)
+    print(evolver.latest_log())
+
+    try:
+        df = evolver.history_plot()
+        print(df.tail())
+    except Exception:  # pragma: no cover - pandas optional
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ governance-sim = "alpha_factory_v1.demos.solving_agi_governance.governance_sim:m
 edge-runner = "alpha_factory_v1.edge_runner:main"
 alpha-asi-demo = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo:_main"
 validate-demos = "alpha_factory_v1.demos.validate_demos:main"
+aiga-meta-demo = "alpha_factory_v1.demos.aiga_meta_evolution.meta_evolver:cli"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here

--- a/tests/test_aiga_meta_cli.py
+++ b/tests/test_aiga_meta_cli.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+import unittest
+
+class TestAigaMetaCLI(unittest.TestCase):
+    def test_cli_runs(self) -> None:
+        result = subprocess.run(
+            [sys.executable, '-m', 'alpha_factory_v1.demos.aiga_meta_evolution.meta_evolver', '--gens', '1'],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn('Champion', result.stdout)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small CLI entrypoint to `meta_evolver.py`
- expose the CLI via new `aiga-meta-demo` script
- add optional Sentry/OTEL support and API rate limiting
- provide regression test for the new CLI

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`