### PR TITLE
Add unit test for best alpha helper

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -188,7 +188,7 @@ Set the variable yourself to customise the agent list.
 #     set `ALPHA_BEST_ONLY=1` to only emit the single highest-scoring one
 #     and optionally `YFINANCE_SYMBOL=SPY` to pull a live price via `yfinance`
 #     set `ALPHA_TOP_N=3` to publish the top 3 opportunities each cycle
-#     or run `python examples/find_best_alpha.py` to print the current highest-scoring entry
+#     or run `python examples/find_best_alpha.py` to print the current highest-scoring entry (validated by unit tests)
 #   • **AlphaExecutionAgent** converts an opportunity into an executed trade
 #   • **AlphaRiskAgent** performs a trivial risk assessment
 #   • **AlphaComplianceAgent** validates regulatory compliance

--- a/tests/test_find_best_alpha.py
+++ b/tests/test_find_best_alpha.py
@@ -1,0 +1,20 @@
+import json
+import subprocess
+from pathlib import Path
+import sys
+import unittest
+
+EXAMPLE_DIR = Path('alpha_factory_v1/demos/alpha_agi_business_v1/examples')
+SCRIPT = EXAMPLE_DIR / 'find_best_alpha.py'
+DATA_FILE = EXAMPLE_DIR / 'alpha_opportunities.json'
+
+class TestFindBestAlpha(unittest.TestCase):
+    def test_output_highest_score(self) -> None:
+        data = json.loads(DATA_FILE.read_text(encoding='utf-8'))
+        best = max(data, key=lambda x: x.get('score', 0))
+        result = subprocess.check_output([sys.executable, str(SCRIPT)], text=True)
+        self.assertIn(best['alpha'], result)
+        self.assertIn(str(best['score']), result)
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test for `find_best_alpha.py` to ensure highest-scoring entry is printed
- document the helper in the alpha_agi_business_v1 README

## Testing
- `pytest tests/test_find_best_alpha.py -q` *(fails: command not found)*