### PR TITLE
Improve live mode config for era_of_experience demo

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -47,7 +47,7 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
 
    ```bash
    cp config.env.sample config.env
-   $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, etc.
+   $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, LIVE_FEED, etc.
    ```
 
 2. Enable real-time collectors and metrics with the `--live` flag:
@@ -55,6 +55,8 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
    ```bash
    ./run_experience_demo.sh --live
    ```
+
+   (equivalent to setting `LIVE_FEED=1` in `config.env`)
 
    The orchestrator automatically switches to offline mode whenever
    `OPENAI_API_KEY` is left empty.

--- a/alpha_factory_v1/demos/era_of_experience/config.env.sample
+++ b/alpha_factory_v1/demos/era_of_experience/config.env.sample
@@ -23,6 +23,7 @@ OLLAMA_URL=http://ollama:11434   # internal service; override for LAN cache
 STREAM_RATE_HZ=1                 # synthetic experience events per second
 MEMORY_BACKEND=qdrant            # vector store: vector | qdrant | chroma
 MEMORY_CAPACITY=100000           # max embeddings before LRU eviction
+LIVE_FEED=0                      # 1 mixes in real sensor/web data
 
 ###########################  Reward shaping  #################################
 FITNESS_REWARD_WEIGHT=0.50       # weight on `fitness_reward()` backend

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -78,6 +78,7 @@ TEMPERATURE=0.2
 FRED_API_KEY=
 WEARABLES_API_KEY=
 PG_PASSWORD=alpha
+LIVE_FEED=0
 EOF
 fi
 
@@ -97,6 +98,7 @@ profiles=()
 has_gpu && profiles+=(gpu)
 [[ -z "${OPENAI_API_KEY:-}" ]] && profiles+=(offline)
 (( PROFILE_LIVE )) && profiles+=(live-feed)
+export LIVE_FEED=${PROFILE_LIVE}
 profile_arg=""
 [[ ${#profiles[@]} -gt 0 ]] && profile_arg="--profile $(IFS=,; echo "${profiles[*]}")"
 


### PR DESCRIPTION
## Summary
- default config now includes `LIVE_FEED=0`
- export `LIVE_FEED` when `--live` flag is used
- document `LIVE_FEED` usage in README

## Testing
- `bash -n alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh`
- `python -m py_compile alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py`
- `python -m py_compile -q alpha_factory_v1/demos/era_of_experience/reward_backends/*.py`
