### PR TITLE
Add Codex setup script and update contributor guidelines

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
-# Minimal setup script for Codex development environments.
+# Setup script for Codex development environments.
 set -euo pipefail
 
-python -m pip install --upgrade pip
-python -m pip install 'pydantic<2' pytest openai anthropic prometheus_client
+# Keep tooling modern.
+python -m pip install --upgrade pip setuptools wheel
 
-# Attempt to install optional extras needed for some demos.
-python check_env.py --auto-install || true
+# Core runtime requirements for tests and demos.
+python -m pip install --prefer-binary 'pydantic<2' pytest openai anthropic \
+    prometheus_client
 
-# Install the package in editable mode.
+# Install the project in editable mode.
 python -m pip install -e .
+
+# Validate optional extras. Failures do not stop the build.
+python check_env.py --auto-install || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-These instructions guide both human contributors and automated agents working in this repository.
+These guidelines apply to all contributors and automated agents.
 
 ## Coding style
 - Target Python 3.11 or newer and use type hints.
@@ -8,5 +8,6 @@ These instructions guide both human contributors and automated agents working in
 - Write concise Google style docstrings for all public modules, classes and functions.
 
 ## Workflow
-1. Run `python check_env.py --auto-install` to ensure optional packages are available.
-2. Execute `pytest -q` and confirm the suite completes. If tests fail, mention why in your pull request.
+1. Run `.codex/setup.sh` to configure the environment.
+2. Execute `python check_env.py --auto-install`.
+3. Run `pytest -q`. If tests fail, note the cause in the pull request description.


### PR DESCRIPTION
## Summary
- refine `.codex/setup.sh` for a fast Codex environment
- simplify repository guidelines in `AGENTS.md`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError from pydantic)*