### PR TITLE
Improve offline demo resilience

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -44,11 +44,11 @@ import uvicorn
 
 try:  # gradio may be absent in minimal environments
     import gradio as gr
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     gr = None
 try:  # optional for tests
     from openai_agents import Agent, OpenAIAgent, Tool, memory
-except Exception:  # pragma: no cover - allow import without package
+except ImportError:  # pragma: no cover - allow import without package
     Agent = OpenAIAgent = Tool = memory = None
 
 if Tool is None:  # type: ignore

--- a/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
@@ -30,7 +30,7 @@ def _read_first_row(path: Path) -> Dict[str, str] | None:
     """Return the first row of a CSV as a mapping or ``None`` if empty."""
     if pd is not None:  # use pandas when available for convenience
         try:
-            df = pd.read_csv(path)
+            df = pd.read_csv(path, nrows=1)
         except FileNotFoundError:
             raise
         except Exception:  # pragma: no cover - handle corrupt CSV gracefully

--- a/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict
 
-import pandas as pd
+try:  # Optional dependency
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - fallback when pandas missing
+    pd = None
+import csv
 
 # Path to offline sample within the repo
 _BASE = Path(__file__).resolve().parent.parent / "macro_sentinel" / "offline_samples"
@@ -22,14 +26,40 @@ _YIELD_CURVE_CSV = _BASE / "yield_curve.csv"
 _STABLE_FLOWS_CSV = _BASE / "stable_flows.csv"
 
 
+def _read_first_row(path: Path) -> Dict[str, str] | None:
+    """Return the first row of a CSV as a mapping or ``None`` if empty."""
+    if pd is not None:  # use pandas when available for convenience
+        try:
+            df = pd.read_csv(path)
+        except FileNotFoundError:
+            raise
+        except Exception:  # pragma: no cover - handle corrupt CSV gracefully
+            pass
+        else:
+            if not df.empty:
+                return df.iloc[0].to_dict()
+
+    try:
+        with open(path, newline="") as fh:
+            reader = csv.DictReader(fh)
+            return next(reader, None)
+    except FileNotFoundError:
+        raise
+
+    return None
+
+
 def detect_yield_curve_alpha() -> str:
     """Return a short message describing the yield-curve state."""
     try:
-        data = pd.read_csv(_YIELD_CURVE_CSV)
+        row = _read_first_row(_YIELD_CURVE_CSV)
     except FileNotFoundError:
         return "offline data missing"
 
-    spread = float(data["10y"][0]) - float(data["3m"][0])
+    if not row:
+        return "offline data missing"
+
+    spread = float(row.get("10y", 0)) - float(row.get("3m", 0))
     return (
         f"Yield curve spread {spread:.2f} – consider long bonds"
         if spread < 0
@@ -40,11 +70,14 @@ def detect_yield_curve_alpha() -> str:
 def detect_supply_chain_alpha(threshold: float = 50.0) -> str:
     """Return a basic message about supply‑chain flow levels."""
     try:
-        data = pd.read_csv(_STABLE_FLOWS_CSV)
+        row = _read_first_row(_STABLE_FLOWS_CSV)
     except FileNotFoundError:
         return "offline data missing"
 
-    flow = float(data["usd_mn"][0])
+    if not row or "usd_mn" not in row:
+        return "offline data missing"
+
+    flow = float(row["usd_mn"])
     if flow < threshold:
         return f"Flows {flow:.1f} M USD – potential bottleneck"
     return f"Flows {flow:.1f} M USD – supply chain normal"

--- a/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
@@ -15,7 +15,7 @@ from typing import Dict
 
 try:  # Optional dependency
     import pandas as pd  # type: ignore
-except Exception:  # pragma: no cover - fallback when pandas missing
+except ImportError:  # pragma: no cover - fallback when pandas missing
     pd = None
 import csv
 


### PR DESCRIPTION
## Summary
- support running alpha detection without pandas
- make demo agent import optional deps lazily
- include noop Tool decorator when openai_agents is missing
- skip demo launch if gradio not installed
- fix run_experience_demo.sh executable bit

## Testing
- `python check_env.py`
- `python -m unittest tests.test_era_experience`
- `python -m unittest tests.test_alpha_detection`
- `python -m unittest discover tests` *(fails: missing deps & non executable scripts)*