### PR TITLE
Enhance AIGA demo usability

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -84,6 +84,8 @@ pip install -r alpha_factory_v1/requirements.txt
 python alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
 # optional cross‑platform launcher
 python alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py --help
+# or via module entrypoint
+python -m alpha_factory_v1.demos.aiga_meta_evolution --help
 ```
 
 Set `OPENAI_API_KEY` in your environment to enable cloud models. Without

--- a/alpha_factory_v1/demos/aiga_meta_evolution/__main__.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/__main__.py
@@ -1,0 +1,4 @@
+from .start_aiga_demo import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aiga_meta_module.py
+++ b/tests/test_aiga_meta_module.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+import unittest
+
+class TestAigaMetaModule(unittest.TestCase):
+    def test_module_entrypoint(self) -> None:
+        result = subprocess.run([
+            sys.executable, '-m', 'alpha_factory_v1.demos.aiga_meta_evolution', '--help'
+        ], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn('meta-evolution demo', result.stdout.lower())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_aiga_meta_module.py
+++ b/tests/test_aiga_meta_module.py
@@ -6,7 +6,7 @@ class TestAigaMetaModule(unittest.TestCase):
     def test_module_entrypoint(self) -> None:
         result = subprocess.run([
             sys.executable, '-m', 'alpha_factory_v1.demos.aiga_meta_evolution', '--help'
-        ], capture_output=True, text=True)
+        ], capture_output=True, text=True, check=True)
         self.assertEqual(result.returncode, 0)
         self.assertIn('usage:', result.stdout.lower())
 

--- a/tests/test_aiga_meta_module.py
+++ b/tests/test_aiga_meta_module.py
@@ -8,7 +8,7 @@ class TestAigaMetaModule(unittest.TestCase):
             sys.executable, '-m', 'alpha_factory_v1.demos.aiga_meta_evolution', '--help'
         ], capture_output=True, text=True)
         self.assertEqual(result.returncode, 0)
-        self.assertIn('meta-evolution demo', result.stdout.lower())
+        self.assertIn('usage:', result.stdout.lower())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add a module entrypoint so the AI‑GA meta‑evolution demo can be launched via `python -m`
- document the new command in the demo README
- test the module entrypoint

## Testing
- `python -m py_compile alpha_factory_v1/demos/aiga_meta_evolution/__main__.py tests/test_aiga_meta_module.py`
- `pytest -q` *(fails: command not found)*