### PR TITLE
[alpha_factory] fix metrics setup

### DIFF
--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -169,10 +169,12 @@ class PingAgent(AgentBase):
 
         span_cm = (
             _OTEL.tracer.start_as_current_span("ping-agent.step")
-            if _OTEL.tracer else
-            nullcontext()
+            if _OTEL.tracer
+            else nullcontext()
         )
-        async with span_cm:  # type: ignore[var-annotated]
+        # ``start_as_current_span`` returns a synchronous context manager so we
+        # use a regular ``with`` block for compatibility.
+        with span_cm:  # type: ignore[var-annotated]
             now_iso = start_ts.isoformat(timespec="seconds")
             ctx: Mapping[str, Any] = {"agent": self.NAME}
 


### PR DESCRIPTION
## Summary
- fix metrics registration to avoid duplication in Prometheus registry
- update PingAgent to use normal context manager for OpenTelemetry spans

## Testing
- `python check_env.py --auto-install`
- `pytest alpha_factory_v1/tests/test_ping_agent.py::PingAgentTest::test_metrics_setup_with_stubs -q`
- `pytest tests/test_agents_registry.py::TestAgentRegistryFunctions::test_register_and_get -q`
