### PR TITLE
Add Colab notebook for alpha_agi_business_v1 demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -2,6 +2,7 @@
 <h1 align="center">
  Large‑Scale α‑AGI Business 👁️✨ <sup><code>$AGIALPHA</code></sup>
 </h1>
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb)
 
 <p align="center">
  <b>Proof‑of‑Alpha 🚀 — an autonomous business entity that finds, exploits & compounds live market alpha<br/>

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Alpha-AGI Business v1 \u2022 Colab Notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run a minimal **Alpha-Factory** orchestrator. Works fully offline or upgrades automatically when `OPENAI_API_KEY` is set."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 \u00b7 Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "%%bash\nif [ ! -d AGI-Alpha-Agent-v0 ]; then\n  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\nfi\ncd AGI-Alpha-Agent-v0\npip -q install fastapi uvicorn requests openai_agents"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 \u00b7 (Optional) Configure your OpenAI API key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import os, getpass\nos.environ['OPENAI_API_KEY'] = getpass.getpass('Enter OpenAI API key (leave blank for offline): ')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 \u00b7 Launch orchestrator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import subprocess, sys, time, requests\nfrom IPython.display import display, IFrame\nroot = 'AGI-Alpha-Agent-v0/alpha_factory_v1'\nproc = subprocess.Popen([sys.executable, '-m', 'alpha_factory_v1.backend.orchestrator', '--dev'], cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)\nfor _ in range(40):\n    try:\n        if requests.get('http://localhost:8000/healthz').status_code == 200:\n            break\n    except Exception:\n        time.sleep(0.5)\ndisplay(IFrame(src='http://localhost:8000/docs', width='100%', height=600))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 \u00b7 Post a demo alpha job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import requests, json\njob = {\n    'agent': 'planning',\n    'pair': 'LME:HG/COMEX:HG',\n    'note': 'Deploy copper spread arbitrage strategy'\n}\nresp = requests.post('http://localhost:8000/agent/planning/trigger', json=job)\nprint(resp.status_code, resp.text)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 \u00b7 Graceful shutdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "proc.terminate(); print('\u2705 Orchestrator stopped')"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- provide Colab notebook for the `alpha_agi_business_v1` demo
- link the notebook from its README for easy access

## Testing
- `pytest` *(fails: No module named pytest)*