### PR TITLE
Improve era_of_experience docs

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -18,6 +18,14 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 
 ---
 
+## 🛠 Requirements
+
+- **Docker 24+** with the Compose plugin
+- At least **4 CPU cores** (or a modest GPU) for smooth local runs
+- *(Optional)* `OPENAI_API_KEY` for cloud LLMs — leave blank to use the built‑in Mixtral via Ollama
+
+---
+
 ## 🚀 Quick‑start (macOS / Windows / Linux)
 
 ```bash


### PR DESCRIPTION
## Summary
- mention prerequisites for the era_of_experience demo

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*