### PR TITLE
Improve Macro-Sentinel notebook UX

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
+++ b/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
@@ -165,8 +165,12 @@
     "threading.Thread(target=_tail, daemon=True).start()\n",
     "\n",
     "print('\u23f3 Waiting for Gradio tunnel...')\n",
-    "url = link_q.get()\n",
-    "print(f'\ud83c\udfaf Open dashboard \u2192 {url}')\n"
+    "try:\n",
+    "    url = link_q.get(timeout=120)\n",
+    "    from IPython.display import Markdown, display\n",
+    "    display(Markdown(f'### \u2705 Dashboard ready: [Open \u2197]({url})'))\n",
+    "except queue.Empty:\n",
+    "    print('\u26a0\ufe0f Tunnel timeout')\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- enhance the Colab demo for Macro-Sentinel
- show dashboard link directly in notebook output
- handle tunnel timeout gracefully

## Testing
- `python -m unittest tests.test_macro_sentinel`
