### PR TITLE
Fix test logic and optional import

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/__init__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__init__.py
@@ -1,6 +1,13 @@
 """MiniMu demo package for MuZero Planning."""
 
-from .agent_muzero_entrypoint import launch_dashboard
+try:
+    from .agent_muzero_entrypoint import launch_dashboard
+except Exception:  # pragma: no cover - optional deps may be missing
+    def launch_dashboard() -> None:  # type: ignore[return-type]
+        """Placeholder when optional dependencies are absent."""
+        raise RuntimeError(
+            "gradio and other optional packages are required for the MuZero demo"
+        )
 
 __all__ = ["launch_dashboard"]
 

--- a/alpha_factory_v1/demos/muzero_planning/__init__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__init__.py
@@ -2,7 +2,7 @@
 
 try:
     from .agent_muzero_entrypoint import launch_dashboard
-except Exception:  # pragma: no cover - optional deps may be missing
+except ImportError:  # pragma: no cover - optional deps may be missing
     def launch_dashboard() -> None:  # type: ignore[return-type]
         """Placeholder when optional dependencies are absent."""
         raise RuntimeError(

--- a/tests/test_alpha_detection.py
+++ b/tests/test_alpha_detection.py
@@ -13,8 +13,10 @@ class TestAlphaDetection(unittest.TestCase):
         msg = alpha_detection.detect_supply_chain_alpha()
         self.assertIsInstance(msg, str)
         # The message should either mention "USD" or indicate that "offline data" is missing.
-        self.assertTrue("USD" in msg, "Expected 'USD' to be in the message.")
-        self.assertTrue("offline data missing" in msg, "Expected 'offline data missing' to be in the message.")
+        self.assertTrue(
+            "USD" in msg or "offline data missing" in msg,
+            "Expected 'USD' or 'offline data missing' in the message.",
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- ensure shell scripts in demo directories are executable
- gracefully handle missing dependencies in `muzero_planning`
- fix `test_alpha_detection` expectation logic

## Testing
- `python -m unittest tests/test_alpha_detection.py -v`
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: openai_agents)*
