### PR TITLE
[alpha_factory] update insight demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ sequenceDiagram
 |11|`muzero_planning`|♟|MuZero in 60 s; online world‑model with MCTS.|Distills planning research into a one‑command demo.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
 |13|`meta_agentic_tree_search_v0`|🌳|Recursive agent rewrites via best‑first search.|Rapidly surfaces AGI-driven trading alpha.|`cd alpha_factory_v1/demos/meta_agentic_tree_search_v0 && python run_demo.py --episodes 10`|
-|14|`alpha_agi_insight_v0`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`alpha-agi-insight-production --episodes 5`|
+|14|`alpha_agi_insight_v0`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`alpha-agi-beyond-foresight --episodes 5`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.
 


### PR DESCRIPTION
## Summary
- update README to use `alpha-agi-beyond-foresight` as the quickstart command for the insight demo

## Testing
- `bash codex/setup.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 41 failed, 181 passed, 7 skipped)*