### PR TITLE
[alpha_factory] finalize α‑AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py
@@ -16,15 +16,13 @@ if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
 
-from . import __main__
+from . import __main__, insight_demo
 
 
 def main(argv: List[str] | None = None) -> None:
     """Run the α‑AGI Insight demo with environment validation."""
-    args = ["--verify-env"]
-    if argv:
-        args.extend(argv)
-    __main__.main(args)
+    insight_demo.verify_environment()
+    __main__.main(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- verify environment directly in the `official_demo` helper
- delegate to the package entry point unchanged

## Testing
- `pytest tests/test_alpha_agi_insight_demo.py tests/test_alpha_agi_insight_main.py tests/test_alpha_agi_insight_bridge.py tests/test_official_insight_demo.py -q`