### PR TITLE
[alpha_factory] add dashboard option to insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -180,6 +180,7 @@ python official_demo_final.py --offline --episodes 2
 ```
 Use ``--enable-adk`` to expose the agent via the optional Google ADK gateway.
 Pass ``--list-sectors`` to display the resolved sector list without running the search.
+Use ``--dashboard`` to launch the interactive Streamlit dashboard instead of the CLI.
 Use ``--no-banner`` or set ``ALPHA_AGI_NO_BANNER=true`` to suppress the startup banner when embedding the demo in automated scripts. The same flag also works with ``alpha-agi-insight-production``.
 ``--adk-host`` and ``--adk-port`` customise the gateway bind address.
 Use ``--version`` to print the installed package version and exit.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -28,6 +28,7 @@ if __package__ is None:  # pragma: no cover - allow `python official_demo_final.
 
 from . import insight_demo
 from . import openai_agents_bridge
+from . import insight_dashboard
 from ... import get_version
 
 
@@ -116,6 +117,11 @@ def main(argv: List[str] | None = None) -> None:
         help="Return JSON summary instead of text",
     )
     parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="Launch the Streamlit dashboard and exit",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {get_version()}",
@@ -156,6 +162,10 @@ def main(argv: List[str] | None = None) -> None:
         print("Sectors:")
         for name in sector_list:
             print(f"- {name}")
+        return
+
+    if args.dashboard:
+        insight_dashboard.main()
         return
 
     if args.offline or not _agents_available():


### PR DESCRIPTION
## Summary
- allow launching the Streamlit dashboard directly from `official_demo_final.py`
- document the new `--dashboard` flag in the demo README

## Testing
- `pytest tests/test_official_final_demo.py::TestOfficialFinalDemo::test_final_demo_short -q`
- `pytest tests/test_official_insight_demo.py::TestOfficialInsightDemo::test_official_demo_short -q`
- `pytest -q` *(fails: 40 failed, 182 passed, 7 skipped)*