### PR TITLE
Fix MATS demo exports

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
@@ -1,6 +1,8 @@
-"""meta_agentic_tree_search_v0 demo package."""
+"""Meta-Agentic Tree Search v0 demo package."""
 
 from . import mats
+from .run_demo import run as run_demo
+from . import openai_agents_bridge
 
 __all__ = ["run_demo", "mats", "openai_agents_bridge"]
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
@@ -1,7 +1,7 @@
 """Core components for the Meta-Agentic Tree Search demo."""
 
 from .tree import Node, Tree
-from .meta_rewrite import meta_rewrite
+from .meta_rewrite import meta_rewrite, openai_rewrite
 from .evaluators import evaluate
 
-__all__ = ["Node", "Tree", "meta_rewrite", "evaluate"]
+__all__ = ["Node", "Tree", "meta_rewrite", "openai_rewrite", "evaluate"]

--- a/tests/test_meta_agentic_tree_search_import.py
+++ b/tests/test_meta_agentic_tree_search_import.py
@@ -1,0 +1,14 @@
+import importlib
+import unittest
+
+class TestMetaAgenticTreeSearchImport(unittest.TestCase):
+    """Verify package-level exports for the MATS demo."""
+
+    def test_package_exports(self) -> None:
+        mod = importlib.import_module("alpha_factory_v1.demos.meta_agentic_tree_search_v0")
+        self.assertTrue(hasattr(mod, "run_demo"))
+        self.assertTrue(hasattr(mod, "mats"))
+        self.assertTrue(hasattr(mod, "openai_agents_bridge"))
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- export `run_demo` and `openai_agents_bridge` from `meta_agentic_tree_search_v0`
- expose `openai_rewrite` via the `mats` package
- add regression test for package-level exports

## Testing
- `pytest -q` *(fails: command not found)*