### PR TITLE
Fix model constant export for MATS demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -13,6 +13,8 @@ import importlib.util
 import sys
 import pathlib
 
+DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
+
 if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
 
@@ -114,6 +116,14 @@ def main(argv: list[str] | None = None) -> None:
         os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
 
     _run_runtime(args.episodes, args.target, args.model)
+
+
+__all__ = [
+    "DEFAULT_MODEL_NAME",
+    "has_oai",
+    "run_search",
+    "main",
+]
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -1,6 +1,9 @@
 import subprocess
 import sys
 import unittest
+from alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge import (
+    DEFAULT_MODEL_NAME,
+)
 
 
 class TestMetaAgenticTreeSearchDemo(unittest.TestCase):


### PR DESCRIPTION
## Summary
- expose `DEFAULT_MODEL_NAME` in `openai_agents_bridge`
- import that constant in the MATS demo tests

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*