### PR TITLE
Add one-click demo launcher

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -14,9 +14,10 @@ This short guide summarises how to launch the business demo either locally or in
    ```
 3. **Run the demo**
    ```bash
-   python run_business_v1_local.py --bridge
+   # one-click launcher (opens docs in your browser)
+   python start_alpha_business.py
    # optional: choose a different port
-   python run_business_v1_local.py --bridge --port 9000
+   PORT=9000 python start_alpha_business.py
    ```
    The dashboard is available at [http://localhost:<port>/docs](http://localhost:<port>/docs), where `<port>` is the port number used (default is `8000`).
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -144,9 +144,12 @@ All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google AD
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 
-# launch demo (GPU optional)
+# easiest path – auto-installs dependencies and opens the docs
+python start_alpha_business.py
+
+# Docker-based run (GPU optional)
 ./run_business_v1_demo.sh
-# or run directly without Docker (adds --auto-install and optionally --wheelhouse to fetch deps, including offline installs)
+# or run directly without Docker
 python run_business_v1_local.py --bridge --auto-install
 # expose orchestrator on a custom port
 python run_business_v1_local.py --bridge --port 9000

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
@@ -29,7 +29,7 @@ def main() -> None:
     proc = subprocess.Popen(cmd, cwd=SCRIPT_DIR, env=env)
 
     url = f"http://localhost:{port}/docs"
-    for _ in range(20):
+    for _ in range(MAX_HEALTH_CHECK_RETRIES):
         if proc.poll() is not None:
             break
         try:

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
@@ -33,7 +33,6 @@ def main() -> None:
         if proc.poll() is not None:
             break
         try:
-            import requests
 
             if requests.get(f"http://localhost:{port}/healthz", timeout=1).status_code == 200:
                 break

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""One-click launcher for the Alpha‑AGI Business v1 demo.
+
+This helper checks dependencies, starts the local orchestrator with the
+OpenAI Agents bridge enabled, and opens the REST dashboard in the
+system default web browser.  Useful for non‑technical users.
+"""
+import os
+import subprocess
+import sys
+import time
+import webbrowser
+
+import check_env
+
+
+SCRIPT_DIR = os.path.dirname(__file__)
+
+
+def main() -> None:
+    try:
+        check_env.main(["--auto-install"])
+    except Exception as exc:  # pragma: no cover - optional network failure
+        print(f"⚠️  Environment check failed: {exc}")
+
+    env = os.environ.copy()
+    port = env.get("PORT", "8000")
+    cmd = [sys.executable, "run_business_v1_local.py", "--bridge"]
+    proc = subprocess.Popen(cmd, cwd=SCRIPT_DIR, env=env)
+
+    url = f"http://localhost:{port}/docs"
+    for _ in range(20):
+        if proc.poll() is not None:
+            break
+        try:
+            import requests
+
+            if requests.get(f"http://localhost:{port}/healthz", timeout=1).status_code == 200:
+                break
+        except Exception:
+            time.sleep(0.5)
+    try:
+        webbrowser.open(url, new=1)
+    except Exception:
+        print(f"Open {url} to access the dashboard")
+    try:
+        proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        proc.wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_alpha_business.py` to simplify running the business demo
- document the new helper in README and QUICK_START

## Testing
- `python check_env.py --auto-install` *(fails: Could not install packages)*
- `pytest -q` *(fails: command not found)*