### PR TITLE
[alpha_factory] add beyond foresight demo wrapper

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -92,6 +92,13 @@ python official_demo_final.py --offline --episodes 2
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
+For a splashier startup message use ``alpha-agi-beyond-foresight`` which
+displays a short banner before running the same final demo:
+
+```bash
+alpha-agi-beyond-foresight --offline --episodes 2
+```
+The arguments mirror ``alpha-agi-insight-final``.
 Use ``--version`` to show the installed package version and exit.
 
 ## Usage

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -6,5 +6,13 @@ from . import openai_agents_bridge
 from .run_demo import main as run_demo
 from .official_demo import main as official_demo
 from .official_demo_final import main as official_demo_final
+from .beyond_human_foresight import main as beyond_human_foresight
 
-__all__ = ["main", "openai_agents_bridge", "run_demo", "official_demo", "official_demo_final"]
+__all__ = [
+    "main",
+    "openai_agents_bridge",
+    "run_demo",
+    "official_demo",
+    "official_demo_final",
+    "beyond_human_foresight",
+]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Launch the Beyond Human Foresight variant of the α‑AGI Insight demo.
+
+This thin wrapper simply prints a short banner before delegating to
+:mod:`official_demo_final`. It inherits all functionality from the
+standard final demo including automatic environment verification,
+optional OpenAI Agents SDK integration and graceful offline mode.
+"""
+from __future__ import annotations
+
+from typing import List
+
+if __package__ is None:  # pragma: no cover - allow direct execution
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
+
+from .official_demo_final import main as _main
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Entry point for the Beyond Human Foresight demo."""
+    banner = "\N{MILITARY MEDAL} \N{GREEK SMALL LETTER ALPHA}\N{HYPHEN-MINUS}AGI Insight \N{EYE}\N{SPARKLES} — Beyond Human Foresight"
+    print(banner)
+    _main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ alpha-agi-insight-demo = "alpha_factory_v1.demos.alpha_agi_insight_v0.run_demo:m
 alpha-agi-insight-bridge = "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge:main"
 alpha-agi-insight-official = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo:main"
 alpha-agi-insight-final = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final:main"
+alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add `beyond_human_foresight.py` wrapper printing a banner then delegating to the final demo
- export new helper from package and expose console script
- document the new entry point in README

## Testing
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight --offline --episodes 1`
- `python alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py --offline --episodes 1`
- `pytest tests/test_official_final_demo.py -q`