### PR TITLE
[alpha_factory] enhance insight api

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/api_server.py
@@ -15,7 +15,12 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 import uvicorn
 
-from .insight_demo import parse_sectors, run, verify_environment
+from .insight_demo import (
+    DEFAULT_SECTORS,
+    parse_sectors,
+    run,
+    verify_environment,
+)
 
 app = FastAPI(title="α‑AGI Insight API")
 
@@ -55,6 +60,13 @@ def insight(req: InsightRequest) -> dict:
         json_output=True,
     )
     return json.loads(summary)
+
+
+@app.get("/sectors")
+def list_sectors() -> list[str]:
+    """Return the default sector list."""
+
+    return list(DEFAULT_SECTORS)
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- add a convenience `/sectors` endpoint exposing the default sector list

## Testing
- `./codex/setup.sh` *(failed: network access required)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: 38 failed, 184 passed, 7 skipped)*