### PR TITLE
Update insight demo bridge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -81,7 +81,8 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --ver
 ```
 The bridge automatically falls back to offline mode when the optional
 packages or API keys are missing. Use ``--enable-adk`` to expose the agent via
-the optional Google ADK gateway when available. Pass ``--log-dir`` to store
+the optional Google ADK gateway when available. Use ``--list-sectors`` to view
+the resolved sector list without running the search. Pass ``--log-dir`` to store
 episode metrics in ``scores.csv``.
 
 ### MCP Logging

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -85,11 +85,14 @@ if has_oai:
         model: str | None = None,
         rewriter: str | None = None,
         log_dir: str | None = None,
+        sectors: str | None = None,
     ) -> None:
         if model:
             os.environ.setdefault("OPENAI_MODEL", model)
         if rewriter:
             os.environ.setdefault("MATS_REWRITER", rewriter)
+        if sectors:
+            os.environ.setdefault("ALPHA_AGI_SECTORS", sectors)
         runtime = AgentRuntime(api_key=os.getenv("OPENAI_API_KEY"))
         agent = InsightAgent()
         runtime.register(agent)
@@ -136,6 +139,7 @@ else:
         model: str | None = None,
         rewriter: str | None = None,
         log_dir: str | None = None,
+        sectors: str | None = None,
     ) -> None:
         reasons = []
         if _spec is None:
@@ -144,7 +148,7 @@ else:
             reasons.append("OPENAI_API_KEY not set")
         msg = " and ".join(reasons) or "offline mode"
         print(f"Running offline demo in {msg}…")
-        sector_list = parse_sectors(None, None)
+        sector_list = parse_sectors(None, sectors)
         run(
             episodes=episodes,
             target=target,
@@ -178,6 +182,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Directory to store episode logs",
     )
     parser.add_argument(
+        "--list-sectors",
+        action="store_true",
+        help="Print the resolved sector list and exit",
+    )
+    parser.add_argument(
         "--enable-adk",
         action="store_true",
         help="Enable the Google ADK gateway",
@@ -192,10 +201,24 @@ def main(argv: list[str] | None = None) -> None:
     if args.verify_env:
         verify_environment()
 
+    sector_list = parse_sectors(None, args.sectors)
+    if args.list_sectors:
+        print("Sectors:")
+        for name in sector_list:
+            print(f"- {name}")
+        return
+
     if args.enable_adk:
         os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
 
-    _run_runtime(args.episodes, args.target, args.model, args.rewriter, args.log_dir)
+    _run_runtime(
+        args.episodes,
+        args.target,
+        args.model,
+        args.rewriter,
+        args.log_dir,
+        args.sectors,
+    )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add `--list-sectors` to the OpenAI Agents bridge
- allow passing sectors through environment or CLI
- document the new option in the demo README

## Testing
- `python -m tests.test_alpha_agi_insight_bridge`
- `python -m tests.test_alpha_agi_insight_demo`
- `python -m tests.test_alpha_agi_insight_env`