### PR TITLE
Add health check tool for BusinessAgent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -200,6 +200,7 @@ The bridge exposes several helper tools:
 - `trigger_opportunity`
 - `trigger_execution`
 - `recent_alpha` (to retrieve the latest opportunities)
+- `check_health` (orchestrator health status)
 - `submit_job` (to post a custom job payload to any orchestrator agent)
 
 *No Docker?*


### PR DESCRIPTION
## Summary
- expose orchestrator health endpoint in OpenAI Agents bridge
- document new `check_health` tool in alpha_agi_business_v1 README

## Testing
- `pytest -q` *(fails: command not found)*