### PR TITLE
Add env sector override for α‑AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -39,6 +39,10 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo \
 Use ``--list-sectors`` to display the resolved sector list without running the
 search. This is helpful when providing custom lists via ``--sectors``.
 
+Set the ``ALPHA_AGI_SECTORS`` environment variable to override the default
+sector list without editing configuration files.  Provide a comma-separated
+string or the path to a text file containing one sector per line.
+
 Export ``MCP_ENDPOINT`` to capture all prompts and replies for later audit using
 the Model Context Protocol. When unset the logging step is silently skipped.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -88,9 +88,13 @@ def parse_sectors(cfg_val: object | None, cli_val: str | None) -> List[str]:
         a YAML array.
     cli_val:
         Optional value passed via ``--sectors``.
+
+    Environment variable ``ALPHA_AGI_SECTORS`` overrides ``cfg_val`` when
+    ``cli_val`` is not supplied. The variable accepts a comma-separated list or
+    a text file path.
     """
 
-    source = cli_val or cfg_val
+    source = cli_val or os.getenv("ALPHA_AGI_SECTORS") or cfg_val
     if isinstance(source, list):
         return [str(s).strip() for s in source if str(s).strip()]
     if isinstance(source, str):

--- a/tests/test_alpha_agi_insight_env.py
+++ b/tests/test_alpha_agi_insight_env.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import sys
+import unittest
+import re
+
+
+class TestAlphaAgiInsightEnv(unittest.TestCase):
+    """Check environment variable sector override."""
+
+    def test_env_override(self) -> None:
+        env = os.environ.copy()
+        env["ALPHA_AGI_SECTORS"] = "Finance,Healthcare,Space"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_demo",
+                "--episodes",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        match = re.search(r"Best sector:\s*(\w+)", result.stdout)
+        self.assertIsNotNone(match, result.stdout)
+        self.assertIn(match.group(1), {"Finance", "Healthcare", "Space"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- parse `ALPHA_AGI_SECTORS` environment variable in Insight demo
- document the override behaviour in the demo README
- add regression test covering the env override logic

## Testing
- `pip install pytest` *(fails: No route to host)*
- `python -m pytest -k alpha_agi_insight_demo tests/test_alpha_agi_insight_demo.py` *(fails: No module named pytest)*