### PR TITLE
[alpha_factory] enhance final AGI Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -94,6 +94,7 @@ python official_demo_final.py --offline --episodes 2
 ```
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
+Use `--no-banner` to suppress the startup banner when embedding the demo in automated scripts.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
 For production deployments launch ``official_demo_production.py`` or use the
 ``alpha-agi-insight-production`` entrypoint. This variant verifies the

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -114,6 +114,11 @@ def main(argv: List[str] | None = None) -> None:
         version=f"%(prog)s {get_version()}",
         help="Show package version and exit",
     )
+    parser.add_argument(
+        "--no-banner",
+        action="store_true",
+        help="Suppress the startup banner",
+    )
     args = parser.parse_args(argv)
 
     enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
@@ -124,6 +129,12 @@ def main(argv: List[str] | None = None) -> None:
             args.adk_port = int(os.getenv("ALPHA_AGI_ADK_PORT"))
         except ValueError:
             args.adk_port = None
+
+    if not args.no_banner:
+        print(
+            "\N{MILITARY MEDAL} \N{GREEK SMALL LETTER ALPHA}\N{HYPHEN-MINUS}AGI Insight "
+            "\N{EYE}\N{SPARKLES} — Beyond Human Foresight"
+        )
 
     if not args.skip_verify:
         insight_demo.verify_environment()


### PR DESCRIPTION
## Summary
- allow suppressing banner in the final demo via `--no-banner`
- document the option in the demo README

## Testing
- `pytest tests/test_official_final_demo.py -q`
- `pytest -q` *(fails: alpha_factory_v1/tests/test_alpha_model.py, alpha_factory_v1/tests/test_genetic_tests.py, alpha_factory_v1/tests/test_local_pytest.py, alpha_factory_v1/tests/test_memory.py, alpha_factory_v1/tests/test_memory_provider.py, alpha_factory_v1/tests/test_orchestrator_rest.py, alpha_factory_v1/tests/test_planner_agent.py, alpha_factory_v1/tests/test_vector_memory.py, tests/test_alpha_opportunity_env.py, tests/test_energy_agent_behavior.py, tests/test_energy_utils.py, tests/test_finance_utils.py, tests/test_manufacturing_agent.py, tests/test_meta_agentic_tree_search_demo.py, tests/test_omni_factory_plugins.py, tests/test_supply_chain_agent.py)*