### PR TITLE
[alpha_factory] add official demo entrypoint

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -70,6 +70,9 @@ To always verify dependencies before running, launch the companion
 python official_demo.py --episodes 5
 ```
 
+When installed as a package, the `alpha-agi-insight-official` command
+offers the same behaviour.
+
 ## Usage
 
 The command line interface mirrors the options of the general MATS demo:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ aiga-meta-demo = "alpha_factory_v1.demos.aiga_meta_evolution.meta_evolver:cli"
 muzero-demo = "alpha_factory_v1.demos.muzero_planning.agent_muzero_entrypoint:launch_dashboard"
 alpha-agi-insight-demo = "alpha_factory_v1.demos.alpha_agi_insight_v0.run_demo:main"
 alpha-agi-insight-bridge = "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge:main"
+alpha-agi-insight-official = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add `alpha-agi-insight-official` console script
- document new command in the α‑AGI Insight demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*