### PR TITLE
Improve business agent bridge usability

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -249,6 +249,7 @@ Expose the business demo via the OpenAI Agents SDK (specify `--host` if the orch
 python openai_agents_bridge.py --host http://localhost:8000 --port 6001 --wait-secs 10
 # → http://localhost:6001/v1/agents
 ```
+Pass `--open-ui` to automatically open the runtime URL in your browser.
 When the optional `google-adk` dependency is installed and `ALPHA_FACTORY_ENABLE_ADK=true` is set,
 the same helper agent is also exposed via an ADK gateway for A2A messaging.
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -325,7 +325,7 @@ def main() -> None:
             import webbrowser
 
             webbrowser.open(url, new=1)
-        except Exception:
+        except webbrowser.Error:
             print(f"Open {url} to access the Agents runtime")
 
     if ADK_AVAILABLE:

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -117,6 +117,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         metavar="SECONDS",
         help="How long to wait for orchestrator health check (default: 5)",
     )
+    parser.add_argument(
+        "--open-ui",
+        action="store_true",
+        help="Open the Agents runtime URL in the default browser",
+    )
     return parser.parse_args(argv)
 
 
@@ -314,6 +319,14 @@ def main() -> None:
     agent = BusinessAgent()
     runtime.register(agent)
     print(f"Registered BusinessAgent -> {HOST} [port {args.port}]")
+    if args.open_ui:
+        url = f"http://localhost:{args.port}/v1/agents"
+        try:
+            import webbrowser
+
+            webbrowser.open(url, new=1)
+        except Exception:
+            print(f"Open {url} to access the Agents runtime")
 
     if ADK_AVAILABLE:
         auto_register([agent])


### PR DESCRIPTION
## Summary
- allow `openai_agents_bridge.py` to open the runtime URL in a browser
- document the new `--open-ui` option in the demo README

## Testing
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py`
- `pytest -q` *(fails: command not found)*