### PR TITLE
Add quick start guide

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -1,0 +1,24 @@
+# Quick Start – Alpha‑AGI Business v1 Demo
+
+This short guide summarises how to launch the business demo either locally or in Google Colab.
+
+## Local Launch
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
+   cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
+   ```
+2. **Check dependencies**
+   ```bash
+   python ../../check_env.py --auto-install
+   ```
+3. **Run the demo**
+   ```bash
+   python run_business_v1_local.py --bridge
+   ```
+   The dashboard is available at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
+
+## Colab Notebook
+Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook checks requirements, starts the orchestrator, and exposes helper tools via the OpenAI Agents SDK.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -139,6 +139,7 @@ All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google AD
 <a id="quick"></a>
 ## 6 Quick Start 🚀
 
+*For a concise walkthrough see [QUICK_START.md](QUICK_START.md).*
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1


### PR DESCRIPTION
## Summary
- document quick start steps for the alpha_agi_business_v1 demo
- link the new guide from the main demo README

## Testing
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement pytest)*
- `pytest -q` *(fails: command not found)*