### PR TITLE
Fix path in Era-of-Experience Colab

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
+++ b/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
@@ -257,7 +257,7 @@
    "source": [
     "import pandas as pd\n",
     "from pathlib import Path\n",
-    "csv_path = Path(__file__).parent / 'macro_sentinel/offline_samples/stable_flows.csv'\n",
+    "csv_path = root.parent / 'macro_sentinel/offline_samples/stable_flows.csv'\n",
     "data = pd.read_csv(csv_path)\n",
     "flow = float(data['usd_mn'][0])\n",
     "msg = 'Bottleneck risk' if flow < 50 else 'Supply chain normal'\n",


### PR DESCRIPTION
## Summary
- fix path for supply chain alpha sample in the Colab demo

## Testing
- `python -m unittest tests.test_era_experience -v`
