### PR TITLE
Improve MuZero planning demo packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ sequenceDiagram
 |8|`era_of_experience`|🏛️|Streams of life events build autobiographical memory‑graph tutor.|Transforms tacit SME knowledge into tradable signals.|`./alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh`|
 |9|`finance_alpha`|💹|Live momentum + risk‑parity bot on Binance test‑net.|Generates real P&L; stress‑tested against CVaR.|`./alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh`|
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|
-|11|`muzero_planning`|♟️|MuZero plans synthetic markets → optimal execution curves.|Validates world‑model planning in noisy domains.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
+|11|`muzero_planning`|♟|MuZero in 60 s; online world‑model with MCTS.|Distills planning research into a one‑command demo.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -52,7 +52,7 @@ Opens **http://localhost:7860** with a Gradio portal to every demo. Works on ma
 |8|`era_of_experience`|🏛️|Streams of life events build autobiographical memory‑graph tutor.|Transforms tacit SME knowledge into tradable signals.|`docker compose -f demos/docker-compose.era.yml up`|
 |9|`finance_alpha`|💹|Live momentum + risk‑parity bot on Binance test‑net.|Generates real P&L; stress‑tested against CVaR.|`./alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh`|
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|
-|11|`muzero_planning`|♟️|MuZero plans synthetic markets → optimal execution curves.|Validates world‑model planning in noisy domains.|`docker compose -f demos/docker-compose.muzero.yml up`|
+|11|`muzero_planning`|♟|MuZero in 60 s; online world‑model with MCTS.|Distills planning research into a one‑command demo.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -34,6 +34,13 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning
 ./run_muzero_demo.sh
 ```
 
+Alternatively run natively:
+
+```bash
+pip install -r requirements.txt
+python -m alpha_factory_v1.demos.muzero_planning
+```
+
 1. **Docker Desktop** builds the container (~45 s on first run).
 2. **Open <http://localhost:${HOST_PORT:-7861}>** and press **“▶ Run MuZero”**.
 3. Watch the live video feed, reward ticker and optional commentary.

--- a/alpha_factory_v1/demos/muzero_planning/__main__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__main__.py
@@ -1,0 +1,4 @@
+from .agent_muzero_entrypoint import launch_dashboard
+
+if __name__ == "__main__":
+    launch_dashboard()

--- a/alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml
+++ b/alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml
@@ -7,7 +7,9 @@ services:
       dockerfile: ./Dockerfile      # uses existing image recipe
     image: alpha_factory_orchestrator:muzero
     env_file: ./config.env
-    command: python /app/demo/agent_muzero_entrypoint.py
+    command: >-
+      sh -c "pip install --no-cache-dir -r /app/demo/requirements.txt && \
+             python /app/demo/agent_muzero_entrypoint.py"
     volumes:
       - ./:/app/demo:ro
     ports:

--- a/alpha_factory_v1/demos/muzero_planning/requirements.txt
+++ b/alpha_factory_v1/demos/muzero_planning/requirements.txt
@@ -1,0 +1,7 @@
+# MuZero Planning demo dependencies
+# Reuse the main project requirements and add RL extras
+-r ../../requirements.txt
+torch>=2.2
+# Gymnasium classic control environments
+gymnasium[classic-control]>=0.29
+gradio>=4.35

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ edge-runner = "alpha_factory_v1.edge_runner:main"
 alpha-asi-demo = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo:_main"
 validate-demos = "alpha_factory_v1.demos.validate_demos:main"
 aiga-meta-demo = "alpha_factory_v1.demos.aiga_meta_evolution.meta_evolver:cli"
+muzero-demo = "alpha_factory_v1.demos.muzero_planning.agent_muzero_entrypoint:launch_dashboard"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- document MuZero planning demo in main README files
- allow running the demo natively via a new module entry point
- install required packages when starting docker-compose
- add MuZero demo requirements file
- expose new `muzero-demo` console script

## Testing
- `python -m unittest tests.test_muzero_planning` *(fails: ModuleNotFoundError: No module named 'gymnasium')*