### PR TITLE
[alpha_factory] α‑AGI Insight demo env enhancements

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -136,6 +136,7 @@ path to the log file is displayed after the run completes.
 - ``ALPHA_AGI_TARGET`` – specify the target sector index.
 - ``ALPHA_AGI_SEED`` – RNG seed for deterministic runs.
 - ``ALPHA_AGI_OFFLINE`` – force offline mode even when OpenAI Agents is available.
+- ``ALPHA_AGI_ENABLE_ADK`` – enable the ADK gateway without ``--enable-adk``.
 
 ### Graceful Offline Mode
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -114,6 +114,8 @@ def main(argv: List[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
+
     if not args.skip_verify:
         insight_demo.verify_environment()
 
@@ -127,7 +129,7 @@ def main(argv: List[str] | None = None) -> None:
     if args.offline or not _agents_available():
         _run_offline(args)
     else:
-        if args.enable_adk:
+        if enable_adk:
             os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
         openai_agents_bridge._run_runtime(
             args.episodes or 5,

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -215,6 +215,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
+
     if not args.skip_verify:
         verify_environment()
 
@@ -225,7 +227,7 @@ def main(argv: list[str] | None = None) -> None:
             print(f"- {name}")
         return
 
-    if args.enable_adk:
+    if enable_adk:
         os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
 
     _run_runtime(


### PR DESCRIPTION
## Summary
- enable ADK gateway via `ALPHA_AGI_ENABLE_ADK` environment variable
- document new variable in insight demo README

## Testing
- `./codex/setup.sh` *(fails: no network)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*