### PR TITLE
Improve finance_alpha demo

### DIFF
--- a/alpha_factory_v1/demos/finance_alpha/README.md
+++ b/alpha_factory_v1/demos/finance_alpha/README.md
@@ -52,6 +52,24 @@ Run the cells to spin up Alpha‑Factory and render positions & P&L as
 Pandas tables right inside the notebook. Tweak `STRATEGY` or `PORT_API`
 in the parameter cell if you need a custom pair or port.
 
+## 🧩 Programmatic control
+
+The container exposes a standard **OpenAI Agents** endpoint. After the
+notebook or CLI demo has launched you can drive the `FinanceAgent`
+directly from Python:
+
+```python
+from openai.agents import AgentRuntime
+rt = AgentRuntime(base_url="http://localhost:8000", api_key=None)
+fin = rt.get_agent("FinanceAgent")
+print("Alpha signals:", fin.alpha_signals())
+```
+
+If the `openai-agents` package is missing the optional
+`agent_control.py` script falls back to plain REST calls. When
+`ADK_MESH=1` is set the agent registers on the Google ADK mesh for
+cross‑agent discovery.
+
 ---
 
 

--- a/alpha_factory_v1/demos/finance_alpha/agent_control.py
+++ b/alpha_factory_v1/demos/finance_alpha/agent_control.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Minimal helper to drive the FinanceAgent programmatically.
+
+This script uses the OpenAI Agents SDK when available and falls back to
+plain REST requests otherwise. It targets a running Alpha-Factory demo
+on ``localhost``.
+"""
+
+from __future__ import annotations
+import os
+import json
+import sys
+from typing import Any
+
+import requests
+
+PORT = int(os.getenv("PORT_API", "8000"))
+BASE = f"http://localhost:{PORT}"
+
+
+def _rest_positions() -> Any:
+    """Return positions via the REST fallback."""
+    return requests.get(f"{BASE}/api/finance/positions", timeout=3).json()
+
+
+def _rest_pnl() -> Any:
+    """Return P&L via the REST fallback."""
+    return requests.get(f"{BASE}/api/finance/pnl", timeout=3).json()
+
+
+if __name__ == "__main__":
+    try:
+        from openai.agents import AgentRuntime
+
+        rt = AgentRuntime(base_url=BASE, api_key=None)
+        fin = rt.get_agent("FinanceAgent")
+        print("Alpha signals:", fin.alpha_signals())
+        print("Portfolio book:", fin.portfolio_state())
+    except Exception as exc:  # noqa: BLE001
+        print("OpenAI Agents SDK unavailable – using REST fallback:", exc)
+        print("Positions:", json.dumps(_rest_positions(), indent=2))
+        print("PnL:", json.dumps(_rest_pnl(), indent=2))
+    sys.exit(0)

--- a/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
+++ b/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
@@ -106,23 +106,50 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca19600f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+  "id": "ca19600f",
+  "metadata": {},
+  "outputs": [],
+  "source": [
     "import pandas as pd, requests, IPython.display as disp\n",
     "base = f\"http://localhost:{PORT_API}/api/finance\"\n",
     "positions = requests.get(base + \"/positions\").json()\n",
     "pnl = requests.get(base + \"/pnl\").json()\n",
     "\n",
     "disp.display(pd.json_normalize(positions).style.set_caption(\"Current Positions\"))\n",
-    "disp.display(pd.json_normalize(pnl).style.set_caption(\"P&L (USD)\"))\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "41a7bd2c",
-   "metadata": {},
+   "disp.display(pd.json_normalize(pnl).style.set_caption(\"P&L (USD)\"))\n"
+  ]
+ },
+ {
+  "cell_type": "markdown",
+  "id": "openai_sdk_demo",
+  "metadata": {},
+  "source": [
+   "## 4a \u00b7 Quick SDK demo\n",
+   "Call the FinanceAgent via the OpenAI Agents SDK (falls back to REST)."
+  ]
+ },
+ {
+  "cell_type": "code",
+  "execution_count": null,
+  "id": "sdk_demo",
+  "metadata": {},
+  "outputs": [],
+  "source": [
+   "try:\n",
+   "    from openai.agents import AgentRuntime\n",
+   "    rt = AgentRuntime(base_url=f'http://localhost:{PORT_API}', api_key=None)\n",
+   "    fin = rt.get_agent('FinanceAgent')\n",
+   "    print(fin.alpha_signals())\n",
+   "except Exception as e:\n",
+   "    import requests, json\n",
+   "    print('SDK unavailable, using REST \u2192 positions:')\n",
+   "    print(json.dumps(requests.get(base + '/positions').json(), indent=2))\n"
+  ]
+ },
+ {
+  "cell_type": "markdown",
+  "id": "41a7bd2c",
+  "metadata": {},
    "source": [
     "##\u00a04\u00a0\u00b7\u00a0Explore the trace\u2011graph \u2728\n",
     "Open [http://localhost:8088](http://localhost:8088) in your browser to watch\n",


### PR DESCRIPTION
## Summary
- add OpenAI Agents quick demo section to finance demo README
- provide `agent_control.py` helper for programmatic interaction
- insert SDK example cell in `finance_alpha.ipynb`

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*