### PR TITLE
Improve MATS openai rewrite fallback

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -77,6 +77,8 @@ override the model used by setting ``OPENAI_MODEL`` (defaults to ``gpt-4o``).
 Output from the model is processed via the new ``_parse_numbers`` helper which
 extracts integers from free‑form text so the search loop remains stable even when
 the LLM response contains extra commentary.
+The rewrite routine executes the LLM call in a background thread so it remains
+compatible with async runtimes such as the Agents SDK.
 
 ### 4.2 · OpenAI Agents bridge
 The `openai_agents_bridge.py` script exposes the search loop via the

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -104,6 +104,9 @@ def openai_rewrite(agents: List[int]) -> List[int]:
             thread.join()
             if result is not None:
                 return result
+            else:
+                logging.warning("Result is None; falling back to meta_rewrite.")
+                return meta_rewrite(agents)
         except Exception as exc:  # pragma: no cover - safety net
             logging.warning(f"openai_rewrite fallback due to error: {exc}")
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -95,13 +95,10 @@ def openai_rewrite(agents: List[int]) -> List[int]:
 
             result: list[int] | None = None
 
-            def _runner() -> None:
-                nonlocal result
-                result = asyncio.run(_run())
+            async def _runner() -> list[int]:
+                return await _run()
 
-            thread = threading.Thread(target=_runner)
-            thread.start()
-            thread.join()
+            result = asyncio.run(asyncio.to_thread(_runner))
             if result is not None:
                 return result
             else:

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -9,6 +9,7 @@ import asyncio
 import os
 import logging
 import re
+import threading
 
 
 def meta_rewrite(agents: List[int]) -> List[int]:
@@ -53,13 +54,13 @@ def openai_rewrite(agents: List[int]) -> List[int]:
             @Tool(
                 name="improve_policy", description="Return an improved integer policy"
             )
-            async def improve_policy(policy: list[int]) -> list[int]:
+            def improve_policy(policy: list[int]) -> list[int]:
                 prompt = (
                     "Given the current integer policy "
                     f"{policy}, suggest a slightly improved list of integers."
                 )
                 try:
-                    response = await openai.ChatCompletion.acreate(
+                    response = openai.ChatCompletion.create(
                         model=os.getenv("OPENAI_MODEL", "gpt-4o"),
                         messages=[
                             {
@@ -82,7 +83,7 @@ def openai_rewrite(agents: List[int]) -> List[int]:
 
                 async def policy(self, obs, _ctx):  # type: ignore[override]
                     cand = obs.get("policy", []) if isinstance(obs, dict) else obs
-                    return await improve_policy(list(cand))
+                    return improve_policy(list(cand))
 
             agent = RewriterAgent()
 
@@ -92,7 +93,17 @@ def openai_rewrite(agents: List[int]) -> List[int]:
                     _ = agent2agent  # pragma: no cover - placeholder use
                 return list(result)
 
-            return asyncio.run(_run())
+            result: list[int] | None = None
+
+            def _runner() -> None:
+                nonlocal result
+                result = asyncio.run(_run())
+
+            thread = threading.Thread(target=_runner)
+            thread.start()
+            thread.join()
+            if result is not None:
+                return result
         except Exception as exc:  # pragma: no cover - safety net
             logging.warning(f"openai_rewrite fallback due to error: {exc}")
 


### PR DESCRIPTION
## Summary
- call OpenAI ChatCompletion synchronously inside `openai_rewrite`
- run the async helper in a background thread to avoid event loop clashes
- clarify README about the thread based approach

## Testing
- `pip install pytest prometheus_client --quiet` *(fails: No route to host)*
- `pytest -q` *(command not found)*