### PR TITLE
Add alpha conversion stub demo

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -160,6 +160,16 @@ python alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
 
 The `alpha_discovery` agent exposes a single `identify_alpha` tool that asks the LLM to suggest three inefficiencies in a chosen domain. It works offline when `OPENAI_API_KEY` is unset.
 
+## ♻️ Alpha conversion stub
+
+Turn a discovered opportunity into a short execution plan:
+
+```bash
+python alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py --alpha "Battery arbitrage"
+```
+
+The tool outputs a three‑step JSON plan and logs it to `alpha_conversion_log.json`. When `OPENAI_API_KEY` is configured, it queries an OpenAI model; otherwise a sample plan is returned.
+
 
 ---
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Alpha conversion stub.
+
+Given a text description of an opportunity, output a short JSON plan
+for how one might capitalise on it. Works fully offline via a canned
+response but will query OpenAI when ``OPENAI_API_KEY`` is set and the
+``openai`` package is available.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import contextlib
+from pathlib import Path
+from typing import Dict
+
+with contextlib.suppress(ModuleNotFoundError):
+    import openai  # type: ignore
+
+SAMPLE_PLAN = {
+    "steps": [
+        "Validate market potential and regulatory constraints",
+        "Prototype a minimal solution to capture early demand",
+        "Deploy iteratively while measuring ROI"
+    ]
+}
+
+DEFAULT_LEDGER = Path(__file__).with_name("alpha_conversion_log.json")
+
+
+def _ledger_path(path: str | os.PathLike | None) -> Path:
+    if path:
+        return Path(path).expanduser().resolve()
+    env = os.getenv("ALPHA_CONVERSION_LEDGER")
+    if env:
+        return Path(env).expanduser().resolve()
+    return DEFAULT_LEDGER
+
+
+def convert_alpha(alpha: str, *, ledger: Path | None = None, model: str = "gpt-4o-mini") -> Dict[str, object]:
+    """Return a plan dictionary and log to *ledger*."""
+    plan: Dict[str, object] = SAMPLE_PLAN
+    if "openai" in globals() and os.getenv("OPENAI_API_KEY"):
+        prompt = (
+            f"Given the opportunity: {alpha}\n"
+            "Provide a short JSON plan with three concise steps to realise value."
+        )
+        try:
+            resp = openai.ChatCompletion.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            plan = json.loads(resp.choices[0].message.content)  # type: ignore[index]
+            if not isinstance(plan, dict):
+                plan = SAMPLE_PLAN
+        except Exception:
+            plan = SAMPLE_PLAN
+    (_ledger_path(ledger)).write_text(json.dumps(plan, indent=2))
+    return plan
+
+
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI wrapper
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--alpha", default="Generic opportunity", help="text description of the opportunity")
+    p.add_argument("--ledger", help="path to ledger JSON file")
+    p.add_argument("--model", default=os.getenv("ALPHA_CONVERSION_MODEL", "gpt-4o-mini"), help="OpenAI model when API key present")
+    p.add_argument("--no-log", action="store_true", help="do not write ledger file")
+    args = p.parse_args(argv)
+
+    ledger = _ledger_path(args.ledger)
+    plan = convert_alpha(args.alpha, ledger=None if args.no_log else ledger, model=args.model)
+    if args.no_log:
+        ledger.unlink(missing_ok=True)
+    print(json.dumps(plan, indent=2))
+    if not args.no_log:
+        print(f"Logged to {ledger}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -41,7 +41,7 @@ def _ledger_path(path: str | os.PathLike | None) -> Path:
 def convert_alpha(alpha: str, *, ledger: Path | None = None, model: str = "gpt-4o-mini") -> Dict[str, object]:
     """Return a plan dictionary and log to *ledger*."""
     plan: Dict[str, object] = SAMPLE_PLAN
-    if "openai" in globals() and os.getenv("OPENAI_API_KEY"):
+    if openai is not None and os.getenv("OPENAI_API_KEY"):
         prompt = (
             f"Given the opportunity: {alpha}\n"
             "Provide a short JSON plan with three concise steps to realise value."

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -54,7 +54,8 @@ def convert_alpha(alpha: str, *, ledger: Path | None = None, model: str = "gpt-4
             plan = json.loads(resp.choices[0].message.content)  # type: ignore[index]
             if not isinstance(plan, dict):
                 plan = SAMPLE_PLAN
-        except Exception:
+        except Exception as e:
+            logging.exception("OpenAI API call failed. Falling back to SAMPLE_PLAN.")
             plan = SAMPLE_PLAN
     (_ledger_path(ledger)).write_text(json.dumps(plan, indent=2))
     return plan

--- a/tests/test_alpha_conversion_stub.py
+++ b/tests/test_alpha_conversion_stub.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+import tempfile
+
+STUB = 'alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py'
+
+
+class TestAlphaConversionStub(unittest.TestCase):
+    def test_generate_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = Path(tmp) / 'plan.json'
+            result = subprocess.run(
+                [sys.executable, STUB, '--alpha', 'test opportunity', '--ledger', str(ledger)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(ledger.exists())
+            data = json.loads(ledger.read_text())
+            self.assertIsInstance(data, dict)
+            self.assertIn('steps', data)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `alpha_conversion_stub.py` to show how to generate a short plan from a discovered opportunity
- document the new stub in the AI‑GA meta evolution README
- test the stub with a new unit test

## Testing
- `python -m unittest tests.test_alpha_conversion_stub -v`
- `python -m unittest discover -v` *(fails: several demo shell scripts not executable)*