### PR TITLE
[alpha_factory] add default insight alias

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -7,11 +7,12 @@ transformed by Artificial General Intelligence. It runs a small
  list with ``--sectors`` to experiment with your own domains. When the argument
  points to a text file, each non-empty line is treated as a sector name.
 
-**Quick Start:** run ``alpha-agi-beyond-foresight --episodes 5`` to launch the
-final production demo with automatic environment selection. This command maps to
-``official_demo_final.py`` and transparently chooses between the hosted runtime
+**Quick Start:** run ``alpha-agi-insight --episodes 5`` or
+``alpha-agi-beyond-foresight --episodes 5`` to launch the final production demo
+with automatic environment selection. Both commands map to
+``official_demo_final.py`` and transparently choose between the hosted runtime
 and offline mode depending on available credentials.
-Alternatively run ``alpha-agi-insight-final`` for the same behaviour or
+You may also run ``alpha-agi-insight-final`` for the same behaviour or
 ``alpha-agi-insight-production`` to verify the environment and enable the
 optional ADK gateway when available. The companion
 ``official_demo_production.py`` script offers identical behaviour and is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ alpha-agi-insight-demo = "alpha_factory_v1.demos.alpha_agi_insight_v0.run_demo:m
 alpha-agi-insight-bridge = "alpha_factory_v1.demos.alpha_agi_insight_v0.openai_agents_bridge:main"
 alpha-agi-insight-official = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo:main"
 alpha-agi-insight-final = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final:main"
+alpha-agi-insight = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final:main"
 alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-bhf = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_production:main"


### PR DESCRIPTION
## Summary
- add `alpha-agi-insight` console entrypoint
- document new command in α‑AGI Insight README

## Testing
- `./codex/setup.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 41 failed, 181 passed, 7 skipped)*