### PR TITLE
Improve MATS demo output

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -119,6 +119,8 @@ python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --see
 `run_demo.py` prints a per‑episode scoreboard.  Pass `--log-dir logs` to save a
 `scores.csv` file for further analysis. A ready‑to‑run Colab notebook is also
 provided as `colab_meta_agentic_tree_search.ipynb`.
+The underlying :func:`run` helper returns the best policy and score so the demo
+can be scripted from other tools.
 Add ``--enable-adk`` to the command above to start the optional ADK
 gateway for remote control via the A2A protocol.
 The default environment is a simple number‑line task defined in `mats/env.py` where each agent must approach a target integer. Pass `--target 7` (for example) to experiment with different goals.

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
@@ -49,6 +49,13 @@
    "execution_count": null,
    "outputs": [],
    "source": "!python run_demo.py --episodes 10 --rewriter openai"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from run_demo import run\nbest, score = run(episodes=5)\nprint(\"Best\", best, \"Score\", score)"
   }
  ],
  "metadata": {

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -32,8 +32,11 @@ if has_oai:
         """Execute the search loop and return a summary string."""
         if model:
             os.environ.setdefault("OPENAI_MODEL", model)
-        run(episodes=episodes, target=target, model=model)
-        return f"completed {episodes} episodes toward target {target}"
+        agents, score = run(episodes=episodes, target=target, model=model)
+        return (
+            f"completed {episodes} episodes toward target {target} | "
+            f"best {agents} score {score:.3f}"
+        )
 
     class MATSAgent(Agent):
         """Tiny helper agent wrapping :func:`run_search`."""
@@ -76,8 +79,11 @@ else:
         """Execute the search loop and return a summary string."""
         if model:
             os.environ.setdefault("OPENAI_MODEL", model)
-        run(episodes=episodes, target=target, model=model)
-        return f"completed {episodes} episodes toward target {target}"
+        agents, score = run(episodes=episodes, target=target, model=model)
+        return (
+            f"completed {episodes} episodes toward target {target} | "
+            f"best {agents} score {score:.3f}"
+        )
     async def run_search(episodes: int = 10, target: int = 5, model: str | None = None) -> str:
         return _run_search_helper(episodes, target, model)
 
@@ -109,7 +115,8 @@ def main(argv: list[str] | None = None) -> None:
 
     if not has_oai:
         print("openai-agents package is missing. Running offline demo...")
-        run(episodes=args.episodes, target=args.target, model=args.model)
+        agents, score = run(episodes=args.episodes, target=args.target, model=args.model)
+        print(f"best {agents} score {score:.3f}")
         return
 
     if args.enable_adk:

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -41,8 +41,8 @@ def run(
     target: int = 5,
     seed: Optional[int] = None,
     model: str | None = None,
-) -> None:
-    """Run a toy tree search for a small number of episodes.
+) -> tuple[list[int], float]:
+    """Run a toy tree search for a small number of episodes and return the best result.
 
     Parameters
     ----------
@@ -58,6 +58,11 @@ def run(
         Optional RNG seed for reproducible runs.
     model:
         Optional OpenAI model override used by :func:`openai_rewrite`.
+
+    Returns
+    -------
+    tuple[list[int], float]
+        The best policy discovered and its average score.
     """
     if seed is not None:
         random.seed(seed)
@@ -92,6 +97,7 @@ def run(
     if log_fh:
         log_fh.write(f"best,{best.agents},{score:.6f}\n")
         log_fh.close()
+    return best.agents, score
 
 
 def load_config(path: Path) -> dict:


### PR DESCRIPTION
## Summary
- make `run()` return the best policy and score
- surface that information in the OpenAI Agents bridge
- mention new return values in the README
- append a short example cell in the Colab notebook

## Testing
- `python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 2 --seed 42`
- `python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge --episodes 1 --target 3`
- `python -m py_compile alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py`
- `pytest -k meta_agentic_tree_search -q` *(fails: command not found)*