### PR TITLE
Add discovery agent to alpha business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -145,6 +145,10 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 # launch demo (GPU optional)
 ./run_business_v1_demo.sh
 
+# the demo starts two stub agents:
+#   • **IncorporatorAgent** registers the business
+#   • **AlphaDiscoveryAgent** emits a placeholder market opportunity
+
 open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_copper_spread.json
 ```

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Alpha‑AGI Business v1 demo.
 
-Bootstraps a minimal Alpha‑Factory orchestrator with a single
-``IncorporatorAgent``. The demo runs fully offline but upgrades to cloud
-LLM tooling automatically when ``OPENAI_API_KEY`` is present.
+Bootstraps a minimal Alpha‑Factory orchestrator with two stub agents.
+The demo operates fully offline but upgrades to cloud LLM tooling
+automatically when ``OPENAI_API_KEY`` is present.
 """
 from __future__ import annotations
 
@@ -26,8 +26,22 @@ class IncorporatorAgent(AgentBase):
         await self.publish("alpha.business", {"msg": "company incorporated"})
 
 
+class AlphaDiscoveryAgent(AgentBase):
+    """Stub agent that emits a placeholder alpha opportunity."""
+
+    NAME = "alpha_discovery"
+    CAPABILITIES = ["discover"]
+    CYCLE_SECONDS = 120
+    __slots__ = ()
+
+    async def step(self) -> None:
+        await self.publish(
+            "alpha.discovery", {"alpha": "cross-market synergy identified"}
+        )
+
+
 def register_demo_agents() -> None:
-    """Register the demo agent with the framework."""
+    """Register built-in demo agents with the framework."""
 
     register_agent(
         AgentMetadata(
@@ -35,6 +49,15 @@ def register_demo_agents() -> None:
             cls=IncorporatorAgent,
             version="1.0.0",
             capabilities=IncorporatorAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=AlphaDiscoveryAgent.NAME,
+            cls=AlphaDiscoveryAgent,
+            version="1.0.0",
+            capabilities=AlphaDiscoveryAgent.CAPABILITIES,
         )
     )
 


### PR DESCRIPTION
## Summary
- expand alpha_agi_business_v1 demo with a new `AlphaDiscoveryAgent`
- document the new agents in the demo README

## Testing
- `pytest -q` *(fails: command not found)*