### PR TITLE
Finalize AGI Insight demo entrypoint

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -11,6 +11,18 @@ transformed by Artificial General Intelligence. It runs a small
 python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 5
 ```
 
+### Single Command Launcher
+
+Run the package itself to automatically select the best interface. By default it
+routes through the OpenAI Agents runtime when available and transparently
+degrades to the local CLI otherwise:
+
+```bash
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --verify-env
+```
+
+Pass ``--offline`` to skip the agent runtime entirely.
+
 ## Usage
 
 The command line interface mirrors the options of the general MATS demo:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -1,6 +1,7 @@
 """α‑AGI Insight demo package."""
 
-from .insight_demo import main
+# ``main`` gives callers the convenient entrypoint from ``__main__``.
+from .__main__ import main  # re-export
 from . import openai_agents_bridge
 
 __all__ = ["main", "openai_agents_bridge"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Command line entrypoint for the α‑AGI Insight demo.
+
+This tiny wrapper lets users run ``python -m alpha_factory_v1.demos.alpha_agi_insight_v0``
+directly.  By default it delegates to :mod:`openai_agents_bridge` so the demo
+can be controlled via the OpenAI Agents runtime when available.  Use
+``--offline`` to force the simpler command line interface from
+``insight_demo.py``.
+"""
+from __future__ import annotations
+
+import argparse
+from . import openai_agents_bridge, insight_demo
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the α‑AGI Insight demo")
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Run the basic CLI without the OpenAI Agents runtime",
+    )
+    args, remainder = parser.parse_known_args(argv)
+
+    if args.offline:
+        insight_demo.main(remainder)
+    else:
+        openai_agents_bridge.main(remainder)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -16,6 +16,10 @@ import pathlib
 
 DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
 
+# Prefix used when running without the optional ``openai-agents`` package.
+# Makes it easy for unit tests and calling code to detect the offline path.
+FALLBACK_MODE_PREFIX = "fallback_mode_active: "
+
 
 if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))


### PR DESCRIPTION
## Summary
- expose a unified `__main__` entrypoint for the α‑AGI Insight demo
- re-export `main` from package init
- document the new launcher in README
- fix undefined constant in the OpenAI Agents bridge

## Testing
- `pytest` *(fails: command not found)*