### PR TITLE
Enhance MATS demo docs and bridge helper

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -108,9 +108,11 @@ Run a quick environment check with ``--verify-env`` if desired:
 ```bash
 python openai_agents_bridge.py --verify-env --episodes 3 --target 4 --model gpt-4o
 ```
-If the `openai_agents` package or API keys are missing the bridge automatically
-falls back to running the search loop locally so the notebook remains
-reproducible anywhere.  When running offline you can still invoke
+The bridge exposes a small :func:`verify_env` helper that performs the same
+sanity check programmatically. Call it from Python or rely on the command
+above. If the `openai_agents` package or API keys are missing the bridge
+automatically falls back to running the search loop locally so the notebook
+remains reproducible anywhere. When running offline you can still invoke
 `run_search` directly to verify the helper logic:
 
 ```bash
@@ -135,6 +137,14 @@ python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes
 `run_demo.py` prints a per‑episode scoreboard.  Pass `--log-dir logs` to save a
 `scores.csv` file for further analysis. A ready‑to‑run Colab notebook is also
 provided as `colab_meta_agentic_tree_search.ipynb`.
+
+### Notebook quick start
+1. Click the “Open In Colab” badge at the top of this document.
+2. Execute the first cell to clone the repository and install dependencies.
+3. Optionally provide `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` values in the second cell.
+4. Run the demo cell to launch the search loop.
+5. Optionally invoke `openai_agents_bridge.py --verify-env` from a new cell to confirm your runtime.
+
 Add ``--enable-adk`` to the command above to start the optional ADK
 gateway for remote control via the A2A protocol.
 The default environment is a simple number‑line task defined in `mats/env.py` where each agent must approach a target integer. Pass `--target 7` (for example) to experiment with different goals.

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
@@ -40,7 +40,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3 \u00b7 Run demo"
+    "## 3 \u00b7 Verify environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "!python openai_agents_bridge.py --verify-env --episodes 3 --target 4"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 \u00b7 Run demo"
    ]
   },
   {
@@ -49,6 +63,20 @@
    "execution_count": null,
    "outputs": [],
    "source": "!python run_demo.py --episodes 10 --rewriter openai"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 \u00b7 Agents bridge (optional)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "!python openai_agents_bridge.py --episodes 5 --target 5 --rewriter openai"
   }
  ],
  "metadata": {

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -15,6 +15,16 @@ import pathlib
 
 DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
 
+
+def verify_env() -> None:
+    """Best-effort runtime dependency check."""
+    try:
+        import check_env  # type: ignore
+
+        check_env.main([])
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"Environment verification failed: {exc}")
+
 if __package__ is None:  # pragma: no cover - allow direct execution
     # Ensure imports resolve when running the script directly
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
@@ -129,12 +139,7 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     if args.verify_env:
-        try:
-            import check_env  # type: ignore
-
-            check_env.main([])
-        except Exception as exc:  # pragma: no cover - best effort
-            print(f"Environment verification failed: {exc}")
+        verify_env()
 
     if not has_oai:
         print("openai-agents package is missing. Running offline demo...")
@@ -156,6 +161,7 @@ __all__ = [
     "DEFAULT_MODEL_NAME",
     "has_oai",
     "run_search",
+    "verify_env",
     "main",
 ]
 


### PR DESCRIPTION
## Summary
- add `verify_env` helper to MATS OpenAI Agents bridge
- document the helper in README and expand notebook instructions
- extend the Colab notebook with environment verification and bridge demo

## Testing
- `pip install pytest prometheus_client --quiet` *(fails: no route to host)*
- `pytest -q` *(fails: command not found)*