### PR TITLE
Improve MuZero Planning demo

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -87,7 +87,8 @@ python -m alpha_factory_v1.demos.muzero_planning
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb)
 
 Colab spins up the same dashboard via an ngrok tunnel — handy when Docker isn’t.
-It also runs a short unit test so you know the environment is ready before launching the demo.
+It installs the tiny MuZero package, runs a quick sanity test and opens a shareable link.
+Two extra cells let you tweak the Gym environment, port number and gracefully stop the demo.
 
 ---
 

--- a/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
+++ b/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
@@ -1,15 +1,15 @@
 {
- "cells": [
+"cells": [
   {
    "cell_type": "markdown",
    "id": "ecfd703e",
    "metadata": {},
    "source": [
     "# MuZero Planning Demo \u2013 Colab\n",
-    "Experience MuZero-style planning with a lightweight agent. Run the cells below and an interactive dashboard will appear.\n",
+    "Experience MuZero-style planning in seconds. Run each cell to install dependencies, test the environment and launch a shareable dashboard.\n",
     "\n",
-    "Optionally set your **OpenAI API key** to enable narrated explanations; without it the demo stays fully offline."
-   ]
+    "Add your **OpenAI API key** if you want narrated moves; otherwise Mixtral runs locally for a 100% offline demo."
+  ]
   },
   {
    "cell_type": "code",
@@ -20,35 +20,51 @@
    "source": [
     "# Install core dependencies\n",
     "!pip -q install \"torch>=2.1\" gymnasium[classic-control] gradio openai_agents pytest\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "881ead00",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+  ]
+ },
+ {
+  "cell_type": "code",
+  "execution_count": null,
+  "id": "881ead00",
+  "metadata": {},
+  "outputs": [],
+  "source": [
     "# Clone Alpha\u2011Factory repository\n",
     "!git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
     "%cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
+  ]
+ },
+ {
+  "cell_type": "code",
+  "metadata": {},
+  "execution_count": null,
+  "outputs": [],
+  "source": [
     "# Run quick sanity tests (optional)\n",
     "!pytest -q tests/test_muzero_planning.py\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0afcf7b6",
-   "metadata": {},
+  ]
+ },
+ {
+  "cell_type": "code",
+  "execution_count": null,
+  "id": "config-env",
+  "metadata": {},
+  "outputs": [],
+  "source": [
+    "# Optional environment settings\n",
+    "MUZERO_ENV_ID = 'CartPole-v1'  # change to try other Gym tasks\n",
+    "HOST_PORT = 7861\n",
+    "import os\n",
+    "os.environ['MUZERO_ENV_ID'] = MUZERO_ENV_ID\n",
+    "os.environ['HOST_PORT'] = str(HOST_PORT)\n",
+    "print(f'Environment: {MUZERO_ENV_ID}, dashboard \→ http://localhost:{HOST_PORT}')"
+  ]
+ },
+ {
+  "cell_type": "code",
+  "execution_count": null,
+  "id": "0afcf7b6",
+  "metadata": {},
    "outputs": [],
    "source": [
     "# \ud83d\udc49\u00a0OPTIONAL: set your OpenAI key for commentary\n",
@@ -74,10 +90,23 @@
     "except KeyboardInterrupt:\n",
     "    process.send_signal(signal.SIGINT)\n",
     "    process.wait()\n"
-   ]
-  }
- ],
- "metadata": {
+  ]
+ },
+ {
+  "cell_type": "code",
+  "execution_count": null,
+  "id": "shutdown",
+  "metadata": {},
+  "outputs": [],
+  "source": [
+    "# \u23F9\uFE0F Stop the MuZero dashboard\n",
+    "process.send_signal(signal.SIGINT)\n",
+    "process.wait()\n",
+    "print('MuZero demo stopped.')"
+  ]
+ }
+],
+"metadata": {
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
## Summary
- expand Colab notebook with environment configuration and stop cell
- document extra notebook features in README
- make demo script executable

## Testing
- `PYTHONPATH=. python tests/test_muzero_planning.py`