### PR TITLE
Improve α‑AGI Insight demo

### DIFF
--- a/alpha_factory_v1/backend/mcp_bridge.py
+++ b/alpha_factory_v1/backend/mcp_bridge.py
@@ -23,7 +23,10 @@ import os
 import time
 from typing import Dict, List, TypedDict
 
-import httpx
+try:
+    import httpx  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    httpx = None
 
 from .logger import get_logger
 
@@ -50,6 +53,10 @@ async def store(messages: List[ChatMessage]) -> None:
     The call is fire-and-forget and **never** raises – MCP is non-critical.
     """
     if not _ENDPOINT:
+        return
+
+    if httpx is None:
+        _LOG.debug("MCP disabled – httpx missing")
         return
 
     payload = {"messages": messages, "timestamp": time.time()}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -39,6 +39,9 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo \
 Use ``--list-sectors`` to display the resolved sector list without running the
 search. This is helpful when providing custom lists via ``--sectors``.
 
+Export ``MCP_ENDPOINT`` to capture all prompts and replies for later audit using
+the Model Context Protocol. When unset the logging step is silently skipped.
+
 When optional dependencies such as ``openai`` or ``anthropic`` are not
 installed, the program automatically falls back to a simple offline rewriter so
 the demo remains functional anywhere.  Episode scores are printed to the console
@@ -61,3 +64,11 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --ver
 The bridge automatically falls back to offline mode when the optional
 packages or API keys are missing. Use ``--enable-adk`` to expose the agent via
 the optional Google ADK gateway when available.
+
+### MCP Logging
+
+Set the ``MCP_ENDPOINT`` environment variable to automatically store all
+LLM prompts and replies using the
+[Model Context Protocol](https://www.anthropic.com/news/model-context-protocol).
+This best-effort persistence operates transparently and never blocks the
+search loop.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -27,7 +27,11 @@ if __package__ is None:  # pragma: no cover - allow direct execution
 
 from .insight_demo import run, verify_environment
 
-has_oai = importlib.util.find_spec("openai_agents") is not None
+try:
+    _spec = importlib.util.find_spec("openai_agents")
+except ValueError:  # loaded stub with missing spec
+    _spec = None
+has_oai = _spec is not None
 
 if has_oai:
     from openai_agents import Agent, AgentRuntime, Tool  # type: ignore

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -30,7 +30,11 @@ if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.meta_agentic_tree_search_v0"
 
-has_oai = importlib.util.find_spec("openai_agents") is not None
+try:
+    _spec = importlib.util.find_spec("openai_agents")
+except ValueError:
+    _spec = None
+has_oai = _spec is not None
 if has_oai:
     from openai_agents import Agent, AgentRuntime, Tool  # type: ignore
 


### PR DESCRIPTION
## Summary
- log prompts and completions via MCP when available
- handle missing `openai_agents` stubs gracefully
- note optional MCP logging in the demo docs

## Testing
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --list-sectors`
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo --episodes 1 --seed 1`
- `pytest -q tests/test_alpha_agi_insight_demo.py` *(fails: `pytest: command not found`)*