### PR TITLE
Enhance MATS demo model selection

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -72,7 +72,8 @@ When the optional `openai` package is also present, `openai_rewrite` uses
 `ChatCompletion` to refine candidate integer policies.  Supply an
 `OPENAI_API_KEY` environment variable to activate this behaviour.  Without a
 key or in fully offline environments the routine simply increments the
-proposed policy elements so the rest of the demo keeps working.
+proposed policy elements so the rest of the demo keeps working.  You can
+override the model used by setting ``OPENAI_MODEL`` (defaults to ``gpt-4o``).
 
 ### 4.2 · OpenAI Agents bridge
 The `openai_agents_bridge.py` script exposes the search loop via the
@@ -88,7 +89,7 @@ reproducible anywhere.  When running offline you can still invoke
 `run_search` directly to verify the helper logic:
 
 ```bash
-python openai_agents_bridge.py --episodes 3 --target 4
+python openai_agents_bridge.py --episodes 3 --target 4 --model gpt-4o
 ```
 This prints a short completion summary after executing the demo loop.
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "import os\nos.environ['OPENAI_API_KEY'] = ''"
+   "source": "import os\nos.environ['OPENAI_API_KEY'] = ''\nos.environ['OPENAI_MODEL'] = 'gpt-4o'"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -49,7 +49,7 @@ def openai_rewrite(agents: List[int]) -> List[int]:
                 )
                 try:
                     response = await openai.ChatCompletion.acreate(
-                        model="gpt-4o",
+                        model=os.getenv("OPENAI_MODEL", "gpt-4o"),
                         messages=[
                             {"role": "system", "content": "You rewrite policies for a simple number line game."},
                             {"role": "user", "content": prompt},

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -26,8 +26,10 @@ if has_oai:
         from alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo import run
 
     @Tool(name="run_search", description="Run the MATS demo for a few episodes")
-    async def run_search(episodes: int = 10, target: int = 5) -> str:
+    async def run_search(episodes: int = 10, target: int = 5, model: str | None = None) -> str:
         """Execute the search loop and return a summary string."""
+        if model:
+            os.environ.setdefault("OPENAI_MODEL", model)
         run(episodes=episodes, target=target)
         return f"completed {episodes} episodes toward target {target}"
 
@@ -40,9 +42,12 @@ if has_oai:
         async def policy(self, obs, _ctx):  # type: ignore[override]
             episodes = int(obs.get("episodes", 10)) if isinstance(obs, dict) else 10
             target = int(obs.get("target", 5)) if isinstance(obs, dict) else 5
-            return await run_search(episodes=episodes, target=target)
+            model = obs.get("model") if isinstance(obs, dict) else None
+            return await run_search(episodes=episodes, target=target, model=model)
 
-    def _run_runtime(episodes: int, target: int) -> None:
+    def _run_runtime(episodes: int, target: int, model: str | None = None) -> None:
+        if model:
+            os.environ.setdefault("OPENAI_MODEL", model)
         runtime = AgentRuntime(api_key=os.getenv("OPENAI_API_KEY"))
         agent = MATSAgent()
         runtime.register(agent)
@@ -62,19 +67,21 @@ else:
     except ImportError:  # pragma: no cover - direct script execution
         from alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo import run
 
-    def _run_search_helper(episodes: int, target: int) -> str:
+    def _run_search_helper(episodes: int, target: int, model: str | None = None) -> str:
         """Execute the search loop and return a summary string."""
+        if model:
+            os.environ.setdefault("OPENAI_MODEL", model)
         run(episodes=episodes, target=target)
         return f"completed {episodes} episodes toward target {target}"
-
-    async def run_search(episodes: int = 10, target: int = 5) -> str:
-        return _run_search_helper(episodes, target)
+    async def run_search(episodes: int = 10, target: int = 5, model: str | None = None) -> str:
+        return _run_search_helper(episodes, target, model)
 
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="OpenAI Agents bridge for MATS")
     parser.add_argument("--episodes", type=int, default=10, help="Search episodes when offline")
     parser.add_argument("--target", type=int, default=5, help="Target integer when offline")
+    parser.add_argument("--model", type=str, help="Optional OpenAI model override")
     args = parser.parse_args(argv)
 
     if not has_oai:
@@ -82,7 +89,7 @@ def main(argv: list[str] | None = None) -> None:
         run(episodes=args.episodes, target=args.target)
         return
 
-    _run_runtime(args.episodes, args.target)
+    _run_runtime(args.episodes, args.target, args.model)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- allow overriding the OpenAI model via `OPENAI_MODEL`
- expose `--model` argument in `openai_agents_bridge.py`
- note the model override in the README and Colab notebook

## Testing
- `python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 1 --rewriter openai --target 3`
- `python alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py --episodes 1 --target 2 --model gpt-4o`
- `pytest` *(fails: command not found)*