### PR TITLE
[alpha_factory] enhance AGI Insight demo env vars

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -146,6 +146,8 @@ path to the log file is displayed after the run completes.
 - ``ALPHA_AGI_SEED`` – RNG seed for deterministic runs.
 - ``ALPHA_AGI_OFFLINE`` – force offline mode even when OpenAI Agents is available.
 - ``ALPHA_AGI_ENABLE_ADK`` – enable the ADK gateway without ``--enable-adk``.
+- ``ALPHA_AGI_ADK_HOST`` – custom bind host for the ADK gateway.
+- ``ALPHA_AGI_ADK_PORT`` – custom bind port for the ADK gateway.
 
 ### Graceful Offline Mode
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -117,6 +117,13 @@ def main(argv: List[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
+    if args.adk_host is None:
+        args.adk_host = os.getenv("ALPHA_AGI_ADK_HOST")
+    if args.adk_port is None and os.getenv("ALPHA_AGI_ADK_PORT"):
+        try:
+            args.adk_port = int(os.getenv("ALPHA_AGI_ADK_PORT"))
+        except ValueError:
+            args.adk_port = None
 
     if not args.skip_verify:
         insight_demo.verify_environment()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -250,6 +250,13 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
+    if args.adk_host is None:
+        args.adk_host = os.getenv("ALPHA_AGI_ADK_HOST")
+    if args.adk_port is None and os.getenv("ALPHA_AGI_ADK_PORT"):
+        try:
+            args.adk_port = int(os.getenv("ALPHA_AGI_ADK_PORT"))
+        except ValueError:
+            args.adk_port = None
 
     if not args.skip_verify:
         verify_environment()


### PR DESCRIPTION
## Summary
- support `ALPHA_AGI_ADK_HOST` and `ALPHA_AGI_ADK_PORT` environment variables
- document new variables in the demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError due to pydantic and other issues)*