### PR TITLE
[alpha_factory] unify banner printing for Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
@@ -2,10 +2,10 @@
 """Launch the Beyond Human Foresight variant of the α‑AGI Insight demo.
 
 This thin wrapper prints a short banner then delegates to
-:mod:`official_demo_production`, inheriting automatic environment
+:mod:`official_demo_final`, inheriting automatic environment
 verification, optional OpenAI Agents SDK integration and graceful
-offline mode.  The behaviour mirrors ``alpha-agi-insight-production``
-while providing a flashier startup message.
+offline mode.  The behaviour mirrors ``alpha-agi-insight-final`` while
+providing a flashier startup message.
 """
 from __future__ import annotations
 
@@ -18,13 +18,13 @@ if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
 
-from .official_demo_production import main as _main
+from .official_demo_final import main as _main
+from .openai_agents_bridge import print_banner
 
 
 def main(argv: List[str] | None = None) -> None:
     """Entry point for the Beyond Human Foresight demo."""
-    banner = "\N{MILITARY MEDAL} \N{GREEK SMALL LETTER ALPHA}\N{HYPHEN-MINUS}AGI Insight \N{EYE}\N{SPARKLES} — Beyond Human Foresight"
-    print(banner)
+    print_banner()
     _main(argv)
 
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -135,10 +135,7 @@ def main(argv: List[str] | None = None) -> None:
             args.adk_port = None
 
     if not args.no_banner:
-        print(
-            "\N{MILITARY MEDAL} \N{GREEK SMALL LETTER ALPHA}\N{HYPHEN-MINUS}AGI Insight "
-            "\N{EYE}\N{SPARKLES} — Beyond Human Foresight"
-        )
+        openai_agents_bridge.print_banner()
 
     if not args.skip_verify:
         insight_demo.verify_environment()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -24,6 +24,19 @@ DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
 FALLBACK_MODE_PREFIX = "fallback_mode_active: "
 
 
+def banner() -> str:
+    """Return the standard startup banner."""
+    return (
+        "\N{MILITARY MEDAL} \N{GREEK SMALL LETTER ALPHA}\N{HYPHEN-MINUS}AGI"
+        " Insight \N{EYE}\N{SPARKLES} — Beyond Human Foresight"
+    )
+
+
+def print_banner() -> None:
+    """Display the default banner."""
+    print(banner())
+
+
 if __package__ is None:  # pragma: no cover - allow direct execution
     sys.path.append(str(Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
@@ -289,6 +302,8 @@ __all__ = [
     "DEFAULT_MODEL_NAME",
     "has_oai",
     "run_insight_search",
+    "banner",
+    "print_banner",
     "main",
 ]
 


### PR DESCRIPTION
## Summary
- centralize banner in Insight demo utilities
- show banner in beyond_human_foresight and official_demo_final

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_official_final_demo.py tests/test_official_insight_demo.py -q`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry and multiple other failures)*