### PR TITLE
Add dedicated launcher for AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -25,10 +25,15 @@ Pass ``--offline`` to skip the agent runtime entirely.
 
 ### Quick Start Script
 
-Ensure the script is executable by running ``chmod +x run_insight_demo.sh`` if needed.
-Then, run ``./run_insight_demo.sh`` from this directory for an instant launch. The
-helper delegates to the package entry point so the demo works with or without
-OpenAI API credentials.
+Ensure the shell helper is executable by running ``chmod +x run_insight_demo.sh`` if needed.
+Execute ``./run_insight_demo.sh`` from this directory for an instant launch. The
+wrapper delegates to the package entry point so the demo works with or without
+OpenAI API credentials.  Alternatively invoke ``run_demo.py`` directly with
+Python for the same behaviour:
+
+```bash
+python run_demo.py --episodes 5
+```
 
 ## Usage
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -3,5 +3,6 @@
 # ``main`` gives callers the convenient entrypoint from ``__main__``.
 from .__main__ import main  # re-export
 from . import openai_agents_bridge
+from .run_demo import main as run_demo
 
-__all__ = ["main", "openai_agents_bridge"]
+__all__ = ["main", "openai_agents_bridge", "run_demo"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/run_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/run_demo.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Standalone launcher for the α‑AGI Insight demo.
+
+This convenience wrapper allows running the demo directly via
+``python run_demo.py``. It delegates to :mod:`alpha_factory_v1.demos.alpha_agi_insight_v0`
+which automatically selects the best runtime (OpenAI Agents when available
+with configured API keys, otherwise the offline CLI).
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+if __package__ is None:  # pragma: no cover - allow execution via `python run_demo.py`
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
+
+import importlib
+
+main = importlib.import_module(
+    "alpha_factory_v1.demos.alpha_agi_insight_v0.__main__"
+).main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- provide `run_demo.py` for alpha_agi_insight_v0 demo
- expose new `run_demo` helper from the package
- mention the Python launcher in README

## Testing
- `python alpha_factory_v1/demos/alpha_agi_insight_v0/run_demo.py --episodes 1`
