### PR TITLE
Improve Alpha-AGI Business demo notebook

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -89,11 +89,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-    "outputs": [],
-    "source": [
+   "outputs": [],
+   "source": [
     "import requests\nprint('Available agents:', requests.get('http://localhost:8000/agents').json())"
-    ]
-   },
+   ]
+  },
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -127,6 +127,18 @@
     "python openai_agents_bridge.py >/tmp/bridge.log 2>&1 &",
     "sleep 2",
     "tail -n 5 /tmp/bridge.log"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 5c \u00b7 Query recent alpha via OpenAI Agents bridge\n",
+    "import requests\n",
+    "resp = requests.post('http://localhost:5001/v1/agents/business_helper/invoke', json={'action':'recent_alpha'})\n",
+    "print('recent alpha:', resp.json())"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- extend the Colab demo notebook with a cell that queries recent alpha via the OpenAI Agents bridge

## Testing
- `pytest -q` *(fails: command not found)*