### PR TITLE
Add minimal Codex setup script and simplify AGENTS guide

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Minimal setup script for Codex development environments.
+set -euo pipefail
+
+python -m pip install --upgrade pip
+python -m pip install 'pydantic<2' pytest openai anthropic prometheus_client
+
+# Attempt to install optional extras needed for some demos.
+python check_env.py --auto-install || true
+
+# Install the package in editable mode.
+python -m pip install -e .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,12 @@
 # AGENTS.md
 
-This file defines coding and testing guidelines for contributors and AI agents working on this repository.
-
-## Scope
-These instructions apply to the entire repository.
+These instructions guide both human contributors and automated agents working in this repository.
 
 ## Coding style
-- Prefer Python 3.9+ syntax with type hints.
-- Use 4 spaces per indentation level.
-- Keep lines under **120** characters when possible.
-- Document functions and classes with concise English docstrings and comments, following the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
+- Target Python 3.11 or newer and use type hints.
+- Indent with 4 spaces and keep lines under 120 characters.
+- Write concise Google style docstrings for all public modules, classes and functions.
 
-## Tests
-- Always run the full test suite with `pytest -q` before committing changes.
-- If dependencies are missing, run `python check_env.py --auto-install` to install them locally.
-- Tests must pass or the failure should be explained in the pull request.
-
+## Workflow
+1. Run `python check_env.py --auto-install` to ensure optional packages are available.
+2. Execute `pytest -q` and confirm the suite completes. If tests fail, mention why in your pull request.


### PR DESCRIPTION
## Summary
- create `.codex/setup.sh` for a lightweight dev environment
- simplify `AGENTS.md` with concise workflow instructions

## Testing
- `python check_env.py --auto-install` *(fails: openai_agents, google_adk missing)*
- `pytest -q` *(fails: 16 errors during collection)*