### PR TITLE
Improve business demo customization

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -147,6 +147,8 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 ./run_business_v1_demo.sh
 # or run directly without Docker (adds --auto-install and optionally --wheelhouse to fetch deps, including offline installs)
 python run_business_v1_local.py --bridge --auto-install
+# Set `ALPHA_OPPS_FILE` to use a custom opportunity list
+# ALPHA_OPPS_FILE=examples/my_alpha.json python run_business_v1_local.py --bridge
 
 By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the four
 lightweight demo stubs so the orchestrator runs even on minimal setups.
@@ -156,6 +158,7 @@ Set the variable yourself to customise the agent list.
 #   • **IncorporatorAgent** registers the business
 #   • **AlphaDiscoveryAgent** emits a placeholder market opportunity
 #   • **AlphaOpportunityAgent** picks a random scenario from `examples/alpha_opportunities.json`
+#     (override with `ALPHA_OPPS_FILE=/path/to/custom.json`)
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 
 open http://localhost:7878      # Dashboard SPA

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -53,9 +53,10 @@ class AlphaOpportunityAgent(AgentBase):
 
     def __init__(self) -> None:
         super().__init__()
-        path = Path(__file__).with_name("examples") / "alpha_opportunities.json"
+        env_path = os.getenv("ALPHA_OPPS_FILE")
+        path = Path(env_path) if env_path else Path(__file__).with_name("examples") / "alpha_opportunities.json"
         try:
-            self._opportunities = json.loads(path.read_text(encoding="utf-8"))
+            self._opportunities = json.loads(Path(path).read_text(encoding="utf-8"))
         except FileNotFoundError:  # pragma: no cover - fallback when file missing
             self._opportunities = [
                 {"alpha": "generic supply-chain inefficiency"}

--- a/tests/test_alpha_opportunity_env.py
+++ b/tests/test_alpha_opportunity_env.py
@@ -1,0 +1,22 @@
+import json
+import os
+import unittest
+from pathlib import Path
+
+from alpha_factory_v1.demos.alpha_agi_business_v1 import alpha_agi_business_v1 as biz
+
+class TestAlphaOpportunityEnv(unittest.TestCase):
+    def test_env_override(self):
+        data = [{"alpha": "env test"}]
+        tmp = Path("/tmp/opps.json")
+        tmp.write_text(json.dumps(data), encoding="utf-8")
+        os.environ["ALPHA_OPPS_FILE"] = str(tmp)
+        try:
+            agent = biz.AlphaOpportunityAgent()
+            self.assertEqual(agent._opportunities, data)
+        finally:
+            del os.environ["ALPHA_OPPS_FILE"]
+            tmp.unlink()
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `ALPHA_OPPS_FILE` env var to specify alpha opportunities
- document the variable in the demo README
- test that custom opportunity files are loaded

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`