### PR TITLE
[alpha_factory] improve json output for insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -174,7 +174,8 @@ def run(
     sector = sectors[best.agents[0] % len(sectors)]
     score = best.reward / (best.visits or 1)
     summary_text = f"Best sector: {sector} score: {score:.3f}"
-    print(summary_text)
+    if not json_output:
+        print(summary_text)
 
     sector_scores: dict[int, float] = {}
     stack = [tree.root]
@@ -188,7 +189,7 @@ def run(
     ranking = sorted(
         ((sectors[i], sc) for i, sc in sector_scores.items()), key=lambda t: t[1], reverse=True
     )
-    if ranking:
+    if ranking and not json_output:
         print("Top sectors:")
         for pos, (name, sc) in enumerate(ranking[:3], 1):
             print(f" {pos}. {name} → {sc:.3f}")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py
@@ -216,7 +216,7 @@ else:
             seed_env = os.getenv("ALPHA_AGI_SEED")
             seed = int(seed_env) if seed_env else None
         model = model or os.getenv("OPENAI_MODEL")
-        run(
+        summary = run(
             episodes=episodes,
             exploration=exploration,
             rewriter=rewriter,
@@ -227,6 +227,8 @@ else:
             sectors=sector_list,
             json_output=bool(json_output),
         )
+        if json_output:
+            print(summary)
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- only print text summaries when not using JSON
- return JSON result from the OpenAI bridge when run offline

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_alpha_agi_insight_demo.py tests/test_alpha_agi_insight_bridge.py tests/test_official_final_demo.py tests/test_official_insight_demo.py -q`