### PR TITLE
Improve MATS demo with toy env

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -51,7 +51,7 @@ def MATS(root_agents, env, horizon_days):
 | `best_first`       | UCB1, TS, ε‑greedy (UCB1) |
 | `meta_rewrite`     | PPO fine‑tune, CMA‑ES, GPT‑4 code‑gen (PPO) |
 | Reward             | IRR, CumPnL/√Var, Sharpe (IRR) |
-| Environment        | Toy limit‑order‑book sim, OpenAI Gym trading env (Gym) |
+| Environment        | Toy number-line env (default), limit‑order‑book sim, OpenAI Gym trading env |
 
 ## 5 Quick start
 ```bash
@@ -61,7 +61,8 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt          # torch, gymnasium, networkx, etc.
 python run_demo.py --config configs/default.yaml --episodes 500
 ```
-`run_demo.py` prints a live scoreboard of best‑leaf α and writes checkpoints to `./checkpoints/`. A ready‑to‑run Colab notebook is also provided as `colab_meta_agentic_tree_search.ipynb`.
+`run_demo.py` prints a per‑episode scoreboard and writes checkpoints to `./checkpoints/`. A ready‑to‑run Colab notebook is also provided as `colab_meta_agentic_tree_search.ipynb`.
+The default environment is a simple number‑line task defined in `mats/env.py` where each agent must approach a target integer.
 
 > **Tip:** Set `--market-data my_feed.csv` to replay real tick data.
 
@@ -73,7 +74,8 @@ meta_agentic_tree_search_v0/
 ├── mats/                    ← core library
 │   ├── tree.py
 │   ├── meta_rewrite.py
-│   └── evaluators.py
+│   ├── evaluators.py
+│   └── env.py
 └── configs/
     └── default.yaml
 ```

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
@@ -1,4 +1,6 @@
 """meta_agentic_tree_search_v0 demo package."""
 
-__all__ = ["run_demo"]
+from . import mats
+
+__all__ = ["run_demo", "mats"]
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
@@ -1,0 +1,17 @@
+"""Simple evaluation environment for the MATS demo."""
+from __future__ import annotations
+
+import random
+from typing import List
+
+class NumberLineEnv:
+    """Toy environment where agents aim for a target integer."""
+
+    def __init__(self, target: int = 5) -> None:
+        self.target = target
+
+    def rollout(self, agents: List[int]) -> float:
+        """Return a pseudo reward after a single rollout."""
+        distance = sum(abs(a - self.target) for a in agents)
+        noise = random.random() * 0.1
+        return -distance + noise

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
@@ -1,15 +1,22 @@
-"""Toy evaluation utilities for the MATS demo."""
+"""Evaluation utilities for the MATS demo."""
 from __future__ import annotations
 
 from typing import List
-import random
-
-TARGET = 5
+from .env import NumberLineEnv
 
 
-def evaluate(agents: List[int]) -> float:
-    """Return a pseudo reward for the agents."""
-    distance = sum(abs(a - TARGET) for a in agents)
-    noise = random.random() * 0.1
-    return -distance + noise
+def evaluate(agents: List[int], env: NumberLineEnv | None = None) -> float:
+    """Return a pseudo reward for the agents using ``env``.
+
+    Parameters
+    ----------
+    agents:
+        Current candidate policies represented as integers.
+    env:
+        Optional environment instance.  A new :class:`NumberLineEnv` is created
+        when omitted so the function remains backward compatible.
+    """
+
+    environment = env or NumberLineEnv()
+    return environment.rollout(agents)
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -14,19 +14,22 @@ except Exception:  # pragma: no cover - fallback parser
 from .mats.tree import Node, Tree
 from .mats.meta_rewrite import meta_rewrite
 from .mats.evaluators import evaluate
+from .mats.env import NumberLineEnv
 
 
 def run(episodes: int = 10, exploration: float = 1.4) -> None:
     """Run a toy tree search for a small number of episodes."""
     root_agents: List[int] = [0, 0, 0, 0]
+    env = NumberLineEnv()
     tree = Tree(Node(root_agents), exploration=exploration)
     for _ in range(episodes):
         node = tree.select()
         improved = meta_rewrite(node.agents)
-        reward = evaluate(improved)
+        reward = evaluate(improved, env)
         child = Node(improved, reward=reward)
         tree.add_child(node, child)
         tree.backprop(child)
+        print(f"Episode {_+1:>3}: candidate {improved} → reward {reward:.3f}")
     best = tree.best_leaf()
     score = best.reward / (best.visits or 1)
     print(f"Best agents: {best.agents} score: {score:.3f}")

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -21,6 +21,13 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Best agents", result.stdout)
 
+    def test_env_rollout(self) -> None:
+        from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.env import NumberLineEnv
+
+        env = NumberLineEnv(target=3)
+        reward = env.rollout([3, 3, 3])
+        self.assertGreaterEqual(reward, -0.1)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- add a small `NumberLineEnv` environment
- print per-episode rewards in `run_demo.py`
- export `mats` submodule in demo package
- update README with new environment info
- extend unit tests with environment rollout check

## Testing
- `python check_env.py`
- `python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 3`
- `python -m pytest -q` *(fails: No module named pytest)*