### PR TITLE
Enhance MATS demo openai rewrite

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -55,8 +55,10 @@ def MATS(root_agents, env, horizon_days):
 
 ### 4.1 · OpenAI/ADK rewrite option
 When the optional `openai-agents` and `google-adk` packages are installed the
-demo can leverage the OpenAI Agents SDK together with the A2A protocol to
-generate candidate policies. Enable this behaviour with:
+demo can leverage a tiny ``RewriterAgent`` built with the OpenAI Agents SDK
+together with the A2A protocol to generate candidate policies.  The agent is
+instantiated directly from :func:`openai_rewrite` and executed once per tree
+step. Enable this behaviour with:
 
 ```bash
 python run_demo.py --rewriter openai --episodes 500

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -51,7 +51,7 @@ def openai_rewrite(agents: List[int]) -> List[int]:
             # Execute the policy once via asyncio to keep things simple and
             # avoid setting up a full runtime. ``agent2agent`` is touched so
             # static analysers confirm integration when available.
-            result = asyncio.run(agent.policy({"policy": agents}, {}))
+            result = await agent.policy({"policy": agents}, {})
             if have_adk:
                 _ = agent2agent  # pragma: no cover - placeholder use
             return list(result)


### PR DESCRIPTION
## Summary
- plug `RewriterAgent` into openai rewrite path for the Meta‑Agentic Tree Search demo
- document the behaviour in the demo README

## Testing
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest tests/test_meta_agentic_tree_search_demo.py::TestMetaAgenticTreeSearchDemo.test_openai_rewrite_fallback -q` *(fails: command not found)*