### PR TITLE
Add OpenAI Agents bridge for AI‑GA demo

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -84,6 +84,19 @@ python alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
 Set `OPENAI_API_KEY` in your environment to enable cloud models. Without
 it the demo falls back to the bundled offline mixtral model.
 
+### 🤖 OpenAI Agents bridge
+
+Expose the evolver to the **OpenAI Agents SDK** runtime:
+
+```bash
+python alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+```
+
+The bridge registers an `aiga_evolver` agent offering two tools:
+`evolve` (run N generations) and `best_alpha` (return the champion).
+It works offline by routing to the local Mixtral server when no API key
+is configured.
+
 ## 🔐 API authentication
 
 Export `AUTH_BEARER_TOKEN` to require a static token on every API request. For

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -1,0 +1,64 @@
+"""OpenAI Agents SDK bridge for the AI-GA Meta-Evolution demo.
+
+This script registers a minimal agent capable of driving the evolutionary
+loop via the OpenAI Agents runtime. It works fully offline when no
+``OPENAI_API_KEY`` is configured by falling back to the local Ollama
+instance started by ``run_aiga_demo.sh``.
+"""
+from __future__ import annotations
+
+import os
+from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
+
+from meta_evolver import MetaEvolver
+from curriculum_env import CurriculumEnv
+
+
+# ---------------------------------------------------------------------------
+# LLM setup -----------------------------------------------------------------
+# ---------------------------------------------------------------------------
+LLM = OpenAIAgent(
+    model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url=(None if os.getenv("OPENAI_API_KEY") else os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")),
+)
+
+# single MetaEvolver instance reused across tool invocations
+EVOLVER = MetaEvolver(env_cls=CurriculumEnv, llm=LLM)
+
+
+@Tool(name="evolve", description="Run N generations of evolution")
+async def evolve(generations: int = 1) -> str:
+    EVOLVER.run_generations(generations)
+    return EVOLVER.latest_log()
+
+
+@Tool(name="best_alpha", description="Return current best architecture")
+async def best_alpha() -> dict:
+    return {
+        "architecture": EVOLVER.best_architecture,
+        "fitness": EVOLVER.best_fitness,
+    }
+
+
+class EvolverAgent(Agent):
+    """Tiny agent exposing the meta-evolver tools."""
+
+    name = "aiga_evolver"
+    tools = [evolve, best_alpha]
+
+    async def policy(self, obs, ctx):  # type: ignore[override]
+        gens = int(obs.get("gens", 1)) if isinstance(obs, dict) else 1
+        await evolve(gens)
+        return await best_alpha()
+
+
+def main() -> None:
+    runtime = AgentRuntime(api_key=None)
+    runtime.register(EvolverAgent())
+    print("Registered EvolverAgent with runtime")
+    runtime.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -18,5 +18,10 @@ class TestOpenAIBridge(unittest.TestCase):
         path = Path('alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py')
         py_compile.compile(path, doraise=True)
 
+    def test_aiga_bridge_compiles(self):
+        """Ensure the AI-GA demo bridge compiles."""
+        path = Path('alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py')
+        py_compile.compile(path, doraise=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `openai_agents_bridge.py` to expose the AI‑GA demo via the OpenAI Agents SDK
- document the new bridge in the demo README
- test bridge compilation

## Testing
- `pytest tests/test_openai_bridge.py::TestOpenAIBridge::test_aiga_bridge_compiles -q` *(fails: command not found)*