### PR TITLE
Add workflow demo bridging alpha discovery & conversion

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -182,7 +182,7 @@ The tool outputs a three‑step JSON plan and logs it to `alpha_conversion_log.j
 Combine discovery and conversion into a single agent:
 
 ```bash
-python alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py --domain finance
+python alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
 ```
 
 The `alpha_workflow` agent lists opportunities in the chosen domain, selects the

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -187,8 +187,8 @@ python alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
 
 The `alpha_workflow` agent lists opportunities in the chosen domain, selects the
 first suggestion and returns a short execution plan. When Google ADK is enabled
-(via `ALPHA_FACTORY_ENABLE_ADK=1`), the same agent is published over the A2A
-protocol for orchestration by external controllers.
+(via `ALPHA_FACTORY_ENABLE_ADK=1` and successful import of the ADK module), the same
+agent is published over the A2A protocol for orchestration by external controllers.
 
 
 ---

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -177,6 +177,19 @@ python alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py --alp
 
 The tool outputs a three‑step JSON plan and logs it to `alpha_conversion_log.json`. When `OPENAI_API_KEY` is configured, it queries an OpenAI model; otherwise a sample plan is returned.
 
+## 🤝 End‑to‑end workflow
+
+Combine discovery and conversion into a single agent:
+
+```bash
+python alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py --domain finance
+```
+
+The `alpha_workflow` agent lists opportunities in the chosen domain, selects the
+first suggestion and returns a short execution plan. When Google ADK is enabled
+(via `ALPHA_FACTORY_ENABLE_ADK=1`), the same agent is published over the A2A
+protocol for orchestration by external controllers.
+
 
 ---
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
@@ -1,0 +1,77 @@
+"""End-to-end Alpha Factory workflow demo.
+
+This script chains the ``alpha_discovery`` and ``alpha_conversion``
+stubs via the OpenAI Agents runtime. It works offline when
+``OPENAI_API_KEY`` is unset and optionally exposes the agent over
+the Google ADK gateway if available.
+"""
+from __future__ import annotations
+
+import os
+
+try:
+    from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(
+        "openai_agents package is required. Install with `pip install openai-agents`"
+    ) from exc
+
+from alpha_opportunity_stub import identify_alpha
+from alpha_conversion_stub import convert_alpha
+
+try:
+    from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+    ADK_AVAILABLE = True
+except Exception:  # pragma: no cover - optional
+    ADK_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# LLM setup -----------------------------------------------------------------
+# ---------------------------------------------------------------------------
+LLM = OpenAIAgent(
+    model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url=(None if os.getenv("OPENAI_API_KEY") else os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")),
+)
+
+
+@Tool(name="discover_alpha", description="List market opportunities in a domain")
+async def discover_alpha(domain: str = "finance") -> str:
+    return await identify_alpha(domain)
+
+
+@Tool(name="convert_alpha", description="Turn an opportunity into an execution plan")
+async def convert_alpha_tool(alpha: str) -> dict:
+    return convert_alpha(alpha)
+
+
+class WorkflowAgent(Agent):
+    """Simple agent chaining discovery and conversion."""
+
+    name = "alpha_workflow"
+    tools = [discover_alpha, convert_alpha_tool]
+
+    async def policy(self, obs, ctx):  # type: ignore[override]
+        domain = obs.get("domain", "finance") if isinstance(obs, dict) else "finance"
+        alphas = await discover_alpha(domain)
+        first = alphas.split("\n")[0].strip()
+        plan = await convert_alpha_tool(first)
+        return {"alpha": first, "plan": plan}
+
+
+def main() -> None:
+    runtime = AgentRuntime(api_key=None)
+    agent = WorkflowAgent()
+    runtime.register(agent)
+    print("Registered WorkflowAgent with runtime")
+
+    if ADK_AVAILABLE:
+        auto_register([agent])
+        maybe_launch()
+        print("WorkflowAgent exposed via ADK gateway")
+
+    runtime.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
@@ -60,7 +60,7 @@ class WorkflowAgent(Agent):
 
 
 def main() -> None:
-    runtime = AgentRuntime(api_key=None)
+    runtime = AgentRuntime(llm=LLM)
     agent = WorkflowAgent()
     runtime.register(agent)
     print("Registered WorkflowAgent with runtime")


### PR DESCRIPTION
## Summary
- introduce `workflow_demo.py` to chain `identify_alpha` and `convert_alpha` using OpenAI Agents
- expose optional ADK gateway for remote orchestration
- document usage in `aiga_meta_evolution` README

## Testing
- `pytest -q` *(fails: command not found)*