### PR TITLE
Improve MuZero Planning demo config

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -24,6 +24,9 @@ Clone the repository and run the helper script. It generates a
 `config.env` with safe defaults – edit it to add your `OPENAI_API_KEY` if
 you want narrated moves.
 
+Set `HOST_PORT` to expose a different dashboard port and `MUZERO_ENV_ID`
+to experiment with other Gymnasium tasks.
+
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning
@@ -31,7 +34,7 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning
 ```
 
 1. **Docker Desktop** builds the container (~45 s on first run).
-2. **Open <http://localhost:7861>** and press **“▶ Run MuZero”**.
+2. **Open <http://localhost:${HOST_PORT:-7861}>** and press **“▶ Run MuZero”**.
 3. Watch the live video feed, reward ticker and optional commentary.
 
 > **Offline by default** – leaving `OPENAI_API_KEY` empty runs the demo

--- a/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
+++ b/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
@@ -1,7 +1,8 @@
 """
 MuZero Planning demo – Cross‑industry Alpha‑Factory illustration.
-Runs a lightweight MuZero agent (MiniMu) on Gymnasium’s CartPole‑v1,
-and streams a live Gradio dashboard (port 7861).
+Runs a lightweight MuZero agent (MiniMu) on Gymnasium’s CartPole‑v1
+(or ``$MUZERO_ENV_ID``) and streams a live Gradio dashboard
+on ``$HOST_PORT`` (default 7861).
 
 Core algorithm follows the public pseudocode from Schrittwieser et al. (2020)
 but trimmed to <300 LoC for pedagogy.
@@ -14,8 +15,9 @@ import gradio as gr
 # (full implementation lives in demo/minimuzero.py, imported here)
 from demo.minimuzero import MiniMu, mcts_policy, play_episode
 
-ENV_ID = "CartPole-v1"           # fast & visual
-EPISODES = 3
+ENV_ID = os.getenv("MUZERO_ENV_ID", "CartPole-v1")  # default environment
+EPISODES = int(os.getenv("MUZERO_EPISODES", 3))
+PORT = int(os.getenv("HOST_PORT", 7861))
 
 # ── Optional commentary agent -------------------------------------------------
 llm = OpenAIAgent(
@@ -45,7 +47,7 @@ def launch_dashboard():
             return (frames[::2], txt)
         start = gr.Button("▶ Run MuZero")
         start.click(run, outputs=[vid, log])
-    demo.launch(server_name="0.0.0.0", server_port=7861)
+    demo.launch(server_name="0.0.0.0", server_port=PORT)
 
 if __name__ == "__main__":
     launch_dashboard()

--- a/alpha_factory_v1/demos/muzero_planning/config.env.sample
+++ b/alpha_factory_v1/demos/muzero_planning/config.env.sample
@@ -3,3 +3,7 @@ OPENAI_API_KEY=
 
 MODEL_NAME="gpt-4o-mini"    # only used for commentary overlay
 TEMPERATURE=0.3
+
+# Optional customisations
+#HOST_PORT=7861
+#MUZERO_ENV_ID=CartPole-v1

--- a/alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml
+++ b/alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./:/app/demo:ro
     ports:
-      - "7861:7861"
+      - "${HOST_PORT:-7861}:7861"  # allow custom external port
     depends_on:
       - ollama
 

--- a/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
+++ b/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
@@ -15,7 +15,8 @@ command -v docker >/dev/null 2>&1 || {
   cp "$demo_dir/config.env.sample" "$demo_dir/config.env"; }
 
 echo "🚢  Building & starting MuZero Planning demo …"
+HOST_PORT=${HOST_PORT:-7861}
 docker compose --project-name alpha_muzero -f "$compose" up -d --build
 
-echo -e "\n🎉  Open http://localhost:7861 for the live MuZero dashboard."
+echo -e "\n🎉  Open http://localhost:${HOST_PORT} for the live MuZero dashboard."
 echo "🛑  Stop → docker compose -p alpha_muzero down\n"


### PR DESCRIPTION
## Summary
- make all demo shell scripts executable for quality tests
- allow `HOST_PORT`, `MUZERO_ENV_ID`, and `MUZERO_EPISODES` env vars in MuZero Planning demo
- update docker compose file to use custom port
- document new variables in README and sample env

## Testing
- `python3 -m unittest tests.test_demos.TestDemos.test_demo_shell_scripts`
- `python3 -m unittest alpha_factory_v1.tests.test_muzero_demo`
- `python3 -m unittest discover -s tests -p 'test_*.py' -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*