### PR TITLE
Improve era_of_experience Colab demo

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -69,7 +69,7 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
 |----------|---------|--------|
 | `colab_era_of_experience.ipynb` | CPU / GPU | <a href="https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"></a> |
 
-The notebook installs a lean Python stack (&lt; 120 s), exposes Gradio via ngrok and lets you call tools directly from cells.
+The notebook installs a lean Python stack (&lt; 120 s), exposes Gradio via ngrok and lets you call tools directly from cells. It also verifies package versions and lists the reward back‑ends available for blending.
 
 ---
 

--- a/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
+++ b/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
@@ -1,199 +1,245 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "title",
-   "metadata": {},
-   "source": [
-    "# 🌱 *Era-of-Experience* · Colab Notebook\n",
-    "*Alpha-Factory v1 👁️✨ — Lifelong-RL playground*  \n",
-    "\n",
-    "A five-minute tour of Sutton & Silver’s **four pillars** — continuous experience, sensor-motor tools, grounded rewards, and non-human reasoning — implemented with the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "title",
+      "metadata": {},
+      "source": [
+        "# 🌱 *Era-of-Experience* · Colab Notebook\n",
+        "*Alpha-Factory v1 👁️✨ — Lifelong-RL playground*  \n",
+        "\n",
+        "A five-minute tour of Sutton & Silver’s **four pillars** — continuous experience, sensor-motor tools, grounded rewards, and non-human reasoning — implemented with the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "roadmap",
+      "metadata": {},
+      "source": [
+        "### Notebook itinerary\n",
+        "1. ✅ Environment check (GPU / CPU)\n",
+        "2. 📦 Clone repo & install lean deps (≤ 90 s)\n",
+        "3. 🔑 Configure secrets (`OPENAI_API_KEY` optional)\n",
+        "4. 🚀 Launch **Era-of-Experience** agent (Gradio tunnel)\n",
+        "5. 🧪 Probe the agent from Python *(bonus)*\n",
+        "\n",
+        "> **Offline-friendly** — leave the key blank and the agent automatically switches to *Mixtral-8x7B-Instruct* via Ollama."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "rtcheck-h",
+      "metadata": {},
+      "source": [
+        "## 0 · Runtime check"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "rtcheck",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!nvidia-smi -L || echo '🔹 GPU not detected — running on CPU'"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "pkgcheck-h",
+      "metadata": {},
+      "source": [
+        "## 0b · Verify package versions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "pkgcheck",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import sys, importlib\n",
+        "def pkg_ver(name):\n",
+        "    try:\n",
+        "        mod = importlib.import_module(name)\n",
+        "        return getattr(mod, '__version__', 'n/a')\n",
+        "    except Exception:\n",
+        "        return 'missing'\n",
+        "print('Python', sys.version.split()[0])\n",
+        "print('openai_agents', pkg_ver('openai_agents'))\n",
+        "print('gradio', pkg_ver('gradio'))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "clone-h",
+      "metadata": {},
+      "source": [
+        "## 1 · Clone repo & install Python deps"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "clone",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "set -e\n",
+        "if [ ! -d AGI-Alpha-Agent-v0 ]; then\n",
+        "  echo '📥 Cloning Alpha-Factory v1…'\n",
+        "  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
+        "fi\n",
+        "echo '📦 Installing minimal dependencies…'\n",
+        "pip -qq install -U openai_agents gradio aiohttp pretty_errors"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cfg-h",
+      "metadata": {},
+      "source": [
+        "## 2 · Configure secrets & runtime flags"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cfg",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os, getpass, json, textwrap\n",
+        "\n",
+        "# 🔑 Supply your OpenAI key or leave blank for offline mode\n",
+        "os.environ['OPENAI_API_KEY'] = getpass.getpass('OpenAI key (blank for offline): ')\n",
+        "os.environ['MODEL_NAME']     = os.getenv('MODEL_NAME', 'gpt-4o-mini')\n",
+        "os.environ['TEMPERATURE']    = os.getenv('TEMPERATURE', '0.4')\n",
+        "\n",
+        "print({k:('•••••' if v else '') for k,v in os.environ.items() if k.startswith('OPENAI')})"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "launch-h",
+      "metadata": {},
+      "source": [
+        "## 3 · Launch **Era-of-Experience** dashboard"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "launch",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import subprocess, sys, pathlib, threading, queue, re, time, textwrap\n",
+        "\n",
+        "root = pathlib.Path('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience')\n",
+        "proc = subprocess.Popen([\n",
+        "        sys.executable, 'agent_experience_entrypoint.py'],\n",
+        "        cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,\n",
+        "        text=True, bufsize=1)\n",
+        "\n",
+        "# -- capture the public Gradio link (Colab tunnels automatically)\n",
+        "link_q = queue.Queue()\n",
+        "def _tail():\n",
+        "    for line in proc.stdout:\n",
+        "        print(line, end='')\n",
+        "        if 'Running on' in line and 'https://' in line:\n",
+        "            m = re.search(r'(https://[\\w.-]+\\.gradio\\.live)', line)\n",
+        "            if m: link_q.put(m.group(1))\n",
+        "threading.Thread(target=_tail, daemon=True).start()\n",
+        "\n",
+        "print('⏳ Waiting for Gradio tunnel …')\n",
+        "url = link_q.get()   # blocks until found\n",
+        "print(f'🎉 Open dashboard → {url}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "probe-h",
+      "metadata": {},
+      "source": [
+        "## 4 · Quick-probe the agent (Python API)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "probe",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import asyncio, sys, json, importlib, pathlib\n",
+        "sys.path.append('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience')\n",
+        "exp = importlib.import_module('agent_experience_entrypoint')\n",
+        "\n",
+        "async def one_cycle():\n",
+        "    evt   = next(exp.experience_stream())\n",
+        "    meal  = await exp.plan_meal(550)\n",
+        "    site  = await exp.web_search('benefits of interval training')\n",
+        "    print(json.dumps({'event': evt, 'meal': meal, 'search': site}, indent=2))\n",
+        "\n",
+        "await one_cycle()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "reward-h",
+      "metadata": {},
+      "source": [
+        "## 4b · Available reward backends"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "reward-list",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from alpha_factory_v1.demos.era_of_experience import reward_backends\n",
+        "print('Reward modules:', ', '.join(reward_backends.list_rewards()))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "stop-h",
+      "metadata": {},
+      "source": [
+        "## 5 · Terminate (optional)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "stop",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "proc.terminate(); proc.wait(); print('✅ Agent stopped')"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    },
+    "colab": {
+      "name": "colab_era_of_experience.ipynb",
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "roadmap",
-   "metadata": {},
-   "source": [
-    "### Notebook itinerary\n",
-    "1. ✅ Environment check (GPU / CPU)\n",
-    "2. 📦 Clone repo & install lean deps (≤ 90 s)\n",
-    "3. 🔑 Configure secrets (`OPENAI_API_KEY` optional)\n",
-    "4. 🚀 Launch **Era-of-Experience** agent (Gradio tunnel)\n",
-    "5. 🧪 Probe the agent from Python *(bonus)*\n",
-    "\n",
-    "> **Offline-friendly** — leave the key blank and the agent automatically switches to *Mixtral-8x7B-Instruct* via Ollama."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "rtcheck-h",
-   "metadata": {},
-   "source": [
-    "## 0 · Runtime check"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "rtcheck",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!nvidia-smi -L || echo '🔹 GPU not detected — running on CPU'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "clone-h",
-   "metadata": {},
-   "source": [
-    "## 1 · Clone repo & install Python deps"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "clone",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -e\n",
-    "if [ ! -d AGI-Alpha-Agent-v0 ]; then\n",
-    "  echo '📥 Cloning Alpha-Factory v1…'\n",
-    "  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
-    "fi\n",
-    "echo '📦 Installing minimal dependencies…'\n",
-    "pip -qq install -U openai_agents gradio aiohttp pretty_errors"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cfg-h",
-   "metadata": {},
-   "source": [
-    "## 2 · Configure secrets & runtime flags"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cfg",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os, getpass, json, textwrap\n",
-    "\n",
-    "# 🔑 Supply your OpenAI key or leave blank for offline mode\n",
-    "os.environ['OPENAI_API_KEY'] = getpass.getpass('OpenAI key (blank for offline): ')\n",
-    "os.environ['MODEL_NAME']     = os.getenv('MODEL_NAME', 'gpt-4o-mini')\n",
-    "os.environ['TEMPERATURE']    = os.getenv('TEMPERATURE', '0.4')\n",
-    "\n",
-    "print({k:('•••••' if v else '') for k,v in os.environ.items() if k.startswith('OPENAI')})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "launch-h",
-   "metadata": {},
-   "source": [
-    "## 3 · Launch **Era-of-Experience** dashboard"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "launch",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import subprocess, sys, pathlib, threading, queue, re, time, textwrap\n",
-    "\n",
-    "root = pathlib.Path('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience')\n",
-    "proc = subprocess.Popen([\n",
-    "        sys.executable, 'agent_experience_entrypoint.py'],\n",
-    "        cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,\n",
-    "        text=True, bufsize=1)\n",
-    "\n",
-    "# -- capture the public Gradio link (Colab tunnels automatically)\n",
-    "link_q = queue.Queue()\n",
-    "def _tail():\n",
-    "    for line in proc.stdout:\n",
-    "        print(line, end='')\n",
-    "        if 'Running on' in line and 'https://' in line:\n",
-    "            m = re.search(r'(https://[\\w.-]+\\.gradio\\.live)', line)\n",
-    "            if m: link_q.put(m.group(1))\n",
-    "threading.Thread(target=_tail, daemon=True).start()\n",
-    "\n",
-    "print('⏳ Waiting for Gradio tunnel …')\n",
-    "url = link_q.get()   # blocks until found\n",
-    "print(f'🎉 Open dashboard → {url}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "probe-h",
-   "metadata": {},
-   "source": [
-    "## 4 · Quick-probe the agent (Python API)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "probe",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import asyncio, sys, json, importlib, pathlib\n",
-    "sys.path.append('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience')\n",
-    "exp = importlib.import_module('agent_experience_entrypoint')\n",
-    "\n",
-    "async def one_cycle():\n",
-    "    evt   = next(exp.experience_stream())\n",
-    "    meal  = await exp.plan_meal(550)\n",
-    "    site  = await exp.web_search('benefits of interval training')\n",
-    "    print(json.dumps({'event': evt, 'meal': meal, 'search': site}, indent=2))\n",
-    "\n",
-    "await one_cycle()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "stop-h",
-   "metadata": {},
-   "source": [
-    "## 5 · Terminate (optional)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "stop",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "proc.terminate(); print('✅ Agent stopped')"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.10"
-  },
-  "colab": {
-   "name": "colab_era_of_experience.ipynb",
-   "provenance": []
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- enhance README with extra notebook details
- expand the Colab notebook with package verification and reward listing
- ensure graceful shutdown of the demo process

## Testing
- `python -m unittest discover -v tests` *(fails: demo shell scripts not executable)*