### PR TITLE
Enhance governance demo with agentic summary

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -102,6 +102,14 @@ illustrating convergence toward the cooperative fixed point when the
 discount factor `δ` is at least 0.8. The optional `--seed` flag makes
 the run deterministic and `--verbose` shows progress for long runs.
 
+Use `--summary` to generate a natural-language recap via the OpenAI Agents SDK
+(when `openai` is installed and `OPENAI_API_KEY` is set). Without network
+access, the script falls back to a local summary string.
+
+```bash
+governance-sim --agents 500 --summary
+```
+
 ---
 
 ### 10 · Quick Start & Troubleshooting

--- a/alpha_factory_v1/demos/solving_agi_governance/__init__.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/__init__.py
@@ -1,5 +1,5 @@
 """Minimal support package for the governance demo."""
 
-from .governance_sim import main, run_sim
+from .governance_sim import main, run_sim, summarise_with_agent
 
-__all__ = ["main", "run_sim"]
+__all__ = ["main", "run_sim", "summarise_with_agent"]

--- a/tests/test_governance_sim.py
+++ b/tests/test_governance_sim.py
@@ -1,0 +1,15 @@
+import unittest
+from alpha_factory_v1.demos.solving_agi_governance import run_sim, summarise_with_agent
+
+class TestGovernanceSim(unittest.TestCase):
+    def test_basic_convergence(self) -> None:
+        coop = run_sim(agents=50, rounds=500, delta=0.85, stake=2.5, seed=1)
+        self.assertGreater(coop, 0.7)
+
+    def test_summary_offline(self) -> None:
+        text = summarise_with_agent(0.8, agents=10, rounds=100, delta=0.9, stake=1.0)
+        self.assertIsInstance(text, str)
+        self.assertIn("mean cooperation", text)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend governance simulator with optional `--summary` flag
- add LLM-powered summary helper with offline fallback
- expose helper in package API
- document new usage in README
- provide unit tests for simulator and summary

## Testing
- `python -m unittest tests.test_governance_sim`
- `python -m unittest discover -s tests -p 'test_*.py' -v` *(fails: demo shell scripts not executable)*