### PR TITLE
Improve α‑AGI Insight demo usability

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -24,6 +24,9 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo \
     --sectors Finance,Healthcare,Energy
 ```
 
+Use ``--list-sectors`` to display the resolved sector list without running the
+search. This is helpful when providing custom lists via ``--sectors``.
+
 When optional dependencies such as ``openai`` or ``anthropic`` are not
 installed, the program automatically falls back to a simple offline rewriter so
 the demo remains functional anywhere.  Episode scores are printed to the console


### PR DESCRIPTION
## Summary
- add `--list-sectors` option to print the resolved sector list
- document the option in the demo README

## Testing
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 1 --list-sectors`
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 2 --seed 1`
- `python check_env.py` *(fails: Missing packages)*