### PR TITLE
Improve α‑AGI Insight logging

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -77,7 +77,8 @@ the Model Context Protocol. When unset the logging step is silently skipped.
 When optional dependencies such as ``openai`` or ``anthropic`` are not
 installed, the program automatically falls back to a simple offline rewriter so
 the demo remains functional anywhere.  Episode scores are printed to the console
-and optionally written to ``scores.csv`` when ``--log-dir`` is supplied.
+and optionally written to ``scores.csv`` when ``--log-dir`` is supplied.  The
+path to the log file is displayed after the run completes.
 
 ### Environment Variables
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -146,9 +146,11 @@ def run(
     env = NumberLineEnv(target=target)
     tree = Tree(Node(root_agents), exploration=exploration)
     log_fh = None
+    log_path: Path | None = None
     if log_dir is not None:
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_fh = open(log_dir / "scores.csv", "w", encoding="utf-8")
+        log_path = log_dir / "scores.csv"
+        log_fh = open(log_path, "w", encoding="utf-8")
         log_fh.write("episode,candidate,reward\n")
     for idx_ep in range(episodes):
         node = tree.select()
@@ -169,6 +171,8 @@ def run(
     if log_fh:
         log_fh.write(f"best,{sector},{score:.6f}\n")
         log_fh.close()
+        if log_path:
+            print(f"Episode metrics written to {log_path}")
     return summary
 
 
@@ -223,11 +227,19 @@ def main(argv: List[str] | None = None) -> None:
         if args.exploration is not None
         else os.getenv("ALPHA_AGI_EXPLORATION", cfg.get("exploration", 1.4))
     )
-    rewriter = args.rewriter or os.getenv("MATS_REWRITER") or cfg.get("rewriter", "random")
-    target = int(
-        args.target if args.target is not None else os.getenv("ALPHA_AGI_TARGET", cfg.get("target", 3))
+    rewriter = (
+        args.rewriter or os.getenv("MATS_REWRITER") or cfg.get("rewriter", "random")
     )
-    seed_val = args.seed if args.seed is not None else os.getenv("ALPHA_AGI_SEED") or cfg.get("seed")
+    target = int(
+        args.target
+        if args.target is not None
+        else os.getenv("ALPHA_AGI_TARGET", cfg.get("target", 3))
+    )
+    seed_val = (
+        args.seed
+        if args.seed is not None
+        else os.getenv("ALPHA_AGI_SEED") or cfg.get("seed")
+    )
     seed = int(seed_val) if seed_val is not None else None
     model = args.model or cfg.get("model")
     sectors = parse_sectors(cfg.get("sectors"), args.sectors)


### PR DESCRIPTION
## Summary
- print log path when using `--log-dir`
- mention log file path in README

## Testing
- `./codex/setup.sh` *(fails: Could not install deps)*
- `python check_env.py --auto-install`
- `pytest tests/test_alpha_agi_insight_demo.py::TestAlphaAgiInsightDemo::test_run_demo_short -q`
- `pytest -q` *(fails: 16 errors during collection)*