### PR TITLE
Improve Era-of-Experience demo

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -134,6 +134,7 @@ Result: an agent that <strong>evolves faster than you can refresh the page</stro
 | `docker-compose.experience.yml` | orchestrator + Ollama services |
 | `reward_backends/` | 🍬 Drop‑in reward plug‑ins (auto‑discovery) |
 | `simulation/` | Tiny Gym‑like env stubs (ready to extend) |
+| `stub_agents.py` | Minimal agent classes for OpenAI SDK & ADK workflows |
 | `colab_era_of_experience.ipynb` | Cloud twin notebook |
 
 ---
@@ -182,6 +183,12 @@ for _ in range(3):
     state, reward, done, info = env.step("act")
     print(state, reward)
 ```
+
+* **Prototype a custom agent**
+
+  `stub_agents.py` contains minimal classes
+  (`ExperienceAgent`, `FederatedExperienceAgent`) illustrating how to build
+  on the OpenAI SDK and Google ADK respectively.
 
 
 * **Cluster‑scale**

--- a/alpha_factory_v1/demos/era_of_experience/__init__.py
+++ b/alpha_factory_v1/demos/era_of_experience/__init__.py
@@ -4,9 +4,12 @@ from .alpha_detection import (
     detect_supply_chain_alpha,
 )
 from .simulation import SimpleExperienceEnv
+from .stub_agents import ExperienceAgent, FederatedExperienceAgent
 
 __all__ = [
     "detect_yield_curve_alpha",
     "detect_supply_chain_alpha",
     "SimpleExperienceEnv",
+    "ExperienceAgent",
+    "FederatedExperienceAgent",
 ]

--- a/alpha_factory_v1/demos/era_of_experience/stub_agents.py
+++ b/alpha_factory_v1/demos/era_of_experience/stub_agents.py
@@ -1,0 +1,48 @@
+"""Stub agents illustrating potential OpenAI SDK and Google ADK workflows.
+
+This module provides bare-bones agent classes demonstrating how the
+`openai_agents` SDK and Google's ADK could be extended within the
+Era-of-Experience demo. These classes intentionally keep the
+implementation minimal so they can serve as educational starting points
+for custom deployments.
+
+The stubs operate without network calls when the respective libraries
+are missing, allowing the tests to import the file even in restricted
+CI environments.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:  # OpenAI Agents SDK (tool-calling, memory, planning)
+    from openai_agents import Agent
+except Exception:  # pragma: no cover - optional dependency
+    Agent = object  # type: ignore
+
+try:  # Google Agent Development Kit (A2A protocol)
+    from google_adk import Agent as ADKAgent
+except Exception:  # pragma: no cover - optional dependency
+    ADKAgent = object  # type: ignore
+
+
+class ExperienceAgent(Agent):
+    """Tiny wrapper around :class:`openai_agents.Agent`.
+
+    This stub illustrates where one could attach custom tools or reward
+    functions. The default ``act`` simply returns a placeholder action so
+    unit tests can run without an API key.
+    """
+
+    async def act(self) -> Dict[str, Any]:  # type: ignore[override]
+        return {"action": "noop"}
+
+
+class FederatedExperienceAgent(ADKAgent):
+    """Sketch of an ADK-compatible agent for A2A federation.
+
+    Real implementations would define ``handle_request`` to process A2A
+    messages. Here we return a minimal canned response.
+    """
+
+    async def handle_request(self, payload: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[override]
+        return {"echo": payload}

--- a/tests/test_era_experience.py
+++ b/tests/test_era_experience.py
@@ -4,6 +4,10 @@ import asyncio
 from alpha_factory_v1.demos.era_of_experience import agent_experience_entrypoint as demo
 from alpha_factory_v1.demos.era_of_experience import reward_backends
 from alpha_factory_v1.demos.era_of_experience.simulation import SimpleExperienceEnv
+from alpha_factory_v1.demos.era_of_experience.stub_agents import (
+    ExperienceAgent,
+    FederatedExperienceAgent,
+)
 
 class TestEraOfExperience(unittest.TestCase):
     def test_experience_stream_yields_event(self) -> None:
@@ -30,6 +34,12 @@ class TestEraOfExperience(unittest.TestCase):
         self.assertEqual(state, 0)
         state, reward, done, info = env.step("act")
         self.assertIsInstance(reward, float)
+
+    def test_stub_agents_instantiable(self) -> None:
+        exp = ExperienceAgent()
+        fed = FederatedExperienceAgent()
+        self.assertTrue(hasattr(exp, "act"))
+        self.assertTrue(hasattr(fed, "handle_request"))
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- expose new stub agent classes for OpenAI Agents SDK and Google ADK workflows
- document stub agents in the Era of Experience README
- export stub agent names from the package
- test that stub agents can be instantiated

## Testing
- `python -m unittest tests.test_era_experience`
- `python -m unittest tests.test_alpha_detection`
