### PR TITLE
Add Colab demo for meta-agentic AGI

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/README.md
@@ -109,6 +109,12 @@ streamlit run ui/lineage_app.py
 demo.  The path resolves automatically when running the scripts.
 
 *No GPU?* llama‑cpp‑python auto‑selects 4‑bit quantisation < 6 GB RAM.
+
+### 🎓 Colab notebook
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/meta_agentic_agi/colab_meta_agentic_agi.ipynb)
+
+Spin up the demo end‑to‑end without installing anything. Works offline using open‑weights or with your API keys.
 ---
 
 ## 2 Folder Structure 📁

--- a/alpha_factory_v1/demos/meta_agentic_agi/colab_meta_agentic_agi.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_agi/colab_meta_agentic_agi.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Meta-Agentic \u03b1-AGI Demo \ud83d\udcca",
+    "",
+    "Run the evolutionary **meta-agentic** search loop in one click. Works offline with open weights or with your API key."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 \u00b7 Clone repository & install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "%%bash --no-stderr\nif [[ ! -d AGI-Alpha-Agent-v0 ]]; then\n  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git -q\nfi\ncd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_agi\npip -q install -r requirements.txt"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 \u00b7 Optional API keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nos.environ['OPENAI_API_KEY'] = ''\nos.environ['ANTHROPIC_API_KEY'] = ''"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 \u00b7 Run meta-agentic search loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "!python meta_agentic_agi_demo.py --gens 6 --provider mistral:7b-instruct.gguf"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 \u00b7 Explore lineage dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import subprocess, sys, signal, time\nproc = subprocess.Popen(['streamlit','run','ui/lineage_app.py','--server.headless','true'])\ntime.sleep(3)\nprint('UI \u2192 http://localhost:8501')\ntry:\n    proc.wait()\nexcept KeyboardInterrupt:\n    proc.send_signal(signal.SIGINT)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\u26a0\ufe0f Research demo only. Results are not production audited."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a ready-to-run `colab_meta_agentic_agi.ipynb`
- link to the notebook from the demo README

## Testing
- `python -m unittest discover -s tests -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*