### PR TITLE
[alpha_factory] Add version flags to insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -84,6 +84,7 @@ python official_demo_final.py --episodes 5
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
+Use ``--version`` to show the installed package version and exit.
 
 ## Usage
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 from . import insight_demo
+from ... import get_version
 import os
 
 
@@ -20,6 +21,12 @@ def main(argv: list[str] | None = None) -> None:
         "--offline",
         action="store_true",
         help="Run the basic CLI without the OpenAI Agents runtime",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+        help="Show package version and exit",
     )
     args, remainder = parser.parse_known_args(argv)
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -25,6 +25,7 @@ if __package__ is None:  # pragma: no cover - allow `python official_demo_final.
 
 from . import insight_demo
 from . import openai_agents_bridge
+from ... import get_version
 
 
 def _agents_available() -> bool:
@@ -76,6 +77,12 @@ def main(argv: List[str] | None = None) -> None:
         "--list-sectors",
         action="store_true",
         help="Display the resolved sector list and exit",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+        help="Show package version and exit",
     )
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
## Summary
- expose package version via `--version` in `alpha_agi_insight_v0` CLI wrappers
- document the new flag in the demo README

## Testing
- `pytest tests/test_official_final_demo.py tests/test_alpha_agi_insight_main.py -q`
