### PR TITLE
Add config sample for alpha_agi_business_v1

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -158,6 +158,11 @@ python run_business_v1_local.py --bridge --port 9000
 # Set `ALPHA_OPPS_FILE` to use a custom opportunity list
 # ALPHA_OPPS_FILE=examples/my_alpha.json python run_business_v1_local.py --bridge
 
+# Optional configuration
+# Copy `config.env.sample` to `config.env` and edit variables such as
+# `OPENAI_API_KEY`, `YFINANCE_SYMBOL`, and `ALPHA_BEST_ONLY`.
+# The launcher automatically picks up these settings.
+
 By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the five
 lightweight demo stubs so the orchestrator runs even on minimal setups.
 Set the variable yourself to customise the agent list.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -158,9 +158,13 @@ python run_business_v1_local.py --bridge --port 9000
 # Set `ALPHA_OPPS_FILE` to use a custom opportunity list
 # ALPHA_OPPS_FILE=examples/my_alpha.json python run_business_v1_local.py --bridge
 
+```bash
 # Optional configuration
-# Copy `config.env.sample` to `config.env` and edit variables such as
-# `OPENAI_API_KEY`, `YFINANCE_SYMBOL`, and `ALPHA_BEST_ONLY`.
+cp config.env.sample config.env
+# Edit the `config.env` file to set variables such as:
+#   - OPENAI_API_KEY
+#   - YFINANCE_SYMBOL
+#   - ALPHA_BEST_ONLY
 # The launcher automatically picks up these settings.
 
 By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the five

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
@@ -18,7 +18,7 @@ TEMPERATURE=0.35                         # generation temperature
 PORT=8000                                # FastAPI orchestrator
 GRADIO_PORT=7860                         # Gradio dashboard
 AGENTS_RUNTIME_PORT=5001                 # OpenAI Agents runtime
-BUSINESS_HOST="http://localhost:${PORT}" # base URL for bridges
+BUSINESS_HOST="http://localhost:8000"    # base URL for bridges (update as needed)
 LOGLEVEL="INFO"                         # DEBUG | INFO | WARNING | ERROR
 
 ###############################################################################

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
@@ -1,0 +1,42 @@
+# ╔══════════════════════════════════════════════════════════════════════════╗
+# ║  Alpha‑AGI Business v1 • Sample .env                                     ║
+# ║  Rename to **config.env** (git‑ignored). Any variable you omit falls      ║
+# ║  back to safe defaults baked in the demo.                                 ║
+# ║  👉  Values here are placeholders – customise as needed.                   ║
+# ╚══════════════════════════════════════════════════════════════════════════╝
+
+###############################################################################
+#  1️⃣  LLM & TOOLING                                                         #
+###############################################################################
+OPENAI_API_KEY=""                       # leave blank for offline mode
+MODEL_NAME="gpt-4o-mini"                # or any Agents SDK compatible model
+TEMPERATURE=0.35                         # generation temperature
+
+###############################################################################
+#  2️⃣  SERVICE ENDPOINTS & NETWORK                                          #
+###############################################################################
+PORT=8000                                # FastAPI orchestrator
+GRADIO_PORT=7860                         # Gradio dashboard
+AGENTS_RUNTIME_PORT=5001                 # OpenAI Agents runtime
+BUSINESS_HOST="http://localhost:${PORT}" # base URL for bridges
+LOGLEVEL="INFO"                         # DEBUG | INFO | WARNING | ERROR
+
+###############################################################################
+#  3️⃣  DEMO BEHAVIOUR                                                       #
+###############################################################################
+ALPHA_ENABLED_AGENTS="IncorporatorAgent,AlphaDiscoveryAgent,AlphaOpportunityAgent,AlphaExecutionAgent,AlphaRiskAgent,PlanningAgent,ResearchAgent,StrategyAgent,MarketAnalysisAgent,MemoryAgent,SafetyAgent"
+ALPHA_OPPS_FILE="examples/alpha_opportunities.json"  # custom opportunity list
+ALPHA_BEST_ONLY=0                       # 1 ⇒ emit highest scoring opportunity
+YFINANCE_SYMBOL=""                       # optional live price feed
+
+###############################################################################
+#  4️⃣  OPTIONAL GATEWAYS & SECURITY                                         #
+###############################################################################
+ALPHA_FACTORY_ENABLE_ADK=false           # 1 ⇒ expose Google ADK gateway
+ALPHA_FACTORY_ADK_PORT=9000              # ADK port when enabled
+ALPHA_FACTORY_ADK_TOKEN=""               # optional ADK auth token
+AUTH_BEARER_TOKEN=""                     # static REST auth token
+JWT_PUBLIC_KEY=""                        # PEM for JWT verification
+JWT_ISSUER="alpha-business.local"       # expected issuer claim
+
+# End of file – happy hacking!


### PR DESCRIPTION
## Summary
- add `config.env.sample` with common environment settings for the business demo
- mention the config file in the README

## Testing
- `pytest -q` *(fails: command not found)*