### PR TITLE
Add Colab badge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -211,6 +211,11 @@ python run_business_v1_local.py --auto-install --wheelhouse /path/to/wheels
 ```
 
 Or open `colab_alpha_agi_business_v1_demo.ipynb` to run everything in Colab.
+<p align="center">
+  <a href="https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb">
+    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab" />
+  </a>
+</p>
 The notebook now includes an optional **Gradio dashboard** (step 5b) so you can interact with the agents without writing any code.
 To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_bridge.py` (see step 5 in the notebook). Use `--host http://<host>:<port>` when the orchestrator is exposed elsewhere. If the script complains about a missing `openai_agents` package, install it with:
 ```bash


### PR DESCRIPTION
## Summary
- add one-click Colab badge to the alpha_agi_business_v1 README

## Testing
- `pytest -q` *(fails: command not found)*