### PR TITLE
Improve world model helper guards

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -54,6 +54,8 @@ Success criteria ✓
 # ░ Local Python (CPU or GPU)
 pip install -r requirements.txt        # torch, fastapi, uvicorn…
 
+# All interactive helpers (`run_ui`, `run_headless`) require these packages.
+
 # new CLI (after `pip install -e .` at repo root)
 alpha-asi-demo --demo        # same as `python -m alpha_asi_world_model_demo --demo`
 open http://localhost:7860             # dashboard & Swagger

--- a/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
@@ -81,6 +81,11 @@ def run_headless(steps: int = 50_000) -> Orchestrator:  # pragma: no cover
         >>> orch = α.run_headless(10_000)
         >>> assert orch.learner.buffer  # trained a bit
     """
+    if not _DEPS_AVAILABLE:
+        raise ImportError(
+            "Optional dependencies missing; install requirements.txt to run"
+        )
+
     orch = Orchestrator()
 
     CFG.max_steps = steps
@@ -104,6 +109,11 @@ def run_ui(
         >>> import alpha_asi_world_model as α
         >>> α.run_ui(port=9999)  # then open http://localhost:9999
     """
+    if not _DEPS_AVAILABLE:
+        raise ImportError(
+            "Optional dependencies missing; install requirements.txt to run"
+        )
+
     uvicorn = _lazy_import_uvicorn()
     uvicorn.run(
         "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo:app",


### PR DESCRIPTION
## Summary
- clarify quick-start instructions
- guard `run_headless` and `run_ui` when optional deps missing

## Testing
- `python -c 'import torch, sys; print("torch" in sys.modules)'` *(fails: ModuleNotFoundError)*