### PR TITLE
Add α‑AGI Insight bridge tests and docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -29,6 +29,12 @@ installed, the program automatically falls back to a simple offline rewriter so
 the demo remains functional anywhere.  Episode scores are printed to the console
 and optionally written to ``scores.csv`` when ``--log-dir`` is supplied.
 
+### Graceful Offline Mode
+
+The demo detects missing API keys and transparently switches to a local search
+strategy so it operates without network access. Supply ``--verify-env`` to run a
+best‑effort dependency check before launching.
+
 ## OpenAI Agents Bridge
 
 Launch ``openai_agents_bridge.py`` to control the demo via the
@@ -38,4 +44,5 @@ Launch ``openai_agents_bridge.py`` to control the demo via the
 python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --verify-env
 ```
 The bridge automatically falls back to offline mode when the optional
-packages or API keys are missing.
+packages or API keys are missing. Use ``--enable-adk`` to expose the agent via
+the optional Google ADK gateway when available.

--- a/tests/test_alpha_agi_insight_bridge.py
+++ b/tests/test_alpha_agi_insight_bridge.py
@@ -1,0 +1,45 @@
+import subprocess
+import sys
+import unittest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge import (
+    DEFAULT_MODEL_NAME,
+    has_oai,
+    run_insight_search,
+)
+
+
+class TestAlphaAgiInsightBridge(unittest.TestCase):
+    """Verify the OpenAI Agents bridge for the insight demo."""
+
+    def test_bridge_fallback(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge",
+                "--episodes",
+                "1",
+                "--target",
+                "2",
+                "--model",
+                DEFAULT_MODEL_NAME,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("demo", result.stdout.lower())
+
+    def test_bridge_run_helper(self) -> None:
+        import asyncio
+
+        if has_oai:  # pragma: no cover - only run offline path
+            self.skipTest("openai-agents installed")
+
+        summary = asyncio.run(run_insight_search(episodes=1, target=1))
+        self.assertIn("sector", summary)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -33,5 +33,10 @@ class TestOpenAIBridge(unittest.TestCase):
         path = Path('alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py')
         py_compile.compile(path, doraise=True)
 
+    def test_insight_bridge_compiles(self):
+        """Ensure the α‑AGI Insight demo bridge compiles."""
+        path = Path('alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py')
+        py_compile.compile(path, doraise=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- expand README for α‑AGI Insight demo to document offline mode and ADK usage
- add test to ensure α‑AGI Insight bridge compiles
- add new `test_alpha_agi_insight_bridge` for runtime fallback check

## Testing
- `pytest` *(fails: command not found)*