### PR TITLE
[alpha_factory] enhance insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -187,8 +187,9 @@ The bridge automatically falls back to offline mode when the optional
 packages or API keys are missing. Use ``--enable-adk`` to expose the agent via
 the optional Google ADK gateway when available. Use ``--list-sectors`` to view
 the resolved sector list without running the search. Pass ``--log-dir`` to store
-episode metrics in ``scores.csv``. Additional ``--exploration`` and ``--seed``
-arguments mirror the offline CLI options.
+episode metrics in ``scores.csv``. Use ``--no-banner`` or set ``ALPHA_AGI_NO_BANNER=true``
+to suppress the startup message in automated scripts. Additional ``--exploration``
+and ``--seed`` arguments mirror the offline CLI options.
 
 ### MCP Logging
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -243,6 +243,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Print the resolved sector list and exit",
     )
     parser.add_argument(
+        "--no-banner",
+        action="store_true",
+        help="Suppress the startup banner",
+    )
+    parser.add_argument(
         "--enable-adk",
         action="store_true",
         help="Enable the Google ADK gateway",
@@ -261,6 +266,9 @@ def main(argv: list[str] | None = None) -> None:
         help="Show package version and exit",
     )
     args = parser.parse_args(argv)
+
+    if not args.no_banner and os.getenv("ALPHA_AGI_NO_BANNER", "false").lower() not in {"1", "true", "yes"}:
+        print_banner()
 
     enable_adk = args.enable_adk or os.getenv("ALPHA_AGI_ENABLE_ADK") == "true"
     if args.adk_host is None:


### PR DESCRIPTION
## Summary
- add banner toggle to openai_agents_bridge
- document `--no-banner` option for runtime

## Testing
- `python -m alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge --episodes 1 --list-sectors --no-banner`
- `pytest -q` *(fails: 51 failed, 171 passed, 7 skipped)*