### PR TITLE
docs: link agent framework resources

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -41,3 +41,11 @@ This guide summarises the minimal steps required to run the **Alpha‑AGI Busine
    - Native Python: press `Ctrl+C`; the orchestrator shuts down gracefully.
 
 For advanced options see [`README.md`](README.md) in the same directory.
+
+---
+
+## Further Resources
+
+- [OpenAI Agents SDK docs](https://openai.github.io/openai-agents-python/)
+- [Google ADK reference](https://google.github.io/adk-docs/)
+- [Agent-to-Agent protocol](https://github.com/google/A2A)

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -39,6 +39,7 @@
 11. [Roadmap](#roadmap)
 12. [FAQ](#faq)
 13. [License](#license)
+14. [Resources](#resources)
 
 ---
 
@@ -356,3 +357,14 @@ The **SafetyAgent** & **PlanningAgent** collaborate to absorb shocks; metrics sh
 Apache 2.0 © 2025 **MONTREAL.AI**
 
 <p align="center"><sub>Made with ❤️, ☕ and <b>real</b> GPUs by the Alpha‑Factory core team.</sub></p>
+
+---
+
+<a id="resources"></a>
+## 14 Resources 📚
+
+- [OpenAI Agents SDK documentation](https://openai.github.io/openai-agents-python/)
+- [A&nbsp;practical guide to building agents](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf)
+- [Google Agent Development Kit docs](https://google.github.io/adk-docs/)
+- [Agent‑to‑Agent protocol](https://github.com/google/A2A)
+- [Model Context Protocol](https://www.anthropic.com/news/model-context-protocol)


### PR DESCRIPTION
## Summary
- add resource links for OpenAI Agents SDK, ADK, A2A protocol and practical guide
- update table of contents

## Testing
- `pytest -q tests/test_alpha_business_v1_script.py` *(fails: command not found)*
- `python check_env.py --auto-install` *(fails to install due to network)*