### PR TITLE
[alpha_factory] make production insight demo runnable standalone

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -16,6 +16,13 @@ import os
 from pathlib import Path
 from typing import List
 
+if __package__ is None:  # pragma: no cover - allow direct execution
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
+
 from . import insight_demo, openai_agents_bridge
 from ... import get_version
 


### PR DESCRIPTION
## Summary
- allow running `official_demo_production.py` without needing the package

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_official_final_demo.py -q`
- `pytest tests/test_alpha_agi_insight_demo.py -q`
- `pytest tests/test_alpha_agi_insight_bridge.py -q`
- `pytest tests/test_alpha_agi_insight_main.py -q`
- `pytest tests/test_official_insight_demo.py -q`
- `pytest -q` *(fails: ImportError while importing alpha_model, 16 errors)*