### PR TITLE
Improve offline guidance

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -227,6 +227,7 @@ To drive the orchestrator via the OpenAI Agents SDK run `python openai_agents_br
 ```bash
 pip install openai-agents
 ```
+In fully offline environments provide a local wheel via the `WHEELHOUSE` environment variable and run `check_env.py --auto-install` before launching the bridge.
 
 ### 🎛️ Local Gradio Dashboard
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -53,6 +53,11 @@ def _require_openai_agents() -> bool:
             return True
         except Exception as exc:  # pragma: no cover - install failed
             sys.stderr.write(f"\n⚠️  openai_agents unavailable: {exc}\n")
+            if "No route to host" in str(exc) or "Temporary failure" in str(exc):
+                sys.stderr.write(
+                    "   Network appears unreachable. Install 'openai_agents' "
+                    "manually or provide a local wheel via WHEELHOUSE.\n"
+                )
             sys.stderr.write("   Continuing without OpenAI Agents bridge.\n")
             return False
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -53,7 +53,7 @@ def _require_openai_agents() -> bool:
             return True
         except Exception as exc:  # pragma: no cover - install failed
             sys.stderr.write(f"\n⚠️  openai_agents unavailable: {exc}\n")
-            if "No route to host" in str(exc) or "Temporary failure" in str(exc):
+            if isinstance(exc, requests.exceptions.ConnectionError):
                 sys.stderr.write(
                     "   Network appears unreachable. Install 'openai_agents' "
                     "manually or provide a local wheel via WHEELHOUSE.\n"


### PR DESCRIPTION
## Summary
- clarify how to install openai_agents without network in README
- hint about offline installations in bridge helper

## Testing
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement pytest)*
- `pytest -q` *(fails: command not found)*