### PR TITLE
Improve MATS number parsing

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -76,11 +76,12 @@ When the optional `openai` package is also present, `openai_rewrite` uses
 key or in fully offline environments the routine simply increments the
 proposed policy elements so the rest of the demo keeps working.  You can
 override the model used by setting ``OPENAI_MODEL`` (defaults to ``gpt-4o``).
-Output from the model is processed via the new ``_parse_numbers`` helper which
-extracts integers from free‑form text so the search loop remains stable even when
-the LLM response contains extra commentary. The rewrite routine executes the LLM
-call via a small synchronous helper so it functions both with and without an
-active event loop.
+Output from the model is processed via the ``_parse_numbers`` helper which
+extracts integers from free‑form text and validates their length so the search
+loop remains stable even when the LLM response contains extra commentary. When
+the output is malformed or incomplete the helper simply increments the previous
+policy as a safe fallback. The rewrite routine executes the LLM call via a small
+synchronous helper so it functions both with and without an active event loop.
 
 ### 4.2 · OpenAI Agents bridge
 The `openai_agents_bridge.py` script exposes the search loop via the

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -25,9 +25,11 @@ def _parse_numbers(text: str, fallback: List[int]) -> List[int]:
 
     The helper ensures the returned list has the same length as ``fallback`` so
     the rest of the demo remains stable even when the LLM response is malformed
-    or incomplete.
+    or incomplete. If ``fallback`` is an empty list, an empty list is returned.
     """
     numbers = [int(n) for n in re.findall(r"-?\d+", text)]
+    if not fallback:
+        return []
     if len(numbers) != len(fallback) or not numbers:
         return [p + 1 for p in fallback]
     return numbers

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -21,9 +21,16 @@ def meta_rewrite(agents: List[int]) -> List[int]:
 
 
 def _parse_numbers(text: str, fallback: List[int]) -> List[int]:
-    """Return integers parsed from ``text`` or a simple increment fallback."""
+    """Return integers parsed from ``text`` or a simple increment fallback.
+
+    The helper ensures the returned list has the same length as ``fallback`` so
+    the rest of the demo remains stable even when the LLM response is malformed
+    or incomplete.
+    """
     numbers = [int(n) for n in re.findall(r"-?\d+", text)]
-    return numbers or [p + 1 for p in fallback]
+    if len(numbers) != len(fallback) or not numbers:
+        return [p + 1 for p in fallback]
+    return numbers
 
 
 def openai_rewrite(agents: List[int], model: str | None = None) -> List[int]:

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -67,6 +67,10 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         res = _parse_numbers(text, [0, 0, 0])
         self.assertEqual(res, [1, 2, -3])
 
+        malformed = "{oops: 7}"
+        res_fallback = _parse_numbers(malformed, [4, 4, 4])
+        self.assertEqual(res_fallback, [5, 5, 5])
+
     def test_run_demo_with_target(self) -> None:
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary
- handle malformed LLM output in `_parse_numbers`
- test fallback behaviour for malformed output
- clarify README about `_parse_numbers` helper

## Testing
- `pytest -k meta_agentic_tree_search -q` *(fails: command not found)*