### PR TITLE
Add OMNI‑Factory Colab demo

### DIFF
--- a/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
+++ b/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OMNI-Factory Smart City Demo \ud83c\udf06",
+    "",
+    "Run the autonomous smart-city simulation right in Colab."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 \u00b7 Clone repository & install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash --no-stderr",
+    "if [[ ! -d AGI-Alpha-Agent-v0 ]]; then",
+    "  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git -q",
+    "fi",
+    "cd AGI-Alpha-Agent-v0",
+    "pip -q install -r alpha_factory_v1/requirements-colab.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 \u00b7 Optional API keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os",
+    "os.environ['OPENAI_API_KEY'] = ''",
+    "os.environ['GOOGLE_ADK_KEY'] = ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 \u00b7 Launch demo & dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {"id": "03-launch"},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash --bg",
+    "cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/omni_factory_demo",
+    "python omni_factory_demo.py --metrics-port 9137 &> omni_demo.log &",
+    "python omni_metrics_exporter.py --port 9137 &> exporter.log &",
+    "python omni_dashboard.py --host 0.0.0.0 --port 8050 --no-browser"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 \u00b7 Expose dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pyngrok import ngrok, conf",
+    "conf.get_default().region = 'us'",
+    "url = ngrok.connect(8050, 'http')",
+    "print('Dashboard \u2192', url.public_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\u26a0\ufe0f Research demo only. Results are not production audited."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `colab_omni_factory_demo.ipynb` with installation, launch and dashboard steps

## Testing
- `python alpha_factory_v1/scripts/run_tests.py`