### PR TITLE
[alpha_factory] fix BaseSettings import

### DIFF
--- a/alpha_factory_v1/backend/memory_fabric.py
+++ b/alpha_factory_v1/backend/memory_fabric.py
@@ -74,7 +74,11 @@ with contextlib.suppress(ModuleNotFoundError):
 with contextlib.suppress(ModuleNotFoundError):
     import openai  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
-    from pydantic import BaseSettings, Field, PositiveInt  # type: ignore
+    try:
+        from pydantic import BaseSettings, Field, PositiveInt  # type: ignore
+    except ImportError:  # pragma: no cover - pydantic >= 2
+        from pydantic import Field, PositiveInt  # type: ignore
+        from pydantic_settings import BaseSettings  # type: ignore
 
 # ───────────────────────── logging ░──────────────────────────
 logger = logging.getLogger("AlphaFactory.MemoryFabric")


### PR DESCRIPTION
## Summary
- fix BaseSettings import for pydantic v2 compatibility

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: TypeError function_tool, duplicated timeseries)*