### PR TITLE
Add Codex setup script and contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,19 @@
-# Contribution Guidelines
+# Contributor Guide
 
-These instructions apply to all contributors and automated agents.
+This repository hosts the Alpha-Factory v1 package and demos. These rules apply to all contributors and automated agents.
+
+## Development Environment
+- Run `./codex/setup.sh` to install minimal dependencies. Set `WHEELHOUSE=/path/to/wheels` for offline installs.
+- After setup execute `python check_env.py --auto-install`.
+- Run `pytest -q` and ensure all tests pass. If a test fails explain the reason in the PR description.
 
 ## Coding Style
-- Target **Python 3.11** or newer and include type hints.
+- Target **Python 3.11** or newer and provide type hints.
 - Use 4 spaces per indentation level and keep lines under 120 characters.
-- Provide concise Google style docstrings for all public modules, classes and functions.
-
-## Environment Setup
-1. Run `./codex/setup.sh` to install the project and minimal dependencies. Set `WHEELHOUSE=/path/to/wheels` for offline installation.
-2. Execute `python check_env.py --auto-install`.
-3. Run `pytest -q`. If any tests fail, explain the reason in the pull request description.
+- Write concise Google style docstrings for public modules, classes and functions.
 
 ## Pull Requests
 - Keep commits focused and descriptive.
-- Ensure the working tree is clean (`git status` shows no changes) before submitting.
+- Ensure the working tree is clean (`git status` shows no changes).
+- Summarize your changes and test results in the PR body.
 

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON=${PYTHON:-python3}
+
+# Support offline installation via WHEELHOUSE
+wheel_opts=()
+if [[ -n "${WHEELHOUSE:-}" ]]; then
+  wheel_opts+=(--no-index --find-links "$WHEELHOUSE")
+fi
+
+# Upgrade pip quietly
+$PYTHON -m pip install --quiet --upgrade pip
+
+# Install package in editable mode
+$PYTHON -m pip install --quiet "${wheel_opts[@]}" -e .
+
+# Minimal runtime/test dependencies
+packages=(
+  pytest
+  prometheus_client
+  openai
+  openai_agents
+  google_adk
+  anthropic
+)
+$PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
+


### PR DESCRIPTION
## Summary
- add `codex/setup.sh` for lightweight environment provisioning
- update AGENTS guide with development and PR instructions
- run setup, dependency check, and tests

## Testing
- `bash codex/setup.sh` *(fails: Could not install build dependencies)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*