### PR TITLE
Add OpenAI Agents bridge for business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -155,7 +155,16 @@ open http://localhost:7878      # Dashboard SPA
 
 Or open `colab_alpha_agi_business_v1_demo.ipynb` to run everything in Colab.
 
-*No Docker?* 
+### 🤖 OpenAI Agents bridge
+
+Expose the business demo via the OpenAI Agents SDK:
+
+```bash
+python openai_agents_bridge.py
+# → http://localhost:5001/v1/agents
+```
+
+*No Docker?*
 `bash <(curl -sL https://get.alpha-factory.ai/business_demo.sh)` boots an ephemeral VM (CPU‑only mode).
 
 ---

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -1,0 +1,48 @@
+"""OpenAI Agents SDK bridge for the alpha_agi_business_v1 demo.
+
+This utility registers a small helper agent that interacts with the
+local orchestrator. It works offline when no API key is configured.
+"""
+from __future__ import annotations
+
+import requests
+from openai_agents import Agent, AgentRuntime, Tool
+
+HOST = "http://localhost:8000"
+
+
+@Tool(name="list_agents", description="List active orchestrator agents")
+async def list_agents() -> list[str]:
+    resp = requests.get(f"{HOST}/agents", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@Tool(name="trigger_discovery", description="Trigger the AlphaDiscoveryAgent")
+async def trigger_discovery() -> str:
+    resp = requests.post(f"{HOST}/agent/alpha_discovery/trigger", timeout=5)
+    resp.raise_for_status()
+    return "alpha_discovery queued"
+
+
+class BusinessAgent(Agent):
+    """Tiny agent exposing orchestrator helper tools."""
+
+    name = "business_helper"
+    tools = [list_agents, trigger_discovery]
+
+    async def policy(self, obs, ctx):  # type: ignore[override]
+        if isinstance(obs, dict) and obs.get("action") == "discover":
+            return await self.tools.trigger_discovery()
+        return await self.tools.list_agents()
+
+
+def main() -> None:
+    runtime = AgentRuntime(api_key=None)
+    runtime.register(BusinessAgent())
+    print("Registered BusinessAgent with runtime")
+    runtime.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/test_business_notebook.py
+++ b/tests/test_business_notebook.py
@@ -1,0 +1,15 @@
+import json
+import unittest
+from pathlib import Path
+
+class TestBusinessNotebook(unittest.TestCase):
+    def test_notebook_valid(self) -> None:
+        nb_path = Path("alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb")
+        self.assertTrue(nb_path.exists(), "Notebook missing")
+        data = json.loads(nb_path.read_text(encoding="utf-8"))
+        self.assertIn("cells", data)
+        self.assertIn("nbformat", data)
+        self.assertGreaterEqual(data.get("nbformat", 0), 4)
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -13,5 +13,10 @@ class TestOpenAIBridge(unittest.TestCase):
         path = Path('alpha_factory_v1/demos/meta_agentic_agi/openai_agents_bridge.py')
         py_compile.compile(path, doraise=True)
 
+    def test_business_bridge_compiles(self):
+        """Ensure the business demo bridge compiles."""
+        path = Path('alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py')
+        py_compile.compile(path, doraise=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add OpenAI Agents bridge helper for `alpha_agi_business_v1`
- document bridge usage in the business demo README
- verify business demo notebook via new test
- extend existing bridge tests

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`