### PR TITLE
Enable optional ADK gateway for AI‑GA demo

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -98,6 +98,20 @@ The bridge registers an `aiga_evolver` agent exposing four tools:
 It works offline by routing to the local Mixtral server when no API key
 is configured.
 
+### 🛰️ Google ADK gateway
+
+Set `ALPHA_FACTORY_ENABLE_ADK=true` to expose the same agent via a local
+Google **Agent Development Kit** gateway:
+
+```bash
+ALPHA_FACTORY_ENABLE_ADK=true python openai_agents_bridge.py &
+```
+
+This publishes the tools over the **A2A protocol** so other agents can
+orchestrate evolution remotely.
+Set `ALPHA_FACTORY_ENABLE_ADK=1` in `config.env` to auto-start the gateway
+when running `./run_aiga_demo.sh`.
+
 ## 🔐 API authentication
 
 Export `AUTH_BEARER_TOKEN` to require a static token on every API request. For

--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -46,6 +46,11 @@ except ImportError:  # pragma: no cover
     A2ASocket = None  # type: ignore
 
 from openai_agents import OpenAIAgent, Tool
+try:
+    from alpha_factory_v1.backend import adk_bridge
+except Exception:  # pragma: no cover - optional dependency
+    adk_bridge = None
+from openai_agents_bridge import EvolverAgent
 from meta_evolver import MetaEvolver
 from curriculum_env import CurriculumEnv
 import gradio as gr
@@ -297,6 +302,10 @@ if __name__ == "__main__":
         AgentRuntime.register(SERVICE_NAME, f"http://localhost:{API_PORT}")
     if A2ASocket:
         A2ASocket(host="0.0.0.0", port=5555, app_id=SERVICE_NAME).start()
+    if adk_bridge and adk_bridge.adk_enabled():
+        evolver_agent = EvolverAgent()
+        adk_bridge.auto_register([evolver_agent])
+        adk_bridge.maybe_launch()
 
     # run FastAPI (blocking)
     uvicorn.run(app, host="0.0.0.0", port=API_PORT, log_level="info")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample
@@ -77,5 +77,6 @@ RESOURCES_LIMIT_CPU="2"                # k8s limit
 RESOURCES_LIMIT_MEM="4Gi"
 NODE_SELECTOR=""                        # e.g. gpu=true
 GPU_ENABLE=false                        # set true for CUDA runtime
+ALPHA_FACTORY_ENABLE_ADK=0              # 1 → expose Google ADK gateway
 
-# End of file – happy hacking!                                               
+# End of file – happy hacking!

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 import os
 from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
 
+try:
+    from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+    ADK_AVAILABLE = True
+except Exception:  # pragma: no cover - optional
+    ADK_AVAILABLE = False
+
 from meta_evolver import MetaEvolver
 from curriculum_env import CurriculumEnv
 
@@ -67,8 +73,15 @@ class EvolverAgent(Agent):
 
 def main() -> None:
     runtime = AgentRuntime(api_key=None)
-    runtime.register(EvolverAgent())
+    agent = EvolverAgent()
+    runtime.register(agent)
     print("Registered EvolverAgent with runtime")
+
+    if ADK_AVAILABLE:
+        auto_register([agent])
+        maybe_launch()
+        print("EvolverAgent exposed via ADK gateway")
+
     runtime.run()
 
 


### PR DESCRIPTION
## Summary
- allow exposing the AI‑GA meta-evolver via Google ADK
- document the ADK gateway usage
- expose EvolverAgent through ADK bridge in the service
- add `ALPHA_FACTORY_ENABLE_ADK` to sample env

## Testing
- `pytest -q` *(fails: command not found)*