### PR TITLE
Improve business demo with optional live data

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -19,6 +19,7 @@ This short guide summarises how to launch the business demo either locally or in
    The dashboard is available at [http://localhost:8000/docs](http://localhost:8000/docs).
 
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
+Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.
 
 ## Colab Notebook
 Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook checks requirements, starts the orchestrator, and exposes helper tools via the OpenAI Agents SDK.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -160,6 +160,7 @@ Set the variable yourself to customise the agent list.
 #   • **AlphaDiscoveryAgent** emits a placeholder market opportunity
 #   • **AlphaOpportunityAgent** picks a random scenario from `examples/alpha_opportunities.json`
 #     (override with `ALPHA_OPPS_FILE=/path/to/custom.json`)
+#     or set `YFINANCE_SYMBOL=SPY` to pull a live price via `yfinance`
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
 
@@ -167,6 +168,8 @@ open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_copper_spread.json
 # or
 ./scripts/post_alpha_job.sh examples/job_supply_chain_alpha.json
+# or
+./scripts/post_alpha_job.sh examples/job_forex_alpha.json
 # or
 ./scripts/post_alpha_job.sh examples/job_execute_alpha.json
 ```

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -49,7 +49,7 @@ class AlphaOpportunityAgent(AgentBase):
     NAME = "alpha_opportunity"
     CAPABILITIES = ["opportunity"]
     CYCLE_SECONDS = 300
-    __slots__ = ("_opportunities",)
+    __slots__ = ("_opportunities", "_yf", "_symbol")
 
     def __init__(self) -> None:
         super().__init__()
@@ -66,7 +66,31 @@ class AlphaOpportunityAgent(AgentBase):
                 {"alpha": "generic supply-chain inefficiency"}
             ]
 
+        # Optional live price feed via yfinance
+        self._symbol = os.getenv("YFINANCE_SYMBOL")
+        if self._symbol:
+            try:  # soft dependency
+                import yfinance as yf  # type: ignore
+
+                self._yf = yf
+            except Exception:  # pragma: no cover - fallback when yfinance missing
+                self._yf = None
+        else:
+            self._yf = None
+
     async def step(self) -> None:
+        if self._symbol and self._yf:
+            try:
+                data = self._yf.download(self._symbol, period="1d", progress=False)
+                price = data["Close"].iloc[-1]
+                await self.publish(
+                    "alpha.opportunity",
+                    {"symbol": self._symbol, "price": float(price)},
+                )
+                return
+            except Exception:  # pragma: no cover - network/unavailable
+                pass
+
         choice = random.choice(self._opportunities)
         await self.publish("alpha.opportunity", choice)
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -88,8 +88,8 @@ class AlphaOpportunityAgent(AgentBase):
                     {"symbol": self._symbol, "price": float(price)},
                 )
                 return
-            except Exception:  # pragma: no cover - network/unavailable
-                pass
+            except Exception as e:  # pragma: no cover - network/unavailable
+                logging.error("Failed to download live price feed for symbol %s: %s", self._symbol, e, exc_info=True)
 
         choice = random.choice(self._opportunities)
         await self.publish("alpha.opportunity", choice)

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -77,8 +77,25 @@
    "outputs": [],
    "source": [
     "import os, getpass\nos.environ['OPENAI_API_KEY'] = getpass.getpass('Enter OpenAI API key (leave blank for offline): ')"
-   ]
-  },
+  ]
+ },
+ {
+  "cell_type": "markdown",
+  "metadata": {},
+  "source": [
+   "### (Optional) Live market price feed",
+   "Set `YFINANCE_SYMBOL` to fetch a current closing price using `yfinance`."
+  ]
+ },
+ {
+  "cell_type": "code",
+  "execution_count": null,
+  "metadata": {},
+  "outputs": [],
+  "source": [
+   "import os\nos.environ['YFINANCE_SYMBOL'] = os.getenv('YFINANCE_SYMBOL', 'SPY')"
+  ]
+ },
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/job_forex_alpha.json
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/job_forex_alpha.json
@@ -1,0 +1,6 @@
+{
+  "agent": "alpha_opportunity",
+  "symbol": "EURUSD",
+  "action": "fetch_price",
+  "note": "Demonstrate live forex quote via yfinance if available"
+}


### PR DESCRIPTION
## Summary
- extend `AlphaOpportunityAgent` with optional live price feed via yfinance
- document new `YFINANCE_SYMBOL` env var
- include new Forex example job
- update Colab demo to demonstrate live price option

## Testing
- `python check_env.py` *(fails: Missing packages)*
- `pytest -q` *(fails: command not found)*