### PR TITLE
Improve MATS demo env checks

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -86,6 +86,10 @@ the bridge to control the demo through API calls or the Agents runtime UI:
 ```bash
 python openai_agents_bridge.py --help
 ```
+Run a quick environment check with ``--verify-env`` if desired:
+```bash
+python openai_agents_bridge.py --verify-env --episodes 3 --target 4 --model gpt-4o
+```
 If the `openai_agents` package or API keys are missing the bridge automatically
 falls back to running the search loop locally so the notebook remains
 reproducible anywhere.  When running offline you can still invoke
@@ -104,6 +108,7 @@ git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_tree_search_v0
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt          # torch, gymnasium, networkx, etc.
+python run_demo.py --verify-env          # optional sanity check
 python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --seed 42
 ```
 `run_demo.py` prints a per‑episode scoreboard.  Pass `--log-dir logs` to save a

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -90,7 +90,20 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Enable the Google ADK gateway for remote control",
     )
+    parser.add_argument(
+        "--verify-env",
+        action="store_true",
+        help="Check runtime dependencies before launching",
+    )
     args = parser.parse_args(argv)
+
+    if args.verify_env:
+        try:
+            import check_env  # type: ignore
+
+            check_env.main([])
+        except Exception as exc:  # pragma: no cover - best effort
+            print(f"Environment verification failed: {exc}")
 
     if not has_oai:
         print("openai-agents package is missing. Running offline demo...")

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -106,8 +106,21 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--target", type=int, help="Target integer for the environment")
     parser.add_argument("--seed", type=int, help="Optional RNG seed")
     parser.add_argument("--log-dir", type=Path, help="Optional directory to store episode logs")
+    parser.add_argument(
+        "--verify-env",
+        action="store_true",
+        help="Check runtime dependencies before running",
+    )
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+
+    if args.verify_env:
+        try:
+            import check_env  # type: ignore
+
+            check_env.main([])
+        except Exception as exc:  # pragma: no cover - best effort
+            print(f"Environment verification failed: {exc}")
     episodes = args.episodes or int(cfg.get("episodes", 10))
     exploration = float(cfg.get("exploration", 1.4))
     rewriter = args.rewriter or cfg.get("rewriter", "random")

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -115,12 +115,7 @@ def main(argv: List[str] | None = None) -> None:
     cfg = load_config(args.config)
 
     if args.verify_env:
-        try:
-            import check_env  # type: ignore
-
-            check_env.main([])
-        except Exception as exc:  # pragma: no cover - best effort
-            print(f"Environment verification failed: {exc}")
+        verify_environment()
     episodes = args.episodes or int(cfg.get("episodes", 10))
     exploration = float(cfg.get("exploration", 1.4))
     rewriter = args.rewriter or cfg.get("rewriter", "random")

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -98,6 +98,22 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Best agents", result.stdout)
 
+    def test_run_demo_verify_env(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo",
+                "--episodes",
+                "1",
+                "--verify-env",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best agents", result.stdout)
+
     def test_bridge_fallback(self) -> None:
         result = subprocess.run(
             [
@@ -126,6 +142,21 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
 
         result = asyncio.run(bridge.run_search(episodes=1, target=2))
         self.assertIn("completed", result)
+
+    def test_bridge_verify_env(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge",
+                "--episodes",
+                "1",
+                "--verify-env",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add `--verify-env` option in `run_demo.py`
- add `--verify-env` option in `openai_agents_bridge.py`
- document new flags in the MATS README
- test new flags in `test_meta_agentic_tree_search_demo.py`

## Testing
- `pytest -q` *(fails: command not found)*