### PR TITLE
Improve MATS demo usability

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -115,6 +115,7 @@ reproducible anywhere.  When running offline you can still invoke
 
 ```bash
 python openai_agents_bridge.py --episodes 3 --target 4 --model gpt-4o
+python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge --episodes 3 --target 4
 ```
 Enable the optional ADK gateway with ``--enable-adk`` (or set
 ``ALPHA_FACTORY_ENABLE_ADK=true``) to expose the agent over the A2A protocol.
@@ -128,6 +129,8 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt          # torch, gymnasium, networkx, etc.
 python run_demo.py --verify-env          # optional sanity check
 python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --seed 42 --model gpt-4o
+# or equivalently
+python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 500 --target 5
 ```
 `run_demo.py` prints a per‑episode scoreboard.  Pass `--log-dir logs` to save a
 `scores.csv` file for further analysis. A ready‑to‑run Colab notebook is also

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -16,7 +16,9 @@ import pathlib
 DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
 
 if __package__ is None:  # pragma: no cover - allow direct execution
+    # Ensure imports resolve when running the script directly
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.meta_agentic_tree_search_v0"
 
 has_oai = importlib.util.find_spec("openai_agents") is not None
 if has_oai:

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -5,8 +5,15 @@ from __future__ import annotations
 import argparse
 import os
 import random
+import sys
+import pathlib
 from pathlib import Path
 from typing import List, Optional
+
+if __package__ is None:  # pragma: no cover - allow execution via `python run_demo.py`
+    # Add repository root so package imports resolve when executed directly
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.meta_agentic_tree_search_v0"
 
 try:  # PyYAML optional for offline environments
     import yaml  # type: ignore


### PR DESCRIPTION
## Summary
- support running `run_demo.py` and `openai_agents_bridge.py` directly
- clarify script invocation methods in the MATS demo README

## Testing
- `python alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py --episodes 2 --target 3`
- `python alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py --episodes 1 --target 3`
- `python check_env.py --auto-install` *(fails: Could not install due to missing network)*
- `pytest -q` *(fails: command not found)*