### PR TITLE
Improve offline operation for AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
@@ -10,7 +10,7 @@ can be controlled via the OpenAI Agents runtime when available.  Use
 from __future__ import annotations
 
 import argparse
-from . import openai_agents_bridge, insight_demo
+from . import insight_demo
 import os
 
 
@@ -29,6 +29,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.offline:
         insight_demo.main(remainder)
     else:
+        from . import openai_agents_bridge
         openai_agents_bridge.main(remainder)
 
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
@@ -2,7 +2,6 @@
 
 from . import mats
 from .run_demo import run as run_demo
-from . import openai_agents_bridge
 
-__all__ = ["run_demo", "mats", "openai_agents_bridge"]
+__all__ = ["run_demo", "mats"]
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import random
+import logging
 from typing import List
 
-from alpha_factory_v1.backend.mcp_bridge import store_sync
+try:
+    from alpha_factory_v1.backend.mcp_bridge import store_sync
+except Exception as exc:  # pragma: no cover - optional dep may fail
+    logging.getLogger(__name__).warning("MCP bridge unavailable: %s", exc)
+
+    def store_sync(messages: list) -> None:
+        """No-op fallback when the MCP helper is missing."""
+        return
+
 import importlib
 import asyncio
 import os
-import logging
 import re
 import threading
 


### PR DESCRIPTION
## Summary
- gracefully handle missing MCP bridge in MATS demo
- lazy import the OpenAI Agents bridge so `--offline` works without the package
- avoid importing OpenAI Agents in the MATS package unless needed

## Testing
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --offline --episodes 2`
- `pytest -q` *(fails: pydantic import errors)*