### PR TITLE
[alpha_factory] add JSON output option to insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -66,7 +66,7 @@ def _run_offline(args: argparse.Namespace) -> None:
     seed = int(seed_val) if seed_val is not None else None
     model = args.model or os.getenv("OPENAI_MODEL")
 
-    insight_demo.run(
+    result = insight_demo.run(
         episodes=episodes,
         exploration=exploration,
         rewriter=rewriter,
@@ -75,7 +75,10 @@ def _run_offline(args: argparse.Namespace) -> None:
         seed=seed,
         model=model,
         sectors=sectors,
+        json_output=args.json,
     )
+    if args.json:
+        print(result)
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -107,6 +110,11 @@ def main(argv: List[str] | None = None) -> None:
         "--list-sectors",
         action="store_true",
         help="Display the resolved sector list and exit",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Return JSON summary instead of text",
     )
     parser.add_argument(
         "--version",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -52,7 +52,7 @@ def _run_offline(args: argparse.Namespace) -> None:
     seed = int(seed_val) if seed_val is not None else None
     model = args.model or os.getenv("OPENAI_MODEL")
 
-    insight_demo.run(
+    result = insight_demo.run(
         episodes=episodes,
         exploration=exploration,
         rewriter=rewriter,
@@ -61,7 +61,10 @@ def _run_offline(args: argparse.Namespace) -> None:
         seed=seed,
         model=model,
         sectors=sectors,
+        json_output=args.json,
     )
+    if args.json:
+        print(result)
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -96,6 +99,11 @@ def main(argv: List[str] | None = None) -> None:
         "--list-sectors",
         action="store_true",
         help="Show the resolved sector list and exit",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Return JSON summary instead of text",
     )
     parser.add_argument(
         "--version",
@@ -151,6 +159,7 @@ def main(argv: List[str] | None = None) -> None:
             args.sectors,
             exploration=args.exploration,
             seed=args.seed,
+            json_output=args.json,
             adk_host=args.adk_host,
             adk_port=args.adk_port,
         )

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -65,6 +65,7 @@ if has_oai:
         log_dir: str | None = None,
         exploration: float | None = None,
         seed: int | None = None,
+        json_output: bool | None = None,
     ) -> str:
         """Execute the search loop and return the textual summary."""
         if model:
@@ -81,6 +82,7 @@ if has_oai:
             exploration=exploration or 1.4,
             seed=seed,
             sectors=sector_list,
+            json_output=bool(json_output),
         )
         return result
 
@@ -99,6 +101,7 @@ if has_oai:
                 log_dir=params.get("log_dir"),
                 exploration=float(params.get("exploration", 1.4)),
                 seed=params.get("seed"),
+                json_output=params.get("json", False),
             )
 
     def _run_runtime(
@@ -110,6 +113,7 @@ if has_oai:
         sectors: str | None = None,
         exploration: float | None = None,
         seed: int | None = None,
+        json_output: bool | None = None,
         *,
         adk_host: str | None = None,
         adk_port: int | None = None,
@@ -154,6 +158,7 @@ else:
         log_dir: str | None = None,
         exploration: float | None = None,
         seed: int | None = None,
+        json_output: bool | None = None,
     ) -> str:
         sector_list = parse_sectors(None, sectors)
         summary = run(
@@ -165,6 +170,7 @@ else:
             exploration=exploration or 1.4,
             seed=seed,
             sectors=sector_list,
+            json_output=bool(json_output),
         )
         return f"{FALLBACK_MODE_PREFIX}{summary}"
 
@@ -177,6 +183,7 @@ else:
         sectors: str | None = None,
         exploration: float | None = None,
         seed: int | None = None,
+        json_output: bool | None = None,
         *,
         adk_host: str | None = None,
         adk_port: int | None = None,
@@ -206,6 +213,7 @@ else:
             seed=seed,
             model=model,
             sectors=sector_list,
+            json_output=bool(json_output),
         )
 
 
@@ -260,6 +268,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Skip runtime dependency checks",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Return JSON summary when offline or via tool",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {get_version()}",
@@ -301,6 +314,7 @@ def main(argv: list[str] | None = None) -> None:
         args.sectors,
         args.exploration,
         args.seed,
+        json_output=args.json,
         adk_host=args.adk_host,
         adk_port=args.adk_port,
     )


### PR DESCRIPTION
## Summary
- extend `insight_demo.run` with optional JSON output
- plumb `--json` flag through CLI wrappers
- support JSON mode in OpenAI Agents bridge

## Testing
- `./codex/setup.sh` *(fails: no network access)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 51 failed, 171 passed)*