### PR TITLE
Improve offline mode for Era-of-Experience demo

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -66,6 +66,8 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
    ```
    You may override the path for built-in offline samples with
    `SAMPLE_DATA_DIR=/path/to/csvs`.
+   Sample CSVs (`wearable_daily.csv`, `edu_progress.csv`) are shipped in
+   `offline_samples/` so the demo also works without internet access.
 
 2. Enable real-time collectors and metrics with the `--live` flag:
 

--- a/alpha_factory_v1/demos/era_of_experience/offline_samples/edu_progress.csv
+++ b/alpha_factory_v1/demos/era_of_experience/offline_samples/edu_progress.csv
@@ -1,0 +1,2 @@
+week,subject,score
+1,math,0.75

--- a/alpha_factory_v1/demos/era_of_experience/offline_samples/wearable_daily.csv
+++ b/alpha_factory_v1/demos/era_of_experience/offline_samples/wearable_daily.csv
@@ -1,0 +1,2 @@
+steps,heartrate,calories
+8000,72,2200

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -90,6 +90,9 @@ declare -A urls=(
   [edu_progress.csv]  =https://raw.githubusercontent.com/MontrealAI/demo-assets/main/edu_progress.csv
 )
 for f in "${!urls[@]}"; do
+  if [[ -f "$offline_dir/$f" ]]; then
+    continue  # local file already present
+  fi
   if ! curl -sfL "${urls[$f]}" -o "$offline_dir/$f"; then
     warn "Failed downloading $f – using empty placeholder"
     : > "$offline_dir/$f"


### PR DESCRIPTION
## Summary
- ship small offline CSV samples for the `era_of_experience` demo
- skip download when local samples exist
- document bundled samples in the README

## Testing
- `python -m unittest tests.test_era_experience -v`
- `python check_env.py` *(fails: Missing packages)*