### PR TITLE
[alpha_factory] add REST API for insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -60,6 +60,18 @@ the companion ``alpha-agi-insight-bridge`` command:
 alpha-agi-insight-bridge --episodes 5
 ```
 
+### REST API
+
+Launch a small FastAPI server that exposes the search loop via ``/insight``. The
+service runs entirely offline by default and mirrors the CLI options:
+
+```bash
+alpha-agi-insight-api --port 8000
+```
+
+Send a POST request with JSON payload ``{"episodes":5}`` to ``/insight`` to
+retrieve the ranking as structured data.
+
 ### Quick Start Script
 
 Ensure the shell helper is executable by running ``chmod +x run_insight_demo.sh`` if needed.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -8,6 +8,7 @@ from .official_demo import main as official_demo
 from .official_demo_final import main as official_demo_final
 from .official_demo_production import main as official_demo_production
 from .beyond_human_foresight import main as beyond_human_foresight
+from .api_server import main as api_server
 
 __all__ = [
     "main",
@@ -17,4 +18,5 @@ __all__ = [
     "official_demo_final",
     "official_demo_production",
     "beyond_human_foresight",
+    "api_server",
 ]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/api_server.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Minimal FastAPI wrapper for the α‑AGI Insight demo.
+
+The server exposes a single ``/insight`` endpoint that runs the
+Meta‑Agentic Tree Search and returns the ranked sector scores as JSON.
+It can operate fully offline and requires no external data.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn
+
+from .insight_demo import parse_sectors, run, verify_environment
+
+app = FastAPI(title="α‑AGI Insight API")
+
+
+class InsightRequest(BaseModel):
+    """Request payload for the ``/insight`` endpoint."""
+
+    episodes: int = 5
+    exploration: float = 1.4
+    rewriter: Optional[str] = None
+    target: int = 3
+    seed: Optional[int] = None
+    model: Optional[str] = None
+    sectors: Optional[str] = None
+
+
+@app.get("/healthz")
+def health() -> dict[str, str]:
+    """Simple health probe used by tests and orchestrators."""
+
+    return {"status": "ok"}
+
+
+@app.post("/insight")
+def insight(req: InsightRequest) -> dict:
+    """Run the search loop and return a JSON summary."""
+
+    sector_list = parse_sectors(None, req.sectors)
+    summary = run(
+        episodes=req.episodes,
+        exploration=req.exploration,
+        rewriter=req.rewriter,
+        target=req.target,
+        seed=req.seed,
+        model=req.model,
+        sectors=sector_list,
+        json_output=True,
+    )
+    return json.loads(summary)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Launch the API server."""
+
+    parser = argparse.ArgumentParser(description="Run the α‑AGI Insight API")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port")
+    parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip environment verification",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.skip_verify:
+        verify_environment()
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ alpha-agi-insight-official = "alpha_factory_v1.demos.alpha_agi_insight_v0.offici
 alpha-agi-insight-final = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final:main"
 alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_production:main"
+alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add FastAPI api_server exposing /insight endpoint
- export new api entrypoint in package and pyproject
- document REST API usage in README

## Testing
- `./codex/setup.sh` *(failed: Could not fetch dependencies)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 41 failed, 181 passed, 7 skipped)*