### PR TITLE
Improve omni demo alpha discovery

### DIFF
--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -21,13 +21,17 @@ Ensure `pytest` and `prometheus_client` are present so the built-in tests and
 metrics exporter function correctly.
 ### Quick Alpha Discovery
 
-Run the lightweight **alpha_discovery_stub.py** to generate example cross-industry opportunities entirely offline:
+Run the lightweight **alpha_discovery_stub.py** to generate example cross-industry opportunities entirely offline. It now supports a tiny CLI:
 
 ```bash
-python alpha_discovery_stub.py
+# list all builtin samples
+python alpha_discovery_stub.py --list
+
+# record two random picks with a deterministic seed
+python alpha_discovery_stub.py -n 2 --seed 42
 ```
 
-The script logs the selected opportunity to `omni_alpha_log.json` for later reference.
+The script logs the selected opportunity (unless `--no-log` is used) to `omni_alpha_log.json` for later reference.
 
 
 

--- a/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
@@ -1,52 +1,60 @@
 #!/usr/bin/env python3
-"""Simple offline alpha discovery stub.
+"""Offline alpha discovery stub with minimal CLI.
 
-This script showcases how the OMNI-Factory demo might surface
-cross-industry "alpha" opportunities without any external
-services. It randomly selects a scenario from an internal list and
-logs it to stdout. The intent is purely illustrative.
+This script illustrates how the OMNI-Factory demo might surface
+cross-industry "alpha" opportunities without external services.
+It can list predefined scenarios or log a random selection to a
+JSON file. All functionality works offline.
 """
 from __future__ import annotations
 
+import argparse
 import json
 import random
 from pathlib import Path
+from typing import List, Dict
 
-SAMPLE_ALPHA = [
-    {
-        "sector": "Energy",
-        "opportunity": "Battery storage arbitrage between solar overproduction and evening peak demand",
-    },
-    {
-        "sector": "Supply Chain",
-        "opportunity": "Reroute shipping from congested port to alternate harbor to cut delays",
-    },
-    {
-        "sector": "Finance",
-        "opportunity": "Hedge currency exposure using futures due to predicted FX volatility",
-    },
-    {
-        "sector": "Manufacturing",
-        "opportunity": "Optimize machine maintenance schedule to reduce unplanned downtime",
-    },
+SAMPLE_ALPHA: List[Dict[str, str]] = [
+    {"sector": "Energy", "opportunity": "Battery storage arbitrage between solar overproduction and evening peak demand"},
+    {"sector": "Supply Chain", "opportunity": "Reroute shipping from congested port to alternate harbor to cut delays"},
+    {"sector": "Finance", "opportunity": "Hedge currency exposure using futures due to predicted FX volatility"},
+    {"sector": "Manufacturing", "opportunity": "Optimize machine maintenance schedule to reduce unplanned downtime"},
+    {"sector": "Biotech", "opportunity": "Repurpose existing drug for new therapeutic target"},
+    {"sector": "Agriculture", "opportunity": "Precision irrigation to save water during drought conditions"},
+    {"sector": "Retail", "opportunity": "Dynamic pricing to clear excess seasonal inventory"},
+    {"sector": "Transportation", "opportunity": "Last-mile delivery optimization with electric micro-vehicles"},
 ]
 
 LEDGER = Path(__file__).with_name("omni_alpha_log.json")
 
 
-def discover_alpha() -> dict:
-    """Return a randomly selected alpha opportunity."""
-    pick = random.choice(SAMPLE_ALPHA)
-    LEDGER.write_text(json.dumps(pick, indent=2))
-    return pick
+def discover_alpha(num: int = 1, *, seed: int | None = None) -> List[Dict[str, str]]:
+    """Return ``num`` randomly selected opportunities."""
+    if seed is not None:
+        random.seed(seed)
+    picks = [random.choice(SAMPLE_ALPHA) for _ in range(max(1, num))]
+    LEDGER.write_text(json.dumps(picks[0] if num == 1 else picks, indent=2))
+    return picks
 
 
-def main() -> None:
-    alpha = discover_alpha()
-    print("Discovered alpha:")
-    print(json.dumps(alpha, indent=2))
-    print(f"Logged to {LEDGER}")
+def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapper
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("-n", "--num", type=int, default=1, help="number of opportunities to sample")
+    p.add_argument("--list", action="store_true", help="list all sample opportunities and exit")
+    p.add_argument("--seed", type=int, help="seed RNG for reproducible output")
+    p.add_argument("--no-log", action="store_true", help="do not write to ledger")
+    args = p.parse_args(argv)
+
+    if args.list:
+        print(json.dumps(SAMPLE_ALPHA, indent=2))
+        return
+
+    picks = discover_alpha(args.num, seed=args.seed)
+    if args.no_log:
+        LEDGER.unlink(missing_ok=True)
+    print(json.dumps(picks[0] if args.num == 1 else picks, indent=2))
+    print(f"Logged to {LEDGER}" if not args.no_log else "Ledger write skipped")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/tests/test_alpha_discovery_stub.py
+++ b/tests/test_alpha_discovery_stub.py
@@ -1,0 +1,31 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+STUB = 'alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py'
+LEDGER = Path('alpha_factory_v1/demos/omni_factory_demo/omni_alpha_log.json')
+
+
+class TestAlphaDiscoveryStub(unittest.TestCase):
+    def test_list_option(self) -> None:
+        result = subprocess.run([sys.executable, STUB, '--list'], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0)
+        data = json.loads(result.stdout)
+        self.assertIsInstance(data, list)
+        self.assertGreaterEqual(len(data), 5)
+
+    def test_sampling(self) -> None:
+        if LEDGER.exists():
+            LEDGER.unlink()
+        result = subprocess.run([sys.executable, STUB, '-n', '2', '--seed', '1'], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0)
+        self.assertTrue(LEDGER.exists())
+        logged = json.loads(LEDGER.read_text())
+        self.assertIsInstance(logged, list)
+        self.assertEqual(len(logged), 2)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend alpha discovery stub with CLI and more sample opportunities
- document new usage options in demo README
- add unit tests for the discovery stub

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*
- `pip install pytest prometheus_client --quiet` *(fails: no route to host)*