### PR TITLE
Improve era_of_experience demo docs

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -25,7 +25,10 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 - *(Optional)* `OPENAI_API_KEY` for cloud LLMs — leave blank to use the built‑in Mixtral via Ollama
 - If running without `run_experience_demo.sh`, install the
   [`openai-agents`](https://openai.github.io/openai-agents-python/) SDK and
-  `gradio` via `pip install openai-agents gradio`
+  `gradio` via `pip install openai-agents gradio`.
+  Then, you can run the script directly with a command like:
+  ```bash
+  SAMPLE_DATA_DIR=/path/to/csvs python agent_experience_entrypoint.py
 
 ---
 

--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -23,6 +23,9 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 - **Docker 24+** with the Compose plugin
 - At least **4 CPU cores** (or a modest GPU) for smooth local runs
 - *(Optional)* `OPENAI_API_KEY` for cloud LLMs — leave blank to use the built‑in Mixtral via Ollama
+- If running without `run_experience_demo.sh`, install the
+  [`openai-agents`](https://openai.github.io/openai-agents-python/) SDK and
+  `gradio` via `pip install openai-agents gradio`
 
 ---
 
@@ -58,6 +61,8 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
    cp config.env.sample config.env
    $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, LIVE_FEED, etc.
    ```
+   You may override the path for built-in offline samples with
+   `SAMPLE_DATA_DIR=/path/to/csvs`.
 
 2. Enable real-time collectors and metrics with the `--live` flag:
 

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -50,6 +50,9 @@ try:  # optional for tests
     from openai_agents import Agent, OpenAIAgent, Tool, memory
 except ImportError:  # pragma: no cover - allow import without package
     Agent = OpenAIAgent = Tool = memory = None
+    _NO_OPENAI_AGENTS = True
+else:
+    _NO_OPENAI_AGENTS = False
 
 if Tool is None:  # type: ignore
     def Tool(*_args, **_kwargs):  # noqa: D401 - simple passthrough decorator
@@ -213,6 +216,10 @@ async def main() -> None:
     • Feeds the stream to the agent
     • Shows a slim Gradio dashboard (memory + live reasoning)
     """
+    if _NO_OPENAI_AGENTS:
+        raise RuntimeError(
+            "OpenAI Agents SDK is required; install via 'pip install openai-agents'"
+        )
     if gr is None:
         raise RuntimeError(
             "gradio is required for the demo UI; install via 'pip install gradio'"

--- a/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
@@ -10,6 +10,7 @@ agent toolkit.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Dict
 
@@ -20,7 +21,8 @@ except ImportError:  # pragma: no cover - fallback when pandas missing
 import csv
 
 # Path to offline sample within the repo
-_BASE = Path(__file__).resolve().parent.parent / "macro_sentinel" / "offline_samples"
+_DEFAULT_BASE = Path(__file__).resolve().parent.parent / "macro_sentinel" / "offline_samples"
+_BASE = Path(os.getenv("SAMPLE_DATA_DIR", _DEFAULT_BASE))
 
 _YIELD_CURVE_CSV = _BASE / "yield_curve.csv"
 _STABLE_FLOWS_CSV = _BASE / "stable_flows.csv"


### PR DESCRIPTION
## Summary
- clarify local requirements in README
- mention SAMPLE_DATA_DIR for custom data path
- guard entrypoint if OpenAI Agents SDK is missing
- allow custom sample data location in detection helpers

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`