### PR TITLE
Improve meta-agentic demo notebook

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
@@ -123,6 +123,8 @@ streamlit run ui/lineage_app.py      # provenance graph
 streamlit run ui/alpha_monitor.py     # live alpha dashboard
 ```
 
+For a **one‑click** experience, open [`colab_meta_agentic_agi_v3.ipynb`](colab_meta_agentic_agi_v3.ipynb) on Colab and run each cell in order.
+
 *Hardware:* CPU‑only works (llama‑cpp 4‑bit); GPU speeds things up. 8 GB RAM minimum.
 
 ---

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/colab_meta_agentic_agi_v3.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/colab_meta_agentic_agi_v3.ipynb
@@ -13,6 +13,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Note:** This Colab downloads the repository, runs a quick environment check, and then launches the meta-agentic search demo. No API key is required, but you can set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` to enable frontier models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1 \u00b7 Clone repository & install dependencies"
    ]
   },
@@ -22,6 +29,13 @@
    "metadata": {},
    "outputs": [],
    "source": "%%bash --no-stderr\nif [[ ! -d AGI-Alpha-Agent-v0 ]]; then\n  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git -q\nfi\ncd AGI-Alpha-Agent-v0\npip -q install -r requirements.txt\ncd alpha_factory_v1/demos/meta_agentic_agi_v3\npip -q install streamlit pandas streamlit-autorefresh altair"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "!python -m alpha_factory_v1.demos.validate_demos --min-lines 5 --require-code-block"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -49,7 +63,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "!python meta_agentic_agi_demo_v3.py --gens 6 --provider mistral:7b-instruct.gguf"
+   "source": [
+    "!python meta_agentic_agi_demo_v3.py --gens 6 --provider mistral:7b-instruct.gguf --mode cli"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- update meta-agentic README with a direct Colab link
- enhance Colab notebook with environment note, validation step and CLI run options

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*