### PR TITLE
Extend business demo with new opportunity agent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -148,10 +148,20 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 # the demo starts two stub agents:
 #   • **IncorporatorAgent** registers the business
 #   • **AlphaDiscoveryAgent** emits a placeholder market opportunity
+#   • **AlphaOpportunityAgent** signals a supply‑chain bottleneck example
 
 open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_copper_spread.json
+# or
+./scripts/post_alpha_job.sh examples/job_supply_chain_alpha.json
 ```
+
+If dependencies are missing, run:
+
+```bash
+python ../../../check_env.py --auto-install
+```
+Use `--wheelhouse /path/to/wheels` for offline installs.
 
 Or open `colab_alpha_agi_business_v1_demo.ipynb` to run everything in Colab.
 To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_bridge.py` (see step 5 in the notebook).

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -39,6 +39,17 @@ class AlphaDiscoveryAgent(AgentBase):
             "alpha.discovery", {"alpha": "cross-market synergy identified"}
         )
 
+class AlphaOpportunityAgent(AgentBase):
+    """Stub agent emitting a sample market inefficiency."""
+
+    NAME = "alpha_opportunity"
+    CAPABILITIES = ["opportunity"]
+    CYCLE_SECONDS = 300
+    __slots__ = ()
+
+    async def step(self) -> None:
+        await self.publish("alpha.opportunity", {"alpha": "supply-chain bottleneck detected"})
+
 
 def register_demo_agents() -> None:
     """Register built-in demo agents with the framework."""
@@ -58,6 +69,15 @@ def register_demo_agents() -> None:
             cls=AlphaDiscoveryAgent,
             version="1.0.0",
             capabilities=AlphaDiscoveryAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=AlphaOpportunityAgent.NAME,
+            cls=AlphaOpportunityAgent,
+            version="1.0.0",
+            capabilities=AlphaOpportunityAgent.CAPABILITIES,
         )
     )
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/job_supply_chain_alpha.json
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/job_supply_chain_alpha.json
@@ -1,0 +1,4 @@
+{
+  "agent": "alpha_opportunity",
+  "note": "Detect supply-chain bottleneck"
+}

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -26,15 +26,25 @@ async def trigger_discovery() -> str:
     return "alpha_discovery queued"
 
 
+@Tool(name="trigger_opportunity", description="Trigger the AlphaOpportunityAgent")
+async def trigger_opportunity() -> str:
+    resp = requests.post(f"{HOST}/agent/alpha_opportunity/trigger", timeout=5)
+    resp.raise_for_status()
+    return "alpha_opportunity queued"
+
+
 class BusinessAgent(Agent):
     """Tiny agent exposing orchestrator helper tools."""
 
     name = "business_helper"
-    tools = [list_agents, trigger_discovery]
+    tools = [list_agents, trigger_discovery, trigger_opportunity]
 
     async def policy(self, obs, ctx):  # type: ignore[override]
-        if isinstance(obs, dict) and obs.get("action") == "discover":
-            return await self.tools.trigger_discovery()
+        if isinstance(obs, dict):
+            if obs.get("action") == "discover":
+                return await self.tools.trigger_discovery()
+            if obs.get("action") == "opportunity":
+                return await self.tools.trigger_opportunity()
         return await self.tools.list_agents()
 
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -43,7 +43,7 @@ class BusinessAgent(Agent):
         if isinstance(obs, dict):
             if obs.get("action") == "discover":
                 return await self.tools.trigger_discovery()
-            if obs.get("action") == "opportunity":
+            elif obs.get("action") == "opportunity":
                 return await self.tools.trigger_opportunity()
         return await self.tools.list_agents()
 


### PR DESCRIPTION
## Summary
- add `AlphaOpportunityAgent` stub to business demo
- expose new agent via OpenAI Agents bridge
- document new agent and offline setup in the demo README
- add example job for the new agent

## Testing
- `pytest -q` *(fails: command not found)*
- `python check_env.py --auto-install` *(fails to install packages due to no network)*