### PR TITLE
Fix alpha business demo defaults

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -148,6 +148,10 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 # or run directly without Docker (adds --auto-install and optionally --wheelhouse to fetch deps, including offline installs)
 python run_business_v1_local.py --bridge --auto-install
 
+By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the four
+lightweight demo stubs so the orchestrator runs even on minimal setups.
+Set the variable yourself to customise the agent list.
+
 # the demo starts three stub agents:
 #   • **IncorporatorAgent** registers the business
 #   • **AlphaDiscoveryAgent** emits a placeholder market opportunity

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -15,11 +15,8 @@ import random
 from pathlib import Path
 
 from alpha_factory_v1.backend import orchestrator
-from alpha_factory_v1.backend.agents import (
-    AgentBase,
-    AgentMetadata,
-    register_agent,
-)
+from alpha_factory_v1.backend.agents import AgentMetadata, register_agent
+from alpha_factory_v1.backend.agents.base import AgentBase
 
 
 class IncorporatorAgent(AgentBase):

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -51,20 +51,18 @@ def main(argv: list[str] | None = None) -> None:
 
     check_env.main(check_opts)
 
-    # Lazy-import demo after environment is configured so the orchestrator
-    # picks up the ALPHA_ENABLED_AGENTS value at module import time.
-    from alpha_factory_v1.demos.alpha_agi_business_v1 import alpha_agi_business_v1
-
+    # Configure the environment so the orchestrator picks up the ALPHA_ENABLED_AGENTS value at module import time.
     if not os.getenv("ALPHA_ENABLED_AGENTS"):
         os.environ["ALPHA_ENABLED_AGENTS"] = ",".join(
             [
-                alpha_agi_business_v1.IncorporatorAgent.NAME,
-                alpha_agi_business_v1.AlphaDiscoveryAgent.NAME,
-                alpha_agi_business_v1.AlphaOpportunityAgent.NAME,
-                alpha_agi_business_v1.AlphaExecutionAgent.NAME,
+                "IncorporatorAgent",
+                "AlphaDiscoveryAgent",
+                "AlphaOpportunityAgent",
+                "AlphaExecutionAgent",
             ]
         )
 
+    from alpha_factory_v1.demos.alpha_agi_business_v1 import alpha_agi_business_v1
     if args.bridge:
         _start_bridge()
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -8,10 +8,10 @@ experimentation on a developer workstation or inside a Colab runtime.
 from __future__ import annotations
 
 import argparse
+import os
 import threading
 
 import check_env
-from alpha_factory_v1.demos.alpha_agi_business_v1 import alpha_agi_business_v1
 
 
 def _start_bridge() -> None:
@@ -50,6 +50,20 @@ def main(argv: list[str] | None = None) -> None:
         check_opts.extend(["--wheelhouse", args.wheelhouse])
 
     check_env.main(check_opts)
+
+    # Lazy-import demo after environment is configured so the orchestrator
+    # picks up the ALPHA_ENABLED_AGENTS value at module import time.
+    from alpha_factory_v1.demos.alpha_agi_business_v1 import alpha_agi_business_v1
+
+    if not os.getenv("ALPHA_ENABLED_AGENTS"):
+        os.environ["ALPHA_ENABLED_AGENTS"] = ",".join(
+            [
+                alpha_agi_business_v1.IncorporatorAgent.NAME,
+                alpha_agi_business_v1.AlphaDiscoveryAgent.NAME,
+                alpha_agi_business_v1.AlphaOpportunityAgent.NAME,
+                alpha_agi_business_v1.AlphaExecutionAgent.NAME,
+            ]
+        )
 
     if args.bridge:
         _start_bridge()

--- a/check_env.py
+++ b/check_env.py
@@ -32,7 +32,12 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     missing: list[str] = []
     for pkg in REQUIRED:
-        if importlib.util.find_spec(pkg) is None:
+        try:
+            spec = importlib.util.find_spec(pkg)
+        except ValueError:
+            # handle cases where a namespace package left an invalid entry
+            spec = None
+        if spec is None:
             missing.append(pkg)
     if missing:
         print("WARNING: Missing packages:", ", ".join(missing))


### PR DESCRIPTION
## Summary
- import AgentBase from proper module
- set ALPHA_ENABLED_AGENTS defaults only after env configured
- mention env variable in README
- make `check_env` tolerant of invalid packages

## Testing
- `pytest -q` *(fails: command not found)*