### PR TITLE
Add example OpenAI Agents client

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -279,6 +279,11 @@ Visit `http://localhost:9000/docs` to explore the gateway when enabled (default 
 - `check_health` (orchestrator health status)
 - `submit_job` (to post a custom job payload to any orchestrator agent)
 
+For a programmatic example see `examples/openai_agent_client.py`:
+```bash
+python examples/openai_agent_client.py --action recent_alpha
+```
+
 *No Docker?*
 `bash <(curl -sL https://get.alpha-factory.ai/business_demo.sh)` boots an ephemeral VM (CPU‑only mode).
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/openai_agent_client.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/openai_agent_client.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Minimal OpenAI Agents client for the business demo.
+
+This helper queries the ``business_helper`` agent exposed by
+``openai_agents_bridge.py``.  It works offline and upgrades
+transparently when ``OPENAI_API_KEY`` is set.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+try:
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - offline shim
+    from alpha_factory_v1 import requests  # type: ignore
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Call BusinessAgent via OpenAI Agents runtime"
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("AGENTS_HOST", "http://localhost:5001"),
+        help="Base URL for the Agents runtime (default: http://localhost:5001)",
+    )
+    parser.add_argument(
+        "--action",
+        default="recent_alpha",
+        help="Action to invoke (default: recent_alpha)",
+    )
+    parser.add_argument(
+        "--job",
+        help="Optional JSON file with a custom job payload",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    payload: dict[str, object] = {"action": args.action}
+    if args.job:
+        payload["job"] = json.loads(Path(args.job).read_text(encoding="utf-8"))
+    headers = {}
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    url = f"{args.host}/v1/agents/business_helper/invoke"
+    resp = requests.post(url, json=payload, headers=headers, timeout=10)
+    try:
+        print(json.dumps(resp.json(), indent=2))
+    except Exception:
+        print(resp.text)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/openai_agent_client.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/openai_agent_client.py
@@ -52,7 +52,7 @@ def main(argv: list[str] | None = None) -> None:
     resp = requests.post(url, json=payload, headers=headers, timeout=10)
     try:
         print(json.dumps(resp.json(), indent=2))
-    except Exception:
+    except json.JSONDecodeError:
         print(resp.text)
 
 


### PR DESCRIPTION
## Summary
- add a minimal `openai_agent_client.py` example to showcase calling the BusinessAgent runtime
- reference the new script in the business demo README

## Testing
- `pip install black --quiet`
- `black alpha_factory_v1/demos/alpha_agi_business_v1/examples/openai_agent_client.py --line-length 88`
- `pytest -q` *(fails: command not found)*