### PR TITLE
Add portfolio agent demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -120,6 +120,7 @@ flowchart LR
 | **SafetyAgent** | Constitutional‑AI & seccomp sandbox | Filter unsafe code / data exfiltration | `backend/agents/safety_agent.py` |
 | **ExecutionAgent** | Order‑routing & trade settlement | Convert opportunities into executed trades | `backend/agents/execution` |
 | **AlphaComplianceAgent** | Regulatory checklist | Validate trade compliance | `demos/alpha_agi_business_v1/alpha_agi_business_v1.py` |
+| **AlphaPortfolioAgent** | Portfolio snapshot | Summarise executed positions | `demos/alpha_agi_business_v1/alpha_agi_business_v1.py` |
 
 All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google ADK**, auto‑fallback to offline GGUF models — *no API key required*.
 
@@ -187,6 +188,7 @@ Set the variable yourself to customise the agent list.
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
 #   • **AlphaComplianceAgent** validates regulatory compliance
+#   • **AlphaPortfolioAgent** summarises portfolio state
 #   • **PlanningAgent**, **ResearchAgent**, **StrategyAgent**, **MarketAnalysisAgent**,
 #     **MemoryAgent** and **SafetyAgent** emit placeholder events to illustrate the
 #     full role architecture

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -171,6 +171,18 @@ class AlphaComplianceAgent(AgentBase):
         await self.publish("alpha.compliance", {"status": "ok"})
 
 
+class AlphaPortfolioAgent(AgentBase):
+    """Stub agent summarising portfolio state."""
+
+    NAME = "alpha_portfolio"
+    CAPABILITIES = ["portfolio"]
+    CYCLE_SECONDS = 300
+    __slots__ = ()
+
+    async def step(self) -> None:
+        await self.publish("alpha.portfolio", {"summary": "nominal"})
+
+
 def register_demo_agents() -> None:
     """Register built-in demo agents with the framework."""
 
@@ -225,6 +237,15 @@ def register_demo_agents() -> None:
             cls=AlphaComplianceAgent,
             version="1.0.0",
             capabilities=AlphaComplianceAgent.CAPABILITIES,
+        )
+    )
+
+    register_agent(
+        AgentMetadata(
+            name=AlphaPortfolioAgent.NAME,
+            cls=AlphaPortfolioAgent,
+            version="1.0.0",
+            capabilities=AlphaPortfolioAgent.CAPABILITIES,
         )
     )
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
@@ -24,7 +24,7 @@ LOGLEVEL = "INFO"  # DEBUG | INFO | WARNING | ERROR
 ###############################################################################
 #  3️⃣  DEMO BEHAVIOUR                                                       #
 ###############################################################################
-ALPHA_ENABLED_AGENTS = "IncorporatorAgent,AlphaDiscoveryAgent,AlphaOpportunityAgent,AlphaExecutionAgent,AlphaRiskAgent,AlphaComplianceAgent,PlanningAgent,ResearchAgent,StrategyAgent,MarketAnalysisAgent,MemoryAgent,SafetyAgent"
+ALPHA_ENABLED_AGENTS = "IncorporatorAgent,AlphaDiscoveryAgent,AlphaOpportunityAgent,AlphaExecutionAgent,AlphaRiskAgent,AlphaComplianceAgent,AlphaPortfolioAgent,PlanningAgent,ResearchAgent,StrategyAgent,MarketAnalysisAgent,MemoryAgent,SafetyAgent"
 ALPHA_OPPS_FILE = "examples/alpha_opportunities.json"  # custom opportunity list
 ALPHA_BEST_ONLY = 0  # 1 ⇒ emit highest scoring opportunity
 ALPHA_TOP_N = 0  # >0 ⇒ publish top N opportunities each cycle

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -149,6 +149,13 @@ async def trigger_compliance() -> str:
     return "alpha_compliance queued"
 
 
+@Tool(name="trigger_portfolio", description="Trigger the AlphaPortfolioAgent")
+async def trigger_portfolio() -> str:
+    resp = requests.post(f"{HOST}/agent/alpha_portfolio/trigger", timeout=5)
+    resp.raise_for_status()
+    return "alpha_portfolio queued"
+
+
 @Tool(name="check_health", description="Return orchestrator health status")
 async def check_health() -> str:
     """Check orchestrator /healthz endpoint."""
@@ -237,6 +244,7 @@ class BusinessAgent(Agent):
         trigger_execution,
         trigger_risk,
         trigger_compliance,
+        trigger_portfolio,
         check_health,
         recent_alpha,
         search_memory,
@@ -255,6 +263,8 @@ class BusinessAgent(Agent):
                 return await self.tools.trigger_risk()
             elif obs.get("action") == "compliance":
                 return await self.tools.trigger_compliance()
+            elif obs.get("action") == "portfolio":
+                return await self.tools.trigger_portfolio()
             elif obs.get("action") == "health":
                 return await self.tools.check_health()
             elif obs.get("action") == "recent_alpha":

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -99,6 +99,7 @@ def main(argv: list[str] | None = None) -> None:
                 "AlphaExecutionAgent",
                 "AlphaRiskAgent",
                 "AlphaComplianceAgent",
+                "AlphaPortfolioAgent",
                 "PlanningAgent",
                 "ResearchAgent",
                 "StrategyAgent",


### PR DESCRIPTION
## Summary
- add `AlphaPortfolioAgent` stub for demo portfolio tracking
- register agent in local launcher and sample config
- expose `trigger_portfolio` tool through OpenAI Agents bridge
- document new agent in README

## Testing
- `pip install pytest --quiet` *(fails: no network)*
- `pytest -q` *(fails: command not found)*