### PR TITLE
Improve environment checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Cells with \(Δ\mathcal F < 0\) glow 🔵 on Grafana; Ω‑Agents race to harves
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
 ./quickstart.sh --preflight   # optional environment check
+python check_env.py           # verify test dependencies
 ./quickstart.sh               # creates venv, installs deps, launches
 # open the docs in your browser
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -100,6 +100,9 @@ def main() -> None:
     ok &= check_docker_compose()
     ok &= check_pkg('openai')
     ok &= check_pkg('openai_agents')
+    # Ensure local dev environment can run automated tests
+    ok &= check_pkg('pytest')
+    ok &= check_pkg('prometheus_client')
     ensure_dir(MEM_DIR)
 
     for key in ('OPENAI_API_KEY', 'ANTHROPIC_API_KEY'):

--- a/check_env.py
+++ b/check_env.py
@@ -1,0 +1,22 @@
+import importlib.util
+import sys
+
+REQUIRED = [
+    'pytest',
+    'prometheus_client',
+]
+
+def main() -> int:
+    missing = []
+    for pkg in REQUIRED:
+        if importlib.util.find_spec(pkg) is None:
+            missing.append(pkg)
+    if missing:
+        print('Missing packages:', ', '.join(missing))
+        print('Install with: pip install -r requirements.txt')
+        return 1
+    print('Environment OK')
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `check_env.py` for verifying local test requirements
- extend preflight checks to ensure `pytest` and `prometheus_client` are installed
- mention `check_env.py` in the quickstart steps

## Testing
- `python check_env.py`
- `python alpha_factory_v1/scripts/preflight.py | tail -n 5`
- `python -m pytest` *(fails: No module named pytest)*