### PR TITLE
Fix MATS logging import

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -6,6 +6,7 @@ from typing import List
 import importlib
 import asyncio
 import os
+import logging
 
 
 def meta_rewrite(agents: List[int]) -> List[int]:


### PR DESCRIPTION
## Summary
- import `logging` in `openai_rewrite`

## Testing
- `pytest -q tests/test_meta_agentic_tree_search_demo.py::TestMetaAgenticTreeSearchDemo.test_openai_rewrite_fallback` *(fails: command not found)*
