### PR TITLE
[alpha_factory] clarify offline demo usage

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -82,6 +82,11 @@ the ``alpha-agi-insight-final`` command:
 ```bash
 python official_demo_final.py --episodes 5
 ```
+For a quick offline run with minimal dependencies:
+
+```bash
+python official_demo_final.py --offline --episodes 2
+```
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.


### PR DESCRIPTION
## Summary
- improve demo README with offline usage example

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError due to missing dependencies)*
- `python alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py --episodes 2 --offline`