### PR TITLE
Update business demo launcher

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -15,8 +15,10 @@ This short guide summarises how to launch the business demo either locally or in
 3. **Run the demo**
    ```bash
    python run_business_v1_local.py --bridge
+   # optional: choose a different port
+   python run_business_v1_local.py --bridge --port 9000
    ```
-   The dashboard is available at [http://localhost:8000/docs](http://localhost:8000/docs).
+   The dashboard is available at [http://localhost:8000/docs](http://localhost:8000/docs) unless `--port` is used.
 
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
 Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -18,7 +18,7 @@ This short guide summarises how to launch the business demo either locally or in
    # optional: choose a different port
    python run_business_v1_local.py --bridge --port 9000
    ```
-   The dashboard is available at [http://localhost:8000/docs](http://localhost:8000/docs) unless `--port` is used.
+   The dashboard is available at [http://localhost:<port>/docs](http://localhost:<port>/docs), where `<port>` is the port number used (default is `8000`).
 
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
 Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -148,6 +148,8 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 ./run_business_v1_demo.sh
 # or run directly without Docker (adds --auto-install and optionally --wheelhouse to fetch deps, including offline installs)
 python run_business_v1_local.py --bridge --auto-install
+# expose orchestrator on a custom port
+python run_business_v1_local.py --bridge --port 9000
 # Set `ALPHA_OPPS_FILE` to use a custom opportunity list
 # ALPHA_OPPS_FILE=examples/my_alpha.json python run_business_v1_local.py --bridge
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -33,6 +33,12 @@ def main(argv: list[str] | None = None) -> None:
         help="Launch OpenAI Agents bridge if available",
     )
     parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Expose orchestrator on this port (default: 8000)",
+    )
+    parser.add_argument(
         "--auto-install",
         action="store_true",
         help="Attempt automatic installation of missing packages",
@@ -50,6 +56,9 @@ def main(argv: list[str] | None = None) -> None:
         check_opts.extend(["--wheelhouse", args.wheelhouse])
 
     check_env.main(check_opts)
+
+    if args.port:
+        os.environ["PORT"] = str(args.port)
 
     # Configure the environment so the orchestrator picks up the ALPHA_ENABLED_AGENTS value at module import time.
     if not os.getenv("ALPHA_ENABLED_AGENTS"):

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -35,7 +35,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--port",
         type=int,
-        default=None,
+        default=8000,
         help="Expose orchestrator on this port (default: 8000)",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- allow running the business demo on a custom port
- document custom port usage in README and Quick Start

## Testing
- `pytest -q` *(fails: command not found)*