### PR TITLE
Add skeleton for Meta-Agentic Tree Search demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
@@ -1,0 +1,4 @@
+"""meta_agentic_tree_search_v0 demo package."""
+
+__all__ = ["run_demo"]
+

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/configs/default.yaml
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/configs/default.yaml
@@ -1,0 +1,3 @@
+# Default configuration for the MATS demo
+episodes: 10
+exploration: 1.4

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
@@ -1,0 +1,7 @@
+"""Core components for the Meta-Agentic Tree Search demo."""
+
+from .tree import Node, Tree
+from .meta_rewrite import meta_rewrite
+from .evaluators import evaluate
+
+__all__ = ["Node", "Tree", "meta_rewrite", "evaluate"]

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
@@ -1,0 +1,15 @@
+"""Toy evaluation utilities for the MATS demo."""
+from __future__ import annotations
+
+from typing import List
+import random
+
+TARGET = 5
+
+
+def evaluate(agents: List[int]) -> float:
+    """Return a pseudo reward for the agents."""
+    distance = sum(abs(a - TARGET) for a in agents)
+    noise = random.random() * 0.1
+    return -distance + noise
+

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -1,0 +1,14 @@
+"""Placeholder meta-rewrite function."""
+from __future__ import annotations
+
+import random
+from typing import List
+
+
+def meta_rewrite(agents: List[int]) -> List[int]:
+    """Return a modified copy of ``agents`` with a small random change."""
+    new_agents = list(agents)
+    idx = random.randrange(len(new_agents))
+    new_agents[idx] += random.choice([-1, 1])
+    return new_agents
+

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
@@ -1,0 +1,55 @@
+"""Simple best-first tree search utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+import math
+
+@dataclass
+class Node:
+    agents: List[int]
+    reward: float = 0.0
+    visits: int = 0
+    parent: Optional["Node"] = None
+    children: List["Node"] = field(default_factory=list)
+
+
+class Tree:
+    """Minimal UCB1-style search tree."""
+
+    def __init__(self, root: Node, exploration: float = 1.4) -> None:
+        self.root = root
+        self.exploration = exploration
+
+    def select(self) -> Node:
+        node = self.root
+        while node.children:
+            node = max(
+                node.children,
+                key=lambda n: (n.reward / (n.visits or 1e-9))
+                + self.exploration * math.sqrt(math.log(node.visits + 1) / ((n.visits) or 1e-9)),
+            )
+        return node
+
+    def add_child(self, parent: Node, child: Node) -> None:
+        child.parent = parent
+        parent.children.append(child)
+
+    def backprop(self, node: Node) -> None:
+        reward = node.reward
+        while node is not None:
+            node.visits += 1
+            node.reward += reward
+            node = node.parent
+
+    def best_leaf(self) -> Node:
+        best = self.root
+        stack = [self.root]
+        while stack:
+            n = stack.pop()
+            if n.visits and (n.reward / n.visits) > (best.reward / (best.visits or 1)):
+                best = n
+            stack.extend(n.children)
+        return best
+

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
@@ -48,7 +48,7 @@ class Tree:
         stack = [self.root]
         while stack:
             n = stack.pop()
-            if n.visits and (n.reward / n.visits) > (best.reward / (best.visits or 1)):
+            if n.visits and (n.reward / n.visits) > (best.reward / (best.visits or self.exploration)):
                 best = n
             stack.extend(n.children)
         return best

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.txt
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.txt
@@ -1,0 +1,7 @@
+# Meta-Agentic Tree Search demo dependencies
+-r ../../requirements.txt
+# Additional RL tooling (optional)
+torch>=2.2
+gymnasium>=0.29
+networkx>=3.3
+

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Minimal Meta-Agentic Tree Search demo."""
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+from .mats.tree import Node, Tree
+from .mats.meta_rewrite import meta_rewrite
+from .mats.evaluators import evaluate
+
+
+def run(episodes: int = 10) -> None:
+    """Run a toy tree search for a small number of episodes."""
+    root_agents: List[int] = [0, 0, 0, 0]
+    tree = Tree(Node(root_agents))
+    for _ in range(episodes):
+        node = tree.select()
+        improved = meta_rewrite(node.agents)
+        reward = evaluate(improved)
+        child = Node(improved, reward=reward)
+        tree.add_child(node, child)
+        tree.backprop(child)
+    best = tree.best_leaf()
+    score = best.reward / (best.visits or 1)
+    print(f"Best agents: {best.agents} score: {score:.3f}")
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the Meta-Agentic Tree Search demo")
+    parser.add_argument("--episodes", type=int, default=10, help="Number of search iterations")
+    args = parser.parse_args(argv)
+    run(args.episodes)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
+    """Ensure the MATS demo entrypoint runs successfully."""
+
+    def test_run_demo_short(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo",
+                "--episodes",
+                "3",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best agents", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add minimal runnable demo for `meta_agentic_tree_search_v0`
- include toy tree search implementation
- provide requirements and default config
- add unit test to execute the demo

## Testing
- `python -m py_compile alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/*.py tests/test_meta_agentic_tree_search_demo.py`
- `python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 3`
- `python check_env.py`