### PR TITLE
Improve MuZero planning demo notebook

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -87,6 +87,7 @@ python -m alpha_factory_v1.demos.muzero_planning
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb)
 
 Colab spins up the same dashboard via an ngrok tunnel — handy when Docker isn’t.
+It also runs a short unit test so you know the environment is ready before launching the demo.
 
 ---
 

--- a/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
+++ b/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
@@ -5,10 +5,10 @@
    "id": "ecfd703e",
    "metadata": {},
    "source": [
-    "# MuZero Planning Demo – Colab\n",
-    "Run the Alpha‑Factory **MuZero** illustration in one click. In ~60 s you’ll get a Gradio dashboard with live video and reward curves.\n",
+    "# MuZero Planning Demo \u2013 Colab\n",
+    "Experience MuZero-style planning with a lightweight agent. Run the cells below and an interactive dashboard will appear.\n",
     "\n",
-    "*Optional:* set your **OpenAI API key** below for narrative commentary; otherwise the demo runs fully offline."
+    "Optionally set your **OpenAI API key** to enable narrated explanations; without it the demo stays fully offline."
    ]
   },
   {
@@ -19,7 +19,7 @@
    "outputs": [],
    "source": [
     "# Install core dependencies\n",
-    "!pip -q install \"torch>=2.1\" gymnasium[classic-control] gradio openai_agents"
+    "!pip -q install \"torch>=2.1\" gymnasium[classic-control] gradio openai_agents pytest\n"
    ]
   },
   {
@@ -29,9 +29,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Clone Alpha‑Factory repository\n",
+    "# Clone Alpha\u2011Factory repository\n",
     "!git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
     "%cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Run quick sanity tests (optional)\n",
+    "!pytest -q tests/test_muzero_planning.py\n"
    ]
   },
   {
@@ -41,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 👉 OPTIONAL: set your OpenAI key for commentary\n",
+    "# \ud83d\udc49\u00a0OPTIONAL: set your OpenAI key for commentary\n",
     "# import os, getpass\n",
     "# os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(prompt=\"Enter OpenAI API key: \")"
    ]
@@ -57,7 +67,7 @@
     "import os, subprocess, time, signal, sys, threading\n",
     "os.environ[\"GRADIO_SHARE\"] = \"1\"\n",
     "process = subprocess.Popen([sys.executable, \"agent_muzero_entrypoint.py\"])\n",
-    "print(\"⌛ Booting… wait for the public URL ↴\")\n",
+    "print(\"\u231b\u00a0Booting\u2026 wait for the public URL \u21b4\")\n",
     "try:\n",
     "    while process.poll() is None:\n",
     "        time.sleep(5)\n",


### PR DESCRIPTION
## Summary
- enhance the Colab notebook with clearer text and a quick unit test
- install pytest in the Colab setup
- clarify README about the new unit test

## Testing
- `python -m unittest tests/test_muzero_planning.py` *(fails: ModuleNotFoundError: No module named 'gymnasium')*
