### PR TITLE
Extend business demo with role agent stubs

### DIFF
--- a/alpha_factory_v1/backend/agents/market_analysis_agent.py
+++ b/alpha_factory_v1/backend/agents/market_analysis_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import AgentBase
+
+class MarketAnalysisAgent(AgentBase):
+    """Stub agent scanning market data for inefficiencies."""
+
+    NAME = "market_analysis"
+    CAPABILITIES = ["analyze"]
+    CYCLE_SECONDS = 200
+
+    async def step(self) -> None:
+        await self.publish("alpha.market", {"msg": "market snapshot processed"})

--- a/alpha_factory_v1/backend/agents/memory_agent.py
+++ b/alpha_factory_v1/backend/agents/memory_agent.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .base import AgentBase
+
+class MemoryAgent(AgentBase):
+    """Stub retrieval-augmented memory store."""
+
+    NAME = "memory"
+    CAPABILITIES = ["remember"]
+    CYCLE_SECONDS = 0  # event-driven
+
+    async def step(self) -> None:
+        # In a real implementation, this would persist and recall alpha items.
+        await self.publish("alpha.memory", {"msg": "memory accessed"})

--- a/alpha_factory_v1/backend/agents/planning_agent.py
+++ b/alpha_factory_v1/backend/agents/planning_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import AgentBase
+
+class PlanningAgent(AgentBase):
+    """Simple stub agent planning tasks for the business demo."""
+
+    NAME = "planning"
+    CAPABILITIES = ["plan"]
+    CYCLE_SECONDS = 180
+
+    async def step(self) -> None:
+        await self.publish("alpha.plan", {"msg": "planning cycle completed"})

--- a/alpha_factory_v1/backend/agents/research_agent.py
+++ b/alpha_factory_v1/backend/agents/research_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import AgentBase
+
+class ResearchAgent(AgentBase):
+    """Stub research agent harvesting external data."""
+
+    NAME = "research"
+    CAPABILITIES = ["research"]
+    CYCLE_SECONDS = 300
+
+    async def step(self) -> None:
+        await self.publish("alpha.research", {"msg": "research sweep complete"})

--- a/alpha_factory_v1/backend/agents/safety_agent.py
+++ b/alpha_factory_v1/backend/agents/safety_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import AgentBase
+
+class SafetyAgent(AgentBase):
+    """Stub safety agent performing compliance checks."""
+
+    NAME = "safety"
+    CAPABILITIES = ["guard"]
+    CYCLE_SECONDS = 250
+
+    async def step(self) -> None:
+        await self.publish("alpha.safety", {"msg": "safety check ok"})

--- a/alpha_factory_v1/backend/agents/strategy_agent.py
+++ b/alpha_factory_v1/backend/agents/strategy_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import AgentBase
+
+class StrategyAgent(AgentBase):
+    """Stub agent that transforms raw alpha into actionable strategy."""
+
+    NAME = "strategy"
+    CAPABILITIES = ["strategy"]
+    CYCLE_SECONDS = 240
+
+    async def step(self) -> None:
+        await self.publish("alpha.strategy", {"msg": "strategy drafted"})

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -20,6 +20,9 @@ This short guide summarises how to launch the business demo either locally or in
    PORT=9000 python start_alpha_business.py
    ```
    The dashboard is available at [http://localhost:<port>/docs](http://localhost:<port>/docs), where `<port>` is the port number used (default is `8000`).
+   By default the orchestrator launches stub agents for planning, research,
+   strategy, market analysis, memory and safety in addition to the core
+   discovery/execution pipeline.
 
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
 Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -112,12 +112,12 @@ flowchart LR
 
 | Agent | Core Skill | Business Role | Repo Path |
 |-------|------------|---------------|-----------|
-| **PlanningAgent** | Task‑graph MuZero++ search | Decompose α‑jobs, allocate compute & budget | `backend/agents/planning` |
-| **ResearchAgent** | Tool‑former LLM + Web/DB taps | Harvest filings, patents, alt‑data | `backend/agents/research` |
-| **StrategyAgent** | Game‑theoretic optimiser | Transform raw alpha into executable, risk‑adjusted playbooks | `backend/agents/strategy` |
-| **MarketAnalysisAgent** | 5 M ticks/s ingest, micro‑alpha scanner | Benchmark edge vs baseline & stress‑test PnL | `backend/agents/market_analysis` |
-| **MemoryAgent** | Retrieval‑augmented vector store | Persist & recall reusable alpha templates | `backend/agents/memory` |
-| **SafetyAgent** | Constitutional‑AI & seccomp sandbox | Filter unsafe code / data exfiltration | `backend/agents/safety` |
+| **PlanningAgent** | Task‑graph MuZero++ search | Decompose α‑jobs, allocate compute & budget | `backend/agents/planning_agent.py` |
+| **ResearchAgent** | Tool‑former LLM + Web/DB taps | Harvest filings, patents, alt‑data | `backend/agents/research_agent.py` |
+| **StrategyAgent** | Game‑theoretic optimiser | Transform raw alpha into executable, risk‑adjusted playbooks | `backend/agents/strategy_agent.py` |
+| **MarketAnalysisAgent** | 5 M ticks/s ingest, micro‑alpha scanner | Benchmark edge vs baseline & stress‑test PnL | `backend/agents/market_analysis_agent.py` |
+| **MemoryAgent** | Retrieval‑augmented vector store | Persist & recall reusable alpha templates | `backend/agents/memory_agent.py` |
+| **SafetyAgent** | Constitutional‑AI & seccomp sandbox | Filter unsafe code / data exfiltration | `backend/agents/safety_agent.py` |
 | **ExecutionAgent** | Order‑routing & trade settlement | Convert opportunities into executed trades | `backend/agents/execution` |
 
 All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google ADK**, auto‑fallback to offline GGUF models — *no API key required*.
@@ -160,7 +160,7 @@ By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the five
 lightweight demo stubs so the orchestrator runs even on minimal setups.
 Set the variable yourself to customise the agent list.
 
-# the demo starts three stub agents:
+# the demo starts several stub agents:
 #   • **IncorporatorAgent** registers the business
 #   • **AlphaDiscoveryAgent** emits a placeholder market opportunity
 #   • **AlphaOpportunityAgent** picks a random scenario from `examples/alpha_opportunities.json`
@@ -168,6 +168,9 @@ Set the variable yourself to customise the agent list.
 #     or set `YFINANCE_SYMBOL=SPY` to pull a live price via `yfinance`
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
+#   • **PlanningAgent**, **ResearchAgent**, **StrategyAgent**, **MarketAnalysisAgent**,
+#     **MemoryAgent** and **SafetyAgent** emit placeholder events to illustrate the
+#     full role architecture
 
 open http://localhost:7878      # Dashboard SPA
 ./scripts/post_alpha_job.sh examples/job_copper_spread.json

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -17,6 +17,12 @@ from pathlib import Path
 from alpha_factory_v1.backend import orchestrator
 from alpha_factory_v1.backend.agents import AgentMetadata, register_agent
 from alpha_factory_v1.backend.agents.base import AgentBase
+from alpha_factory_v1.backend.agents.planning_agent import PlanningAgent
+from alpha_factory_v1.backend.agents.research_agent import ResearchAgent
+from alpha_factory_v1.backend.agents.strategy_agent import StrategyAgent
+from alpha_factory_v1.backend.agents.market_analysis_agent import MarketAnalysisAgent
+from alpha_factory_v1.backend.agents.memory_agent import MemoryAgent
+from alpha_factory_v1.backend.agents.safety_agent import SafetyAgent
 
 
 class IncorporatorAgent(AgentBase):
@@ -164,6 +170,61 @@ def register_demo_agents() -> None:
             cls=AlphaRiskAgent,
             version="1.0.0",
             capabilities=AlphaRiskAgent.CAPABILITIES,
+        )
+    )
+
+    # --- additional role agents ---
+    register_agent(
+        AgentMetadata(
+            name=PlanningAgent.NAME,
+            cls=PlanningAgent,
+            version="1.0.0",
+            capabilities=PlanningAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=ResearchAgent.NAME,
+            cls=ResearchAgent,
+            version="1.0.0",
+            capabilities=ResearchAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=StrategyAgent.NAME,
+            cls=StrategyAgent,
+            version="1.0.0",
+            capabilities=StrategyAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=MarketAnalysisAgent.NAME,
+            cls=MarketAnalysisAgent,
+            version="1.0.0",
+            capabilities=MarketAnalysisAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=MemoryAgent.NAME,
+            cls=MemoryAgent,
+            version="1.0.0",
+            capabilities=MemoryAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=SafetyAgent.NAME,
+            cls=SafetyAgent,
+            version="1.0.0",
+            capabilities=SafetyAgent.CAPABILITIES,
         )
     )
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -69,6 +69,12 @@ def main(argv: list[str] | None = None) -> None:
                 "AlphaOpportunityAgent",
                 "AlphaExecutionAgent",
                 "AlphaRiskAgent",
+                "PlanningAgent",
+                "ResearchAgent",
+                "StrategyAgent",
+                "MarketAnalysisAgent",
+                "MemoryAgent",
+                "SafetyAgent",
             ]
         )
 


### PR DESCRIPTION
## Summary
- add planning, research, strategy, market analysis, memory and safety agent stubs
- register new agents in the business demo
- enable new agents by default in the local launcher
- document the extra agents in README and quick start

## Testing
- `pip install pytest prometheus_client --quiet` *(fails: no network)*
- `pytest -q` *(fails: command not found)*