### PR TITLE
[alpha_factory] Improve fallback modes

### DIFF
--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -131,14 +131,14 @@ class PingAgent(AgentBase):
     # ════════════════════════════════════════════════════════════════════════
     async def setup(self) -> None:
         """Initialise metrics and announce readiness."""
-        if _Prom.Counter:
+        if _Prom.Counter and self._prom_ping_total is None:
             self._prom_ping_total = _Prom.Counter(
                 "af_ping_total",
-                "Cumulative number of successful pings."
+                "Cumulative number of successful pings.",
             )
             self._prom_last_epoch = _Prom.Gauge(
                 "af_ping_last_epoch",
-                "Unix epoch of the most recent ping."
+                "Unix epoch of the most recent ping.",
             )
             self._prom_cycle_hist = _Prom.Histogram(
                 "af_ping_cycle_seconds",

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -46,7 +46,7 @@ from typing import Any, Dict, List, Optional
 
 # ────────────────────────── soft-imports (all optional) ───────────────
 with contextlib.suppress(ModuleNotFoundError):
-    from fastapi import FastAPI, HTTPException
+    from fastapi import FastAPI, HTTPException, File
     from fastapi.responses import PlainTextResponse
     import uvicorn
 


### PR DESCRIPTION
## Summary
- add optional sqlite toggle for vector store
- ensure hash embedder returns python floats
- handle list-based vectors in memory backend
- import `File` in orchestrator
- avoid duplicate Prometheus metrics

## Testing
- `python check_env.py --auto-install`
- `VECTOR_STORE_USE_SQLITE=false pytest alpha_factory_v1/tests/test_memory_provider.py::MemoryFabricFallbackTest::test_vector_ram_mode alpha_factory_v1/tests/test_memory_provider.py::EmbedderFallbackTest::test_hash_embedder alpha_factory_v1/tests/test_orchestrator_rest.py::BuildRestTest::test_basic_routes alpha_factory_v1/tests/test_vector_memory.py::VectorMemoryTest::test_add_and_search tests/test_ping_agent.py::TestPingAgent::test_run_cycle_publishes -q`