### PR TITLE
Improve alpha opportunity selection

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -26,6 +26,7 @@ This short guide summarises how to launch the business demo either locally or in
 
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
 Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.
+Set `ALPHA_BEST_ONLY=1` to emit the highest-scoring opportunity from `examples/alpha_opportunities.json`.
 
 ## Colab Notebook
 Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook checks requirements, starts the orchestrator, and exposes helper tools via the OpenAI Agents SDK.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -166,6 +166,7 @@ Set the variable yourself to customise the agent list.
 #   • **AlphaOpportunityAgent** picks a random scenario from `examples/alpha_opportunities.json`
 #     (override with `ALPHA_OPPS_FILE=/path/to/custom.json`)
 #     or set `YFINANCE_SYMBOL=SPY` to pull a live price via `yfinance`
+#     set `ALPHA_BEST_ONLY=1` to always emit the highest-scoring entry
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
 #   • **PlanningAgent**, **ResearchAgent**, **StrategyAgent**, **MarketAnalysisAgent**,

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/alpha_opportunities.json
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/alpha_opportunities.json
@@ -1,12 +1,12 @@
 [
-  {"alpha": "supply-chain bottleneck detected at Port of LA"},
-  {"alpha": "unusual pricing divergence across EU carbon credits"},
-  {"alpha": "emerging market currency mispricing due to election"},
-  {"alpha": "lithium production shortfall predicted in 2025"},
-  {"alpha": "data center energy arbitrage between states"},
-  {"alpha": "anomaly in global shipping container rates"},
-  {"alpha": "gene therapy patent undervalued by market"},
-  {"alpha": "renewable energy credit mispricing due to regulatory change"},
-  {"alpha": "rare earth supply-demand mismatch from policy shifts"},
-  {"alpha": "underutilized manufacturing capacity in Southeastern US"}
+  {"alpha": "supply-chain bottleneck detected at Port of LA", "score": 80},
+  {"alpha": "unusual pricing divergence across EU carbon credits", "score": 75},
+  {"alpha": "emerging market currency mispricing due to election", "score": 78},
+  {"alpha": "lithium production shortfall predicted in 2025", "score": 85},
+  {"alpha": "data center energy arbitrage between states", "score": 70},
+  {"alpha": "anomaly in global shipping container rates", "score": 82},
+  {"alpha": "gene therapy patent undervalued by market", "score": 88},
+  {"alpha": "renewable energy credit mispricing due to regulatory change", "score": 74},
+  {"alpha": "rare earth supply-demand mismatch from policy shifts", "score": 83},
+  {"alpha": "underutilized manufacturing capacity in Southeastern US", "score": 72}
 ]

--- a/tests/test_alpha_opportunity_env.py
+++ b/tests/test_alpha_opportunity_env.py
@@ -18,5 +18,22 @@ class TestAlphaOpportunityEnv(unittest.TestCase):
             del os.environ["ALPHA_OPPS_FILE"]
             tmp.unlink()
 
+    def test_best_only_sorting(self):
+        data = [
+            {"alpha": "low", "score": 1},
+            {"alpha": "high", "score": 5}
+        ]
+        tmp = Path("/tmp/opps2.json")
+        tmp.write_text(json.dumps(data), encoding="utf-8")
+        os.environ["ALPHA_OPPS_FILE"] = str(tmp)
+        os.environ["ALPHA_BEST_ONLY"] = "1"
+        try:
+            agent = biz.AlphaOpportunityAgent()
+            self.assertEqual(agent._opportunities[0]["alpha"], "high")
+        finally:
+            del os.environ["ALPHA_OPPS_FILE"]
+            del os.environ["ALPHA_BEST_ONLY"]
+            tmp.unlink()
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_alpha_opportunity_env.py
+++ b/tests/test_alpha_opportunity_env.py
@@ -25,15 +25,13 @@ class TestAlphaOpportunityEnv(unittest.TestCase):
         ]
         tmp = Path("/tmp/opps2.json")
         tmp.write_text(json.dumps(data), encoding="utf-8")
+        self.temp_files.append(tmp)
         os.environ["ALPHA_OPPS_FILE"] = str(tmp)
         os.environ["ALPHA_BEST_ONLY"] = "1"
-        try:
-            agent = biz.AlphaOpportunityAgent()
-            self.assertEqual(agent._opportunities[0]["alpha"], "high")
-        finally:
-            del os.environ["ALPHA_OPPS_FILE"]
-            del os.environ["ALPHA_BEST_ONLY"]
-            tmp.unlink()
+        self.env_vars["ALPHA_OPPS_FILE"] = str(tmp)
+        self.env_vars["ALPHA_BEST_ONLY"] = "1"
+        agent = biz.AlphaOpportunityAgent()
+        self.assertEqual(agent._opportunities[0]["alpha"], "high")
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- add scores to alpha opportunities list
- allow `AlphaOpportunityAgent` to emit the highest-scoring item when `ALPHA_BEST_ONLY=1`
- document new environment variable in README and QUICK_START guides
- test sorting behaviour

## Testing
- `pytest -q tests/test_alpha_opportunity_env.py` *(fails: command not found)*