### PR TITLE
Improve alpha business demo UX

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -109,7 +109,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import subprocess, re, queue, threading, sys, time\nfrom IPython.display import display, IFrame\n\nroot = 'AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1'\nproc = subprocess.Popen([sys.executable, '-m', 'alpha_agi_business_v1'], cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)\n\nq = queue.Queue()\n\ndef _tail():\n    for line in proc.stdout:\n        print(line, end='')\n        m = re.search(r'http://localhost:(\\d+)/docs', line)\n        if m:\n            q.put(int(m.group(1)))\n\nthreading.Thread(target=_tail, daemon=True).start()\nport = q.get()\nprint(f'\u23f3 Waiting for REST docs on port {port}...')\nfor _ in range(40):\n    try:\n        import requests\n        if requests.get(f'http://localhost:{port}/healthz').status_code == 200:\n            break\n    except Exception:\n        time.sleep(0.2)\n\niframe = IFrame(src=f'http://localhost:{port}/docs', width='100%', height=600)\ndisplay(iframe)"
+    "import subprocess, threading, sys, time, requests\n",
+    "from IPython.display import display, IFrame\n",
+    "\n",
+    "root = 'AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1'\n",
+    "proc = subprocess.Popen([sys.executable, 'start_alpha_business.py', '--no-browser'],\n",
+    "                        cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)\n",
+    "\n",
+    "def _tail():\n",
+    "    for line in proc.stdout:\n",
+    "        print(line, end='')\n",
+    "\n",
+    "threading.Thread(target=_tail, daemon=True).start()\n",
+    "\n",
+    "for _ in range(40):\n",
+    "    try:\n",
+    "        if requests.get('http://localhost:8000/healthz').status_code == 200:\n",
+    "            break\n",
+    "    except Exception:\n",
+    "        time.sleep(0.2)\n",
+    "\n",
+    "display(IFrame(src='http://localhost:8000/docs', width='100%', height=600))\n"
    ]
   },
   {

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
@@ -3,8 +3,10 @@
 
 This helper checks dependencies, starts the local orchestrator with the
 OpenAI Agents bridge enabled, and opens the REST dashboard in the
-system default web browser.  Useful for non‑technical users.
+system default web browser. Pass ``--no-browser`` to suppress the
+automatic browser launch (useful in headless or Colab environments).
 """
+import argparse
 import os
 import subprocess
 import sys
@@ -28,7 +30,18 @@ SCRIPT_DIR = os.path.dirname(__file__)
 MAX_HEALTH_CHECK_RETRIES = 20
 
 
-def main() -> None:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Launch the alpha_agi_business_v1 demo")
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open the REST docs in a web browser",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
     try:
         check_env.main(["--auto-install"])
     except Exception as exc:  # pragma: no cover - optional network failure
@@ -49,10 +62,13 @@ def main() -> None:
                 break
         except Exception:
             time.sleep(0.5)
-    try:
-        webbrowser.open(url, new=1)
-    except Exception:
-        print(f"Open {url} to access the dashboard")
+    if not args.no_browser:
+        try:
+            webbrowser.open(url, new=1)
+        except Exception:
+            print(f"Open {url} to access the dashboard")
+    else:
+        print(f"Dashboard available at {url}")
     try:
         proc.wait()
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- start script accepts `--no-browser` flag for headless launches
- launch the demo from notebook via `start_alpha_business.py`

## Testing
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py`
- `pytest tests/test_alpha_business_v1_script.py::TestAlphaBusinessV1Script.test_script_compiles -q` *(fails: command not found)*