### PR TITLE
[alpha_factory] Add bridge CLI entry

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -44,6 +44,13 @@ same behaviour without specifying the module path:
 alpha-agi-insight-demo --episodes 2
 ```
 
+To expose the demo via the OpenAI Agents runtime (and optional ADK gateway), use
+the companion ``alpha-agi-insight-bridge`` command:
+
+```bash
+alpha-agi-insight-bridge --verify-env --episodes 5
+```
+
 ### Quick Start Script
 
 Ensure the shell helper is executable by running ``chmod +x run_insight_demo.sh`` if needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ validate-demos = "alpha_factory_v1.demos.validate_demos:main"
 aiga-meta-demo = "alpha_factory_v1.demos.aiga_meta_evolution.meta_evolver:cli"
 muzero-demo = "alpha_factory_v1.demos.muzero_planning.agent_muzero_entrypoint:launch_dashboard"
 alpha-agi-insight-demo = "alpha_factory_v1.demos.alpha_agi_insight_v0.run_demo:main"
+alpha-agi-insight-bridge = "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- expose `openai_agents_bridge` as a console script `alpha-agi-insight-bridge`
- document the new helper command in the α‑AGI Insight demo README

## Testing
- `./codex/setup.sh` *(fails: Could not find a version that satisfies the requirement wheel)*
- `python check_env.py --auto-install` *(fails: No matching distribution found for pytest)*
- `pytest -q` *(fails: command not found)*