### PR TITLE
Improve MuZero demo UX

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -35,6 +35,9 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning
 ./run_muzero_demo.sh
 ```
 
+The script prints the local URL and, when possible, automatically opens it in
+your default browser.
+
 Alternatively run natively:
 
 ```bash

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -36,7 +36,8 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning
 ```
 
 The script prints the local URL and, when possible, automatically opens it in
-your default browser.
+your default browser. Automatic browser opening is currently supported only
+on Linux (using `xdg-open`) and macOS (using `open`).
 
 Alternatively run natively:
 

--- a/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
+++ b/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
@@ -27,3 +27,10 @@ docker compose --project-name alpha_muzero -f "$compose" up -d --build
 
 echo -e "\n🎉  Open http://localhost:${HOST_PORT} for the live MuZero dashboard."
 echo "🛑  Stop → docker compose -p alpha_muzero down\n"
+
+# Automatically open the dashboard in a browser when possible
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "http://localhost:${HOST_PORT}" >/dev/null 2>&1 &
+elif command -v open >/dev/null 2>&1; then  # macOS
+  open "http://localhost:${HOST_PORT}" &
+fi

--- a/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
+++ b/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
@@ -32,5 +32,5 @@ echo "🛑  Stop → docker compose -p alpha_muzero down\n"
 if command -v xdg-open >/dev/null 2>&1; then
   xdg-open "http://localhost:${HOST_PORT}" >/dev/null 2>&1 &
 elif command -v open >/dev/null 2>&1; then  # macOS
-  open "http://localhost:${HOST_PORT}" &
+  open "http://localhost:${HOST_PORT}" >/dev/null 2>&1 &
 fi


### PR DESCRIPTION
## Summary
- auto-open MuZero dashboard after starting container
- clarify browser auto-launch behavior in the MuZero demo README

## Testing
- `pytest -q` *(fails: command not found)*