### PR TITLE
Enhance MuZero planning demo

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -26,6 +26,7 @@ you want narrated moves.
 
 Set `HOST_PORT` to expose a different dashboard port and `MUZERO_ENV_ID`
 to experiment with other Gymnasium tasks.
+The helper script warns if the chosen port is already occupied.
 
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git

--- a/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
+++ b/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
@@ -16,6 +16,13 @@ command -v docker >/dev/null 2>&1 || {
 
 echo "🚢  Building & starting MuZero Planning demo …"
 HOST_PORT=${HOST_PORT:-7861}
+
+# Warn if the requested port is already in use (best-effort check)
+if command -v lsof >/dev/null 2>&1 && lsof -i TCP:"${HOST_PORT}" -s TCP:LISTEN >/dev/null 2>&1; then
+  echo "🚨  Port ${HOST_PORT} already in use. Set HOST_PORT to an open port." >&2
+  exit 1
+fi
+
 docker compose --project-name alpha_muzero -f "$compose" up -d --build
 
 echo -e "\n🎉  Open http://localhost:${HOST_PORT} for the live MuZero dashboard."

--- a/tests/test_muzero_planning.py
+++ b/tests/test_muzero_planning.py
@@ -1,0 +1,23 @@
+import unittest
+from alpha_factory_v1.demos.muzero_planning.minimuzero import MiniMu, play_episode
+
+
+class TestMiniMu(unittest.TestCase):
+    def setUp(self):
+        self.mu = MiniMu(env_id="CartPole-v1")
+
+    def test_policy_distribution(self):
+        obs = self.mu.reset()
+        policy = self.mu.policy(obs)
+        self.assertEqual(len(policy), self.mu.action_dim)
+        self.assertAlmostEqual(sum(policy), 1.0, places=2)
+
+    def test_play_episode(self):
+        frames, reward = play_episode(self.mu, render=False, max_steps=10)
+        self.assertIsInstance(frames, list)
+        self.assertIsInstance(reward, float)
+        self.assertLessEqual(len(frames), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add port availability check to `run_muzero_demo.sh`
- document port check in MuZero demo README
- add simple MiniMu regression test

## Testing
- `python -m unittest tests.test_muzero_planning` *(fails: ModuleNotFoundError: No module named 'gymnasium')*