### PR TITLE
[alpha_factory] add alias command for insight demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ After installation, launch the official demo via:
 
 ```bash
 alpha-agi-beyond-foresight --episodes 5
+# Shorter alias
+alpha-agi-bhf --episodes 5
 ```
 
 When API keys are configured the program automatically uses the OpenAI Agents
@@ -373,7 +375,7 @@ sequenceDiagram
 |11|`muzero_planning`|♟|MuZero in 60 s; online world‑model with MCTS.|Distills planning research into a one‑command demo.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
 |13|`meta_agentic_tree_search_v0`|🌳|Recursive agent rewrites via best‑first search.|Rapidly surfaces AGI-driven trading alpha.|`cd alpha_factory_v1/demos/meta_agentic_tree_search_v0 && python run_demo.py --episodes 10`|
-|14|`alpha_agi_insight_v0`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`alpha-agi-beyond-foresight --episodes 5`|
+|14|`alpha_agi_insight_v0`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`alpha-agi-beyond-foresight --episodes 5` or `alpha-agi-bhf --episodes 5`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ alpha-agi-insight-bridge = "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_a
 alpha-agi-insight-official = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo:main"
 alpha-agi-insight-final = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final:main"
 alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
+alpha-agi-bhf = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_production:main"
 alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
 


### PR DESCRIPTION
## Summary
- add `alpha-agi-bhf` alias for Beyond Human Foresight
- document new alias in README

## Testing
- `pytest -q` *(fails: test suite has 41 failures, 181 passed)*