### PR TITLE
[alpha_factory] clarify final demo command

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -8,7 +8,9 @@ transformed by Artificial General Intelligence. It runs a small
  points to a text file, each non-empty line is treated as a sector name.
 
 **Quick Start:** run ``alpha-agi-beyond-foresight --episodes 5`` to launch the
-production demo with automatic environment selection.
+final production demo with automatic environment selection. This command maps to
+``official_demo_final.py`` and transparently chooses between the hosted runtime
+and offline mode depending on available credentials.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- mention that the `alpha-agi-beyond-foresight` command runs the final demo and selects the best runtime

## Testing
- `./codex/setup.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 5 errors during collection)*