### PR TITLE
[alpha_factory] add final AGI insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -73,6 +73,14 @@ python official_demo.py --episodes 5
 When installed as a package, the `alpha-agi-insight-official` command
 offers the same behaviour.
 
+The standalone ``official_demo_final.py`` wrapper combines environment
+verification with automatic runtime selection. Invoke it directly or via
+the ``alpha-agi-insight-final`` command:
+
+```bash
+python official_demo_final.py --episodes 5
+```
+
 ## Usage
 
 The command line interface mirrors the options of the general MATS demo:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -5,5 +5,6 @@ from .__main__ import main  # re-export
 from . import openai_agents_bridge
 from .run_demo import main as run_demo
 from .official_demo import main as official_demo
+from .official_demo_final import main as official_demo_final
 
-__all__ = ["main", "openai_agents_bridge", "run_demo", "official_demo"]
+__all__ = ["main", "openai_agents_bridge", "run_demo", "official_demo", "official_demo_final"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Standalone launcher for the α‑AGI Insight demo.
+
+This helper automatically selects the best interface for the insight
+search. When the optional OpenAI Agents runtime is available and an API
+key is configured the agent is registered with the runtime. Otherwise the
+script falls back to the lightweight command line interface that runs the
+Meta‑Agentic Tree Search locally.  Runtime dependencies are verified when
+``--verify-env`` is supplied.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+from typing import List
+
+from . import insight_demo
+from . import openai_agents_bridge
+
+
+def _agents_available() -> bool:
+    """Return ``True`` when ``openai_agents`` can be used."""
+    spec = importlib.util.find_spec("openai_agents")
+    return bool(spec and os.getenv("OPENAI_API_KEY"))
+
+
+def _run_offline(args: argparse.Namespace) -> None:
+    sectors = insight_demo.parse_sectors(None, args.sectors)
+    insight_demo.run(
+        episodes=args.episodes or 5,
+        exploration=args.exploration or 1.4,
+        rewriter=args.rewriter,
+        log_dir=Path(args.log_dir) if args.log_dir else None,
+        target=args.target or 3,
+        seed=args.seed,
+        model=args.model,
+        sectors=sectors,
+    )
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Launch the α‑AGI Insight demo")
+    parser.add_argument("--episodes", type=int, help="Search iterations")
+    parser.add_argument("--target", type=int, help="Target sector index")
+    parser.add_argument("--exploration", type=float, help="Exploration constant")
+    parser.add_argument("--seed", type=int, help="Optional RNG seed")
+    parser.add_argument("--model", type=str, help="Model override")
+    parser.add_argument("--rewriter", choices=["random", "openai", "anthropic"], help="Rewrite strategy")
+    parser.add_argument("--sectors", type=str, help="Comma-separated sectors or path to file")
+    parser.add_argument("--log-dir", type=str, help="Directory for episode metrics")
+    parser.add_argument("--offline", action="store_true", help="Force offline mode")
+    parser.add_argument("--verify-env", action="store_true", help="Validate runtime dependencies")
+    args = parser.parse_args(argv)
+
+    if args.verify_env:
+        insight_demo.verify_environment()
+
+    if args.offline or not _agents_available():
+        _run_offline(args)
+    else:
+        openai_agents_bridge._run_runtime(
+            args.episodes or 5,
+            args.target or 3,
+            args.model,
+            args.rewriter,
+            args.log_dir,
+            args.sectors,
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ muzero-demo = "alpha_factory_v1.demos.muzero_planning.agent_muzero_entrypoint:la
 alpha-agi-insight-demo = "alpha_factory_v1.demos.alpha_agi_insight_v0.run_demo:main"
 alpha-agi-insight-bridge = "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge:main"
 alpha-agi-insight-official = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo:main"
+alpha-agi-insight-final = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here

--- a/tests/test_official_final_demo.py
+++ b/tests/test_official_final_demo.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestOfficialFinalDemo(unittest.TestCase):
+    """Ensure the final α‑AGI Insight demo launches."""
+
+    def test_final_demo_short(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py",
+                "--episodes",
+                "1",
+                "--offline",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best sector", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- expand the α‑AGI Insight package with a standalone `official_demo_final.py`
- expose the new launcher via a script entry point
- document the helper in the demo README
- export the launcher in `__init__`
- add a unit test covering the new script

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: pydantic import errors and missing packages)*