### PR TITLE
Improve alpha business v1 demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -145,7 +145,7 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 
 # launch demo (GPU optional)
 ./run_business_v1_demo.sh
-# or run directly without Docker (adds --auto-install to fetch deps)
+# or run directly without Docker (adds --auto-install and optionally --wheelhouse to fetch deps, including offline installs)
 python run_business_v1_local.py --bridge --auto-install
 
 # the demo starts three stub agents:

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -145,8 +145,8 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 
 # launch demo (GPU optional)
 ./run_business_v1_demo.sh
-# or run directly without Docker
-python run_business_v1_local.py --bridge
+# or run directly without Docker (adds --auto-install to fetch deps)
+python run_business_v1_local.py --bridge --auto-install
 
 # the demo starts three stub agents:
 #   • **IncorporatorAgent** registers the business
@@ -162,12 +162,12 @@ open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_execute_alpha.json
 ```
 
-If dependencies are missing, run:
+If dependencies are missing, pass `--auto-install` (and optionally
+`--wheelhouse /path/to/wheels`) to the local launcher:
 
 ```bash
-python ../../../check_env.py --auto-install
+python run_business_v1_local.py --auto-install --wheelhouse /path/to/wheels
 ```
-Use `--wheelhouse /path/to/wheels` for offline installs.
 
 Or open `colab_alpha_agi_business_v1_demo.ipynb` to run everything in Colab.
 To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_bridge.py` (see step 5 in the notebook). Use `--host http://<host>:<port>` when the orchestrator is exposed elsewhere. If the script complains about a missing `openai_agents` package, install it with:

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/alpha_opportunities.json
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/alpha_opportunities.json
@@ -3,5 +3,10 @@
   {"alpha": "unusual pricing divergence across EU carbon credits"},
   {"alpha": "emerging market currency mispricing due to election"},
   {"alpha": "lithium production shortfall predicted in 2025"},
-  {"alpha": "data center energy arbitrage between states"}
+  {"alpha": "data center energy arbitrage between states"},
+  {"alpha": "anomaly in global shipping container rates"},
+  {"alpha": "gene therapy patent undervalued by market"},
+  {"alpha": "renewable energy credit mispricing due to regulatory change"},
+  {"alpha": "rare earth supply-demand mismatch from policy shifts"},
+  {"alpha": "underutilized manufacturing capacity in Southeastern US"}
 ]

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -32,9 +32,24 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Launch OpenAI Agents bridge if available",
     )
+    parser.add_argument(
+        "--auto-install",
+        action="store_true",
+        help="Attempt automatic installation of missing packages",
+    )
+    parser.add_argument(
+        "--wheelhouse",
+        help="Optional local wheelhouse path for offline installs",
+    )
     args = parser.parse_args(argv)
 
-    check_env.main([])
+    check_opts: list[str] = []
+    if args.auto_install:
+        check_opts.append("--auto-install")
+    if args.wheelhouse:
+        check_opts += ["--wheelhouse", args.wheelhouse]
+
+    check_env.main(check_opts)
 
     if args.bridge:
         _start_bridge()

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -47,7 +47,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.auto_install:
         check_opts.append("--auto-install")
     if args.wheelhouse:
-        check_opts += ["--wheelhouse", args.wheelhouse]
+        check_opts.extend(["--wheelhouse", args.wheelhouse])
 
     check_env.main(check_opts)
 


### PR DESCRIPTION
## Summary
- enhance local launcher for alpha_agi_business_v1 with optional auto-install
- document the new flags in the demo README
- expand example alpha opportunities

## Testing
- `python check_env.py`
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py`
- `pytest -q` *(fails: command not found)*