### PR TITLE
[alpha_factory] enhance production demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -96,7 +96,7 @@ python official_demo_final.py --offline --episodes 2
 ```
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
-Use `--no-banner` to suppress the startup banner when embedding the demo in automated scripts.
+Use `--no-banner` to suppress the startup banner when embedding the demo in automated scripts. The same flag also works with ``alpha-agi-insight-production``.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
 For production deployments launch ``official_demo_production.py`` or use the
 ``alpha-agi-insight-production`` entrypoint. This variant verifies the

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -83,6 +83,11 @@ def main(argv: List[str] | None = None) -> None:
         version=f"%(prog)s {get_version()}",
         help="Show package version and exit",
     )
+    parser.add_argument(
+        "--no-banner",
+        action="store_true",
+        help="Suppress the startup banner",
+    )
     args = parser.parse_args(argv)
 
     enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
@@ -93,6 +98,12 @@ def main(argv: List[str] | None = None) -> None:
             args.adk_port = int(os.getenv("ALPHA_AGI_ADK_PORT"))
         except ValueError:
             args.adk_port = None
+
+    if not args.no_banner:
+        print(
+            "\N{MILITARY MEDAL} \N{GREEK SMALL LETTER ALPHA}\N{HYPHEN-MINUS}AGI Insight "
+            "\N{EYE}\N{SPARKLES}  Beyond Human Foresight"
+        )
 
     if not args.skip_verify:
         insight_demo.verify_environment()


### PR DESCRIPTION
## Summary
- add `--no-banner` option to `official_demo_production.py`
- show the banner unless suppressed
- document the flag in the insight demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 51 failed, 171 passed, 7 skipped)*