### PR TITLE
Add execution agent demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -118,6 +118,7 @@ flowchart LR
 | **MarketAnalysisAgent** | 5 M ticks/s ingest, micro‑alpha scanner | Benchmark edge vs baseline & stress‑test PnL | `backend/agents/market_analysis` |
 | **MemoryAgent** | Retrieval‑augmented vector store | Persist & recall reusable alpha templates | `backend/agents/memory` |
 | **SafetyAgent** | Constitutional‑AI & seccomp sandbox | Filter unsafe code / data exfiltration | `backend/agents/safety` |
+| **ExecutionAgent** | Order‑routing & trade settlement | Convert opportunities into executed trades | `backend/agents/execution` |
 
 All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google ADK**, auto‑fallback to offline GGUF models — *no API key required*.
 
@@ -130,7 +131,7 @@ All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google AD
 2. **MarketAnalysisAgent** detects anomalous spread widening in copper vs renewable‑ETF flows. 
 3. **PlanningAgent** forks tasks → **StrategyAgent** crafts hedged LME‑COMEX pair‑trade + FX overlay. 
 4. **SafetyAgent** signs‑off compliance pack (Dodd‑Frank §716, EMIR RTS 6). 
-5. Orders hit venue; fills + k‑sigs hashed on‑chain; escrow releases **$AGIALPHA**; live PnL feeds Grafana. 
+5. **ExecutionAgent** routes orders to venues; fills + k‑sigs hashed on‑chain; escrow releases **$AGIALPHA**; live PnL feeds Grafana.
 *Wall clock: 4 min 18 s on a CPU‑only laptop.*
 
 ---
@@ -145,15 +146,18 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 # launch demo (GPU optional)
 ./run_business_v1_demo.sh
 
-# the demo starts two stub agents:
+# the demo starts three stub agents:
 #   • **IncorporatorAgent** registers the business
 #   • **AlphaDiscoveryAgent** emits a placeholder market opportunity
 #   • **AlphaOpportunityAgent** signals a supply‑chain bottleneck example
+#   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 
 open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_copper_spread.json
 # or
 ./scripts/post_alpha_job.sh examples/job_supply_chain_alpha.json
+# or
+./scripts/post_alpha_job.sh examples/job_execute_alpha.json
 ```
 
 If dependencies are missing, run:

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -51,6 +51,18 @@ class AlphaOpportunityAgent(AgentBase):
         await self.publish("alpha.opportunity", {"alpha": "supply-chain bottleneck detected"})
 
 
+class AlphaExecutionAgent(AgentBase):
+    """Stub agent converting an opportunity into an executed trade."""
+
+    NAME = "alpha_execution"
+    CAPABILITIES = ["execute"]
+    CYCLE_SECONDS = 180
+    __slots__ = ()
+
+    async def step(self) -> None:
+        await self.publish("alpha.execution", {"alpha": "order executed"})
+
+
 def register_demo_agents() -> None:
     """Register built-in demo agents with the framework."""
 
@@ -78,6 +90,15 @@ def register_demo_agents() -> None:
             cls=AlphaOpportunityAgent,
             version="1.0.0",
             capabilities=AlphaOpportunityAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=AlphaExecutionAgent.NAME,
+            cls=AlphaExecutionAgent,
+            version="1.0.0",
+            capabilities=AlphaExecutionAgent.CAPABILITIES,
         )
     )
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -89,9 +89,25 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+    "outputs": [],
+    "source": [
+    "import requests\nprint('Available agents:', requests.get('http://localhost:8000/agents').json())"
+    ]
+   },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4b \u00b7 Trigger Execution Agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "import requests\nprint('Available agents:', requests.get('http://localhost:8000/agents').json())"
+    "import requests\nrequests.post('http://localhost:8000/agent/alpha_execution/trigger')\nprint('execution triggered')"
    ]
   },
   {

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/job_execute_alpha.json
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/job_execute_alpha.json
@@ -1,0 +1,4 @@
+{
+  "agent": "alpha_execution",
+  "note": "Execute trade on detected alpha"
+}

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -61,11 +61,18 @@ async def trigger_opportunity() -> str:
     return "alpha_opportunity queued"
 
 
+@Tool(name="trigger_execution", description="Trigger the AlphaExecutionAgent")
+async def trigger_execution() -> str:
+    resp = requests.post(f"{HOST}/agent/alpha_execution/trigger", timeout=5)
+    resp.raise_for_status()
+    return "alpha_execution queued"
+
+
 class BusinessAgent(Agent):
     """Tiny agent exposing orchestrator helper tools."""
 
     name = "business_helper"
-    tools = [list_agents, trigger_discovery, trigger_opportunity]
+    tools = [list_agents, trigger_discovery, trigger_opportunity, trigger_execution]
 
     async def policy(self, obs, ctx):  # type: ignore[override]
         if isinstance(obs, dict):
@@ -73,6 +80,8 @@ class BusinessAgent(Agent):
                 return await self.tools.trigger_discovery()
             elif obs.get("action") == "opportunity":
                 return await self.tools.trigger_opportunity()
+            elif obs.get("action") == "execute":
+                return await self.tools.trigger_execution()
         return await self.tools.list_agents()
 
 


### PR DESCRIPTION
## Summary
- extend business demo with AlphaExecutionAgent
- expose execution trigger via OpenAI Agents bridge
- update Colab notebook and README
- include sample execution job file

## Testing
- `pip install pytest prometheus_client --quiet` *(fails: Could not find a version that satisfies the requirement pytest)*
- `pytest -q` *(fails: command not found)*