### PR TITLE
Enhance Era-of-Experience demo with alpha detection tool

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -136,6 +136,15 @@ from openai_agents import Tool
 async def place_trade(ticker:str, qty:int, side:str="BUY"): ...
 ```
 
+This demo ships with a minimal example:
+
+```python
+@Tool("detect_yield_curve_alpha", "Assess yield curve inversion using offline data.")
+async def detect_yield_curve_alpha_tool():
+    return {"alpha": detect_yield_curve_alpha()}
+```
+
+
 * **Cluster‑scale**
 
 ```bash

--- a/alpha_factory_v1/demos/era_of_experience/__init__.py
+++ b/alpha_factory_v1/demos/era_of_experience/__init__.py
@@ -1,1 +1,4 @@
 # Demo package
+from .alpha_detection import detect_yield_curve_alpha
+
+__all__ = ["detect_yield_curve_alpha"]

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -45,6 +45,8 @@ import uvicorn
 import gradio as gr
 from openai_agents import Agent, OpenAIAgent, Tool, memory
 
+from .alpha_detection import detect_yield_curve_alpha
+
 # ───────────────────────────── configuration ────────────────────────────────
 MODEL       = os.getenv("MODEL_NAME", "gpt-4o-mini")
 TEMP        = float(os.getenv("TEMPERATURE", "0.2"))
@@ -114,7 +116,13 @@ async def schedule_workout(duration_min: int = 30,
             f"{duration_min} min {focus} – warm-up · interval · cool-down"}
 
 
-TOOLS = [web_search, plan_meal, schedule_workout]
+@Tool("detect_yield_curve_alpha", "Assess yield curve inversion using offline data.")
+async def detect_yield_curve_alpha_tool() -> Dict[str, str]:
+    msg = detect_yield_curve_alpha()
+    return {"alpha": msg}
+
+
+TOOLS = [web_search, plan_meal, schedule_workout, detect_yield_curve_alpha_tool]
 
 # ─────────────────────────────── reward functions ───────────────────────────
 def _fitness_reward(evt: Dict[str, Any]) -> float:

--- a/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
@@ -1,0 +1,36 @@
+"""Alpha detection utilities for Era-of-Experience demo.
+
+This module demonstrates how one might detect simple 'alpha' signals
+from offline data samples. Currently it provides a helper analysing the
+U.S. Treasury yield curve to check for potential opportunities when the
+curve is inverted.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+# Path to offline sample within the repo
+_YIELD_CURVE_CSV = (
+    Path(__file__).resolve().parent.parent / "macro_sentinel" / "offline_samples" / "yield_curve.csv"
+)
+
+
+def detect_yield_curve_alpha() -> str:
+    """Return a short message describing the yield-curve state."""
+    try:
+        data = pd.read_csv(_YIELD_CURVE_CSV)
+    except FileNotFoundError:
+        return "offline data missing"
+
+    spread = float(data["10y"][0]) - float(data["3m"][0])
+    return (
+        f"Yield curve spread {spread:.2f} – consider long bonds"
+        if spread < 0
+        else f"Yield curve spread {spread:.2f} – curve normal"
+    )
+
+
+__all__ = ["detect_yield_curve_alpha"]

--- a/tests/test_alpha_detection.py
+++ b/tests/test_alpha_detection.py
@@ -1,0 +1,14 @@
+import unittest
+
+from alpha_factory_v1.demos.era_of_experience import alpha_detection
+
+
+class TestAlphaDetection(unittest.TestCase):
+    def test_detect_yield_curve_alpha(self) -> None:
+        msg = alpha_detection.detect_yield_curve_alpha()
+        self.assertIsInstance(msg, str)
+        self.assertTrue("Yield curve spread" in msg)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `alpha_detection.py` with yield curve alpha helper
- expose helper in demo `__init__`
- integrate new tool in agent entrypoint
- document tool usage in README
- provide unit test for detection logic

## Testing
- `python -m py_compile alpha_factory_v1/demos/era_of_experience/alpha_detection.py`
- `python -m py_compile alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py`
- `pytest` *(fails: command not found)*