### PR TITLE
Improve finance_alpha demo notebook

### DIFF
--- a/alpha_factory_v1/demos/finance_alpha/README.md
+++ b/alpha_factory_v1/demos/finance_alpha/README.md
@@ -40,6 +40,8 @@ different momentum pair on an alternate port.
 
 The first code cell checks for Docker and installs it automatically when running on Colab. Simply run each cell in order to launch Alpha‑Factory, view positions, and open the live trace‑graph.
 
+An additional cell now embeds the trace‑graph UI directly inside the notebook so you can follow the planner's decisions without leaving Colab.
+
 ```bash
 git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1

--- a/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
+++ b/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
@@ -36,10 +36,10 @@
    "cell_type": "markdown",
    "id": "d96a2ed0",
    "metadata": {},
-  "source": [
+   "source": [
     "##\u00a01\u00a0\u00b7\u00a0Parameters\n",
     "Adjust `STRATEGY` for your trading pair and modify `PORT_API` if 8000 is occupied."
-  ]
+   ]
   },
   {
    "cell_type": "code",
@@ -127,6 +127,17 @@
     "##\u00a04\u00a0\u00b7\u00a0Explore the trace\u2011graph \u2728\n",
     "Open [http://localhost:8088](http://localhost:8088) in your browser to watch\n",
     "the planner emit decisions and tool\u2011calls in real time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "open_graph",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import IFrame, display\n",
+    "display(IFrame('http://localhost:8088', width='100%', height=500))\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add inline trace-graph display cell to the finance notebook
- note inline view in demo README

## Testing
- `python -m unittest discover tests` *(fails: demo shell scripts not executable)*