### PR TITLE
[alpha_factory] refresh beyond foresight wrapper

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -95,14 +95,14 @@ Pass ``--list-sectors`` to display the resolved sector list without running the 
 For production deployments launch ``official_demo_production.py`` or use the
 ``alpha-agi-insight-production`` entrypoint. This variant verifies the
 environment by default and automatically selects between the hosted runtime
-and the offline CLI.
-For a splashier startup message use ``alpha-agi-beyond-foresight`` which
-displays a short banner before running the same final demo:
+and the offline CLI.  For a splashier startup message run
+``alpha-agi-beyond-foresight`` which displays a short banner before delegating
+to the same production demo:
 
 ```bash
 alpha-agi-beyond-foresight --offline --episodes 2
 ```
-The arguments mirror ``alpha-agi-insight-final``.
+The arguments mirror ``alpha-agi-insight-production``.
 Use ``--version`` to show the installed package version and exit.
 
 ## Usage

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Launch the Beyond Human Foresight variant of the α‑AGI Insight demo.
 
-This thin wrapper simply prints a short banner before delegating to
-:mod:`official_demo_final`. It inherits all functionality from the
-standard final demo including automatic environment verification,
-optional OpenAI Agents SDK integration and graceful offline mode.
+This thin wrapper prints a short banner then delegates to
+:mod:`official_demo_production`, inheriting automatic environment
+verification, optional OpenAI Agents SDK integration and graceful
+offline mode.  The behaviour mirrors ``alpha-agi-insight-production``
+while providing a flashier startup message.
 """
 from __future__ import annotations
 
@@ -17,7 +18,7 @@ if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
 
-from .official_demo_final import main as _main
+from .official_demo_production import main as _main
 
 
 def main(argv: List[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- point Beyond Human Foresight wrapper at the production demo
- document updated behaviour in the insight README

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_official_final_demo.py -q`
- `pytest tests/test_alpha_agi_insight_demo.py tests/test_alpha_agi_insight_bridge.py tests/test_official_insight_demo.py -q`
- `pytest -q` *(fails: 16 errors during collection)*