### PR TITLE
Enhance alpha_agi_business_v1 demo with risk agent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -150,7 +150,7 @@ python run_business_v1_local.py --bridge --auto-install
 # Set `ALPHA_OPPS_FILE` to use a custom opportunity list
 # ALPHA_OPPS_FILE=examples/my_alpha.json python run_business_v1_local.py --bridge
 
-By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the four
+By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the five
 lightweight demo stubs so the orchestrator runs even on minimal setups.
 Set the variable yourself to customise the agent list.
 
@@ -160,6 +160,7 @@ Set the variable yourself to customise the agent list.
 #   • **AlphaOpportunityAgent** picks a random scenario from `examples/alpha_opportunities.json`
 #     (override with `ALPHA_OPPS_FILE=/path/to/custom.json`)
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
+#   • **AlphaRiskAgent** performs a trivial risk assessment
 
 open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_copper_spread.json

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -83,6 +83,18 @@ class AlphaExecutionAgent(AgentBase):
         await self.publish("alpha.execution", {"alpha": "order executed"})
 
 
+class AlphaRiskAgent(AgentBase):
+    """Stub agent performing a placeholder risk assessment."""
+
+    NAME = "alpha_risk"
+    CAPABILITIES = ["risk"]
+    CYCLE_SECONDS = 240
+    __slots__ = ()
+
+    async def step(self) -> None:
+        await self.publish("alpha.risk", {"risk": "risk level nominal"})
+
+
 def register_demo_agents() -> None:
     """Register built-in demo agents with the framework."""
 
@@ -119,6 +131,15 @@ def register_demo_agents() -> None:
             cls=AlphaExecutionAgent,
             version="1.0.0",
             capabilities=AlphaExecutionAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=AlphaRiskAgent.NAME,
+            cls=AlphaRiskAgent,
+            version="1.0.0",
+            capabilities=AlphaRiskAgent.CAPABILITIES,
         )
     )
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -153,6 +153,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# 5cc \u00b7 Trigger risk assessment via OpenAI Agents bridge\n",
+    "import requests\n",
+    "resp = requests.post('http://localhost:5001/v1/agents/business_helper/invoke', json={'action':'risk'})\n",
+    "print('risk response:', resp.text)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# 5d \u00b7 Submit a custom job via the bridge\n",
     "job = {'agent': 'alpha_execution', 'symbol': 'AAPL', 'qty': 1}\n",
     "resp = requests.post('http://localhost:5001/v1/agents/business_helper/invoke', json={'action':'submit_job', 'job': job})\n",

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -105,6 +105,13 @@ async def trigger_execution() -> str:
     return "alpha_execution queued"
 
 
+@Tool(name="trigger_risk", description="Trigger the AlphaRiskAgent")
+async def trigger_risk() -> str:
+    resp = requests.post(f"{HOST}/agent/alpha_risk/trigger", timeout=5)
+    resp.raise_for_status()
+    return "alpha_risk queued"
+
+
 @Tool(
     name="submit_job",
     description="Submit a custom alpha job JSON to the orchestrator",
@@ -163,6 +170,7 @@ class BusinessAgent(Agent):
         trigger_discovery,
         trigger_opportunity,
         trigger_execution,
+        trigger_risk,
         recent_alpha,
         submit_job,
     ]
@@ -175,6 +183,8 @@ class BusinessAgent(Agent):
                 return await self.tools.trigger_opportunity()
             elif obs.get("action") == "execute":
                 return await self.tools.trigger_execution()
+            elif obs.get("action") == "risk":
+                return await self.tools.trigger_risk()
             elif obs.get("action") == "recent_alpha":
                 return await self.tools.recent_alpha()
             elif obs.get("action") == "submit_job":

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -59,6 +59,7 @@ def main(argv: list[str] | None = None) -> None:
                 "AlphaDiscoveryAgent",
                 "AlphaOpportunityAgent",
                 "AlphaExecutionAgent",
+                "AlphaRiskAgent",
             ]
         )
 


### PR DESCRIPTION
## Summary
- add `AlphaRiskAgent` example
- register the new agent and expose `trigger_risk` tool via OpenAI Agents bridge
- include risk agent in local launcher defaults
- update notebook and README for the new agent

## Testing
- `python -m alpha_factory_v1.scripts.run_tests`