### PR TITLE
Add Colab notebook for alpha AGI business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_2_v1/colab_alpha_agi_business_2_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_2_v1/colab_alpha_agi_business_2_demo.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Alpha-AGI Business v2 \u2022 Colab Notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the minimal **Alpha-AGI Business** demo in minutes.\\n\\nThis notebook boots the orchestrator with two toy agents. It works fully offline or upgrades to GPT-powered tools when `OPENAI_API_KEY` is provided."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 \u00b7 Clone repo & install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\nif [ ! -d AGI-Alpha-Agent-v0 ]; then\n  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\nfi\ncd AGI-Alpha-Agent-v0\n\npip -q install openai_agents fastapi uvicorn gradio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 \u00b7 (Optional) Configure your OpenAI API key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, getpass\nos.environ['OPENAI_API_KEY'] = getpass.getpass('Enter OpenAI API key (leave blank for offline): ')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 \u00b7 Launch demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_2_v1\npython -m alpha_agi_business_2_v1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Colab notebook to run the alpha_agi_business_2_v1 demo

## Testing
- `python -m unittest discover -s tests -v` *(fails: deploy shell scripts not executable)*