### PR TITLE
Add Python launcher for AI-GA demo

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -80,6 +80,8 @@ cd AGI-Alpha-Agent-v0
 pip install -r alpha_factory_v1/requirements.txt
 # ensures `openai-agents` and friends are installed
 python alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+# optional cross‑platform launcher
+python alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py --help
 ```
 
 Set `OPENAI_API_KEY` in your environment to enable cloud models. Without

--- a/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
@@ -73,7 +73,7 @@ def main() -> None:
     print("Stop     → start_aiga_demo.py --stop")
 
     if args.logs:
-        subprocess.run(compose + ["logs", "-f"])
+        run(compose + ["logs", "-f"])
 
 
 if __name__ == "__main__":

--- a/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
@@ -68,8 +68,8 @@ def main() -> None:
     extra = ["--no-build"] if args.pull else []
     run(compose + gpu_args + ["up", "-d", *extra])
 
-    print("Dashboard → http://localhost:7862")
-    print("OpenAPI  → http://localhost:8000/docs")
+    print(f"Dashboard → {DASHBOARD_URL}")
+    print(f"OpenAPI  → {OPENAPI_URL}")
     print("Stop     → start_aiga_demo.py --stop")
 
     if args.logs:

--- a/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Cross-platform launcher for the AI-GA meta-evolution demo.
+
+This utility mirrors ``run_aiga_demo.sh`` for users without a POSIX shell.
+It orchestrates the Docker Compose stack and optionally tails the logs.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+DEMO_DIR = Path(__file__).resolve().parent
+ROOT_DIR = DEMO_DIR.parent.parent
+COMPOSE_YAML = DEMO_DIR / "docker-compose.aiga.yml"
+PROJECT = "alpha_aiga"
+GHCR_IMAGE = "ghcr.io/montrealai/alpha-aiga:latest"
+CONFIG_ENV = DEMO_DIR / "config.env"
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def docker_compose_cmd() -> list[str]:
+    if subprocess.run(["docker", "compose", "version"], capture_output=True).returncode == 0:
+        return ["docker", "compose"]
+    if subprocess.run(["docker-compose", "--version"], capture_output=True).returncode == 0:
+        return ["docker-compose"]
+    sys.exit("docker compose plugin not found")
+
+
+def ensure_env_file() -> None:
+    if not CONFIG_ENV.exists():
+        print("Creating default config.env (edit to add OPENAI_API_KEY)")
+        sample = DEMO_DIR / "config.env.sample"
+        CONFIG_ENV.write_bytes(sample.read_bytes())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Launch the AI-GA meta-evolution demo")
+    ap.add_argument("--pull", action="store_true", help="pull signed image instead of building")
+    ap.add_argument("--gpu", action="store_true", help="enable NVIDIA runtime")
+    ap.add_argument("--logs", action="store_true", help="tail container logs after start-up")
+    ap.add_argument("--reset", action="store_true", help="remove volumes and images")
+    ap.add_argument("--stop", action="store_true", help="stop running containers")
+    args = ap.parse_args()
+
+    dc = docker_compose_cmd()
+    compose = dc + ["--project-name", PROJECT, "--env-file", str(CONFIG_ENV), "-f", str(COMPOSE_YAML)]
+
+    os.chdir(ROOT_DIR)
+    ensure_env_file()
+
+    if args.reset:
+        run(compose + ["down", "-v", "--rmi", "all"])
+        return
+    if args.stop:
+        run(compose + ["down"])
+        return
+
+    if args.pull:
+        run(["docker", "pull", GHCR_IMAGE])
+
+    gpu_args = ["--compatibility", "--profile", "gpu"] if args.gpu else []
+    extra = ["--no-build"] if args.pull else []
+    run(compose + gpu_args + ["up", "-d", *extra])
+
+    print("Dashboard → http://localhost:7862")
+    print("OpenAPI  → http://localhost:8000/docs")
+    print("Stop     → start_aiga_demo.py --stop")
+
+    if args.logs:
+        subprocess.run(compose + ["logs", "-f"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_aiga_demo.py` for cross-platform launching of the AI‑GA meta‑evolution demo
- document the new launcher in the demo README

## Testing
- `pytest -q` *(fails: command not found)*