### PR TITLE
Improve meta agentic notebook test

### DIFF
--- a/tests/test_meta_agentic_notebook.py
+++ b/tests/test_meta_agentic_notebook.py
@@ -3,15 +3,20 @@ import unittest
 from pathlib import Path
 
 class TestMetaAgenticNotebook(unittest.TestCase):
-    """Validate the meta_agentic_agi demo notebook."""
+    """Validate the shipped meta-agentic demo notebooks."""
 
-    def test_notebook_valid(self) -> None:
-        nb_path = Path("alpha_factory_v1/demos/meta_agentic_agi/colab_meta_agentic_agi.ipynb")
-        self.assertTrue(nb_path.exists(), "Notebook missing")
-        data = json.loads(nb_path.read_text(encoding="utf-8"))
+    def _check_notebook(self, path: Path) -> None:
+        self.assertTrue(path.exists(), f"Notebook missing: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
         self.assertIn("cells", data)
         self.assertIn("nbformat", data)
         self.assertGreaterEqual(data.get("nbformat", 0), 4)
+
+    def test_notebook_v1_valid(self) -> None:
+        self._check_notebook(Path("alpha_factory_v1/demos/meta_agentic_agi/colab_meta_agentic_agi.ipynb"))
+
+    def test_notebook_v2_valid(self) -> None:
+        self._check_notebook(Path("alpha_factory_v1/demos/meta_agentic_agi_v2/colab_meta_agentic_agi_v2.ipynb"))
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- test both versions of the meta-agentic demo notebook

## Testing
- `pytest -q tests/test_meta_agentic_notebook.py::TestMetaAgenticNotebook::test_notebook_v2_valid -q` *(fails: command not found)*