### PR TITLE
Extend business demo bridge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -194,9 +194,12 @@ When the optional `google-adk` dependency is installed and `ALPHA_FACTORY_ENABLE
 the same helper agent is also exposed via an ADK gateway for A2A messaging.
 
 The bridge exposes several helper tools:
-`list_agents`, `trigger_discovery`, `trigger_opportunity`, `trigger_execution`,
-`recent_alpha` to retrieve the latest opportunities, and `submit_job` to post a
-custom job payload to any orchestrator agent.
+- `list_agents`
+- `trigger_discovery`
+- `trigger_opportunity`
+- `trigger_execution`
+- `recent_alpha` (to retrieve the latest opportunities)
+- `submit_job` (to post a custom job payload to any orchestrator agent)
 
 *No Docker?*
 `bash <(curl -sL https://get.alpha-factory.ai/business_demo.sh)` boots an ephemeral VM (CPU‑only mode).

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -193,9 +193,10 @@ python openai_agents_bridge.py --host http://localhost:8000
 When the optional `google-adk` dependency is installed and `ALPHA_FACTORY_ENABLE_ADK=true` is set,
 the same helper agent is also exposed via an ADK gateway for A2A messaging.
 
-The bridge exposes four helper tools (`list_agents`, `trigger_discovery`, `trigger_opportunity`,
-`trigger_execution`) and a new `recent_alpha` tool that returns the latest alpha
-opportunities stored in the orchestrator memory.
+The bridge exposes several helper tools:
+`list_agents`, `trigger_discovery`, `trigger_opportunity`, `trigger_execution`,
+`recent_alpha` to retrieve the latest opportunities, and `submit_job` to post a
+custom job payload to any orchestrator agent.
 
 *No Docker?*
 `bash <(curl -sL https://get.alpha-factory.ai/business_demo.sh)` boots an ephemeral VM (CPU‑only mode).

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -148,6 +148,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 5d \u00b7 Submit a custom job via the bridge\n",
+    "job = {'agent': 'alpha_execution', 'symbol': 'AAPL', 'qty': 1}\n",
+    "resp = requests.post('http://localhost:5001/v1/agents/business_helper/invoke', json={'action':'submit_job', 'job': job})\n",
+    "print('job submission:', resp.text)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- support submitting custom jobs via OpenAI Agents bridge
- document new helper tool in demo README
- show job submission in Colab notebook

## Testing
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py`
- `pytest -q` *(fails: command not found)*