### PR TITLE
Improve α‑AGI Insight offline mode

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -49,9 +49,9 @@ and optionally written to ``scores.csv`` when ``--log-dir`` is supplied.
 
 ### Graceful Offline Mode
 
-The demo detects missing API keys and transparently switches to a local search
-strategy so it operates without network access. Supply ``--verify-env`` to run a
-best‑effort dependency check before launching.
+The demo automatically falls back to an offline search strategy whenever the
+required API keys are absent or network access is restricted. Use
+``--verify-env`` for a quick dependency check before launching.
 
 ## OpenAI Agents Bridge
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -31,7 +31,9 @@ try:
     _spec = importlib.util.find_spec("openai_agents")
 except ValueError:  # loaded stub with missing spec
     _spec = None
-has_oai = _spec is not None
+
+_has_key = bool(os.getenv("OPENAI_API_KEY"))
+has_oai = _spec is not None and _has_key
 
 if has_oai:
     from openai_agents import Agent, AgentRuntime, Tool  # type: ignore


### PR DESCRIPTION
## Summary
- degrade Insight demo bridge when OPENAI_API_KEY is missing
- clarify graceful offline behaviour in README

## Testing
- `python -m py_compile alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py`
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --offline --episodes 2`
- `python -m pytest tests/test_alpha_agi_insight_demo.py::TestAlphaAgiInsightDemo::test_run_demo_short -q` *(fails: No module named pytest)*