### PR TITLE
Improve era_of_experience docs and startup checks

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -216,6 +216,19 @@ Shared Redis memory + A2A = emergent cooperation.
 
 ---
 
+## ✅ Tests
+
+Verify the demo locally with Python's builtin test runner:
+
+```bash
+python -m unittest tests.test_era_experience
+```
+
+Run `python ../../../check_env.py --auto-install` first to ensure optional
+packages like `pytest` and `openai-agents` are available.
+
+---
+
 ## 🗺 Road‑map
 
 - [ ] Plug‑and‑play Gym‑Retrowrapper for atari‑style sims 

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -66,6 +66,7 @@ need docker
 docker compose version &>/dev/null || die "Docker Compose plugin missing"
 ver=$(docker version --format '{{.Server.Version}}')
 [[ "${ver%%.*}" -ge 24 ]] || warn "Docker $ver < 24 may slow multi-stage builds"
+need curl
 
 ################################ config.env ###################################
 if [[ ! -f "$env_file" ]]; then


### PR DESCRIPTION
## Summary
- add curl prereq check for `run_experience_demo.sh`
- document how to run tests in the Era-of-Experience README

## Testing
- `python -m tests.test_era_experience`