### PR TITLE
[alpha_factory] default environment check

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -26,10 +26,11 @@ routes through the OpenAI Agents runtime when available and transparently
 degrades to the local CLI otherwise:
 
 ```bash
-python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --verify-env
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0
 ```
 
 Pass ``--offline`` to skip the agent runtime entirely.
+Use ``--skip-verify`` to bypass the startup environment check if desired.
 
 For a quick offline run from anywhere:
 
@@ -48,7 +49,7 @@ To expose the demo via the OpenAI Agents runtime (and optional ADK gateway), use
 the companion ``alpha-agi-insight-bridge`` command:
 
 ```bash
-alpha-agi-insight-bridge --verify-env --episodes 5
+alpha-agi-insight-bridge --episodes 5
 ```
 
 ### Quick Start Script
@@ -128,8 +129,8 @@ path to the log file is displayed after the run completes.
 ### Graceful Offline Mode
 
 The demo automatically falls back to an offline search strategy whenever the
-required API keys are absent or network access is restricted. Use
-``--verify-env`` for a quick dependency check before launching.
+required API keys are absent or network access is restricted. Dependency checks
+run automatically at launch.
 
 ## OpenAI Agents Bridge
 
@@ -137,7 +138,7 @@ Launch ``openai_agents_bridge.py`` to control the demo via the
 `openai-agents` runtime and optionally the Google ADK A2A protocol:
 
 ```bash
-python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --verify-env
+python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge
 ```
 
 Run with ``--enable-adk`` to expose the agent via the optional Google ADK gateway when available. Custom host and

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -51,10 +51,10 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--sectors", type=str, help="Comma-separated sectors or path to file")
     parser.add_argument("--log-dir", type=str, help="Directory for episode metrics")
     parser.add_argument("--offline", action="store_true", help="Force offline mode")
-    parser.add_argument("--verify-env", action="store_true", help="Validate runtime dependencies")
+    parser.add_argument("--skip-verify", action="store_true", help="Skip environment check")
     args = parser.parse_args(argv)
 
-    if args.verify_env:
+    if not args.skip_verify:
         insight_demo.verify_environment()
 
     if args.offline or not _agents_available():

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -202,13 +202,13 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--adk-host", type=str, help="ADK bind host")
     parser.add_argument("--adk-port", type=int, help="ADK bind port")
     parser.add_argument(
-        "--verify-env",
+        "--skip-verify",
         action="store_true",
-        help="Check runtime dependencies before launching",
+        help="Skip runtime dependency checks",
     )
     args = parser.parse_args(argv)
 
-    if args.verify_env:
+    if not args.skip_verify:
         verify_environment()
 
     sector_list = parse_sectors(None, args.sectors)


### PR DESCRIPTION
## Summary
- improve alpha-agi-insight openai bridge and final demo
- add automatic environment check with `--skip-verify` option
- update insight demo readme for new flag

## Testing
- `./codex/setup.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*