### PR TITLE
[alpha_factory] support env skip verify

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -242,6 +242,7 @@ generated in the log directory.
 - ``ALPHA_AGI_ADK_HOST`` – custom bind host for the ADK gateway.
 - ``ALPHA_AGI_ADK_PORT`` – custom bind port for the ADK gateway.
 - ``ALPHA_AGI_NO_BANNER`` – suppress the startup banner when set to ``true``.
+- ``ALPHA_AGI_SKIP_VERIFY`` – skip environment checks when set to ``true``.
 
 ### Graceful Offline Mode
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -128,6 +128,10 @@ def main(argv: List[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    skip_verify_env = os.getenv("ALPHA_AGI_SKIP_VERIFY")
+    if skip_verify_env and not args.skip_verify:
+        args.skip_verify = skip_verify_env.lower() == "true"
+
     no_banner_env = os.getenv("ALPHA_AGI_NO_BANNER")
     if no_banner_env and not args.no_banner:
         args.no_banner = no_banner_env.lower() == "true"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -116,6 +116,10 @@ def main(argv: List[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    skip_verify_env = os.getenv("ALPHA_AGI_SKIP_VERIFY")
+    if skip_verify_env and not args.skip_verify:
+        args.skip_verify = skip_verify_env.lower() == "true"
+
     no_banner_env = os.getenv("ALPHA_AGI_NO_BANNER")
     if no_banner_env and not args.no_banner:
         args.no_banner = no_banner_env.lower() == "true"


### PR DESCRIPTION
## Summary
- allow skipping environment checks via `ALPHA_AGI_SKIP_VERIFY`
- document the new variable in the insight demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 41 failed, 181 passed, 7 skipped)*
