### PR TITLE
Fix OpenAI Agents bridge CLI port argument

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -94,7 +94,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Orchestrator host URL (default: http://localhost:8000)",
     )
     parser.add_argument(
-        "--agents-port",
+        "--port",
         type=int,
         default=AGENT_PORT,
         help=f"Port for the Agents runtime (default: {AGENT_PORT})",


### PR DESCRIPTION
## Summary
- fix `openai_agents_bridge.py` CLI argument to use `--port`

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*