### PR TITLE
Add OpenAI Agents bridge for Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -28,3 +28,14 @@ When optional dependencies such as ``openai`` or ``anthropic`` are not
 installed, the program automatically falls back to a simple offline rewriter so
 the demo remains functional anywhere.  Episode scores are printed to the console
 and optionally written to ``scores.csv`` when ``--log-dir`` is supplied.
+
+## OpenAI Agents Bridge
+
+Launch ``openai_agents_bridge.py`` to control the demo via the
+`openai-agents` runtime and optionally the Google ADK A2A protocol:
+
+```bash
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --verify-env
+```
+The bridge automatically falls back to offline mode when the optional
+packages or API keys are missing.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -1,5 +1,6 @@
 """α‑AGI Insight demo package."""
 
 from .insight_demo import main
+from . import openai_agents_bridge
 
-__all__ = ["main"]
+__all__ = ["main", "openai_agents_bridge"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -80,11 +80,13 @@ if has_oai:
                 adk_bridge.auto_register([agent])
                 adk_bridge.maybe_launch()
             else:
-                print("ADK gateway disabled.")
-        except Exception as exc:  # pragma: no cover - optional ADK
-            print(f"ADK bridge unavailable: {exc}")
+                logger.info("ADK gateway disabled.")
+        except ImportError as exc:  # pragma: no cover - optional ADK
+            logger.warning(f"ADK bridge import failed: {exc}")
+        except AttributeError as exc:  # pragma: no cover - optional ADK
+            logger.error(f"ADK bridge attribute error: {exc}")
 
-        print("Registered InsightAgent with runtime")
+        logger.info("Registered InsightAgent with runtime")
         runtime.run()
 else:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""OpenAI Agents SDK bridge for the α‑AGI Insight demo.
+
+This utility exposes the Meta‑Agentic Tree Search loop used by
+:mod:`alpha_agi_insight_v0` through the OpenAI Agents runtime.
+It gracefully degrades to offline mode when the optional
+``openai-agents`` package is missing or the environment lacks API keys.
+"""
+from __future__ import annotations
+
+import os
+import argparse
+import importlib.util
+import sys
+import pathlib
+
+DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
+
+
+if __package__ is None:  # pragma: no cover - allow direct execution
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
+
+from .insight_demo import run, verify_environment
+
+has_oai = importlib.util.find_spec("openai_agents") is not None
+
+if has_oai:
+    from openai_agents import Agent, AgentRuntime, Tool  # type: ignore
+
+    @Tool(name="run_insight_search", description="Run the α‑AGI Insight demo")
+    async def run_insight_search(
+        episodes: int = 5,
+        target: int = 3,
+        model: str | None = None,
+        rewriter: str | None = None,
+        sectors: str | None = None,
+    ) -> str:
+        if model:
+            os.environ.setdefault("OPENAI_MODEL", model)
+        if rewriter:
+            os.environ.setdefault("MATS_REWRITER", rewriter)
+        result = run(
+            episodes=episodes,
+            target=target,
+            model=model,
+            rewriter=rewriter,
+            sectors=(sectors.split(",") if sectors else None),
+        )
+        return result
+
+    class InsightAgent(Agent):
+        name = "agi_insight_helper"
+        tools = [run_insight_search]
+
+        async def policy(self, obs, _ctx):  # type: ignore[override]
+            params = obs if isinstance(obs, dict) else {}
+            return await run_insight_search(
+                episodes=int(params.get("episodes", 5)),
+                target=int(params.get("target", 3)),
+                model=params.get("model"),
+                rewriter=params.get("rewriter"),
+                sectors=params.get("sectors"),
+            )
+
+    def _run_runtime(
+        episodes: int, target: int, model: str | None = None, rewriter: str | None = None
+    ) -> None:
+        if model:
+            os.environ.setdefault("OPENAI_MODEL", model)
+        if rewriter:
+            os.environ.setdefault("MATS_REWRITER", rewriter)
+        runtime = AgentRuntime(api_key=os.getenv("OPENAI_API_KEY"))
+        agent = InsightAgent()
+        runtime.register(agent)
+        try:
+            from alpha_factory_v1.backend import adk_bridge
+
+            if adk_bridge.adk_enabled():
+                adk_bridge.auto_register([agent])
+                adk_bridge.maybe_launch()
+            else:
+                print("ADK gateway disabled.")
+        except Exception as exc:  # pragma: no cover - optional ADK
+            print(f"ADK bridge unavailable: {exc}")
+
+        print("Registered InsightAgent with runtime")
+        runtime.run()
+else:
+
+    async def run_insight_search(
+        episodes: int = 5,
+        target: int = 3,
+        model: str | None = None,
+        rewriter: str | None = None,
+        sectors: str | None = None,
+    ) -> str:
+        return run(
+            episodes=episodes,
+            target=target,
+            model=model,
+            rewriter=rewriter,
+            sectors=(sectors.split(",") if sectors else None),
+        )
+
+    def _run_runtime(
+        episodes: int, target: int, model: str | None = None, rewriter: str | None = None
+    ) -> None:
+        print("openai-agents package is missing. Running offline demo...")
+        run(episodes=episodes, target=target, model=model, rewriter=rewriter)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="OpenAI Agents bridge for the α‑AGI Insight demo")
+    parser.add_argument("--episodes", type=int, default=5, help="Search episodes when offline")
+    parser.add_argument("--target", type=int, default=3, help="Target sector index when offline")
+    parser.add_argument("--model", type=str, help="Model name override")
+    parser.add_argument(
+        "--rewriter",
+        choices=["random", "openai", "anthropic"],
+        help="Rewrite strategy",
+    )
+    parser.add_argument("--sectors", type=str, help="Comma-separated sector names")
+    parser.add_argument(
+        "--enable-adk",
+        action="store_true",
+        help="Enable the Google ADK gateway",
+    )
+    parser.add_argument(
+        "--verify-env",
+        action="store_true",
+        help="Check runtime dependencies before launching",
+    )
+    args = parser.parse_args(argv)
+
+    if args.verify_env:
+        verify_environment()
+
+    if args.enable_adk:
+        os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
+
+    _run_runtime(args.episodes, args.target, args.model, args.rewriter)
+
+
+__all__ = [
+    "DEFAULT_MODEL_NAME",
+    "has_oai",
+    "run_insight_search",
+    "main",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- expose new `openai_agents_bridge.py` for the α‑AGI Insight demo
- export the bridge helper in the package `__init__`
- document how to launch the bridge in the demo README

## Testing
- `python -m unittest discover tests -v` *(fails: deploy scripts not executable)*