### PR TITLE
Improve business demo bridge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -177,6 +177,8 @@ Expose the business demo via the OpenAI Agents SDK (specify `--host` if the orch
 python openai_agents_bridge.py --host http://localhost:8000
 # → http://localhost:5001/v1/agents
 ```
+When the optional `google-adk` dependency is installed and `ALPHA_FACTORY_ENABLE_ADK=true` is set,
+the same helper agent is also exposed via an ADK gateway for A2A messaging.
 
 *No Docker?*
 `bash <(curl -sL https://get.alpha-factory.ai/business_demo.sh)` boots an ephemeral VM (CPU‑only mode).

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -22,7 +22,7 @@ try:
     # Optional ADK bridge
     from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
     ADK_AVAILABLE = True
-except Exception:  # pragma: no cover - ADK not installed
+except ImportError:  # pragma: no cover - ADK not installed
     ADK_AVAILABLE = False
 
 HOST = os.getenv("BUSINESS_HOST", "http://localhost:8000")

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -18,6 +18,13 @@ except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
     )
     sys.exit(1)
 
+try:
+    # Optional ADK bridge
+    from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+    ADK_AVAILABLE = True
+except Exception:  # pragma: no cover - ADK not installed
+    ADK_AVAILABLE = False
+
 HOST = os.getenv("BUSINESS_HOST", "http://localhost:8000")
 
 
@@ -75,8 +82,15 @@ def main() -> None:
     HOST = args.host
     api_key = os.getenv("OPENAI_API_KEY") or None
     runtime = AgentRuntime(api_key=api_key)
-    runtime.register(BusinessAgent())
+    agent = BusinessAgent()
+    runtime.register(agent)
     print(f"Registered BusinessAgent -> {HOST}")
+
+    if ADK_AVAILABLE:
+        auto_register([agent])
+        maybe_launch()
+        print("BusinessAgent exposed via ADK gateway")
+
     runtime.run()
 
 


### PR DESCRIPTION
## Summary
- support optional Google ADK bridge in `openai_agents_bridge.py`
- document ADK gateway in demo README

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*