### PR TITLE
Improve self-healing repo demo importability

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
+++ b/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
@@ -27,7 +27,10 @@ All file‑system mutations stay **inside `repo_path`** for container safety.
 from __future__ import annotations
 import subprocess, tempfile, pathlib, shutil, os, textwrap
 from typing import List, Tuple
-from openai_agents import OpenAIAgent
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid hard dependency unless actually used
+    from openai_agents import OpenAIAgent
 
 # ─────────────────────────── helpers ─────────────────────────────────────────
 def _run(cmd: List[str], cwd: str) -> Tuple[int, str]:
@@ -115,6 +118,10 @@ if __name__ == "__main__":
     parser.add_argument("--repo", default=".", help="Repository path")
     args = parser.parse_args()
 
+    try:
+        from openai_agents import OpenAIAgent
+    except ImportError as e:
+        raise SystemExit("openai_agents package required. Install dependencies via requirements.txt") from e
     llm = OpenAIAgent(
         model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
         api_key=os.getenv("OPENAI_API_KEY"),

--- a/tests/test_self_healing_patcher.py
+++ b/tests/test_self_healing_patcher.py
@@ -25,7 +25,7 @@ class TestPatcherCore(unittest.TestCase):
                 fh.write("hello\n")
             patch = """--- a/hello.txt
 +++ b/hello.txt
-@@
+@@ -1 +1 @@
 -hello
 +hello world
 """


### PR DESCRIPTION
## Summary
- relax openai_agents dependency in `patcher_core`
- make CLI fail gracefully when openai_agents is missing
- adjust demo test patch format for compatibility

## Testing
- `python -m unittest tests.test_self_healing_patcher -v`