### PR TITLE
Add α‑AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -1,1 +1,13 @@
-🎖️ α‑AGI Insight 👁️✨ — Beyond Human Foresight. An official demo, purely intuitive, requiring zero data. 🌌
+# α‑AGI Insight Demo — v0
+
+This demo illustrates a minimal **Meta‑Agentic Tree Search** setup that
+autonomously searches for sectors likely to experience AGI disruption. It
+runs entirely offline and requires zero data.
+
+```bash
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 5
+```
+
+The search loop mutates a candidate sector index and evaluates it with a
+lightweight number‑line environment. After a few iterations the tree returns
+the sector with the best score.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -1,0 +1,5 @@
+"""α‑AGI Insight demo package."""
+
+from .insight_demo import main
+
+__all__ = ["main"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -38,7 +38,7 @@ def run(episodes: int = 5, *, target: int = 3) -> str:
         tree.add_child(node, child)
         tree.backprop(child)
         idx = improved[0] % len(SECTORS)
-        print(f"Episode {_+1}: candidate {SECTORS[idx]} → reward {reward:.3f}")
+        print(f"Episode {_+1}: candidate {SECTORS[idx]} -> reward {reward:.3f}")
     best = tree.best_leaf()
     sector = SECTORS[best.agents[0] % len(SECTORS)]
     score = best.reward / (best.visits or 1)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Minimal α‑AGI Insight demo using Meta‑Agentic Tree Search."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+from ..meta_agentic_tree_search_v0.mats.tree import Node, Tree
+from ..meta_agentic_tree_search_v0.mats.meta_rewrite import meta_rewrite
+from ..meta_agentic_tree_search_v0.mats.evaluators import evaluate
+from ..meta_agentic_tree_search_v0.mats.env import NumberLineEnv
+
+SECTORS = [
+    "Finance",
+    "Healthcare",
+    "Education",
+    "Manufacturing",
+    "Transportation",
+    "Energy",
+    "Retail",
+    "Agriculture",
+    "Defense",
+    "Real Estate",
+]
+
+
+def run(episodes: int = 5, *, target: int = 3) -> str:
+    """Run a short search predicting the target sector index."""
+    root_agents: List[int] = [0]
+    env = NumberLineEnv(target=target)
+    tree = Tree(Node(root_agents))
+    for _ in range(episodes):
+        node = tree.select()
+        improved = meta_rewrite(node.agents)
+        reward = evaluate(improved, env)
+        child = Node(improved, reward=reward)
+        tree.add_child(node, child)
+        tree.backprop(child)
+        idx = improved[0] % len(SECTORS)
+        print(f"Episode {_+1}: candidate {SECTORS[idx]} → reward {reward:.3f}")
+    best = tree.best_leaf()
+    sector = SECTORS[best.agents[0] % len(SECTORS)]
+    score = best.reward / (best.visits or 1)
+    summary = f"Best sector: {sector} score: {score:.3f}"
+    print(summary)
+    return summary
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the α‑AGI Insight demo")
+    parser.add_argument("--episodes", type=int, default=5, help="Search iterations")
+    parser.add_argument("--target", type=int, default=3, help="Target sector index")
+    args = parser.parse_args(argv)
+    run(args.episodes, target=args.target)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import argparse
 from typing import List
 
-from ..meta_agentic_tree_search_v0.mats.tree import Node, Tree
-from ..meta_agentic_tree_search_v0.mats.meta_rewrite import meta_rewrite
-from ..meta_agentic_tree_search_v0.mats.evaluators import evaluate
-from ..meta_agentic_tree_search_v0.mats.env import NumberLineEnv
+from alpha_factory_v1.meta_agentic_tree_search_v0.mats.tree import Node, Tree
+from alpha_factory_v1.meta_agentic_tree_search_v0.mats.meta_rewrite import meta_rewrite
+from alpha_factory_v1.meta_agentic_tree_search_v0.mats.evaluators import evaluate
+from alpha_factory_v1.meta_agentic_tree_search_v0.mats.env import NumberLineEnv
 
 SECTORS = [
     "Finance",

--- a/tests/test_alpha_agi_insight_demo.py
+++ b/tests/test_alpha_agi_insight_demo.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestAlphaAgiInsightDemo(unittest.TestCase):
+    """Ensure the α‑AGI Insight demo runs successfully."""
+
+    def test_run_demo_short(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo",
+                "--episodes",
+                "2",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best sector", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement alpha_agi_insight_v0 demo using Meta-Agentic Tree Search
- provide module entrypoint and README
- add regression test for the demo

## Testing
- `python alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py --episodes 2`
- `python alpha_factory_v1/scripts/run_tests.py`