### PR TITLE
Improve insight demo offline compatibility

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -41,7 +41,9 @@ search. This is helpful when providing custom lists via ``--sectors``.
 
 Set the ``ALPHA_AGI_SECTORS`` environment variable to override the default
 sector list without editing configuration files.  Provide a comma-separated
-string or the path to a text file containing one sector per line.
+string or the path to a text file containing one sector per line.  The
+``openai_agents_bridge`` respects the same variable when launching via the
+Agents runtime so your custom sector lists work in both modes.
 
 Export ``MCP_ENDPOINT`` to capture all prompts and replies for later audit using
 the Model Context Protocol. When unset the logging step is silently skipped.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -28,7 +28,7 @@ if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
 
-from .insight_demo import run, verify_environment
+from .insight_demo import run, verify_environment, parse_sectors
 
 try:
     _spec = importlib.util.find_spec("openai_agents")
@@ -53,12 +53,13 @@ if has_oai:
             os.environ.setdefault("OPENAI_MODEL", model)
         if rewriter:
             os.environ.setdefault("MATS_REWRITER", rewriter)
+        sector_list = parse_sectors(None, sectors)
         result = run(
             episodes=episodes,
             target=target,
             model=model,
             rewriter=rewriter,
-            sectors=(sectors.split(",") if sectors else None),
+            sectors=sector_list,
         )
         return result
 
@@ -114,12 +115,13 @@ else:
         rewriter: str | None = None,
         sectors: str | None = None,
     ) -> str:
+        sector_list = parse_sectors(None, sectors)
         summary = run(
             episodes=episodes,
             target=target,
             model=model,
             rewriter=rewriter,
-            sectors=(sectors.split(",") if sectors else None),
+            sectors=sector_list,
         )
         return f"{FALLBACK_MODE_PREFIX}{summary}"
 
@@ -130,7 +132,14 @@ else:
         rewriter: str | None = None,
     ) -> None:
         print("openai-agents package is missing. Running offline demo...")
-        run(episodes=episodes, target=target, model=model, rewriter=rewriter)
+        sector_list = parse_sectors(None, None)
+        run(
+            episodes=episodes,
+            target=target,
+            model=model,
+            rewriter=rewriter,
+            sectors=sector_list,
+        )
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- improve alpha_agi_insight_v0 demo bridge
  - parse sector lists using `ALPHA_AGI_SECTORS`
  - use same helper when running offline
- document the environment variable support in README

## Testing
- `python check_env.py`
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --episodes 1 --target 1 --verify-env`
- `ALPHA_AGI_SECTORS=Finance,Healthcare,Space python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --episodes 1 --target 0`