### PR TITLE
Improve governance demo reliability

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -94,3 +94,32 @@ the run deterministic and `--verbose` shows progress for long runs.
 
 ---
 
+### 10 · Quick Start & Troubleshooting
+
+1. **Install** the package in a fresh virtual environment:
+
+   ```bash
+   python -m pip install -e .[tests]
+   ```
+
+   The demo requires only the Python standard library but the optional
+   `tests` extra installs `pytest` for validation.
+
+2. **Run the simulator** using the provided command:
+
+   ```bash
+   governance-sim -N 500 -r 2000 --delta 0.85 --verbose
+   ```
+
+3. **Verify** that everything works by launching the unit tests:
+
+   ```bash
+   python -m unittest discover -s alpha_factory_v1/tests -p 'test_governance_sim.py'
+   ```
+
+If you encounter issues, ensure Python ≥ 3.9 is in your PATH and that
+no corporate firewall interferes with package installation. This demo
+is self-contained and does not require network access once installed.
+
+---
+

--- a/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
@@ -24,9 +24,32 @@ def run_sim(
     seed: int | None = None,
     verbose: bool = False,
 ) -> float:
-    """Return the mean cooperation probability after ``rounds`` iterations."""
+    """Return the mean cooperation probability after ``rounds`` iterations.
+
+    Parameters
+    ----------
+    agents:
+        Number of agents in the simulation. Must be positive.
+    rounds:
+        Number of interaction rounds to simulate. Must be positive.
+    delta:
+        Discount factor in ``[0, 1]`` controlling update momentum.
+    stake:
+        Penalty applied when an agent defects. Must be non-negative.
+    seed:
+        Optional random seed for deterministic runs.
+    verbose:
+        If ``True`` prints progress every 10%% of the run.
+    """
+
+    if agents <= 0:
+        raise ValueError("agents must be positive")
+    if rounds <= 0:
+        raise ValueError("rounds must be positive")
     if not 0.0 <= delta <= 1.0:
         raise ValueError("delta must be between 0 and 1")
+    if stake < 0:
+        raise ValueError("stake must be non-negative")
 
     rng = random.Random(seed)
 

--- a/alpha_factory_v1/tests/test_governance_sim.py
+++ b/alpha_factory_v1/tests/test_governance_sim.py
@@ -8,6 +8,21 @@ class GovernanceSimTest(unittest.TestCase):
         coop = run_sim(agents=20, rounds=100, delta=0.8, stake=2.5, seed=0)
         self.assertGreaterEqual(coop, 0.8)
 
+    def test_invalid_parameters_raise(self):
+        with self.assertRaises(ValueError):
+            run_sim(agents=0, rounds=10, delta=0.5, stake=1)
+        with self.assertRaises(ValueError):
+            run_sim(agents=1, rounds=0, delta=0.5, stake=1)
+        with self.assertRaises(ValueError):
+            run_sim(agents=1, rounds=10, delta=1.5, stake=1)
+        with self.assertRaises(ValueError):
+            run_sim(agents=1, rounds=10, delta=0.5, stake=-1)
+
+    def test_reproducibility(self):
+        a = run_sim(agents=5, rounds=50, delta=0.9, stake=2.0, seed=123)
+        b = run_sim(agents=5, rounds=50, delta=0.9, stake=2.0, seed=123)
+        self.assertAlmostEqual(a, b)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- validate inputs in `governance_sim.run_sim`
- extend tests for edge cases and reproducibility
- add quick-start notes for governance demo

## Testing
- `python -m unittest discover -s alpha_factory_v1/tests`
