### PR TITLE
Add docker launcher for business 3 demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ sequenceDiagram
 |1|`aiga_meta_evolution`|🧬|Agents *evolve* new agents; genetic tests auto‑score fitness.|Expands strategy space, surfacing fringe alpha.|`cd alpha_factory_v1/demos/aiga_meta_evolution && ./run_aiga_demo.sh`|
 |2|`alpha_agi_business_v1`|🏦|Auto‑incorporates a digital‑first company end‑to‑end.|Shows AGI turning ideas → registered business.|`./alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_demo.sh`|
 |3|`alpha_agi_business_2_v1`|🏗|Iterates business model with live market data RAG.|Continuous adaptation → durable competitive alpha.|`./alpha_factory_v1/demos/alpha_agi_business_2_v1/run_business_2_demo.sh`|
-|4|`alpha_agi_business_3_v1`|📊|Financial forecasting & fundraising agent swarm.|Optimises capital stack for ROI alpha.|`docker compose -f demos/docker-compose.business_3.yml up`|
+|4|`alpha_agi_business_3_v1`|📊|Financial forecasting & fundraising agent swarm.|Optimises capital stack for ROI alpha.|`./alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh`|
 |5|`alpha_agi_marketplace_v1`|🛒|Peer‑to‑peer agent marketplace simulating price discovery.|Validates micro‑alpha extraction via agent barter.|`docker compose -f demos/docker-compose.marketplace.yml up`|
 |6|`alpha_asi_world_model`|🌌|Scales MuZero‑style world‑model to an open‑ended grid‑world.|Stress‑tests anticipatory planning for ASI scenarios.|`docker compose -f demos/docker-compose.asi_world.yml up`|
 |7|`cross_industry_alpha_factory`|🌐|Full pipeline: ingest → plan → act across 4 verticals.|Proof that one orchestrator handles multi‑domain alpha.|`./alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh`|

--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -247,7 +247,7 @@ sequenceDiagram
 |1|`aiga_meta_evolution`|🧬|Agents *evolve* new agents; genetic tests auto‑score fitness.|Expands strategy space, surfacing fringe alpha.|`cd alpha_factory_v1/demos/aiga_meta_evolution && ./run_aiga_demo.sh`|
 |2|`alpha_agi_business_v1`|🏦|Auto‑incorporates a digital‑first company end‑to‑end.|Shows AGI turning ideas → registered business.|`./alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_demo.sh`|
 |3|`alpha_agi_business_2_v1`|🏗|Iterates business model with live market data RAG.|Continuous adaptation → durable competitive alpha.|`./alpha_factory_v1/demos/alpha_agi_business_2_v1/run_business_2_demo.sh`|
-|4|`alpha_agi_business_3_v1`|📊|Financial forecasting & fundraising agent swarm.|Optimises capital stack for ROI alpha.|`docker compose -f demos/docker-compose.business_3.yml up`|
+|4|`alpha_agi_business_3_v1`|📊|Financial forecasting & fundraising agent swarm.|Optimises capital stack for ROI alpha.|`./alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh`|
 |5|`alpha_agi_marketplace_v1`|🛒|Peer‑to‑peer agent marketplace simulating price discovery.|Validates micro‑alpha extraction via agent barter.|`docker compose -f demos/docker-compose.marketplace.yml up`|
 |6|`alpha_asi_world_model`|🌌|Scales MuZero‑style world‑model to an open‑ended grid‑world.|Stress‑tests anticipatory planning for ASI scenarios.|`docker compose -f demos/docker-compose.asi_world.yml up`|
 |7|`cross_industry_alpha_factory`|🌐|Full pipeline: ingest → plan → act across 4 verticals.|Proof that one orchestrator handles multi‑domain alpha.|`docker compose -f demos/docker-compose.cross_industry.yml up`|

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -270,6 +270,10 @@ python alpha_agi_business_3_v1.py --loglevel info
 ```
 If the **OpenAI Agents SDK** is installed, each cycle emits a concise LLM
 comment on the computed ΔG. Without it the demo uses an offline placeholder.
+You can also run the Dockerised version:
+```bash
+./run_business_3_demo.sh
+```
 
 ---
 

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Quick launcher for alpha_agi_business_3_v1
+set -euo pipefail
+
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
+root_dir="${script_dir%/*/*}"
+
+cd "$root_dir"
+
+command -v docker >/dev/null 2>&1 || { echo "❌ Docker is required"; exit 1; }
+
+image="alpha_business_v3:latest"
+
+docker build -t "$image" -f alpha_factory_v1/Dockerfile .
+docker run --rm -it -p 7860:7860 -e OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
+  "$image" python -m alpha_factory_v1.demos.alpha_agi_business_3_v1


### PR DESCRIPTION
## Summary
- add `run_business_3_demo.sh` for the alpha_agi_business_3_v1 demo
- update README tables to reference the new script
- document docker usage in demo README

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`