### PR TITLE
Update alpha AGI Insight demo docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -106,6 +106,14 @@ Launch ``openai_agents_bridge.py`` to control the demo via the
 ```bash
 python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --verify-env
 ```
+
+Run with ``--enable-adk`` to expose the agent via the optional Google ADK gateway when available. The following
+example launches the runtime with five episodes and stores episode metrics in ``scores.csv``:
+
+```bash
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge \
+    --enable-adk --episodes 5 --log-dir logs
+```
 The bridge automatically falls back to offline mode when the optional
 packages or API keys are missing. Use ``--enable-adk`` to expose the agent via
 the optional Google ADK gateway when available. Use ``--list-sectors`` to view


### PR DESCRIPTION
## Summary
- clarify how to launch the demo via the OpenAI Agents bridge
- show sample command enabling the ADK gateway

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError due to missing packages)*