### PR TITLE
Fix alpha conversion fallback for missing OpenAI

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -20,6 +20,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s"
 )
+# Initialize `openai` to `None` as a fallback in case the module import fails.
 openai = None
 with contextlib.suppress(ModuleNotFoundError):
     import openai  # type: ignore

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -20,6 +20,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s"
 )
+openai = None
 with contextlib.suppress(ModuleNotFoundError):
     import openai  # type: ignore
 


### PR DESCRIPTION
## Summary
- handle missing `openai` module in alpha conversion stub

## Testing
- `python -m unittest tests.test_alpha_conversion_stub tests.test_alpha_opportunity_stub tests.test_openai_bridge`
