### PR TITLE
[alpha_factory] add banner env toggle

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -96,7 +96,7 @@ python official_demo_final.py --offline --episodes 2
 ```
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
-Use `--no-banner` to suppress the startup banner when embedding the demo in automated scripts. The same flag also works with ``alpha-agi-insight-production``.
+Use ``--no-banner`` or set ``ALPHA_AGI_NO_BANNER=true`` to suppress the startup banner when embedding the demo in automated scripts. The same flag also works with ``alpha-agi-insight-production``.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
 For production deployments launch ``official_demo_production.py`` or use the
 ``alpha-agi-insight-production`` entrypoint. This variant verifies the
@@ -158,6 +158,7 @@ path to the log file is displayed after the run completes.
 - ``ALPHA_AGI_ENABLE_ADK`` – enable the ADK gateway without ``--enable-adk``.
 - ``ALPHA_AGI_ADK_HOST`` – custom bind host for the ADK gateway.
 - ``ALPHA_AGI_ADK_PORT`` – custom bind port for the ADK gateway.
+- ``ALPHA_AGI_NO_BANNER`` – suppress the startup banner when set to ``true``.
 
 ### Graceful Offline Mode
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -121,6 +121,10 @@ def main(argv: List[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    no_banner_env = os.getenv("ALPHA_AGI_NO_BANNER")
+    if no_banner_env and not args.no_banner:
+        args.no_banner = no_banner_env.lower() == "true"
+
     enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
     if args.adk_host is None:
         args.adk_host = os.getenv("ALPHA_AGI_ADK_HOST")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -40,10 +40,14 @@ def _run_offline(args: argparse.Namespace) -> None:
     sectors = insight_demo.parse_sectors(None, args.sectors)
     episodes = int(args.episodes or os.getenv("ALPHA_AGI_EPISODES", 0) or 5)
     exploration = float(
-        args.exploration if args.exploration is not None else os.getenv("ALPHA_AGI_EXPLORATION", 1.4)
+        args.exploration
+        if args.exploration is not None
+        else os.getenv("ALPHA_AGI_EXPLORATION", 1.4)
     )
     rewriter = args.rewriter or os.getenv("MATS_REWRITER")
-    target = int(args.target if args.target is not None else os.getenv("ALPHA_AGI_TARGET", 3))
+    target = int(
+        args.target if args.target is not None else os.getenv("ALPHA_AGI_TARGET", 3)
+    )
     seed_val = args.seed if args.seed is not None else os.getenv("ALPHA_AGI_SEED")
     seed = int(seed_val) if seed_val is not None else None
     model = args.model or os.getenv("OPENAI_MODEL")
@@ -62,21 +66,37 @@ def _run_offline(args: argparse.Namespace) -> None:
 
 def main(argv: List[str] | None = None) -> None:
     """Entry point for the production demo."""
-    parser = argparse.ArgumentParser(description="Launch the α‑AGI Insight production demo")
+    parser = argparse.ArgumentParser(
+        description="Launch the α‑AGI Insight production demo"
+    )
     parser.add_argument("--episodes", type=int, help="Search iterations")
     parser.add_argument("--target", type=int, help="Target sector index")
     parser.add_argument("--exploration", type=float, help="Exploration constant")
     parser.add_argument("--seed", type=int, help="Optional RNG seed")
     parser.add_argument("--model", type=str, help="Model override")
-    parser.add_argument("--rewriter", choices=["random", "openai", "anthropic"], help="Rewrite strategy")
-    parser.add_argument("--sectors", type=str, help="Comma-separated sectors or path to file")
+    parser.add_argument(
+        "--rewriter", choices=["random", "openai", "anthropic"], help="Rewrite strategy"
+    )
+    parser.add_argument(
+        "--sectors", type=str, help="Comma-separated sectors or path to file"
+    )
     parser.add_argument("--log-dir", type=str, help="Directory for episode metrics")
     parser.add_argument("--offline", action="store_true", help="Force offline mode")
-    parser.add_argument("--skip-verify", action="store_true", help="Skip environment check")
-    parser.add_argument("--enable-adk", action="store_true", help="Expose agent via the optional ADK gateway")
+    parser.add_argument(
+        "--skip-verify", action="store_true", help="Skip environment check"
+    )
+    parser.add_argument(
+        "--enable-adk",
+        action="store_true",
+        help="Expose agent via the optional ADK gateway",
+    )
     parser.add_argument("--adk-host", type=str, help="ADK bind host")
     parser.add_argument("--adk-port", type=int, help="ADK bind port")
-    parser.add_argument("--list-sectors", action="store_true", help="Show the resolved sector list and exit")
+    parser.add_argument(
+        "--list-sectors",
+        action="store_true",
+        help="Show the resolved sector list and exit",
+    )
     parser.add_argument(
         "--version",
         action="version",
@@ -89,6 +109,10 @@ def main(argv: List[str] | None = None) -> None:
         help="Suppress the startup banner",
     )
     args = parser.parse_args(argv)
+
+    no_banner_env = os.getenv("ALPHA_AGI_NO_BANNER")
+    if no_banner_env and not args.no_banner:
+        args.no_banner = no_banner_env.lower() == "true"
 
     enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
     if args.adk_host is None:


### PR DESCRIPTION
## Summary
- add `ALPHA_AGI_NO_BANNER` support in `official_demo_final.py`
- add `ALPHA_AGI_NO_BANNER` support in `official_demo_production.py`
- document banner env variable in the insight demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 51 failed, 171 passed, 7 skipped)*