### PR TITLE
Enhance alpha business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -151,7 +151,7 @@ python run_business_v1_local.py --bridge
 # the demo starts three stub agents:
 #   • **IncorporatorAgent** registers the business
 #   • **AlphaDiscoveryAgent** emits a placeholder market opportunity
-#   • **AlphaOpportunityAgent** signals a supply‑chain bottleneck example
+#   • **AlphaOpportunityAgent** picks a random scenario from `examples/alpha_opportunities.json`
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 
 open http://localhost:7878      # Dashboard SPA

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -8,11 +8,18 @@ automatically when ``OPENAI_API_KEY`` is present.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
+import random
+from pathlib import Path
 
 from alpha_factory_v1.backend import orchestrator
-from alpha_factory_v1.backend.agents import AgentBase, AgentMetadata, register_agent
+from alpha_factory_v1.backend.agents import (
+    AgentBase,
+    AgentMetadata,
+    register_agent,
+)
 
 
 class IncorporatorAgent(AgentBase):
@@ -45,10 +52,21 @@ class AlphaOpportunityAgent(AgentBase):
     NAME = "alpha_opportunity"
     CAPABILITIES = ["opportunity"]
     CYCLE_SECONDS = 300
-    __slots__ = ()
+    __slots__ = ("_opportunities",)
+
+    def __init__(self) -> None:
+        super().__init__()
+        path = Path(__file__).with_name("examples") / "alpha_opportunities.json"
+        try:
+            self._opportunities = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover - fallback when file missing
+            self._opportunities = [
+                {"alpha": "generic supply-chain inefficiency"}
+            ]
 
     async def step(self) -> None:
-        await self.publish("alpha.opportunity", {"alpha": "supply-chain bottleneck detected"})
+        choice = random.choice(self._opportunities)
+        await self.publish("alpha.opportunity", choice)
 
 
 class AlphaExecutionAgent(AgentBase):

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -59,7 +59,11 @@ class AlphaOpportunityAgent(AgentBase):
         path = Path(__file__).with_name("examples") / "alpha_opportunities.json"
         try:
             self._opportunities = json.loads(path.read_text(encoding="utf-8"))
-        except Exception:  # pragma: no cover - fallback when file missing
+        except FileNotFoundError:  # pragma: no cover - fallback when file missing
+            self._opportunities = [
+                {"alpha": "generic supply-chain inefficiency"}
+            ]
+        except json.JSONDecodeError:  # pragma: no cover - fallback for invalid JSON
             self._opportunities = [
                 {"alpha": "generic supply-chain inefficiency"}
             ]

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/alpha_opportunities.json
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/alpha_opportunities.json
@@ -1,0 +1,7 @@
+[
+  {"alpha": "supply-chain bottleneck detected at Port of LA"},
+  {"alpha": "unusual pricing divergence across EU carbon credits"},
+  {"alpha": "emerging market currency mispricing due to election"},
+  {"alpha": "lithium production shortfall predicted in 2025"},
+  {"alpha": "data center energy arbitrage between states"}
+]


### PR DESCRIPTION
## Summary
- allow AlphaOpportunityAgent to pick from sample alpha opportunities
- document sample opportunity dataset in demo README
- include alpha_opportunities.json with sample scenarios

## Testing
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py`
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py`
- `pytest -q` *(fails: command not found)*