### PR TITLE
Improve Era-of-Experience robustness

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -90,7 +90,10 @@ declare -A urls=(
   [edu_progress.csv]  =https://raw.githubusercontent.com/MontrealAI/demo-assets/main/edu_progress.csv
 )
 for f in "${!urls[@]}"; do
-  curl -sfL "${urls[$f]}" -o "$offline_dir/$f"
+  if ! curl -sfL "${urls[$f]}" -o "$offline_dir/$f"; then
+    warn "Failed downloading $f – using empty placeholder"
+    : > "$offline_dir/$f"
+  fi
 done
 
 ################################# profiles ####################################

--- a/tests/test_era_experience.py
+++ b/tests/test_era_experience.py
@@ -1,0 +1,28 @@
+import unittest
+import asyncio
+
+from alpha_factory_v1.demos.era_of_experience import agent_experience_entrypoint as demo
+from alpha_factory_v1.demos.era_of_experience import reward_backends
+
+class TestEraOfExperience(unittest.TestCase):
+    def test_experience_stream_yields_event(self) -> None:
+        async def get_event():
+            gen = demo.experience_stream()
+            return await anext(gen)
+        evt = asyncio.run(get_event())
+        self.assertIsInstance(evt, dict)
+        self.assertIn("kind", evt)
+        self.assertIn("payload", evt)
+
+    def test_reward_backends_produce_floats(self) -> None:
+        names = reward_backends.list_rewards()
+        self.assertTrue(names)
+        for name in names:
+            val = reward_backends.reward_signal(name, {}, None, {})
+            self.assertIsInstance(val, float)
+            self.assertGreaterEqual(val, 0.0)
+            self.assertLessEqual(val, 1.0)
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- make offline asset downloads in `run_experience_demo.sh` tolerant to network errors
- add regression tests for `era_of_experience` demo

## Testing
- `python -m alpha_factory_v1.scripts.run_tests tests`