### PR TITLE
Add browser open flag for business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -24,6 +24,12 @@ This short guide summarises how to launch the business demo either locally or in
    strategy, market analysis, memory and safety in addition to the core
    discovery/execution pipeline.
 
+   Alternatively, run the orchestrator directly with:
+   ```bash
+   python run_business_v1_local.py --bridge --open-ui
+   ```
+   This starts the Agents bridge and opens the REST docs automatically once the service is ready.
+
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
 Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.
 Set `ALPHA_BEST_ONLY=1` to emit the highest-scoring opportunity from `examples/alpha_opportunities.json`.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -158,6 +158,8 @@ python start_alpha_business.py
 python run_business_v1_local.py --bridge --auto-install
 # expose orchestrator on a custom port
 python run_business_v1_local.py --bridge --port 9000
+# automatically open the REST docs in your browser
+python run_business_v1_local.py --bridge --open-ui
 # Set `ALPHA_OPPS_FILE` to use a custom opportunity list
 # ALPHA_OPPS_FILE=examples/my_alpha.json python run_business_v1_local.py --bridge
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -66,11 +66,11 @@ def _open_browser_when_ready(url: str, timeout: float = 5.0) -> None:
     """Open *url* in the default browser once the orchestrator responds."""
 
     def _wait_and_open() -> None:
+        import requests  # type: ignore
+
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
-                import requests  # type: ignore
-
                 if requests.get(f"{url.rstrip('/')}/healthz", timeout=1).status_code == 200:
                     webbrowser.open(url, new=1)
                     return

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -63,8 +63,21 @@ def _start_bridge(host: str) -> None:
 
 
 def _open_browser_when_ready(url: str, timeout: float = 5.0) -> None:
-    """Open *url* in the default browser once the orchestrator responds."""
+    """Open *url* in the default browser once the orchestrator responds.
 
+    Parameters
+    ----------
+    url : str
+        The URL to open in the browser.
+    timeout : float, optional
+        The maximum time to wait (in seconds) for the orchestrator to respond
+        before falling back to opening the URL anyway. Default is 5.0 seconds.
+
+    Fallback Behavior
+    -----------------
+    If the orchestrator does not respond within the specified timeout, the
+    URL will still be opened in the browser as a fallback.
+    """
     def _wait_and_open() -> None:
         import requests  # type: ignore
 


### PR DESCRIPTION
## Summary
- add a `--open-ui` option to `run_business_v1_local.py`
- document the new option in `README.md` and `QUICK_START.md`

## Testing
- `python check_env.py --auto-install` *(fails: Could not install packages)*
- `pytest -q` *(fails: command not found)*