### PR TITLE
Improve AGI Insight demo usability

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -25,7 +25,8 @@ Pass ``--offline`` to skip the agent runtime entirely.
 
 ### Quick Start Script
 
-Run ``./run_insight_demo.sh`` from this directory for an instant launch. The
+Ensure the script is executable by running ``chmod +x run_insight_demo.sh`` if needed.
+Then, run ``./run_insight_demo.sh`` from this directory for an instant launch. The
 helper delegates to the package entry point so the demo works with or without
 OpenAI API credentials.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -23,6 +23,12 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --verify-env
 
 Pass ``--offline`` to skip the agent runtime entirely.
 
+### Quick Start Script
+
+Run ``./run_insight_demo.sh`` from this directory for an instant launch. The
+helper delegates to the package entry point so the demo works with or without
+OpenAI API credentials.
+
 ## Usage
 
 The command line interface mirrors the options of the general MATS demo:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/run_insight_demo.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/run_insight_demo.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Quick launcher for the α‑AGI Insight demo
+set -euo pipefail
+
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+root_dir="${script_dir%/*/*}"
+
+cd "$root_dir"
+
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0 "$@"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/run_insight_demo.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/run_insight_demo.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-root_dir="${script_dir%/*/*}"
+root_dir="$(dirname "$(dirname "$script_dir")")"
 
 cd "$root_dir"
 


### PR DESCRIPTION
## Summary
- add convenience launcher `run_insight_demo.sh`
- document the new script in the insight demo README

## Testing
- `python check_env.py`
- `pytest -q tests/test_alpha_agi_insight_demo.py tests/test_alpha_agi_insight_bridge.py tests/test_alpha_agi_insight_env.py` *(fails: pytest not installed)*