### PR TITLE
[alpha_factory] add production launcher for insight demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ sequenceDiagram
 |11|`muzero_planning`|♟|MuZero in 60 s; online world‑model with MCTS.|Distills planning research into a one‑command demo.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
 |13|`meta_agentic_tree_search_v0`|🌳|Recursive agent rewrites via best‑first search.|Rapidly surfaces AGI-driven trading alpha.|`cd alpha_factory_v1/demos/meta_agentic_tree_search_v0 && python run_demo.py --episodes 10`|
-|14|`alpha_agi_insight_v0`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`alpha-agi-insight-final --episodes 5`|
+|14|`alpha_agi_insight_v0`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`alpha-agi-insight-production --episodes 5`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -92,6 +92,10 @@ python official_demo_final.py --offline --episodes 2
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
+For production deployments launch ``official_demo_production.py`` or use the
+``alpha-agi-insight-production`` entrypoint. This variant verifies the
+environment by default and automatically selects between the hosted runtime
+and the offline CLI.
 For a splashier startup message use ``alpha-agi-beyond-foresight`` which
 displays a short banner before running the same final demo:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -6,6 +6,7 @@ from . import openai_agents_bridge
 from .run_demo import main as run_demo
 from .official_demo import main as official_demo
 from .official_demo_final import main as official_demo_final
+from .official_demo_production import main as official_demo_production
 from .beyond_human_foresight import main as beyond_human_foresight
 
 __all__ = [
@@ -14,5 +15,6 @@ __all__ = [
     "run_demo",
     "official_demo",
     "official_demo_final",
+    "official_demo_production",
     "beyond_human_foresight",
 ]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Production launcher for the α‑AGI Insight demo.
+
+This helper unifies environment validation with automatic runtime
+selection. When the optional OpenAI Agents runtime is available and an
+API key is configured the demo is exposed through the hosted runtime.
+Otherwise it falls back to the local command line interface. The Google
+ADK gateway activates when present. This script works entirely offline
+when no API credentials are supplied.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+from typing import List
+
+from . import insight_demo, openai_agents_bridge
+from ... import get_version
+
+
+def _agents_available() -> bool:
+    """Return ``True`` when the OpenAI Agents runtime can be used."""
+    if os.getenv("ALPHA_AGI_OFFLINE"):
+        return False
+    spec = importlib.util.find_spec("openai_agents")
+    return bool(spec and os.getenv("OPENAI_API_KEY"))
+
+
+def _run_offline(args: argparse.Namespace) -> None:
+    print("Running offline demo…")
+    sectors = insight_demo.parse_sectors(None, args.sectors)
+    episodes = int(args.episodes or os.getenv("ALPHA_AGI_EPISODES", 0) or 5)
+    exploration = float(
+        args.exploration if args.exploration is not None else os.getenv("ALPHA_AGI_EXPLORATION", 1.4)
+    )
+    rewriter = args.rewriter or os.getenv("MATS_REWRITER")
+    target = int(args.target if args.target is not None else os.getenv("ALPHA_AGI_TARGET", 3))
+    seed_val = args.seed if args.seed is not None else os.getenv("ALPHA_AGI_SEED")
+    seed = int(seed_val) if seed_val is not None else None
+    model = args.model or os.getenv("OPENAI_MODEL")
+
+    insight_demo.run(
+        episodes=episodes,
+        exploration=exploration,
+        rewriter=rewriter,
+        log_dir=Path(args.log_dir) if args.log_dir else None,
+        target=target,
+        seed=seed,
+        model=model,
+        sectors=sectors,
+    )
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Entry point for the production demo."""
+    parser = argparse.ArgumentParser(description="Launch the α‑AGI Insight production demo")
+    parser.add_argument("--episodes", type=int, help="Search iterations")
+    parser.add_argument("--target", type=int, help="Target sector index")
+    parser.add_argument("--exploration", type=float, help="Exploration constant")
+    parser.add_argument("--seed", type=int, help="Optional RNG seed")
+    parser.add_argument("--model", type=str, help="Model override")
+    parser.add_argument("--rewriter", choices=["random", "openai", "anthropic"], help="Rewrite strategy")
+    parser.add_argument("--sectors", type=str, help="Comma-separated sectors or path to file")
+    parser.add_argument("--log-dir", type=str, help="Directory for episode metrics")
+    parser.add_argument("--offline", action="store_true", help="Force offline mode")
+    parser.add_argument("--skip-verify", action="store_true", help="Skip environment check")
+    parser.add_argument("--enable-adk", action="store_true", help="Expose agent via the optional ADK gateway")
+    parser.add_argument("--adk-host", type=str, help="ADK bind host")
+    parser.add_argument("--adk-port", type=int, help="ADK bind port")
+    parser.add_argument("--list-sectors", action="store_true", help="Show the resolved sector list and exit")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+        help="Show package version and exit",
+    )
+    args = parser.parse_args(argv)
+
+    enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
+    if args.adk_host is None:
+        args.adk_host = os.getenv("ALPHA_AGI_ADK_HOST")
+    if args.adk_port is None and os.getenv("ALPHA_AGI_ADK_PORT"):
+        try:
+            args.adk_port = int(os.getenv("ALPHA_AGI_ADK_PORT"))
+        except ValueError:
+            args.adk_port = None
+
+    if not args.skip_verify:
+        insight_demo.verify_environment()
+
+    if args.list_sectors:
+        for name in insight_demo.parse_sectors(None, args.sectors):
+            print(f"- {name}")
+        return
+
+    if args.offline or not _agents_available():
+        _run_offline(args)
+    else:
+        if enable_adk:
+            os.environ.setdefault("ALPHA_FACTORY_ENABLE_ADK", "true")
+        openai_agents_bridge._run_runtime(
+            args.episodes or 5,
+            args.target or 3,
+            args.model,
+            args.rewriter,
+            args.log_dir,
+            args.sectors,
+            exploration=args.exploration,
+            seed=args.seed,
+            adk_host=args.adk_host,
+            adk_port=args.adk_port,
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ alpha-agi-insight-bridge = "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_a
 alpha-agi-insight-official = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo:main"
 alpha-agi-insight-final = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final:main"
 alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
+alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_production:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add `official_demo_production.py` for the α‑AGI Insight demo
- export new launcher in `__init__.py`
- expose console script `alpha-agi-insight-production`
- document the production launcher in the demo README
- update root README to use the new entrypoint

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*