### PR TITLE
[alpha_factory] refresh insight demo runtime availability

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -40,8 +40,7 @@ def _agents_available() -> bool:
 
     if os.getenv("ALPHA_AGI_OFFLINE"):
         return False
-
-    return openai_agents_bridge.has_oai
+    return openai_agents_bridge.refresh_runtime_availability()
 
 
 def _run_offline(args: argparse.Namespace) -> None:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -31,7 +31,7 @@ def _agents_available() -> bool:
     """Return ``True`` when the OpenAI Agents runtime can be used."""
     if os.getenv("ALPHA_AGI_OFFLINE"):
         return False
-    return openai_agents_bridge.has_oai
+    return openai_agents_bridge.refresh_runtime_availability()
 
 
 def _run_offline(args: argparse.Namespace) -> None:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -52,6 +52,18 @@ except ValueError:  # loaded stub with missing spec
 _has_key = bool(os.getenv("OPENAI_API_KEY"))
 has_oai = _spec is not None and _has_key
 
+
+def refresh_runtime_availability() -> bool:
+    """Recompute :data:`has_oai` after environment changes."""
+    global has_oai
+    try:
+        spec = importlib.util.find_spec("openai_agents")
+    except ValueError:  # pragma: no cover - loaded stub without spec
+        spec = None
+    have_key = bool(os.getenv("OPENAI_API_KEY"))
+    has_oai = spec is not None and have_key
+    return has_oai
+
 if has_oai:
     from openai_agents import Agent, AgentRuntime, Tool  # type: ignore
 
@@ -323,6 +335,7 @@ def main(argv: list[str] | None = None) -> None:
 __all__ = [
     "DEFAULT_MODEL_NAME",
     "has_oai",
+    "refresh_runtime_availability",
     "run_insight_search",
     "banner",
     "print_banner",


### PR DESCRIPTION
## Summary
- refresh OpenAI runtime check after environment changes
- ensure final and production demos use updated detection

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_official_final_demo.py::TestOfficialFinalDemo::test_final_demo_short -q`
- `pytest -q` *(fails: demo shell scripts and others)*