### PR TITLE
Fix α‑AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -3,8 +3,9 @@
 The **α‑AGI Insight** demo predicts which industry sector is most likely to be
 transformed by Artificial General Intelligence. It runs a small
 **Meta‑Agentic Tree Search** (MATS) over a list of sector names. No external
-data is required so the script executes fully offline.  Pass a custom sector
-list with ``--sectors`` to experiment with your own domains.
+ data is required so the script executes fully offline.  Pass a custom sector
+ list with ``--sectors`` to experiment with your own domains. When the argument
+ points to a text file, each non-empty line is treated as a sector name.
 
 ```bash
 python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 5

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -78,6 +78,31 @@ DEFAULT_SECTORS = [
 ]
 
 
+def parse_sectors(cfg_val: object | None, cli_val: str | None) -> List[str]:
+    """Return a cleaned list of sector names.
+
+    Parameters
+    ----------
+    cfg_val:
+        Value loaded from ``default.yaml``. Can be a comma-separated string or
+        a YAML array.
+    cli_val:
+        Optional value passed via ``--sectors``.
+    """
+
+    source = cli_val or cfg_val
+    if isinstance(source, list):
+        return [str(s).strip() for s in source if str(s).strip()]
+    if isinstance(source, str):
+        text = source.strip()
+        file_candidate = Path(text)
+        if file_candidate.exists():
+            lines = file_candidate.read_text(encoding="utf-8").splitlines()
+            return [line.strip() for line in lines if line.strip()]
+        return [s.strip() for s in text.split("\n" if "\n" in text else ",") if s.strip()]
+    return list(DEFAULT_SECTORS)
+
+
 def run(
     episodes: int = 5,
     exploration: float = 1.4,


### PR DESCRIPTION
## Notes
- add `parse_sectors` helper in `insight_demo.py`
- clarify README sector list usage

## Summary
- implement sector parsing from CLI or YAML file
- document text-file support in the demo README

## Testing
- `python -m unittest tests.test_alpha_agi_insight_demo`
- `python -m unittest tests.test_openai_bridge`
- `python -m unittest tests.test_meta_agentic_tree_search_demo -q`
