### PR TITLE
[alpha_factory] add Streamlit dashboard for insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -9,6 +9,7 @@ from .official_demo_final import main as official_demo_final
 from .official_demo_production import main as official_demo_production
 from .beyond_human_foresight import main as beyond_human_foresight
 from .api_server import main as api_server
+from .insight_dashboard import main as insight_dashboard
 
 __all__ = [
     "main",
@@ -19,4 +20,5 @@ __all__ = [
     "official_demo_production",
     "beyond_human_foresight",
     "api_server",
+    "insight_dashboard",
 ]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_dashboard.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_dashboard.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Streamlit dashboard for the α‑AGI Insight demo."""
+from __future__ import annotations
+
+import json
+
+from .insight_demo import DEFAULT_SECTORS, parse_sectors, run, verify_environment
+
+
+def main() -> None:
+    """Launch the Streamlit dashboard."""
+    try:
+        import streamlit as st
+    except Exception as exc:  # pragma: no cover - optional dep
+        raise SystemExit(
+            "Streamlit is required for the dashboard. Install via `pip install streamlit`."
+        ) from exc
+
+    st.set_page_config(page_title="α‑AGI Insight Dashboard", page_icon="👁️")
+    st.title("👁️ α‑AGI Insight — Beyond Human Foresight")
+
+    st.sidebar.header("Configuration")
+
+    episodes = st.sidebar.number_input("Episodes", min_value=1, max_value=50, value=5)
+    exploration = st.sidebar.number_input(
+        "Exploration", min_value=0.1, max_value=5.0, value=1.4, step=0.1
+    )
+    rewriter = st.sidebar.selectbox("Rewriter", ["random", "openai", "anthropic"], 0)
+    target = st.sidebar.number_input("Target index", min_value=0, value=3)
+    sectors_text = st.sidebar.text_area(
+        "Sectors (comma separated)", ", ".join(DEFAULT_SECTORS)
+    )
+    seed = st.sidebar.number_input("Seed", value=0)
+    model = st.sidebar.text_input("Model", value="gpt-4o")
+
+    if st.sidebar.button("Run Search"):
+        verify_environment()
+        sectors = parse_sectors(None, sectors_text)
+        result_json = run(
+            episodes=episodes,
+            exploration=exploration,
+            rewriter=rewriter,
+            target=target,
+            seed=seed,
+            model=model,
+            sectors=sectors,
+            json_output=True,
+        )
+        data = json.loads(result_json)
+        st.subheader(f"Best sector: {data['best']} – score {data['score']:.3f}")
+        if data.get("ranking"):
+            sectors_r, scores = zip(*data["ranking"])
+            st.bar_chart({"impact": scores}, x=sectors_r)
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond
 alpha-agi-bhf = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_production:main"
 alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
+alpha-agi-insight-dashboard = "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_dashboard"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add a small Streamlit dashboard for the α‑AGI Insight demo
- expose the dashboard via the `alpha-agi-insight-dashboard` entrypoint

## Testing
- `python alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py --episodes 1 --offline`
- `pytest tests/test_official_final_demo.py::TestOfficialFinalDemo::test_final_demo_short` *(fails: Streamlit is required for the dashboard. Install via `pip install streamlit`)*