### PR TITLE
[alpha_factory] Clarify insight demo launch

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -11,6 +11,9 @@ transformed by Artificial General Intelligence. It runs a small
 final production demo with automatic environment selection. This command maps to
 ``official_demo_final.py`` and transparently chooses between the hosted runtime
 and offline mode depending on available credentials.
+Alternatively run ``alpha-agi-insight-final`` for the same behaviour or
+``alpha-agi-insight-production`` to verify the environment and enable the
+optional ADK gateway when available.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- clarify README with commands for alpha-agi-insight-final and production launch

## Testing
- `./codex/setup.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 41 failed, 181 passed, 7 skipped)*