### PR TITLE
Enhance business demo notebook

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -190,6 +190,7 @@ python run_business_v1_local.py --auto-install --wheelhouse /path/to/wheels
 ```
 
 Or open `colab_alpha_agi_business_v1_demo.ipynb` to run everything in Colab.
+The notebook now includes an optional **Gradio dashboard** (step 5b) so you can interact with the agents without writing any code.
 To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_bridge.py` (see step 5 in the notebook). Use `--host http://<host>:<port>` when the orchestrator is exposed elsewhere. If the script complains about a missing `openai_agents` package, install it with:
 ```bash
 pip install openai-agents

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -77,25 +77,25 @@
    "outputs": [],
    "source": [
     "import os, getpass\nos.environ['OPENAI_API_KEY'] = getpass.getpass('Enter OpenAI API key (leave blank for offline): ')"
-  ]
- },
- {
-  "cell_type": "markdown",
-  "metadata": {},
-  "source": [
-   "### (Optional) Live market price feed",
-   "Set `YFINANCE_SYMBOL` to fetch a current closing price using `yfinance`."
-  ]
- },
- {
-  "cell_type": "code",
-  "execution_count": null,
-  "metadata": {},
-  "outputs": [],
-  "source": [
-   "import os\nos.environ['YFINANCE_SYMBOL'] = os.getenv('YFINANCE_SYMBOL', 'SPY')"
-  ]
- },
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (Optional) Live market price feed",
+    "Set `YFINANCE_SYMBOL` to fetch a current closing price using `yfinance`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\nos.environ['YFINANCE_SYMBOL'] = os.getenv('YFINANCE_SYMBOL', 'SPY')"
+   ]
+  },
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -161,6 +161,31 @@
     "python openai_agents_bridge.py >/tmp/bridge.log 2>&1 &",
     "sleep 2",
     "tail -n 5 /tmp/bridge.log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5b \u00b7 Interactive Gradio dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\npython gradio_dashboard.py >/tmp/gradio.log 2>&1 &\nsleep 2\ntail -n 5 /tmp/gradio.log"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import IFrame\nIFrame(src='http://localhost:7860', width='100%', height=480)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- document new Gradio dashboard step in the business demo README
- launch the dashboard from the Colab notebook and embed it inline

## Testing
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement pytest)*
- `pytest -q` *(fails: command not found)*