### PR TITLE
Finalize Alpha AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -23,6 +23,12 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --verify-env
 
 Pass ``--offline`` to skip the agent runtime entirely.
 
+For a quick offline run from anywhere:
+
+```bash
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --offline --episodes 2
+```
+
 ### Quick Start Script
 
 Ensure the shell helper is executable by running ``chmod +x run_insight_demo.sh`` if needed.

--- a/tests/test_alpha_agi_insight_main.py
+++ b/tests/test_alpha_agi_insight_main.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestAlphaAgiInsightMain(unittest.TestCase):
+    """Verify the package entry point."""
+
+    def test_main_offline(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.alpha_agi_insight_v0",
+                "--offline",
+                "--episodes",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best sector", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- document offline entry point usage for Alpha AGI Insight demo
- add regression test for the `__main__` package launcher

## Testing
- `python -m alpha_factory_v1.scripts.run_tests tests -q`