### PR TITLE
Improve OpenAI bridge fallback

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -164,7 +164,10 @@ python ../../../check_env.py --auto-install
 Use `--wheelhouse /path/to/wheels` for offline installs.
 
 Or open `colab_alpha_agi_business_v1_demo.ipynb` to run everything in Colab.
-To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_bridge.py` (see step 5 in the notebook).
+To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_bridge.py` (see step 5 in the notebook). If the script complains about a missing `openai_agents` package, install it with:
+```bash
+pip install openai-agents
+```
 
 ### 🤖 OpenAI Agents bridge
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
     sys.stderr.write(
         "\n❌  openai_agents not installed. Install with 'pip install openai-agents'\n"
     )
-    raise SystemExit(1) from exc
+    sys.exit(1)
 
 HOST = os.getenv("BUSINESS_HOST", "http://localhost:8000")
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -6,8 +6,16 @@ local orchestrator. It works offline when no API key is configured.
 from __future__ import annotations
 
 import os
+import sys
 import requests
-from openai_agents import Agent, AgentRuntime, Tool
+
+try:  # soft dependency
+    from openai_agents import Agent, AgentRuntime, Tool  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+    sys.stderr.write(
+        "\n❌  openai_agents not installed. Install with 'pip install openai-agents'\n"
+    )
+    raise SystemExit(1) from exc
 
 HOST = os.getenv("BUSINESS_HOST", "http://localhost:8000")
 


### PR DESCRIPTION
## Summary
- handle missing `openai_agents` dependency gracefully
- document how to install the bridge dependency

## Testing
- `pip install pytest prometheus_client --quiet` *(fails: No route to host)*
- `pytest -q` *(fails: command not found)*