### PR TITLE
[alpha_factory] Enhance α‑AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -81,6 +81,9 @@ the ``alpha-agi-insight-final`` command:
 ```bash
 python official_demo_final.py --episodes 5
 ```
+Pass ``--enable-adk`` to expose the agent through the optional Google ADK
+gateway. Custom host and port may be specified with ``--adk-host`` and
+``--adk-port``.
 
 ## Usage
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -52,6 +52,9 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--log-dir", type=str, help="Directory for episode metrics")
     parser.add_argument("--offline", action="store_true", help="Force offline mode")
     parser.add_argument("--skip-verify", action="store_true", help="Skip environment check")
+    parser.add_argument("--enable-adk", action="store_true", help="Enable the Google ADK gateway")
+    parser.add_argument("--adk-host", type=str, help="ADK bind host")
+    parser.add_argument("--adk-port", type=int, help="ADK bind port")
     args = parser.parse_args(argv)
 
     if not args.skip_verify:
@@ -60,6 +63,8 @@ def main(argv: List[str] | None = None) -> None:
     if args.offline or not _agents_available():
         _run_offline(args)
     else:
+        if args.enable_adk:
+            os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
         openai_agents_bridge._run_runtime(
             args.episodes or 5,
             args.target or 3,
@@ -67,6 +72,8 @@ def main(argv: List[str] | None = None) -> None:
             args.rewriter,
             args.log_dir,
             args.sectors,
+            adk_host=args.adk_host,
+            adk_port=args.adk_port,
         )
 
 


### PR DESCRIPTION
## Summary
- add ADK gateway options to `official_demo_final.py`
- document ADK options in insight demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: BaseSettings has moved to pydantic-settings; ImportError: cannot import name 'AgentRuntime')*