### PR TITLE
Add ComplianceAgent to alpha_agi_business_v1 demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -119,7 +119,7 @@ flowchart LR
 | **MemoryAgent** | Retrieval‑augmented vector store | Persist & recall reusable alpha templates | `backend/agents/memory_agent.py` |
 | **SafetyAgent** | Constitutional‑AI & seccomp sandbox | Filter unsafe code / data exfiltration | `backend/agents/safety_agent.py` |
 | **ExecutionAgent** | Order‑routing & trade settlement | Convert opportunities into executed trades | `backend/agents/execution` |
-| **ComplianceAgent** | Regulatory checklist | Validate trade compliance | `demos/alpha_agi_business_v1/alpha_agi_business_v1.py` |
+| **AlphaComplianceAgent** | Regulatory checklist | Validate trade compliance | `demos/alpha_agi_business_v1/alpha_agi_business_v1.py` |
 
 All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google ADK**, auto‑fallback to offline GGUF models — *no API key required*.
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -119,6 +119,7 @@ flowchart LR
 | **MemoryAgent** | Retrieval‑augmented vector store | Persist & recall reusable alpha templates | `backend/agents/memory_agent.py` |
 | **SafetyAgent** | Constitutional‑AI & seccomp sandbox | Filter unsafe code / data exfiltration | `backend/agents/safety_agent.py` |
 | **ExecutionAgent** | Order‑routing & trade settlement | Convert opportunities into executed trades | `backend/agents/execution` |
+| **ComplianceAgent** | Regulatory checklist | Validate trade compliance | `demos/alpha_agi_business_v1/alpha_agi_business_v1.py` |
 
 All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google ADK**, auto‑fallback to offline GGUF models — *no API key required*.
 
@@ -185,6 +186,7 @@ Set the variable yourself to customise the agent list.
 #     set `ALPHA_TOP_N=3` to publish the top 3 opportunities each cycle
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
+#   • **AlphaComplianceAgent** validates regulatory compliance
 #   • **PlanningAgent**, **ResearchAgent**, **StrategyAgent**, **MarketAnalysisAgent**,
 #     **MemoryAgent** and **SafetyAgent** emit placeholder events to illustrate the
 #     full role architecture

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -159,6 +159,18 @@ class AlphaRiskAgent(AgentBase):
         await self.publish("alpha.risk", {"risk": "risk level nominal"})
 
 
+class AlphaComplianceAgent(AgentBase):
+    """Stub agent performing a simple compliance check."""
+
+    NAME = "alpha_compliance"
+    CAPABILITIES = ["compliance"]
+    CYCLE_SECONDS = 300
+    __slots__ = ()
+
+    async def step(self) -> None:
+        await self.publish("alpha.compliance", {"status": "ok"})
+
+
 def register_demo_agents() -> None:
     """Register built-in demo agents with the framework."""
 
@@ -204,6 +216,15 @@ def register_demo_agents() -> None:
             cls=AlphaRiskAgent,
             version="1.0.0",
             capabilities=AlphaRiskAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=AlphaComplianceAgent.NAME,
+            cls=AlphaComplianceAgent,
+            version="1.0.0",
+            capabilities=AlphaComplianceAgent.CAPABILITIES,
         )
     )
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
@@ -24,7 +24,7 @@ LOGLEVEL = "INFO"  # DEBUG | INFO | WARNING | ERROR
 ###############################################################################
 #  3️⃣  DEMO BEHAVIOUR                                                       #
 ###############################################################################
-ALPHA_ENABLED_AGENTS = "IncorporatorAgent,AlphaDiscoveryAgent,AlphaOpportunityAgent,AlphaExecutionAgent,AlphaRiskAgent,PlanningAgent,ResearchAgent,StrategyAgent,MarketAnalysisAgent,MemoryAgent,SafetyAgent"
+ALPHA_ENABLED_AGENTS = "IncorporatorAgent,AlphaDiscoveryAgent,AlphaOpportunityAgent,AlphaExecutionAgent,AlphaRiskAgent,AlphaComplianceAgent,PlanningAgent,ResearchAgent,StrategyAgent,MarketAnalysisAgent,MemoryAgent,SafetyAgent"
 ALPHA_OPPS_FILE = "examples/alpha_opportunities.json"  # custom opportunity list
 ALPHA_BEST_ONLY = 0  # 1 ⇒ emit highest scoring opportunity
 ALPHA_TOP_N = 0  # >0 ⇒ publish top N opportunities each cycle

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py
@@ -40,6 +40,7 @@ def main() -> None:
             opp_btn = gr.Button("Trigger Opportunity")
             exe_btn = gr.Button("Trigger Execution")
             risk_btn = gr.Button("Trigger Risk")
+            comp_btn = gr.Button("Trigger Compliance")
             alpha_btn = gr.Button("Recent Alpha")
 
         list_btn.click(_list_agents, outputs=out)
@@ -47,6 +48,7 @@ def main() -> None:
         opp_btn.click(lambda: _trigger("alpha_opportunity"), outputs=out)
         exe_btn.click(lambda: _trigger("alpha_execution"), outputs=out)
         risk_btn.click(lambda: _trigger("alpha_risk"), outputs=out)
+        comp_btn.click(lambda: _trigger("alpha_compliance"), outputs=out)
         alpha_btn.click(_recent_alpha, outputs=out)
 
     ui.launch(server_name="0.0.0.0", server_port=PORT, share=False)

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -142,6 +142,13 @@ async def trigger_risk() -> str:
     return "alpha_risk queued"
 
 
+@Tool(name="trigger_compliance", description="Trigger the AlphaComplianceAgent")
+async def trigger_compliance() -> str:
+    resp = requests.post(f"{HOST}/agent/alpha_compliance/trigger", timeout=5)
+    resp.raise_for_status()
+    return "alpha_compliance queued"
+
+
 @Tool(name="check_health", description="Return orchestrator health status")
 async def check_health() -> str:
     """Check orchestrator /healthz endpoint."""
@@ -229,6 +236,7 @@ class BusinessAgent(Agent):
         trigger_opportunity,
         trigger_execution,
         trigger_risk,
+        trigger_compliance,
         check_health,
         recent_alpha,
         search_memory,
@@ -245,6 +253,8 @@ class BusinessAgent(Agent):
                 return await self.tools.trigger_execution()
             elif obs.get("action") == "risk":
                 return await self.tools.trigger_risk()
+            elif obs.get("action") == "compliance":
+                return await self.tools.trigger_compliance()
             elif obs.get("action") == "health":
                 return await self.tools.check_health()
             elif obs.get("action") == "recent_alpha":

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -98,6 +98,7 @@ def main(argv: list[str] | None = None) -> None:
                 "AlphaOpportunityAgent",
                 "AlphaExecutionAgent",
                 "AlphaRiskAgent",
+                "AlphaComplianceAgent",
                 "PlanningAgent",
                 "ResearchAgent",
                 "StrategyAgent",


### PR DESCRIPTION
## Summary
- add `AlphaComplianceAgent` stub and register it
- expose new `trigger_compliance` tool in the OpenAI Agents bridge
- add compliance trigger button to the Gradio dashboard
- enable new agent in run script and sample env file
- document ComplianceAgent in README

## Testing
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py`
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py`
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py`
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py`
- `python check_env.py`
- `pytest -q` *(fails: command not found)*