### PR TITLE
Add OpenAI Agents bridge for cross‑industry demo

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -62,6 +62,14 @@ python cross_alpha_discovery_stub.py --list
 Use `-n 3 --seed 42` to log three deterministic picks to
 `cross_alpha_log.json`. If `OPENAI_API_KEY` is set, the tool queries an LLM for fresh ideas. The model may be overridden with `--model` (default `gpt-4o-mini`).
 
+### 🤖 OpenAI Agents bridge
+Expose the discovery helper via the OpenAI Agents SDK:
+```bash
+python openai_agents_bridge.py
+```
+The agent registers the tools `list_samples`, `discover_alpha` and `recent_log`.
+When Google ADK is installed the bridge auto-registers with the ADK gateway as well.
+
 
 ---
 

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -23,7 +23,7 @@ def _read_log(limit: int) -> List[Dict[str, str]]:
         if isinstance(data, dict):
             data = [data]
         return data[-limit:]
-    except Exception:  # pragma: no cover - missing or invalid log
+    except (FileNotFoundError, PermissionError, json.JSONDecodeError):  # pragma: no cover - missing or invalid log
         return []
 
 

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""OpenAI Agents SDK bridge for the cross-industry Alpha-Factory demo."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+from .cross_alpha_discovery_stub import SAMPLE_ALPHA, discover_alpha, _ledger_path
+
+try:
+    from openai_agents import Agent, AgentRuntime, Tool
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+    raise SystemExit(
+        "openai-agents package is missing. Install with `pip install openai-agents`"
+    ) from exc
+
+
+def _read_log(limit: int) -> List[Dict[str, str]]:
+    path = _ledger_path(None)
+    try:
+        data = json.loads(Path(path).read_text())
+        if isinstance(data, dict):
+            data = [data]
+        return data[-limit:]
+    except Exception:  # pragma: no cover - missing or invalid log
+        return []
+
+
+@Tool(name="list_samples", description="List bundled sample opportunities")
+async def list_samples() -> List[Dict[str, str]]:
+    return SAMPLE_ALPHA
+
+
+@Tool(name="discover_alpha", description="Generate new opportunities")
+async def discover(num: int = 1) -> List[Dict[str, str]]:
+    return discover_alpha(num=num)
+
+
+@Tool(name="recent_log", description="Return recently logged opportunities")
+async def recent_log(limit: int = 5) -> List[Dict[str, str]]:
+    return _read_log(limit)
+
+
+class CrossIndustryAgent(Agent):
+    """Agent exposing cross-industry discovery tools."""
+
+    name = "cross_industry_helper"
+    tools = [list_samples, discover, recent_log]
+
+    async def policy(self, obs, ctx):  # type: ignore[override]
+        if isinstance(obs, dict):
+            action = obs.get("action")
+            if action == "discover":
+                return await self.tools.discover(obs.get("num", 1))
+            if action == "recent":
+                return await self.tools.recent_log(obs.get("limit", 5))
+        return await self.tools.list_samples()
+
+
+def main() -> None:
+    runtime = AgentRuntime(api_key=None)
+    agent = CrossIndustryAgent()
+    runtime.register(agent)
+    try:
+        from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+
+        auto_register([agent])
+        maybe_launch()
+    except Exception as exc:  # pragma: no cover - ADK optional
+        print(f"ADK bridge unavailable: {exc}")
+
+    print("Registered CrossIndustryAgent with runtime")
+    runtime.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -68,9 +68,9 @@ def main() -> None:
         auto_register([agent])
         maybe_launch()
     except Exception as exc:  # pragma: no cover - ADK optional
-        print(f"ADK bridge unavailable: {exc}")
+        logging.warning(f"ADK bridge unavailable: {exc}")
 
-    print("Registered CrossIndustryAgent with runtime")
+    logging.info("Registered CrossIndustryAgent with runtime")
     runtime.run()
 
 

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -23,5 +23,10 @@ class TestOpenAIBridge(unittest.TestCase):
         path = Path('alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py')
         py_compile.compile(path, doraise=True)
 
+    def test_cross_industry_bridge_compiles(self):
+        """Ensure the cross-industry demo bridge compiles."""
+        path = Path('alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py')
+        py_compile.compile(path, doraise=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support bridging the cross-industry demo with an OpenAI Agents runtime
- document how to use the bridge in the cross-industry demo README
- ensure the new bridge compiles via unit test

## Testing
- `pytest -q` *(fails: command not found)*