### PR TITLE
Add helper script to surface best alpha opportunity

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -188,6 +188,7 @@ Set the variable yourself to customise the agent list.
 #     set `ALPHA_BEST_ONLY=1` to only emit the single highest-scoring one
 #     and optionally `YFINANCE_SYMBOL=SPY` to pull a live price via `yfinance`
 #     set `ALPHA_TOP_N=3` to publish the top 3 opportunities each cycle
+#     or run `python examples/find_best_alpha.py` to print the current highest-scoring entry
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
 #   • **AlphaComplianceAgent** validates regulatory compliance

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/find_best_alpha.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/find_best_alpha.py
@@ -1,11 +1,22 @@
 import json
 from pathlib import Path
+import sys
 
 
 def main() -> None:
     """Print the highest scoring alpha opportunity."""
     path = Path(__file__).with_name("alpha_opportunities.json")
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"Error: The file '{path}' was not found.")
+        sys.exit(1)
+    except PermissionError:
+        print(f"Error: Permission denied when trying to read the file '{path}'.")
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"Error: Failed to decode JSON from the file '{path}'. Please check the file's contents.")
+        sys.exit(1)
     best = max(data, key=lambda x: x.get("score", 0))
     print("Best alpha opportunity:")
     print(f"  description: {best['alpha']}")

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/find_best_alpha.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/find_best_alpha.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    """Print the highest scoring alpha opportunity."""
+    path = Path(__file__).with_name("alpha_opportunities.json")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    best = max(data, key=lambda x: x.get("score", 0))
+    print("Best alpha opportunity:")
+    print(f"  description: {best['alpha']}")
+    print(f"  score: {best['score']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script that prints the highest‑scoring alpha from the example list
- document the helper in the business demo README

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*
- `python alpha_factory_v1/demos/alpha_agi_business_v1/examples/find_best_alpha.py`
- `python alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py --no-browser` *(fails: missing packages)*