### PR TITLE
Improve AIGA demo docs and import handling

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -78,6 +78,7 @@ when Docker is unavailable.
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
 pip install -r alpha_factory_v1/requirements.txt
+# ensures `openai-agents` and friends are installed
 python alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
 ```
 
@@ -91,6 +92,8 @@ Expose the evolver to the **OpenAI Agents SDK** runtime:
 ```bash
 python alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
 ```
+
+Requires the `openai-agents` package (installed via requirements).
 
 The bridge registers an `aiga_evolver` agent exposing four tools:
 `evolve` (run N generations), `best_alpha` (return the champion),

--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -45,7 +45,12 @@ try:
 except ImportError:  # pragma: no cover
     A2ASocket = None  # type: ignore
 
-from openai_agents import OpenAIAgent, Tool
+try:  # optional dependency
+    from openai_agents import OpenAIAgent, Tool
+except Exception as exc:  # pragma: no cover - missing package
+    raise SystemExit(
+        "openai_agents package is required. Install with `pip install openai-agents`"
+    ) from exc
 try:
     from alpha_factory_v1.backend import adk_bridge
 except Exception:  # pragma: no cover - optional dependency

--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -47,7 +47,7 @@ except ImportError:  # pragma: no cover
 
 try:  # optional dependency
     from openai_agents import OpenAIAgent, Tool
-except Exception as exc:  # pragma: no cover - missing package
+except ImportError as exc:  # pragma: no cover - missing package
     raise SystemExit(
         "openai_agents package is required. Install with `pip install openai-agents`"
     ) from exc

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -11,7 +11,7 @@ import os
 
 try:  # optional dependency
     from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
-except Exception as exc:  # pragma: no cover - missing package
+except ImportError as exc:  # pragma: no cover - missing package
     raise SystemExit(
         "openai_agents package is required. Install with `pip install openai-agents`"
     ) from exc

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -8,7 +8,13 @@ instance started by ``run_aiga_demo.sh``.
 from __future__ import annotations
 
 import os
-from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
+
+try:  # optional dependency
+    from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
+except Exception as exc:  # pragma: no cover - missing package
+    raise SystemExit(
+        "openai_agents package is required. Install with `pip install openai-agents`"
+    ) from exc
 
 try:
     from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch


### PR DESCRIPTION
## Summary
- ensure openai-agents dependency is optional but required with helpful error
- document openai-agents requirement in README
- minor doc tweaks for Python quick-start

## Testing
- `pytest -q` *(fails: command not found)*