### PR TITLE
Add gradio dashboard for business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -192,6 +192,19 @@ To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_br
 pip install openai-agents
 ```
 
+### 🎛️ Local Gradio Dashboard
+
+For a quick interactive UI run `python gradio_dashboard.py` after the orchestrator starts.
+The dashboard exposes buttons to trigger each demo agent and fetch recent alpha
+opportunities without writing any code.
+
+```bash
+python gradio_dashboard.py  # visits http://localhost:7860
+```
+
+Set `GRADIO_PORT` to use a different port. The dashboard communicates with the
+orchestrator via its REST API (`BUSINESS_HOST` environment variable).
+
 ### 🤖 OpenAI Agents bridge
 
 Expose the business demo via the OpenAI Agents SDK (specify `--host` if the orchestrator runs elsewhere and `--port` to change the runtime port):

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/__init__.py
@@ -1,1 +1,7 @@
-# Demo package
+"""alpha_agi_business_v1 demo package."""
+
+__all__ = [
+    "alpha_agi_business_v1",
+    "openai_agents_bridge",
+    "gradio_dashboard",
+]

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/__init__.py
@@ -1,7 +1,6 @@
 """alpha_agi_business_v1 demo package."""
 
 __all__ = [
-    "alpha_agi_business_v1",
     "openai_agents_bridge",
     "gradio_dashboard",
 ]

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Simple Gradio dashboard for the Alpha‑AGI Business demo."""
+from __future__ import annotations
+
+import os
+import requests
+import gradio as gr
+
+HOST = os.getenv("BUSINESS_HOST", "http://localhost:8000")
+PORT = int(os.getenv("GRADIO_PORT", "7860"))
+
+
+def _list_agents() -> list[str]:
+    resp = requests.get(f"{HOST}/agents", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _trigger(agent: str) -> str:
+    resp = requests.post(f"{HOST}/agent/{agent}/trigger", timeout=5)
+    resp.raise_for_status()
+    return f"{agent} queued"
+
+
+def _recent_alpha(limit: int = 5) -> list[dict]:
+    resp = requests.get(
+        f"{HOST}/memory/alpha_opportunity/recent", params={"n": limit}, timeout=5
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main() -> None:
+    with gr.Blocks(title="Alpha‑AGI Business Dashboard") as ui:
+        gr.Markdown("# Alpha‑AGI Business Dashboard")
+        out = gr.JSON()
+        with gr.Row():
+            list_btn = gr.Button("List Agents")
+            disc_btn = gr.Button("Trigger Discovery")
+            opp_btn = gr.Button("Trigger Opportunity")
+            exe_btn = gr.Button("Trigger Execution")
+            risk_btn = gr.Button("Trigger Risk")
+            alpha_btn = gr.Button("Recent Alpha")
+
+        list_btn.click(_list_agents, outputs=out)
+        disc_btn.click(lambda: _trigger("alpha_discovery"), outputs=out)
+        opp_btn.click(lambda: _trigger("alpha_opportunity"), outputs=out)
+        exe_btn.click(lambda: _trigger("alpha_execution"), outputs=out)
+        risk_btn.click(lambda: _trigger("alpha_risk"), outputs=out)
+        alpha_btn.click(_recent_alpha, outputs=out)
+
+    ui.launch(server_name="0.0.0.0", server_port=PORT, share=False)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_gradio_dashboard.py
+++ b/tests/test_gradio_dashboard.py
@@ -1,0 +1,11 @@
+import py_compile
+import unittest
+from pathlib import Path
+
+class TestGradioDashboard(unittest.TestCase):
+    def test_dashboard_compiles(self) -> None:
+        path = Path('alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py')
+        py_compile.compile(path, doraise=True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a simple Gradio UI to control the business demo
- export new module in `__init__`
- document dashboard usage in README
- test that the dashboard script compiles

## Testing
- `pytest -q` *(fails: command not found)*
- `python check_env.py --auto-install` *(fails: network access required)*