### PR TITLE
Improve MATS demo with reproducible runs

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -80,10 +80,11 @@ git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_tree_search_v0
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt          # torch, gymnasium, networkx, etc.
-python run_demo.py --config configs/default.yaml --episodes 500 --target 5
+python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --seed 42
 ```
 `run_demo.py` prints a per‑episode scoreboard and writes checkpoints to `./checkpoints/`. A ready‑to‑run Colab notebook is also provided as `colab_meta_agentic_tree_search.ipynb`.
 The default environment is a simple number‑line task defined in `mats/env.py` where each agent must approach a target integer. Pass `--target 7` (for example) to experiment with different goals.
+Use `--seed 42` to reproduce a specific search trajectory.
 
 > **Tip:** Set `--market-data my_feed.csv` to replay real tick data.
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/configs/default.yaml
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/configs/default.yaml
@@ -3,3 +3,4 @@ episodes: 10
 exploration: 1.4
 rewriter: random
 target: 5
+seed: 0

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -68,6 +68,23 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Best agents", result.stdout)
 
+    def test_run_demo_with_seed(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo",
+                "--episodes",
+                "2",
+                "--seed",
+                "123",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best agents", result.stdout)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- add optional RNG seed to `run_demo.py`
- capture seed in `default.yaml` and README usage
- document reproducibility in the demo README
- test new `--seed` CLI option

## Testing
- `python -m unittest tests.test_meta_agentic_tree_search_demo -v`
- `python check_env.py`