### PR TITLE
[alpha_factory] document API quickstart

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -56,6 +56,13 @@ Highlights:
 - Optional OpenAI Agents runtime for hosted execution.
 - Built-in Google ADK gateway support via `--enable-adk`.
 - Runs entirely with zero external data by default.
+For programmatic access launch the companion FastAPI server:
+
+```bash
+alpha-agi-insight-api --port 8000
+```
+Send a POST request with a JSON payload like `{"episodes":5}` to `/insight` to
+retrieve the ranked sector list.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- document how to run the API server from the official Insight demo

## Testing
- `./codex/setup.sh` *(fails: Could not find setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(40 failed, 182 passed, 7 skipped)*