### PR TITLE
[alpha_factory] improve metric safety

### DIFF
--- a/alpha_factory_v1/backend/memory_fabric.py
+++ b/alpha_factory_v1/backend/memory_fabric.py
@@ -253,7 +253,8 @@ class _VectorStore:
             self._meta: List[Tuple[str, str, str]] = []  # agent, content, ts
             self._mode = "faiss"
             logger.info("VectorStore: FAISS in-memory index ready.")
-        elif os.getenv("VECTOR_STORE_USE_SQLITE", "true").lower() == "true":
+        # Default to RAM-only mode unless explicitly opting into SQLite.
+        elif os.getenv("VECTOR_STORE_USE_SQLITE", "false").lower() == "true":
             self._sql = sqlite3.connect(Path("vector_mem.db"))
             self._sql.execute(
                 "CREATE TABLE IF NOT EXISTS memories(hash TEXT PRIMARY KEY, agent TEXT, ts TEXT, vec BLOB, content TEXT)"


### PR DESCRIPTION
## Summary
- avoid unwanted SQLite fallback when numpy is present
- de-duplicate PingAgent metrics via registry lookup

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 33 failed, 189 passed, 7 skipped)*
