### PR TITLE
Improve meta-agentic demo with mock provider

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
@@ -1,4 +1,3 @@
-
 # Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**
 
 Identical to **v1** plus a statistical-physics wrapper that logs and minimises **Gibbs / variational free-energy** for each candidate agent during the evolutionary search.
@@ -111,6 +110,8 @@ micromamba activate metaagi
 pip install -r requirements.txt        # ≤ 40 MiB wheels
 
 # 3️⃣ Run – zero‑API mode (pulls a gguf via Ollama)
+python meta_agentic_agi_demo_v2.py --provider mock:echo       # offline demo
+#   …or real weights
 python meta_agentic_agi_demo_v2.py --provider mistral:7b-instruct.gguf
 
 #   …or point to any provider
@@ -201,9 +202,7 @@ Change **provider** to:
 | `openai:gpt-4o`             | needs `OPENAI_API_KEY`     |
 | `anthropic:claude-3-sonnet` | needs `ANTHROPIC_API_KEY`  |
 | `mistral:7b-instruct.gguf`  | default local model        |
-
-Wrapper normalises chat/completions, streams via **MCP**, and window‑slides tokens.
-
+| `mock:echo`                 | offline stub, for tests |
 ---
 
 ## 5 Multi‑Objective Search 🎯

--- a/tests/test_meta_agentic_cli_v2.py
+++ b/tests/test_meta_agentic_cli_v2.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestMetaAgenticCLIV2(unittest.TestCase):
+    def test_cli_runs_one_generation(self) -> None:
+        result = subprocess.run(
+            [sys.executable, '-m', 'alpha_factory_v1.demos.meta_agentic_agi_v2.meta_agentic_agi_demo_v2', '--gens', '1', '--provider', 'mock:echo'],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn('Gen 00', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add offline `mock:` provider to meta agentic demos
- document offline quick-start in README with mock provider
- add CLI regression test for meta agentic v2 demo

## Testing
- `pytest -q` *(fails: command not found)*