### PR TITLE
[alpha_factory] expand default sectors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -11,6 +11,8 @@ transformed by Artificial General Intelligence. It runs a small
 
 - **Zero Data Dependency**: runs entirely offline by default. The default
   sector list ships with the package so no external resources are required.
+  It covers Finance, Healthcare, Education, Manufacturing, Transportation,
+  Energy, Retail, Agriculture, Defense and Real Estate.
 - **OpenAI Agents SDK Integration**: seamlessly switches to hosted execution when API credentials are present.
 - **Automatic ADK Support**: optional Google ADK gateway activates when available.
 - **Model Context Protocol Logging**: export `MCP_ENDPOINT` to persist all prompts and replies.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/configs/default.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/configs/default.yaml
@@ -6,4 +6,14 @@ target: 3
 seed: 0
 model: gpt-4o
 # comma-separated list or YAML array of sectors
-sectors: [Finance, Healthcare, Education]
+sectors:
+  - Finance
+  - Healthcare
+  - Education
+  - Manufacturing
+  - Transportation
+  - Energy
+  - Retail
+  - Agriculture
+  - Defense
+  - Real Estate


### PR DESCRIPTION
## Summary
- expand default sector list to ten entries
- document the default sector list in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: import errors)*