### PR TITLE
Add configurable Agents runtime port

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -185,9 +185,10 @@ pip install openai-agents
 
 ### 🤖 OpenAI Agents bridge
 
-Expose the business demo via the OpenAI Agents SDK (specify `--host` if the orchestrator runs elsewhere):
+Expose the business demo via the OpenAI Agents SDK (specify `--host` if the orchestrator runs elsewhere and `--port` to change the runtime port):
 
 ```bash
+# default port 5001; customise via `--port` or `AGENTS_RUNTIME_PORT`
 python openai_agents_bridge.py --host http://localhost:8000
 # → http://localhost:5001/v1/agents
 ```

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -81,6 +81,7 @@ except ImportError:  # pragma: no cover - ADK not installed
     ADK_AVAILABLE = False
 
 HOST = os.getenv("BUSINESS_HOST", "http://localhost:8000")
+AGENT_PORT = int(os.getenv("AGENTS_RUNTIME_PORT", "5001"))
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -91,6 +92,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--host",
         default=HOST,
         help="Orchestrator host URL (default: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=AGENT_PORT,
+        help="Port for the Agents runtime (default: 5001)",
     )
     parser.add_argument(
         "--no-wait",
@@ -245,10 +252,10 @@ def main() -> None:
                 sys.stderr.write("   continuing in offline mode...\n")
             else:
                 sys.exit(1)
-    runtime = AgentRuntime(api_key=api_key)
+    runtime = AgentRuntime(api_key=api_key, port=args.port)
     agent = BusinessAgent()
     runtime.register(agent)
-    print(f"Registered BusinessAgent -> {HOST}")
+    print(f"Registered BusinessAgent -> {HOST} [port {args.port}]")
 
     if ADK_AVAILABLE:
         auto_register([agent])


### PR DESCRIPTION
## Summary
- allow setting the OpenAI Agents runtime port via `--port` or `AGENTS_RUNTIME_PORT`
- document new option in the demo README

## Testing
- `pytest -q` *(fails: command not found)*