### PR TITLE
[alpha_factory] add official insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -63,6 +63,13 @@ Python for the same behaviour:
 python run_demo.py --episodes 5
 ```
 
+To always verify dependencies before running, launch the companion
+``official_demo.py`` script instead:
+
+```bash
+python official_demo.py --episodes 5
+```
+
 ## Usage
 
 The command line interface mirrors the options of the general MATS demo:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -4,5 +4,6 @@
 from .__main__ import main  # re-export
 from . import openai_agents_bridge
 from .run_demo import main as run_demo
+from .official_demo import main as official_demo
 
-__all__ = ["main", "openai_agents_bridge", "run_demo"]
+__all__ = ["main", "openai_agents_bridge", "run_demo", "official_demo"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Launch the α‑AGI Insight official demo.
+
+This helper ensures the environment is verified before delegating to the
+package entry point. It mirrors ``run_demo.py`` but automatically passes
+``--verify-env`` so users always receive a dependency check.
+"""
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+from typing import List
+
+if __package__ is None:  # pragma: no cover - allow direct execution
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
+
+from . import __main__
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Run the α‑AGI Insight demo with environment validation."""
+    args = ["--verify-env"]
+    if argv:
+        args.extend(argv)
+    __main__.main(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_official_insight_demo.py
+++ b/tests/test_official_insight_demo.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestOfficialInsightDemo(unittest.TestCase):
+    """Ensure the official α‑AGI Insight demo launches."""
+
+    def test_official_demo_short(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py",
+                "--episodes",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best sector", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `official_demo.py` for α‑AGI Insight
- export new helper in the package
- document new helper usage in the Insight README
- add a regression test for the official demo

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_official_insight_demo.py -q`
- `pytest -q` *(fails: 16 errors during collection)*
