### PR TITLE
Improve MATS demo parsing

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -74,6 +74,9 @@ When the optional `openai` package is also present, `openai_rewrite` uses
 key or in fully offline environments the routine simply increments the
 proposed policy elements so the rest of the demo keeps working.  You can
 override the model used by setting ``OPENAI_MODEL`` (defaults to ``gpt-4o``).
+Output from the model is processed via the new ``_parse_numbers`` helper which
+extracts integers from free‑form text so the search loop remains stable even when
+the LLM response contains extra commentary.
 
 ### 4.2 · OpenAI Agents bridge
 The `openai_agents_bridge.py` script exposes the search loop via the
@@ -140,6 +143,7 @@ meta_agentic_tree_search_v0/
 | Swap rewrite strategy          | Subclass `MetaRewriter`           |
 | Use distributed workers        | `ray tune` launcher               |
 | Custom tree policy             | Implement `acquire()` in `Tree`   |
+| Custom output parser           | `_parse_numbers` helper           |
 
 ## 9 Safety & governance guard‑rails
 * Sandboxed code‑gen (`firejail + seccomp + tmpfs`)  

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -39,17 +39,30 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertIn("Best agents", result.stdout)
 
     def test_env_rollout(self) -> None:
-        from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.env import NumberLineEnv
+        from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.env import (
+            NumberLineEnv,
+        )
 
         env = NumberLineEnv(target=3)
         reward = env.rollout([3, 3, 3])
         self.assertGreaterEqual(reward, -0.1)
 
     def test_openai_rewrite_fallback(self) -> None:
-        from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.meta_rewrite import openai_rewrite
+        from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.meta_rewrite import (
+            openai_rewrite,
+        )
 
         out = openai_rewrite([1, 2, 3])
         self.assertEqual(len(out), 3)
+
+    def test_parse_numbers_helper(self) -> None:
+        from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.meta_rewrite import (
+            _parse_numbers,
+        )
+
+        text = "[1, 2, -3]"
+        res = _parse_numbers(text, [0, 0, 0])
+        self.assertEqual(res, [1, 2, -3])
 
     def test_run_demo_with_target(self) -> None:
         result = subprocess.run(
@@ -104,7 +117,9 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
 
     def test_bridge_run_search_helper(self) -> None:
         import asyncio
-        from alpha_factory_v1.demos.meta_agentic_tree_search_v0 import openai_agents_bridge as bridge
+        from alpha_factory_v1.demos.meta_agentic_tree_search_v0 import (
+            openai_agents_bridge as bridge,
+        )
 
         if bridge.has_oai:  # pragma: no cover - only run offline path
             self.skipTest("openai-agents installed")
@@ -115,4 +130,3 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()
-


### PR DESCRIPTION
## Summary
- parse integers from LLM output with `_parse_numbers`
- reference new helper in README
- test helper parsing

## Testing
- `ruff check alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py tests/test_meta_agentic_tree_search_demo.py`
- `pytest -q` *(fails: command not found)*