### PR TITLE
Improve ADK gateway docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -252,6 +252,7 @@ python openai_agents_bridge.py --host http://localhost:8000 --port 6001 --wait-s
 Pass `--open-ui` to automatically open the runtime URL in your browser.
 When the optional `google-adk` dependency is installed and `ALPHA_FACTORY_ENABLE_ADK=true` is set,
 the same helper agent is also exposed via an ADK gateway for A2A messaging.
+Visit `http://localhost:9000/docs` to explore the gateway when enabled.
 
 The bridge exposes several helper tools:
 - `list_agents`

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -252,7 +252,7 @@ python openai_agents_bridge.py --host http://localhost:8000 --port 6001 --wait-s
 Pass `--open-ui` to automatically open the runtime URL in your browser.
 When the optional `google-adk` dependency is installed and `ALPHA_FACTORY_ENABLE_ADK=true` is set,
 the same helper agent is also exposed via an ADK gateway for A2A messaging.
-Visit `http://localhost:9000/docs` to explore the gateway when enabled.
+Visit `http://localhost:9000/docs` to explore the gateway when enabled (default port: 9000). To use a custom port, set the `GATEWAY_PORT` environment variable accordingly.
 
 The bridge exposes several helper tools:
 - `list_agents`

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -186,7 +186,7 @@
       "outputs": [],
       "source": [
         "%%bash",
-        "python openai_agents_bridge.py --wait-secs 15 >/tmp/bridge.log 2>&1 &",
+        "ALPHA_FACTORY_ENABLE_ADK=true python openai_agents_bridge.py --wait-secs 15 >/tmp/bridge.log 2>&1 &",
         "sleep 2",
         "tail -n 5 /tmp/bridge.log"
       ]
@@ -214,6 +214,23 @@
       "outputs": [],
       "source": [
         "from IPython.display import IFrame\nIFrame(src='http://localhost:7860', width='100%', height=480)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5bb · ADK gateway (optional)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from IPython.display import IFrame",
+        "IFrame(src=\"http://localhost:9000/docs\", width=\"100%\", height=320)"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- update the business demo notebook to launch OpenAI bridge with ADK enabled
- show a new notebook section on accessing the ADK gateway
- mention the gateway URL in README

## Testing
- `pytest -q` *(fails: command not found)*