### PR TITLE
[alpha_factory] Add Colab notebook for insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -1,4 +1,6 @@
 # α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v0/colab_alpha_agi_insight_demo.ipynb)
+
 
 The **α‑AGI Insight** demo predicts which industry sector is most likely to be
 transformed by Artificial General Intelligence. It runs a small

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/colab_alpha_agi_insight_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/colab_alpha_agi_insight_demo.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# α-AGI Insight Demo \n",
+    "Explore the Beyond Human Foresight demo directly in Colab. This notebook installs the package and runs the official demo with zero external data by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash --no-stderr\nif [[ ! -d AGI-Alpha-Agent-v0 ]]; then\n  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git -q\nfi\ncd AGI-Alpha-Agent-v0\n./codex/setup.sh >/dev/null 2>&1 || true\npython check_env.py --auto-install || true\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optional API keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os\nos.environ['OPENAI_API_KEY'] = ''\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!python alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py --episodes 5 --offline"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Colab notebook for the α‑AGI Insight demo
- link notebook from README

## Testing
- `pytest tests/test_official_final_demo.py::TestOfficialFinalDemo::test_final_demo_short -q`
- ❌ `pytest -q` *(fails: AttributeError in finance_agent and others)*