### PR TITLE
Improve offline setup docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -34,6 +34,12 @@ Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically wh
 Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.
 Set `ALPHA_BEST_ONLY=1` to emit the highest-scoring opportunity from `examples/alpha_opportunities.json`.
 Set `ALPHA_TOP_N=5` to publish the top 5 opportunities each cycle.
+For air-gapped setups provide pre-downloaded wheels and let `check_env.py` auto-install:
+```bash
+export WHEELHOUSE=/path/to/wheels
+export AUTO_INSTALL_MISSING=1
+python start_alpha_business.py
+```
 
 ## Colab Notebook
 Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook checks requirements, starts the orchestrator, and exposes helper tools via the OpenAI Agents SDK.

--- a/check_env.py
+++ b/check_env.py
@@ -1,4 +1,16 @@
-"""Light-weight dependency check for demos and tests."""
+"""Light-weight dependency check for demos and tests.
+
+This helper validates that the Python packages required by the
+Alpha‑Factory demos and unit tests are present.  When invoked with the
+``--auto-install`` flag (or ``AUTO_INSTALL_MISSING=1`` environment
+variable) it attempts to install any missing dependencies using
+``pip``.  For air‑gapped environments supply ``--wheelhouse`` or set
+``WHEELHOUSE=/path/to/wheels`` so ``pip`` can resolve packages from a
+local directory.
+
+The script prints a warning when packages are missing but continues to
+run so the demos remain usable in restricted setups.
+"""
 
 import importlib.util
 import subprocess


### PR DESCRIPTION
## Summary
- clarify usage of `AUTO_INSTALL_MISSING` and `WHEELHOUSE` in `check_env.py`
- document offline wheelhouse workflow in quick start guide

## Testing
- `python check_env.py`
- `pytest -q` *(fails: command not found)*