### PR TITLE
[alpha_factory] improve metrics setup and memory defaults

### DIFF
--- a/alpha_factory_v1/backend/memory_fabric.py
+++ b/alpha_factory_v1/backend/memory_fabric.py
@@ -253,7 +253,7 @@ class _VectorStore:
             self._meta: List[Tuple[str, str, str]] = []  # agent, content, ts
             self._mode = "faiss"
             logger.info("VectorStore: FAISS in-memory index ready.")
-        elif os.getenv("VECTOR_STORE_USE_SQLITE", "true").lower() == "true":
+        elif os.getenv("VECTOR_STORE_USE_SQLITE", "false").lower() == "true":
             self._sql = sqlite3.connect(Path("vector_mem.db"))
             self._sql.execute(
                 "CREATE TABLE IF NOT EXISTS memories(hash TEXT PRIMARY KEY, agent TEXT, ts TEXT, vec BLOB, content TEXT)"


### PR DESCRIPTION
## Summary
- avoid duplicate prometheus metrics when multiple PingAgent instances run in the same process
- default MemoryFabric vector store to RAM unless VECTOR_STORE_USE_SQLITE=true

## Testing
- `pytest alpha_factory_v1/tests/test_memory_provider.py::MemoryFabricFallbackTest::test_vector_ram_mode tests/test_ping_agent.py::TestPingAgent::test_run_cycle_publishes -q`
- `pytest -q` *(fails: 32 failed, 190 passed, 7 skipped)*