### PR TITLE
[alpha_factory] add dashboard entrypoint

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -120,6 +120,17 @@ alpha-agi-insight-api --port 8000
 Send a POST request with JSON payload ``{"episodes":5}`` to ``/insight`` to
 retrieve the ranking as structured data.
 
+### Streamlit Dashboard
+
+Launch an interactive web dashboard for exploring the demo:
+
+```bash
+alpha-agi-insight-dashboard
+```
+
+The dashboard lets you tweak parameters and immediately visualise the ranked
+sector scores in a browser.
+
 ### Quick Start Script
 
 Ensure the shell helper is executable by running ``chmod +x run_insight_demo.sh`` if needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond
 alpha-agi-bhf = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_production:main"
 alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
+alpha-agi-insight-dashboard = "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_dashboard:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- expose Streamlit dashboard via new `alpha-agi-insight-dashboard` console entry
- document dashboard usage in the demo README

## Testing
- `./codex/setup.sh` *(fails: could not install build dependencies)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 41 failed, 181 passed, 7 skipped)*