### PR TITLE
Add LiveBrokerEnv stub to MATS demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -149,11 +149,15 @@ meta_agentic_tree_search_v0/
 ## 8 Extending this prototype
 | Goal                           | Hook/function                     |
 |--------------------------------|-----------------------------------|
-| Plug‑in real execution broker  | `mats.environment.LiveBrokerEnv`  |
+| Plug‑in real execution broker  | `mats.env.LiveBrokerEnv`          |
 | Swap rewrite strategy          | Subclass `MetaRewriter`           |
 | Use distributed workers        | `ray tune` launcher               |
 | Custom tree policy             | Implement `acquire()` in `Tree`   |
 | Custom output parser           | `_parse_numbers` helper           |
+
+`LiveBrokerEnv` is a minimal subclass of :class:`NumberLineEnv` that accepts a
+market data sequence. It serves as a stub for wiring real brokerage feeds into
+the search loop while keeping the demo runnable completely offline.
 
 ## 9 Safety & governance guard‑rails
 * Sandboxed code‑gen (`firejail + seccomp + tmpfs`)  

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
@@ -3,5 +3,14 @@
 from .tree import Node, Tree
 from .meta_rewrite import meta_rewrite, openai_rewrite
 from .evaluators import evaluate
+from .env import NumberLineEnv, LiveBrokerEnv
 
-__all__ = ["Node", "Tree", "meta_rewrite", "openai_rewrite", "evaluate"]
+__all__ = [
+    "Node",
+    "Tree",
+    "meta_rewrite",
+    "openai_rewrite",
+    "evaluate",
+    "NumberLineEnv",
+    "LiveBrokerEnv",
+]

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
@@ -1,4 +1,12 @@
-"""Simple evaluation environment for the MATS demo."""
+"""Evaluation environments for the MATS demo.
+
+This module exposes a lightweight :class:`NumberLineEnv` used by the unit tests
+and demo loop along with a placeholder :class:`LiveBrokerEnv` that illustrates
+how one might integrate real market data.  The live broker variant currently
+inherits the toy environment so the rest of the demo remains fully runnable
+offline.  It accepts an optional market data feed so advanced users can plug in
+their own price sources.
+"""
 from __future__ import annotations
 
 import random
@@ -15,3 +23,25 @@ class NumberLineEnv:
         distance = sum(abs(a - self.target) for a in agents)
         noise = random.random() * 0.1
         return -distance + noise
+
+
+class LiveBrokerEnv(NumberLineEnv):
+    """Placeholder environment hooking into a live execution broker.
+
+    Parameters
+    ----------
+    target:
+        Target integer used by the base :class:`NumberLineEnv` logic.
+    market_data:
+        Optional sequence of numbers representing live prices.  When omitted the
+        environment behaves exactly like :class:`NumberLineEnv`.
+    """
+
+    def __init__(self, target: int = 5, market_data: List[int] | None = None) -> None:
+        super().__init__(target=target)
+        self.market_data = list(market_data) if market_data else []
+
+    def rollout(self, agents: List[int]) -> float:
+        if self.market_data:
+            self.target = self.market_data.pop(0)
+        return super().rollout(agents)

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -44,11 +44,16 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
     def test_env_rollout(self) -> None:
         from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.env import (
             NumberLineEnv,
+            LiveBrokerEnv,
         )
 
         env = NumberLineEnv(target=3)
         reward = env.rollout([3, 3, 3])
         self.assertGreaterEqual(reward, -0.1)
+
+        live = LiveBrokerEnv(target=2, market_data=[2, 2])
+        live_reward = live.rollout([2, 2])
+        self.assertIsInstance(live_reward, float)
 
     def test_openai_rewrite_fallback(self) -> None:
         from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.meta_rewrite import (

--- a/tests/test_meta_agentic_tree_search_import.py
+++ b/tests/test_meta_agentic_tree_search_import.py
@@ -5,10 +5,14 @@ class TestMetaAgenticTreeSearchImport(unittest.TestCase):
     """Verify package-level exports for the MATS demo."""
 
     def test_package_exports(self) -> None:
-        mod = importlib.import_module("alpha_factory_v1.demos.meta_agentic_tree_search_v0")
+        mod = importlib.import_module(
+            "alpha_factory_v1.demos.meta_agentic_tree_search_v0"
+        )
         self.assertTrue(hasattr(mod, "run_demo"))
         self.assertTrue(hasattr(mod, "mats"))
         self.assertTrue(hasattr(mod, "openai_agents_bridge"))
+        env_mod = mod.mats
+        self.assertTrue(hasattr(env_mod, "LiveBrokerEnv"))
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- add a minimal `LiveBrokerEnv` stub showing how live broker data could integrate
- export the new environment via `mats.__all__`
- document `LiveBrokerEnv` usage in the demo README
- extend tests to cover the new class and package exports

## Testing
- `pytest -q` *(fails: command not found)*