### PR TITLE
Fix logging setup for insight demo bridges

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -13,6 +13,9 @@ import argparse
 import importlib.util
 import sys
 import pathlib
+import logging
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
 
@@ -74,7 +77,10 @@ if has_oai:
             )
 
     def _run_runtime(
-        episodes: int, target: int, model: str | None = None, rewriter: str | None = None
+        episodes: int,
+        target: int,
+        model: str | None = None,
+        rewriter: str | None = None,
     ) -> None:
         if model:
             os.environ.setdefault("OPENAI_MODEL", model)
@@ -98,6 +104,7 @@ if has_oai:
 
         logger.info("Registered InsightAgent with runtime")
         runtime.run()
+
 else:
 
     async def run_insight_search(
@@ -117,16 +124,25 @@ else:
         return f"{FALLBACK_MODE_PREFIX}{summary}"
 
     def _run_runtime(
-        episodes: int, target: int, model: str | None = None, rewriter: str | None = None
+        episodes: int,
+        target: int,
+        model: str | None = None,
+        rewriter: str | None = None,
     ) -> None:
         print("openai-agents package is missing. Running offline demo...")
         run(episodes=episodes, target=target, model=model, rewriter=rewriter)
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="OpenAI Agents bridge for the α‑AGI Insight demo")
-    parser.add_argument("--episodes", type=int, default=5, help="Search episodes when offline")
-    parser.add_argument("--target", type=int, default=3, help="Target sector index when offline")
+    parser = argparse.ArgumentParser(
+        description="OpenAI Agents bridge for the α‑AGI Insight demo"
+    )
+    parser.add_argument(
+        "--episodes", type=int, default=5, help="Search episodes when offline"
+    )
+    parser.add_argument(
+        "--target", type=int, default=3, help="Target sector index when offline"
+    )
     parser.add_argument("--model", type=str, help="Model name override")
     parser.add_argument(
         "--rewriter",

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import List, Dict
+
+logger = logging.getLogger(__name__)
 
 from .cross_alpha_discovery_stub import SAMPLE_ALPHA, discover_alpha, _ledger_path
 
@@ -23,7 +26,11 @@ def _read_log(limit: int) -> List[Dict[str, str]]:
         if isinstance(data, dict):
             data = [data]
         return data[-limit:]
-    except (FileNotFoundError, PermissionError, json.JSONDecodeError):  # pragma: no cover - missing or invalid log
+    except (
+        FileNotFoundError,
+        PermissionError,
+        json.JSONDecodeError,
+    ):  # pragma: no cover - missing or invalid log
         return []
 
 
@@ -68,9 +75,9 @@ def main() -> None:
         auto_register([agent])
         maybe_launch()
     except Exception as exc:  # pragma: no cover - ADK optional
-        logging.warning(f"ADK bridge unavailable: {exc}")
+        logger.warning(f"ADK bridge unavailable: {exc}")
 
-    logging.info("Registered CrossIndustryAgent with runtime")
+    logger.info("Registered CrossIndustryAgent with runtime")
     runtime.run()
 
 


### PR DESCRIPTION
## Summary
- ensure logging configured for `alpha_agi_insight_v0` OpenAI Agents bridge
- fix same issue in cross-industry bridge

## Testing
- `black alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py`
- ❌ `pytest -q` *(failed: `pytest` not installed)*