### PR TITLE
[alpha_factory] add version flag to insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -172,6 +172,7 @@ Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
 Use ``--no-banner`` or set ``ALPHA_AGI_NO_BANNER=true`` to suppress the startup banner when embedding the demo in automated scripts. The same flag also works with ``alpha-agi-insight-production``.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
+Use ``--version`` to print the installed package version and exit.
 For production deployments launch ``official_demo_production.py`` or use the
 ``alpha-agi-insight-production`` entrypoint. This variant verifies the
 environment by default and automatically selects between the hosted runtime

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -20,6 +20,8 @@ import random
 from pathlib import Path
 from typing import List, Optional
 
+from ... import get_version
+
 try:  # optional dependency
     import matplotlib.pyplot as plt
 except Exception:  # pragma: no cover - optional
@@ -289,6 +291,12 @@ def main(argv: List[str] | None = None) -> None:
         "--verify-env",
         action="store_true",
         help="Check runtime dependencies before running",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+        help="Show program version and exit",
     )
     args = parser.parse_args(argv)
     cfg = load_config(args.config)


### PR DESCRIPTION
## Summary
- add `--version` option to insight_demo for parity with other scripts
- document the new flag in the demo README

## Testing
- `pytest -q` *(fails: 41 failed, 181 passed, 7 skipped)*