### PR TITLE
Enhance alpha opportunity agent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -27,6 +27,7 @@ This short guide summarises how to launch the business demo either locally or in
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
 Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.
 Set `ALPHA_BEST_ONLY=1` to emit the highest-scoring opportunity from `examples/alpha_opportunities.json`.
+Set `ALPHA_TOP_N=5` to publish the top 5 opportunities each cycle.
 
 ## Colab Notebook
 Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook checks requirements, starts the orchestrator, and exposes helper tools via the OpenAI Agents SDK.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -177,10 +177,12 @@ Set the variable yourself to customise the agent list.
 #   • **IncorporatorAgent** registers the business
 #   • **AlphaDiscoveryAgent** generates a short opportunity via the LLM provider
 #     (logged via MCP when `MCP_ENDPOINT` is set)
-#   • **AlphaOpportunityAgent** picks a random scenario from `examples/alpha_opportunities.json`
+#   • **AlphaOpportunityAgent** emits market inefficiencies from `examples/alpha_opportunities.json`
 #     (override with `ALPHA_OPPS_FILE=/path/to/custom.json`)
-#     or set `YFINANCE_SYMBOL=SPY` to pull a live price via `yfinance`
-#     set `ALPHA_BEST_ONLY=1` to always emit the highest-scoring entry
+#     set `ALPHA_TOP_N=N` to broadcast the top-N entries or
+#     set `ALPHA_BEST_ONLY=1` to only emit the single highest-scoring one
+#     and optionally `YFINANCE_SYMBOL=SPY` to pull a live price via `yfinance`
+#     set `ALPHA_TOP_N=3` to publish the top 3 opportunities each cycle
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
 #   • **PlanningAgent**, **ResearchAgent**, **StrategyAgent**, **MarketAnalysisAgent**,

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
@@ -27,6 +27,7 @@ LOGLEVEL = "INFO"  # DEBUG | INFO | WARNING | ERROR
 ALPHA_ENABLED_AGENTS = "IncorporatorAgent,AlphaDiscoveryAgent,AlphaOpportunityAgent,AlphaExecutionAgent,AlphaRiskAgent,PlanningAgent,ResearchAgent,StrategyAgent,MarketAnalysisAgent,MemoryAgent,SafetyAgent"
 ALPHA_OPPS_FILE = "examples/alpha_opportunities.json"  # custom opportunity list
 ALPHA_BEST_ONLY = 0  # 1 ⇒ emit highest scoring opportunity
+ALPHA_TOP_N = 0  # >0 ⇒ publish top N opportunities each cycle
 YFINANCE_SYMBOL = ""  # optional live price feed
 
 ###############################################################################

--- a/tests/test_alpha_opportunity_env.py
+++ b/tests/test_alpha_opportunity_env.py
@@ -5,7 +5,21 @@ from pathlib import Path
 
 from alpha_factory_v1.demos.alpha_agi_business_v1 import alpha_agi_business_v1 as biz
 
+
 class TestAlphaOpportunityEnv(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_files: list[Path] = []
+        self.env_vars: dict[str, str] = {}
+
+    def tearDown(self) -> None:
+        for p in self.temp_files:
+            try:
+                Path(p).unlink()
+            except FileNotFoundError:
+                pass
+        for var in self.env_vars:
+            os.environ.pop(var, None)
+
     def test_env_override(self):
         data = [{"alpha": "env test"}]
         tmp = Path("/tmp/opps.json")
@@ -32,6 +46,24 @@ class TestAlphaOpportunityEnv(unittest.TestCase):
         self.env_vars["ALPHA_BEST_ONLY"] = "1"
         agent = biz.AlphaOpportunityAgent()
         self.assertEqual(agent._opportunities[0]["alpha"], "high")
+
+    def test_top_n(self):
+        data = [
+            {"alpha": "low", "score": 1},
+            {"alpha": "mid", "score": 3},
+            {"alpha": "high", "score": 5},
+        ]
+        tmp = Path("/tmp/opps3.json")
+        tmp.write_text(json.dumps(data), encoding="utf-8")
+        self.temp_files.append(tmp)
+        os.environ["ALPHA_OPPS_FILE"] = str(tmp)
+        os.environ["ALPHA_TOP_N"] = "2"
+        self.env_vars["ALPHA_OPPS_FILE"] = str(tmp)
+        self.env_vars["ALPHA_TOP_N"] = "2"
+        agent = biz.AlphaOpportunityAgent()
+        self.assertEqual(agent._top_n, 2)
+        self.assertEqual(agent._opportunities[0]["alpha"], "high")
+        self.assertEqual(agent._opportunities[1]["alpha"], "mid")
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- add ALPHA_TOP_N env variable to AlphaOpportunityAgent to publish top N opportunities
- document new feature in README, QUICK_START, and sample config
- update alpha opportunity environment tests

## Testing
- `pytest -q` *(fails: command not found)*