### PR TITLE
[alpha_factory] fix config path in insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -199,7 +199,7 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument(
         "--config",
         type=Path,
-        default=Path("configs/default.yaml"),
+        default=Path(__file__).resolve().parent / "configs" / "default.yaml",
         help="YAML configuration",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- default to file-relative path for the official α‑AGI Insight demo config

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*