### PR TITLE
Improve env check usage

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -37,6 +37,7 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience
+python ../../../check_env.py --auto-install  # optional env check
 chmod +x run_experience_demo.sh
 ./run_experience_demo.sh      # ← THAT’S IT
 ```

--- a/check_env.py
+++ b/check_env.py
@@ -5,6 +5,7 @@ import subprocess
 import os
 import sys
 import argparse
+from typing import List, Optional
 
 REQUIRED = [
     "pytest",


### PR DESCRIPTION
## Summary
- fix missing typing import in `check_env.py`
- document running `check_env.py` before launching the era of experience demo

## Testing
- `python -m py_compile check_env.py`
- `python check_env.py --auto-install --wheelhouse /workspace/wheelhouse` *(fails: No matching distribution found for pytest)*