### PR TITLE
Improve Alpha opportunity stub CLI

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -158,6 +158,13 @@ For a bite-size illustration of agent-driven opportunity scanning, run:
 python alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
 ```
 
+To query a specific domain once without starting the full runtime:
+
+```bash
+python alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py \
+  --domain supply-chain --once
+```
+
 The `alpha_discovery` agent exposes a single `identify_alpha` tool that asks the LLM to suggest three inefficiencies in a chosen domain. It works offline when `OPENAI_API_KEY` is unset.
 
 ## ♻️ Alpha conversion stub

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
@@ -42,7 +42,25 @@ class AlphaDiscoveryAgent(Agent):
         return await identify_alpha(domain)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    """Launch the agent runtime or run a single query."""
+    import argparse
+    import asyncio
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--domain", default="finance", help="domain to scan")
+    ap.add_argument(
+        "--once",
+        action="store_true",
+        help="run a single identify_alpha call and exit",
+    )
+    args = ap.parse_args(argv)
+
+    if args.once:
+        result = asyncio.run(identify_alpha(args.domain))
+        print(result)
+        return
+
     runtime = AgentRuntime(api_key=None)
     agent = AlphaDiscoveryAgent()
     runtime.register(agent)


### PR DESCRIPTION
## Summary
- add CLI options to `alpha_opportunity_stub.py` for one‑off queries
- document new usage in the AIGA demo README

## Testing
- `pytest -q` *(fails: command not found)*