### PR TITLE
Enhance Era of Experience demo

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -136,6 +136,7 @@ Result: an agent that <strong>evolves faster than you can refresh the page</stro
 | `simulation/` | Tiny Gym‑like env stubs (ready to extend) |
 | `stub_agents.py` | Minimal agent classes for OpenAI SDK & ADK workflows |
 | `colab_era_of_experience.ipynb` | Cloud twin notebook |
+| `alpha_report.py` | CLI helper printing current offline alpha signals |
 
 ---
 

--- a/alpha_factory_v1/demos/era_of_experience/alpha_report.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_report.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Generate a simple alpha opportunity report using offline samples.
+
+This helper aggregates built-in alpha detectors and selects the most
+salient opportunity based on heuristic thresholds. It works fully
+offline so users can see an end-to-end flow without providing an
+API key.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+try:
+    from alpha_factory_v1.demos.era_of_experience.alpha_detection import (
+        detect_yield_curve_alpha,
+        detect_supply_chain_alpha,
+    )
+except ModuleNotFoundError:  # pragma: no cover - running as stand-alone script
+    import pathlib
+    import sys
+
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+    from alpha_factory_v1.demos.era_of_experience.alpha_detection import (
+        detect_yield_curve_alpha,
+        detect_supply_chain_alpha,
+    )
+
+
+def gather_signals() -> Dict[str, str]:
+    """Return raw detector messages for all built-in signals."""
+    return {
+        "yield_curve": detect_yield_curve_alpha(),
+        "supply_chain": detect_supply_chain_alpha(),
+    }
+
+
+def best_alpha(signals: Dict[str, str]) -> str:
+    """Select the most actionable alpha message."""
+    yc = signals.get("yield_curve", "")
+    sc = signals.get("supply_chain", "")
+
+    # simple heuristics
+    if "bottleneck" in sc.lower():
+        return sc
+    if "long bonds" in yc.lower():
+        return yc
+    return yc if yc else sc
+
+
+def main() -> None:
+    signals = gather_signals()
+    choice = best_alpha(signals)
+    print("\nAlpha signals:")
+    for k, v in signals.items():
+        print(f"- {k}: {v}")
+    print("\nBest current alpha →", choice)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/alpha_factory_v1/demos/era_of_experience/alpha_report.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_report.py
@@ -44,7 +44,7 @@ def best_alpha(signals: Dict[str, str]) -> str:
         return sc
     if LONG_BONDS_KEYWORD in yc.lower():
         return yc
-    return yc if yc else sc
+    return yc or sc
 
 
 def main() -> None:

--- a/alpha_factory_v1/demos/era_of_experience/alpha_report.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_report.py
@@ -40,9 +40,9 @@ def best_alpha(signals: Dict[str, str]) -> str:
     sc = signals.get("supply_chain", "")
 
     # simple heuristics
-    if "bottleneck" in sc.lower():
+    if BOTTLENECK_KEYWORD in sc.lower():
         return sc
-    if "long bonds" in yc.lower():
+    if LONG_BONDS_KEYWORD in yc.lower():
         return yc
     return yc if yc else sc
 


### PR DESCRIPTION
## Summary
- document new helper in demo README
- add `alpha_report.py` script to summarize offline alpha signals

## Testing
- `python alpha_factory_v1/demos/era_of_experience/alpha_report.py`
- `python -m pytest -q` *(fails: No module named pytest)*