### PR TITLE
Improve MuZero demo CLI

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -42,6 +42,16 @@ pip install -r requirements.txt
 python -m alpha_factory_v1.demos.muzero_planning
 ```
 
+### Command-line options
+
+You can override the environment, episode count and port directly from the CLI:
+
+```bash
+python -m alpha_factory_v1.demos.muzero_planning --env MountainCar-v0 \
+       --episodes 5 --port 8888
+```
+
+
 1. **Docker Desktop** builds the container (~45 s on first run).
 2. **Open <http://localhost:${HOST_PORT:-7861}>** and press **“▶ Run MuZero”**.
 3. Watch the live video feed, reward ticker and optional commentary.

--- a/alpha_factory_v1/demos/muzero_planning/__init__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__init__.py
@@ -1,2 +1,7 @@
 """MiniMu demo package for MuZero Planning."""
 
+from .agent_muzero_entrypoint import launch_dashboard
+
+__all__ = ["launch_dashboard"]
+
+

--- a/alpha_factory_v1/demos/muzero_planning/__main__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__main__.py
@@ -1,4 +1,41 @@
+"""Command line entry point for the MuZero planning demo."""
+
+from __future__ import annotations
+
+import argparse
+import os
 from .agent_muzero_entrypoint import launch_dashboard
 
-if __name__ == "__main__":
+
+def main(argv: list[str] | None = None) -> None:
+    """Launch the MuZero dashboard with optional CLI overrides."""
+
+    parser = argparse.ArgumentParser(description="Run MuZero planning demo")
+    parser.add_argument(
+        "--env",
+        default=os.getenv("MUZERO_ENV_ID", "CartPole-v1"),
+        help="Gymnasium environment ID",
+    )
+    parser.add_argument(
+        "--episodes",
+        type=int,
+        default=int(os.getenv("MUZERO_EPISODES", 3)),
+        help="Number of episodes to run",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("HOST_PORT", 7861)),
+        help="Dashboard port",
+    )
+    args = parser.parse_args(argv)
+
+    os.environ["MUZERO_ENV_ID"] = args.env
+    os.environ["MUZERO_EPISODES"] = str(args.episodes)
+    os.environ["HOST_PORT"] = str(args.port)
+
     launch_dashboard()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_muzero_cli.py
+++ b/tests/test_muzero_cli.py
@@ -1,0 +1,11 @@
+import subprocess, sys
+
+
+def test_cli_help():
+    result = subprocess.run([
+        sys.executable,
+        '-m', 'alpha_factory_v1.demos.muzero_planning',
+        '--help'
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'MuZero planning demo' in result.stdout


### PR DESCRIPTION
## Summary
- expose a CLI for the MuZero planning demo
- document command-line usage
- re-export `launch_dashboard` from the package
- add regression test for the CLI help output

## Testing
- `pytest -q` *(fails: command not found)*