### PR TITLE
Fix Trace-Graph port in cross-industry demo

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -53,7 +53,7 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/cross_industry_alpha_factory
 |---------|---------------------|
 | Grafana dashboards | `http://localhost:9000` `admin/admin` |
 | Prometheus | `http://localhost:9090` |
-| Trace-Graph (A2A spans) | `http://localhost:7860` |
+| Trace-Graph (A2A spans) | `http://localhost:3000` |
 | Ray dashboard | `http://localhost:8265` |
 | REST orchestrator | `http://localhost:8000` (`GET /healthz`) |
 


### PR DESCRIPTION
## Summary
- fix port reference for Trace-Graph in cross-industry demo docs

## Testing
- `bash -n alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh`