### PR TITLE
Enhance omni demo with alpha stub

### DIFF
--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -19,6 +19,16 @@ pip install --no-index --find-links /path/to/wheels -r requirements.txt
 
 Ensure `pytest` and `prometheus_client` are present so the built-in tests and
 metrics exporter function correctly.
+### Quick Alpha Discovery
+
+Run the lightweight **alpha_discovery_stub.py** to generate example cross-industry opportunities entirely offline:
+
+```bash
+python alpha_discovery_stub.py
+```
+
+The script logs the selected opportunity to `omni_alpha_log.json` for later reference.
+
 
 
 ## Use Case Selection & Rationale

--- a/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Simple offline alpha discovery stub.
+
+This script showcases how the OMNI-Factory demo might surface
+cross-industry "alpha" opportunities without any external
+services. It randomly selects a scenario from an internal list and
+logs it to stdout. The intent is purely illustrative.
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+SAMPLE_ALPHA = [
+    {
+        "sector": "Energy",
+        "opportunity": "Battery storage arbitrage between solar overproduction and evening peak demand",
+    },
+    {
+        "sector": "Supply Chain",
+        "opportunity": "Reroute shipping from congested port to alternate harbor to cut delays",
+    },
+    {
+        "sector": "Finance",
+        "opportunity": "Hedge currency exposure using futures due to predicted FX volatility",
+    },
+    {
+        "sector": "Manufacturing",
+        "opportunity": "Optimize machine maintenance schedule to reduce unplanned downtime",
+    },
+]
+
+LEDGER = Path(__file__).with_name("omni_alpha_log.json")
+
+
+def discover_alpha() -> dict:
+    """Return a randomly selected alpha opportunity."""
+    pick = random.choice(SAMPLE_ALPHA)
+    LEDGER.write_text(json.dumps(pick, indent=2))
+    return pick
+
+
+def main() -> None:
+    alpha = discover_alpha()
+    print("Discovered alpha:")
+    print(json.dumps(alpha, indent=2))
+    print(f"Logged to {LEDGER}")
+
+
+if __name__ == "__main__":
+    main()

--- a/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
+++ b/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
@@ -144,6 +144,15 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "%%bash\ncd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/omni_factory_demo\npython alpha_discovery_stub.py\ncat omni_alpha_log.json\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "!pytest -q"
    ]
   }


### PR DESCRIPTION
## Summary
- add lightweight `alpha_discovery_stub.py` for offline alpha examples
- document stub usage in the omni demo README
- run the stub from the Colab notebook

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*