### PR TITLE
Add best alpha trigger via Agents bridge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
@@ -31,6 +31,15 @@ curl -X POST http://localhost:<PORT>/agent/alpha_execution/trigger \
      -d '{"alpha": "gene therapy patent undervalued by market", "score": 88}'
 ```
 
+Or trigger it via the OpenAI Agents bridge using the ``trigger_best_alpha``
+helper:
+
+```bash
+curl -X POST http://localhost:5001/v1/agents/business_helper/invoke \
+     -H 'Content-Type: application/json' \
+     -d '{"action": "best_alpha"}'
+```
+
 The execution agent will process the input and propagate tasks to downstream agents such as risk and compliance.
 
 ## 4. Monitor Progress

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -262,6 +262,7 @@ Visit `http://localhost:9000/docs` to explore the gateway when enabled (default 
 - `list_agents`
 - `trigger_discovery`
 - `trigger_opportunity`
+- `trigger_best_alpha` (send the highest scoring demo opportunity)
 - `trigger_execution`
 - `trigger_risk`
 - `trigger_compliance`

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -7,9 +7,11 @@ local orchestrator. It works offline when no API key is configured.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import time
+from pathlib import Path
 
 # allow running this script directly from its folder
 SCRIPT_DIR = os.path.dirname(__file__)
@@ -144,6 +146,27 @@ async def trigger_opportunity() -> str:
     resp = requests.post(f"{HOST}/agent/alpha_opportunity/trigger", timeout=5)
     resp.raise_for_status()
     return "alpha_opportunity queued"
+
+
+@Tool(
+    name="trigger_best_alpha",
+    description="Submit the highest scoring demo opportunity to AlphaExecutionAgent",
+)
+async def trigger_best_alpha() -> str:
+    """Read the bundled alpha opportunities and enqueue the best one."""
+    try:
+        path = Path(__file__).with_name("examples") / "alpha_opportunities.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        best = max(data, key=lambda x: x.get("score", 0))
+    except Exception as exc:  # pragma: no cover - file may be missing
+        raise RuntimeError(f"failed to load alpha opportunities: {exc}") from exc
+    resp = requests.post(
+        f"{HOST}/agent/alpha_execution/trigger",
+        json=best,
+        timeout=5,
+    )
+    resp.raise_for_status()
+    return "best alpha queued"
 
 
 @Tool(name="trigger_execution", description="Trigger the AlphaExecutionAgent")
@@ -312,6 +335,7 @@ class BusinessAgent(Agent):
         list_agents,
         trigger_discovery,
         trigger_opportunity,
+        trigger_best_alpha,
         trigger_execution,
         trigger_risk,
         trigger_compliance,
@@ -335,6 +359,8 @@ class BusinessAgent(Agent):
                 return await self.tools.trigger_discovery()
             elif obs.get("action") == "opportunity":
                 return await self.tools.trigger_opportunity()
+            elif obs.get("action") == "best_alpha":
+                return await self.tools.trigger_best_alpha()
             elif obs.get("action") == "execute":
                 return await self.tools.trigger_execution()
             elif obs.get("action") == "risk":

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -157,6 +157,8 @@ async def trigger_best_alpha() -> str:
     try:
         path = Path(__file__).with_name("examples") / "alpha_opportunities.json"
         data = json.loads(path.read_text(encoding="utf-8"))
+        if not data:
+            raise RuntimeError("No alpha opportunities found in the file.")
         best = max(data, key=lambda x: x.get("score", 0))
     except Exception as exc:  # pragma: no cover - file may be missing
         raise RuntimeError(f"failed to load alpha opportunities: {exc}") from exc


### PR DESCRIPTION
## Summary
- support discovering the highest scoring alpha opportunity via `trigger_best_alpha`
- document new helper in README
- show how to call the helper in the Best Alpha workflow guide

## Testing
- `python check_env.py --auto-install` *(fails: Could not install packages)*
- `pytest -q` *(fails: command not found)*