### PR TITLE
Fix plugin loader & offline agent check

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -92,7 +92,10 @@ class AgentGdl:
 async def _llm_comment(delta_g: float) -> str:
     """Return a short LLM comment on ``delta_g`` if OpenAI Agents is available."""
 
-    if OpenAIAgent is None:
+    # When the OpenAI Agents SDK is missing the shim in
+    # ``alpha_factory_v1.backend`` exposes a non-callable placeholder.
+    # Guard against that scenario as well so offline tests succeed.
+    if OpenAIAgent is None or not callable(OpenAIAgent):
         return "LLM offline"
 
     agent = OpenAIAgent(

--- a/alpha_factory_v1/demos/omni_factory_demo/omni_factory_demo.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/omni_factory_demo.py
@@ -394,6 +394,8 @@ def _load_plugins(folder: Path | None = None) -> List[ModuleType]:
         return mods
     global PLUGINS
     for py in folder.glob("*.py"):
+        if py.name == "__init__.py":
+            continue  # ignore package marker
         with contextlib.suppress(Exception):
             spec = importlib.util.spec_from_file_location(py.stem, py)
             if spec and spec.loader:


### PR DESCRIPTION
## Summary
- ensure `_llm_comment` handles missing OpenAI Agents SDK
- skip `__init__.py` when loading omni-factory plugins
- make all demo shell scripts executable

## Testing
- `python -m unittest`
- `python -m unittest tests.test_alpha_agi_business_3_v1 tests.test_omni_factory_plugins tests.test_demos.TestDemos.test_demo_shell_scripts -v`
