### PR TITLE
Improve α‑AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -1,9 +1,10 @@
-# α‑AGI Insight Demo — v0
+# α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo
 
 The **α‑AGI Insight** demo predicts which industry sector is most likely to be
-transformed by Artificial General Intelligence.  It runs a small
-**Meta‑Agentic Tree Search** (MATS) over a list of sector names.  No external
-data is required so the script executes fully offline.
+transformed by Artificial General Intelligence. It runs a small
+**Meta‑Agentic Tree Search** (MATS) over a list of sector names. No external
+data is required so the script executes fully offline.  Pass a custom sector
+list with ``--sectors`` to experiment with your own domains.
 
 ```bash
 python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 5
@@ -18,7 +19,8 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo \
     --episodes 10 \
     --rewriter openai \
     --model gpt-4o \
-    --log-dir logs
+    --log-dir logs \
+    --sectors Finance,Healthcare,Energy
 ```
 
 When optional dependencies such as ``openai`` or ``anthropic`` are not

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/configs/default.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/configs/default.yaml
@@ -5,3 +5,5 @@ rewriter: random
 target: 3
 seed: 0
 model: gpt-4o
+# comma-separated list or YAML array of sectors
+# sectors: [Finance, Healthcare, Education]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/configs/default.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/configs/default.yaml
@@ -6,4 +6,4 @@ target: 3
 seed: 0
 model: gpt-4o
 # comma-separated list or YAML array of sectors
-# sectors: [Finance, Healthcare, Education]
+sectors: [Finance, Healthcare, Education]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -176,19 +176,7 @@ def main(argv: List[str] | None = None) -> None:
     seed = args.seed if args.seed is not None else cfg.get("seed")
     seed = int(seed) if seed is not None else None
     model = args.model or cfg.get("model")
-    sectors = DEFAULT_SECTORS
-    cfg_sectors = cfg.get("sectors")
-    if cfg_sectors and not args.sectors:
-        if isinstance(cfg_sectors, list):
-            sectors = [str(s) for s in cfg_sectors]
-        else:
-            sectors = [s.strip() for s in str(cfg_sectors).split(",") if s.strip()]
-    if args.sectors:
-        path = Path(args.sectors)
-        if path.exists():
-            sectors = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-        else:
-            sectors = [s.strip() for s in args.sectors.split(",") if s.strip()]
+    sectors = parse_sectors(cfg.get("sectors"), args.sectors)
     run(
         episodes,
         exploration,


### PR DESCRIPTION
## Summary
- fix module imports for insight demo
- allow custom sector lists via `--sectors`
- document new usage and config option

## Testing
- `python check_env.py`
- `PYTHONPATH=. python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 2`
- `PYTHONPATH=. python -m unittest tests.test_alpha_agi_insight_demo`