### PR TITLE
Improve MATS demo bridge offline behaviour

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -84,7 +84,13 @@ python openai_agents_bridge.py --help
 ```
 If the `openai_agents` package or API keys are missing the bridge automatically
 falls back to running the search loop locally so the notebook remains
-reproducible anywhere.
+reproducible anywhere.  When running offline you can still invoke
+`run_search` directly to verify the helper logic:
+
+```bash
+python openai_agents_bridge.py --episodes 3 --target 4
+```
+This prints a short completion summary after executing the demo loop.
 
 ## 5 Quick start
 ```bash

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -51,8 +51,12 @@ if has_oai:
 else:
     from .run_demo import run
 
-    async def run_search(episodes: int = 10, target: int = 5) -> str:
+    def _run_search_helper(episodes: int, target: int) -> str:
         """Execute the search loop and return a summary string."""
+        run(episodes=episodes, target=target)
+        return f"completed {episodes} episodes toward target {target}"
+
+    async def run_search(episodes: int = 10, target: int = 5) -> str:
         return _run_search_helper(episodes, target)
 
 

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -102,6 +102,16 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("offline demo", result.stdout.lower())
 
+    def test_bridge_run_search_helper(self) -> None:
+        import asyncio
+        from alpha_factory_v1.demos.meta_agentic_tree_search_v0 import openai_agents_bridge as bridge
+
+        if bridge.has_oai:  # pragma: no cover - only run offline path
+            self.skipTest("openai-agents installed")
+
+        result = asyncio.run(bridge.run_search(episodes=1, target=2))
+        self.assertIn("completed", result)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- fix `openai_agents_bridge` offline helper to run search loop correctly
- document offline invocation in README
- add regression test for offline helper

## Testing
- `pytest -q` *(fails: No module named pytest)*