### PR TITLE
[alpha_factory] add offline launcher

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -194,6 +194,13 @@ to the same production demo:
 ```bash
 alpha-agi-beyond-foresight --offline --episodes 2
 ```
+To force a fully offline run regardless of environment configuration, launch the
+``alpha-agi-insight-offline`` entrypoint which wraps the official demo and sets
+``ALPHA_AGI_OFFLINE=true`` automatically:
+
+```bash
+alpha-agi-insight-offline --episodes 3
+```
 The arguments mirror ``alpha-agi-insight-production``.
 Use ``--version`` to show the installed package version and exit.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__init__.py
@@ -8,6 +8,7 @@ from .official_demo import main as official_demo
 from .official_demo_final import main as official_demo_final
 from .official_demo_production import main as official_demo_production
 from .beyond_human_foresight import main as beyond_human_foresight
+from .official_demo_zero_data import main as official_demo_zero_data
 from .api_server import main as api_server
 from .insight_dashboard import main as insight_dashboard
 
@@ -18,6 +19,7 @@ __all__ = [
     "official_demo",
     "official_demo_final",
     "official_demo_production",
+    "official_demo_zero_data",
     "beyond_human_foresight",
     "api_server",
     "insight_dashboard",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_zero_data.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_zero_data.py
@@ -1,0 +1,30 @@
+"""Zero-data launcher for the α‑AGI Insight demo.
+
+This wrapper enforces offline execution by setting ``ALPHA_AGI_OFFLINE=true``
+before delegating to :mod:`official_demo_final`. It guarantees the search loop
+operates without network dependencies while retaining the production features of
+the official demo.
+"""
+from __future__ import annotations
+
+import os
+from typing import List
+
+if __package__ is None:  # pragma: no cover - allow direct execution
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+    __package__ = "alpha_factory_v1.demos.alpha_agi_insight_v0"
+
+from .official_demo_final import main as _run_final
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Run the official demo in strict offline mode."""
+    os.environ.setdefault("ALPHA_AGI_OFFLINE", "true")
+    _run_final(["--offline", *(argv or [])])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ alpha-agi-insight = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_f
 alpha-agi-beyond-foresight = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-bhf = "alpha_factory_v1.demos.alpha_agi_insight_v0.beyond_human_foresight:main"
 alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_production:main"
+alpha-agi-insight-offline = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_zero_data:main"
 alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
 alpha-agi-insight-dashboard = "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_dashboard:main"
 


### PR DESCRIPTION
## Summary
- provide official_demo_zero_data wrapper for strict offline mode
- expose new entrypoint `alpha-agi-insight-offline`
- document the offline launcher in the demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 182 passed, 7 skipped)*