### PR TITLE
[alpha_factory] add sector listing option to final demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -81,6 +81,7 @@ the ``alpha-agi-insight-final`` command:
 ```bash
 python official_demo_final.py --episodes 5
 ```
+Pass ``--list-sectors`` to display the resolved sector list without running the search.
 
 ## Usage
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -59,10 +59,22 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--log-dir", type=str, help="Directory for episode metrics")
     parser.add_argument("--offline", action="store_true", help="Force offline mode")
     parser.add_argument("--skip-verify", action="store_true", help="Skip environment check")
+    parser.add_argument(
+        "--list-sectors",
+        action="store_true",
+        help="Display the resolved sector list and exit",
+    )
     args = parser.parse_args(argv)
 
     if not args.skip_verify:
         insight_demo.verify_environment()
+
+    if args.list_sectors:
+        sector_list = insight_demo.parse_sectors(None, args.sectors)
+        print("Sectors:")
+        for name in sector_list:
+            print(f"- {name}")
+        return
 
     if args.offline or not _agents_available():
         _run_offline(args)


### PR DESCRIPTION
## Summary
- allow --list-sectors option in `official_demo_final.py`
- document the new flag in the demo README

## Testing
- `./codex/setup.sh` *(fails: Could not find setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*