### PR TITLE
Improve meta demo docs and bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ cd AGI-Alpha-Agent-v0
 ./quickstart.sh --preflight   # optional environment check
 python check_env.py           # verify test dependencies
 ./quickstart.sh               # creates venv, installs deps, launches
+# If the host has no internet access set `WHEELHOUSE=/path/to/wheels` and
+# the helper attempts an offline install.
 # open the docs in your browser
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs
 # Alternatively, ``python alpha_factory_v1/quickstart.py`` provides the same

--- a/alpha_factory_v1/demos/meta_agentic_agi/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/README.md
@@ -89,6 +89,11 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_agi
 python3 -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 
+# Optional sanity check – verifies optional extras and offers
+# an offline install flow when `WHEELHOUSE` points to a local
+# directory of wheels.
+python ../../check_env.py
+
 python app.py --gens 6 --provider mistral:7b-instruct.gguf --ui
 # UI → http://localhost:8501
 ```


### PR DESCRIPTION
## Summary
- document offline wheelhouse usage in root README
- add check_env recommendation in Meta-Agentic README
- fail fast when openai-agents is missing and wire optional ADK bridge

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*