### PR TITLE
Enhance era_of_experience demo with supply chain alpha tool

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -35,9 +35,10 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
 
 1. **Docker Desktop** builds a 300 MB image in ≈ 1 min. 
 2. Your browser opens **http://localhost:7860** featuring 
-  * live trace‑graph 🪄 
-  * reward dashboards 📈 
-  * interactive chat / tool console 💬 
+  * live trace‑graph 🪄
+  * reward dashboards 📈
+  * interactive chat / tool console 💬
+  * built‑in alpha detectors (yield curve & supply‑chain) 🔍
 
 > **Offline/Private mode** — leave `OPENAI_API_KEY=` blank in <code>config.env</code>; the stack falls back to <strong>Ollama ✕ Mixtral‑8x7B</strong> and stays air‑gapped.
 
@@ -69,7 +70,7 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
 |----------|---------|--------|
 | `colab_era_of_experience.ipynb` | CPU / GPU | <a href="https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"></a> |
 
-The notebook installs a lean Python stack (&lt; 120 s), exposes Gradio via ngrok and lets you call tools directly from cells. It also verifies package versions and lists the reward back‑ends available for blending. A small example cell illustrates detecting "alpha" opportunities using the offline yield curve snapshot.
+The notebook installs a lean Python stack (&lt; 120 s), exposes Gradio via ngrok and lets you call tools directly from cells. It also verifies package versions and lists the reward back‑ends available for blending. Example cells illustrate detecting "alpha" opportunities using the offline yield curve **and** a toy supply‑chain flow snapshot.
 
 ---
 
@@ -142,6 +143,10 @@ This demo ships with a minimal example:
 @Tool("detect_yield_curve_alpha", "Assess yield curve inversion using offline data.")
 async def detect_yield_curve_alpha_tool():
     return {"alpha": detect_yield_curve_alpha()}
+
+@Tool("detect_supply_chain_alpha", "Check for potential supply-chain disruptions using offline data.")
+async def detect_supply_chain_alpha_tool(threshold: float = 50.0):
+    return {"alpha": detect_supply_chain_alpha(threshold)}
 ```
 
 

--- a/alpha_factory_v1/demos/era_of_experience/__init__.py
+++ b/alpha_factory_v1/demos/era_of_experience/__init__.py
@@ -1,4 +1,10 @@
 # Demo package
-from .alpha_detection import detect_yield_curve_alpha
+from .alpha_detection import (
+    detect_yield_curve_alpha,
+    detect_supply_chain_alpha,
+)
 
-__all__ = ["detect_yield_curve_alpha"]
+__all__ = [
+    "detect_yield_curve_alpha",
+    "detect_supply_chain_alpha",
+]

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -45,7 +45,10 @@ import uvicorn
 import gradio as gr
 from openai_agents import Agent, OpenAIAgent, Tool, memory
 
-from .alpha_detection import detect_yield_curve_alpha
+from .alpha_detection import (
+    detect_yield_curve_alpha,
+    detect_supply_chain_alpha,
+)
 
 # ───────────────────────────── configuration ────────────────────────────────
 MODEL       = os.getenv("MODEL_NAME", "gpt-4o-mini")
@@ -122,7 +125,22 @@ async def detect_yield_curve_alpha_tool() -> Dict[str, str]:
     return {"alpha": msg}
 
 
-TOOLS = [web_search, plan_meal, schedule_workout, detect_yield_curve_alpha_tool]
+@Tool(
+    "detect_supply_chain_alpha",
+    "Check for potential supply-chain disruptions using offline data.",
+)
+async def detect_supply_chain_alpha_tool(threshold: float = 50.0) -> Dict[str, str]:
+    msg = detect_supply_chain_alpha(threshold)
+    return {"alpha": msg}
+
+
+TOOLS = [
+    web_search,
+    plan_meal,
+    schedule_workout,
+    detect_yield_curve_alpha_tool,
+    detect_supply_chain_alpha_tool,
+]
 
 # ─────────────────────────────── reward functions ───────────────────────────
 def _fitness_reward(evt: Dict[str, Any]) -> float:

--- a/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
@@ -1,9 +1,12 @@
 """Alpha detection utilities for Era-of-Experience demo.
 
-This module demonstrates how one might detect simple 'alpha' signals
-from offline data samples. Currently it provides a helper analysing the
-U.S. Treasury yield curve to check for potential opportunities when the
-curve is inverted.
+This module demonstrates how one might detect simple "alpha" signals
+from offline data samples.  A tiny snapshot of the U.S. Treasury yield
+curve is included to highlight macro opportunities.  For a more
+industry‑agnostic flavour we also provide a toy ``stable_flows`` data
+set representing supply‑chain throughput.  Both helpers are purposely
+minimal yet illustrate how bespoke detectors could be plugged into the
+agent toolkit.
 """
 from __future__ import annotations
 
@@ -13,9 +16,10 @@ from typing import Dict
 import pandas as pd
 
 # Path to offline sample within the repo
-_YIELD_CURVE_CSV = (
-    Path(__file__).resolve().parent.parent / "macro_sentinel" / "offline_samples" / "yield_curve.csv"
-)
+_BASE = Path(__file__).resolve().parent.parent / "macro_sentinel" / "offline_samples"
+
+_YIELD_CURVE_CSV = _BASE / "yield_curve.csv"
+_STABLE_FLOWS_CSV = _BASE / "stable_flows.csv"
 
 
 def detect_yield_curve_alpha() -> str:
@@ -33,4 +37,20 @@ def detect_yield_curve_alpha() -> str:
     )
 
 
-__all__ = ["detect_yield_curve_alpha"]
+def detect_supply_chain_alpha(threshold: float = 50.0) -> str:
+    """Return a basic message about supply‑chain flow levels."""
+    try:
+        data = pd.read_csv(_STABLE_FLOWS_CSV)
+    except FileNotFoundError:
+        return "offline data missing"
+
+    flow = float(data["usd_mn"][0])
+    if flow < threshold:
+        return f"Flows {flow:.1f} M USD – potential bottleneck"
+    return f"Flows {flow:.1f} M USD – supply chain normal"
+
+
+__all__ = [
+    "detect_yield_curve_alpha",
+    "detect_supply_chain_alpha",
+]

--- a/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
+++ b/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
@@ -241,7 +241,7 @@
       "source": [
         "import pandas as pd\n",
         "from pathlib import Path\n",
-        "csv_path = Path('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/macro_sentinel/offline_samples/stable_flows.csv')\n",
+        "csv_path = Path(__file__).parent / 'macro_sentinel/offline_samples/stable_flows.csv'\n",
         "data = pd.read_csv(csv_path)\n",
         "flow = float(data['usd_mn'][0])\n",
         "msg = 'Bottleneck risk' if flow < 50 else 'Supply chain normal'\n",

--- a/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
+++ b/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
@@ -233,6 +233,22 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "supply-alpha-demo",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "from pathlib import Path\n",
+        "csv_path = Path('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/macro_sentinel/offline_samples/stable_flows.csv')\n",
+        "data = pd.read_csv(csv_path)\n",
+        "flow = float(data['usd_mn'][0])\n",
+        "msg = 'Bottleneck risk' if flow < 50 else 'Supply chain normal'\n",
+        "print(f'Stable flows: {flow:.1f} M USD | {msg}')"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "id": "stop-h",
       "metadata": {},


### PR DESCRIPTION
## Summary
- add supply chain alpha detection utility
- expose detection helpers from the demo package
- register new tool in the experience agent
- update README and Colab notebook with detector usage

## Testing
- `python -m alpha_factory_v1.demos.validate_demos --min-lines 10 --require-code-block`
- `pytest -k era_experience -q` *(fails: command not found)*