### PR TITLE
Enhance MATS demo ADK controls

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -91,6 +91,8 @@ reproducible anywhere.  When running offline you can still invoke
 ```bash
 python openai_agents_bridge.py --episodes 3 --target 4 --model gpt-4o
 ```
+Enable the optional ADK gateway with ``--enable-adk`` (or set
+``ALPHA_FACTORY_ENABLE_ADK=true``) to expose the agent over the A2A protocol.
 This prints a short completion summary after executing the demo loop.
 
 ## 5 Quick start
@@ -104,6 +106,8 @@ python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --see
 `run_demo.py` prints a per‑episode scoreboard.  Pass `--log-dir logs` to save a
 `scores.csv` file for further analysis. A ready‑to‑run Colab notebook is also
 provided as `colab_meta_agentic_tree_search.ipynb`.
+Add ``--enable-adk`` to the command above to start the optional ADK
+gateway for remote control via the A2A protocol.
 The default environment is a simple number‑line task defined in `mats/env.py` where each agent must approach a target integer. Pass `--target 7` (for example) to experiment with different goals.
 Use `--seed 42` to reproduce a specific search trajectory.
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -52,10 +52,13 @@ if has_oai:
         agent = MATSAgent()
         runtime.register(agent)
         try:
-            from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+            from alpha_factory_v1.backend import adk_bridge
 
-            auto_register([agent])
-            maybe_launch()
+            if adk_bridge.adk_enabled():
+                adk_bridge.auto_register([agent])
+                adk_bridge.maybe_launch()
+            else:
+                print("ADK gateway disabled.")
         except Exception as exc:  # pragma: no cover - ADK optional
             print(f"ADK bridge unavailable: {exc}")
 
@@ -82,12 +85,20 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--episodes", type=int, default=10, help="Search episodes when offline")
     parser.add_argument("--target", type=int, default=5, help="Target integer when offline")
     parser.add_argument("--model", type=str, help="Optional OpenAI model override")
+    parser.add_argument(
+        "--enable-adk",
+        action="store_true",
+        help="Enable the Google ADK gateway for remote control",
+    )
     args = parser.parse_args(argv)
 
     if not has_oai:
         print("openai-agents package is missing. Running offline demo...")
         run(episodes=args.episodes, target=args.target)
         return
+
+    if args.enable_adk:
+        os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
 
     _run_runtime(args.episodes, args.target, args.model)
 


### PR DESCRIPTION
## Summary
- allow enabling the Google ADK gateway via `--enable-adk`
- improve runtime behaviour when ADK is disabled
- document new option in the MATS README

## Testing
- `python -m py_compile alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py`
- `pytest -q` *(fails: `pytest: command not found`)*