### PR TITLE
Fix verify-env support in MATS demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -25,8 +25,11 @@ def verify_environment() -> None:
         import check_env  # type: ignore
 
         check_env.main([])
-    except Exception as exc:  # pragma: no cover - optional helper
+    except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover - optional helper
         print(f"Environment verification failed: {exc}")
+    except Exception as exc:
+        print(f"Unexpected error during environment verification: {exc}")
+        raise
 
 
 def run(

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -19,6 +19,16 @@ from .mats.evaluators import evaluate
 from .mats.env import NumberLineEnv
 
 
+def verify_environment() -> None:
+    """Best-effort runtime dependency check."""
+    try:
+        import check_env  # type: ignore
+
+        check_env.main([])
+    except Exception as exc:  # pragma: no cover - optional helper
+        print(f"Environment verification failed: {exc}")
+
+
 def run(
     episodes: int = 10,
     exploration: float = 1.4,


### PR DESCRIPTION
## Summary
- implement `verify_environment()` helper in `run_demo.py`
- ensure `--verify-env` flag no longer crashes

## Testing
- `python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 1 --verify-env`
- `pytest -q` *(fails: command not found)*