### PR TITLE
Improve MuZero demo configuration

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -24,8 +24,9 @@ Clone the repository and run the helper script. It generates a
 `config.env` with safe defaults – edit it to add your `OPENAI_API_KEY` if
 you want narrated moves.
 
-Set `HOST_PORT` to expose a different dashboard port and `MUZERO_ENV_ID`
-to experiment with other Gymnasium tasks.
+Set `HOST_PORT` to expose a different dashboard port,
+`MUZERO_ENV_ID` to try other Gymnasium tasks,
+and `MUZERO_EPISODES` to adjust episode count.
 The helper script warns if the chosen port is already occupied.
 
 ```bash

--- a/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
+++ b/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
@@ -1,5 +1,5 @@
 {
-"cells": [
+ "cells": [
   {
    "cell_type": "markdown",
    "id": "ecfd703e",
@@ -9,7 +9,7 @@
     "Experience MuZero-style planning in seconds. Run each cell to install dependencies, test the environment and launch a shareable dashboard.\n",
     "\n",
     "Add your **OpenAI API key** if you want narrated moves; otherwise Mixtral runs locally for a 100% offline demo."
-  ]
+   ]
   },
   {
    "cell_type": "code",
@@ -20,51 +20,53 @@
    "source": [
     "# Install core dependencies\n",
     "!pip -q install \"torch>=2.1\" gymnasium[classic-control] gradio openai_agents pytest\n"
-  ]
- },
- {
-  "cell_type": "code",
-  "execution_count": null,
-  "id": "881ead00",
-  "metadata": {},
-  "outputs": [],
-  "source": [
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "881ead00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Clone Alpha\u2011Factory repository\n",
     "!git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
     "%cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning"
-  ]
- },
- {
-  "cell_type": "code",
-  "metadata": {},
-  "execution_count": null,
-  "outputs": [],
-  "source": [
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "# Run quick sanity tests (optional)\n",
     "!pytest -q tests/test_muzero_planning.py\n"
-  ]
- },
- {
-  "cell_type": "code",
-  "execution_count": null,
-  "id": "config-env",
-  "metadata": {},
-  "outputs": [],
-  "source": [
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "config-env",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Optional environment settings\n",
     "MUZERO_ENV_ID = 'CartPole-v1'  # change to try other Gym tasks\n",
     "HOST_PORT = 7861\n",
+    "MUZERO_EPISODES = 3  # number of episodes to run",
     "import os\n",
     "os.environ['MUZERO_ENV_ID'] = MUZERO_ENV_ID\n",
     "os.environ['HOST_PORT'] = str(HOST_PORT)\n",
-    "print(f'Environment: {MUZERO_ENV_ID}, dashboard \→ http://localhost:{HOST_PORT}')"
-  ]
- },
- {
-  "cell_type": "code",
-  "execution_count": null,
-  "id": "0afcf7b6",
-  "metadata": {},
+    "os.environ['MUZERO_EPISODES'] = str(MUZERO_EPISODES)\n",
+    "print(f'Environment: {MUZERO_ENV_ID}, episodes={MUZERO_EPISODES}, dashboard \u2192 http://localhost:{HOST_PORT}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0afcf7b6",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# \ud83d\udc49\u00a0OPTIONAL: set your OpenAI key for commentary\n",
@@ -90,23 +92,23 @@
     "except KeyboardInterrupt:\n",
     "    process.send_signal(signal.SIGINT)\n",
     "    process.wait()\n"
-  ]
- },
- {
-  "cell_type": "code",
-  "execution_count": null,
-  "id": "shutdown",
-  "metadata": {},
-  "outputs": [],
-  "source": [
-    "# \u23F9\uFE0F Stop the MuZero dashboard\n",
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "shutdown",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# \u23f9\ufe0f Stop the MuZero dashboard\n",
     "process.send_signal(signal.SIGINT)\n",
     "process.wait()\n",
     "print('MuZero demo stopped.')"
-  ]
- }
-],
-"metadata": {
+   ]
+  }
+ ],
+ "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/alpha_factory_v1/demos/muzero_planning/config.env.sample
+++ b/alpha_factory_v1/demos/muzero_planning/config.env.sample
@@ -7,3 +7,4 @@ TEMPERATURE=0.3
 # Optional customisations
 #HOST_PORT=7861
 #MUZERO_ENV_ID=CartPole-v1
+#MUZERO_EPISODES=3  # number of episodes to run


### PR DESCRIPTION
## Summary
- document environment variable to set episode count in MuZero demo
- add sample config for `MUZERO_EPISODES`
- update Colab notebook accordingly

## Testing
- `python -m unittest tests.test_muzero_planning -v`
