### PR TITLE
Enhance dependency check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,10 +352,10 @@ Cells with \(Δ\mathcal F < 0\) glow 🔵 on Grafana; Ω‑Agents race to harves
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
 ./quickstart.sh --preflight   # optional environment check
-AUTO_INSTALL_MISSING=1 python check_env.py  # verify & auto-install deps
+python check_env.py --auto-install  # verify & auto-install deps
 ./quickstart.sh               # creates venv, installs deps, launches
-# If the host has no internet access set `WHEELHOUSE=/path/to/wheels` and
-# the helper attempts an offline install.
+# Use `--wheelhouse /path/to/wheels` to install offline packages
+# when the host has no internet access.
 # open the docs in your browser
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs
 # Alternatively, ``python alpha_factory_v1/quickstart.py`` provides the same

--- a/check_env.py
+++ b/check_env.py
@@ -15,7 +15,7 @@ REQUIRED = [
     "anthropic",
 ]
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Validate runtime dependencies")
     parser.add_argument(
         "--auto-install",


### PR DESCRIPTION
## Summary
- extend `check_env.py` with `--auto-install` and `--wheelhouse` options
- document new usage in quick-start guide

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`
- `python check_env.py --auto-install` *(fails: network unavailable)*