### PR TITLE
[alpha_factory] add offline env override

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -129,6 +129,7 @@ path to the log file is displayed after the run completes.
 - ``ALPHA_AGI_EXPLORATION`` – set the exploration constant for UCB1.
 - ``ALPHA_AGI_TARGET`` – specify the target sector index.
 - ``ALPHA_AGI_SEED`` – RNG seed for deterministic runs.
+- ``ALPHA_AGI_OFFLINE`` – force offline mode even when OpenAI Agents is available.
 
 ### Graceful Offline Mode
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -29,7 +29,16 @@ from ... import get_version
 
 
 def _agents_available() -> bool:
-    """Return ``True`` when ``openai_agents`` can be used."""
+    """Return ``True`` when the OpenAI Agents runtime is usable.
+
+    An explicit ``ALPHA_AGI_OFFLINE`` environment variable forces offline mode
+    even when the package and API key are present.  This mirrors the
+    ``--offline`` command line option and offers parity with other demos.
+    """
+
+    if os.getenv("ALPHA_AGI_OFFLINE"):
+        return False
+
     spec = importlib.util.find_spec("openai_agents")
     return bool(spec and os.getenv("OPENAI_API_KEY"))
 


### PR DESCRIPTION
## Summary
- allow forcing offline mode via `ALPHA_AGI_OFFLINE`
- document the new variable in the Insight demo README

## Testing
- `pytest -q tests/test_official_final_demo.py`
- `pytest -q` *(fails: 16 errors during collection)*