### PR TITLE
[alpha_factory] add ranking chart output

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -140,7 +140,9 @@ When optional dependencies such as ``openai`` or ``anthropic`` are not
 installed, the program automatically falls back to a simple offline rewriter so
 the demo remains functional anywhere.  Episode scores are printed to the console
 and optionally written to ``scores.csv`` when ``--log-dir`` is supplied.  The
-path to the log file is displayed after the run completes.
+path to the log file is displayed after the run completes. When ``matplotlib``
+is available a ``ranking.png`` chart summarizing the sector scores is also
+generated in the log directory.
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
- create bar chart for AGI Insight ranking when matplotlib is available
- document chart generation in demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'better_profanity', TypeError: 'FunctionTool' object is not callable, FileNotFoundError, etc.)*
- `python alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py --offline --episodes 1 --log-dir tmpdemo --json`