### PR TITLE
Add cross-industry alpha discovery helper

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -54,6 +54,14 @@ Click the badge above or run:
 open https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb
 ```
 
+### Quick Alpha Discovery
+Generate offline sample opportunities with:
+```bash
+python cross_alpha_discovery_stub.py --list
+```
+Use `-n 3 --seed 42` to log three deterministic picks to
+`cross_alpha_log.json`. If `OPENAI_API_KEY` is set, the tool queries an LLM for fresh ideas.
+
 
 ---
 

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Cross‑Industry alpha discovery helper.
+
+This minimal command‑line tool surfaces potential "alpha" opportunities
+across industries. It works **fully offline** using a small sample set but
+will query OpenAI when an ``OPENAI_API_KEY`` is configured for live ideas.
+Discovered items are logged to ``cross_alpha_log.json`` by default.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import os
+import contextlib
+from pathlib import Path
+from typing import List, Dict
+
+with contextlib.suppress(ModuleNotFoundError):
+    import openai  # type: ignore
+
+SAMPLE_ALPHA: List[Dict[str, str]] = [
+    {"sector": "Energy", "opportunity": "Battery storage arbitrage between solar overproduction and evening peak demand"},
+    {"sector": "Supply Chain", "opportunity": "Reroute shipping from congested port to alternate harbor to cut delays"},
+    {"sector": "Finance", "opportunity": "Hedge currency exposure using futures due to predicted FX volatility"},
+    {"sector": "Manufacturing", "opportunity": "Optimize machine maintenance schedule to reduce unplanned downtime"},
+    {"sector": "Biotech", "opportunity": "Repurpose existing drug for new therapeutic target"},
+    {"sector": "Agriculture", "opportunity": "Precision irrigation to save water during drought conditions"},
+    {"sector": "Retail", "opportunity": "Dynamic pricing to clear excess seasonal inventory"},
+    {"sector": "Transportation", "opportunity": "Last-mile delivery optimization with electric micro-vehicles"},
+]
+
+DEFAULT_LEDGER = Path(__file__).with_name("cross_alpha_log.json")
+
+def _ledger_path(path: str | os.PathLike | None) -> Path:
+    if path:
+        return Path(path).expanduser().resolve()
+    env = os.getenv("CROSS_ALPHA_LEDGER")
+    if env:
+        return Path(env).expanduser().resolve()
+    return DEFAULT_LEDGER
+
+
+def discover_alpha(
+    num: int = 1,
+    *,
+    seed: int | None = None,
+    ledger: Path | None = None,
+) -> List[Dict[str, str]]:
+    """Return ``num`` opportunities and log to *ledger*.
+
+    If :mod:`openai` is available and ``OPENAI_API_KEY`` is set, an LLM is used
+    to generate live ideas. Otherwise the built-in samples are randomly chosen.
+    """
+    if seed is not None:
+        random.seed(seed)
+    picks: List[Dict[str, str]] = []
+    if "openai" in globals() and os.getenv("OPENAI_API_KEY"):
+        prompt = (
+            "List "
+            f"{num} short cross-industry investment opportunities as JSON"
+        )
+        try:
+            resp = openai.ChatCompletion.create(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            picks = json.loads(resp.choices[0].message.content)  # type: ignore[index]
+            if isinstance(picks, dict):
+                picks = [picks]
+        except Exception:
+            picks = []
+    if not picks:
+        picks = [random.choice(SAMPLE_ALPHA) for _ in range(max(1, num))]
+
+    (_ledger_path(ledger) if ledger else DEFAULT_LEDGER).write_text(
+        json.dumps(picks[0] if num == 1 else picks, indent=2)
+    )
+    return picks
+
+
+def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapper
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("-n", "--num", type=int, default=1, help="number of opportunities to sample")
+    p.add_argument("--list", action="store_true", help="list all sample opportunities and exit")
+    p.add_argument("--seed", type=int, help="seed RNG for reproducible output")
+    p.add_argument("--ledger", help="path to ledger JSON file")
+    p.add_argument("--no-log", action="store_true", help="do not write to ledger")
+    args = p.parse_args(argv)
+
+    if args.list:
+        print(json.dumps(SAMPLE_ALPHA, indent=2))
+        return
+
+    ledger = _ledger_path(args.ledger)
+    picks = discover_alpha(args.num, seed=args.seed, ledger=ledger)
+    if args.no_log:
+        ledger.unlink(missing_ok=True)
+    print(json.dumps(picks[0] if args.num == 1 else picks, indent=2))
+    print(f"Logged to {ledger}" if not args.no_log else "Ledger write skipped")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_cross_alpha_discovery.py
+++ b/tests/test_cross_alpha_discovery.py
@@ -1,0 +1,33 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+import tempfile
+
+STUB = 'alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py'
+
+class TestCrossAlphaDiscoveryStub(unittest.TestCase):
+    def test_list_option(self) -> None:
+        result = subprocess.run([sys.executable, STUB, '--list'], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0)
+        data = json.loads(result.stdout)
+        self.assertIsInstance(data, list)
+        self.assertGreaterEqual(len(data), 5)
+
+    def test_sampling(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = Path(tmp) / 'log.json'
+            result = subprocess.run(
+                [sys.executable, STUB, '-n', '2', '--seed', '1', '--ledger', str(ledger)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(ledger.exists())
+            logged = json.loads(ledger.read_text())
+            self.assertIsInstance(logged, list)
+            self.assertEqual(len(logged), 2)
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add cross_alpha_discovery_stub.py sample script
- document usage of the helper in the cross-industry README
- include unit tests for the new helper

## Testing
- `python -m unittest tests.test_cross_alpha_discovery`
- `python -m unittest tests.test_alpha_discovery_stub`
- `python -m unittest` *(fails: several demo scripts missing execute bits)*