### PR TITLE
Improve alpha business tests

### DIFF
--- a/tests/test_alpha_business_v1_script.py
+++ b/tests/test_alpha_business_v1_script.py
@@ -11,5 +11,10 @@ class TestAlphaBusinessV1Script(unittest.TestCase):
         path = Path('alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py')
         py_compile.compile(path, doraise=True)
 
+    def test_helper_compiles(self) -> None:
+        """Ensure the one-click helper launcher compiles."""
+        path = Path('alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py')
+        py_compile.compile(path, doraise=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- test that the one-click launcher `start_alpha_business.py` compiles

## Testing
- `pytest tests/test_alpha_business_v1_script.py -q` *(fails: command not found)*