### PR TITLE
[alpha_factory] Fix param forwarding in insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -147,6 +147,8 @@ def main(argv: List[str] | None = None) -> None:
             args.rewriter,
             args.log_dir,
             args.sectors,
+            exploration=args.exploration,
+            seed=args.seed,
             adk_host=args.adk_host,
             adk_port=args.adk_port,
         )


### PR DESCRIPTION
## Summary
- ensure `official_demo_final.py` passes exploration and seed options to the OpenAI Agents runtime

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 16 errors during collection)*