### PR TITLE
Add OpenAI Agents bridge to MATS demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -74,6 +74,17 @@ When the optional `openai` package is also present, `openai_rewrite` uses
 key or in fully offline environments the routine simply increments the
 proposed policy elements so the rest of the demo keeps working.
 
+### 4.2 · OpenAI Agents bridge
+A standalone script `openai_agents_bridge.py` exposes the search loop via the
+**OpenAI Agents SDK** and optionally the **Google ADK** federation layer. Launch
+the bridge to control the demo through API calls or the Agents runtime UI:
+
+```bash
+python openai_agents_bridge.py --help
+```
+The bridge runs entirely offline when the `openai_agents` package or API keys
+are missing so the notebook remains reproducible anywhere.
+
 ## 5 Quick start
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
@@ -2,5 +2,5 @@
 
 from . import mats
 
-__all__ = ["run_demo", "mats"]
+__all__ = ["run_demo", "mats", "openai_agents_bridge"]
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""OpenAI Agents SDK bridge for the Meta-Agentic Tree Search demo.
+
+This utility registers a small agent that exposes the tree-search loop via the
+OpenAI Agents runtime.  It gracefully degrades to offline mode when the
+``openai-agents`` package is unavailable or no API key is configured.
+"""
+from __future__ import annotations
+
+import os
+
+try:
+    from openai_agents import Agent, AgentRuntime, Tool  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    raise SystemExit(
+        "openai-agents package is missing. Install with `pip install openai-agents`"
+    ) from exc
+
+from .run_demo import run
+
+
+@Tool(name="run_search", description="Run the MATS demo for a few episodes")
+async def run_search(episodes: int = 10, target: int = 5) -> str:
+    """Execute the search loop and return a summary string."""
+    run(episodes=episodes, target=target)
+    return f"completed {episodes} episodes toward target {target}"
+
+
+class MATSAgent(Agent):
+    """Tiny helper agent wrapping :func:`run_search`."""
+
+    name = "mats_helper"
+    tools = [run_search]
+
+    async def policy(self, obs, _ctx):  # type: ignore[override]
+        episodes = int(obs.get("episodes", 10)) if isinstance(obs, dict) else 10
+        target = int(obs.get("target", 5)) if isinstance(obs, dict) else 5
+        return await run_search(episodes=episodes, target=target)
+
+
+def main() -> None:
+    runtime = AgentRuntime(api_key=os.getenv("OPENAI_API_KEY"))
+    agent = MATSAgent()
+    runtime.register(agent)
+    try:
+        from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+
+        auto_register([agent])
+        maybe_launch()
+    except Exception as exc:  # pragma: no cover - ADK optional
+        print(f"ADK bridge unavailable: {exc}")
+
+    print("Registered MATSAgent with runtime")
+    runtime.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -28,5 +28,10 @@ class TestOpenAIBridge(unittest.TestCase):
         path = Path('alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py')
         py_compile.compile(path, doraise=True)
 
+    def test_mats_bridge_compiles(self):
+        """Ensure the MATS demo bridge compiles."""
+        path = Path('alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py')
+        py_compile.compile(path, doraise=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create `openai_agents_bridge.py` to expose the Meta‑Agentic Tree Search demo via OpenAI Agents SDK
- export the new bridge module from the package
- document the bridge in the demo README
- test that the new bridge script compiles

## Testing
- `python -m tests.test_meta_agentic_tree_search_demo`
- `python -m tests.test_openai_bridge`
