### PR TITLE
[alpha_factory] Ensure env LOGLEVEL preserved

### DIFF
--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -63,7 +63,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     ap.add_argument(
         "--loglevel",
-        default="INFO",
+        default=None,
         help="Logging verbosity",
     )
     ap.add_argument(

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -16,7 +16,11 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--metrics-port", type=int, help="Prometheus metrics port")
     ap.add_argument("--a2a-port", type=int, help="A2A gRPC port")
     ap.add_argument("--enabled", help="Comma separated list of enabled agents")
-    ap.add_argument("--loglevel", default="INFO", help="Log level")
+    ap.add_argument(
+        "--loglevel",
+        default=None,
+        help="Log level (defaults to $LOGLEVEL or INFO)",
+    )
     ap.add_argument("--version", action="store_true", help="Print version and exit")
     ap.add_argument(
         "--list-agents",

--- a/alpha_factory_v1/tests/test_cli.py
+++ b/alpha_factory_v1/tests/test_cli.py
@@ -24,7 +24,7 @@ class CliParseTest(unittest.TestCase):
         self.assertIsNone(args.metrics_port)
         self.assertIsNone(args.a2a_port)
         self.assertIsNone(args.enabled)
-        self.assertEqual(args.loglevel, 'INFO')
+        self.assertIsNone(args.loglevel)
         self.assertFalse(args.list_agents)
 
     def test_apply_env(self):

--- a/alpha_factory_v1/tests/test_edge_runner.py
+++ b/alpha_factory_v1/tests/test_edge_runner.py
@@ -23,7 +23,7 @@ class EdgeRunnerParseTest(unittest.TestCase):
         self.assertIsNone(args.metrics_port)
         self.assertIsNone(args.a2a_port)
         self.assertIsNone(args.cycle)
-        self.assertEqual(args.loglevel, "INFO")
+        self.assertIsNone(args.loglevel)
         self.assertFalse(args.list_agents)
 
     def test_env_defaults(self):

--- a/alpha_factory_v1/tests/test_edge_runner_main.py
+++ b/alpha_factory_v1/tests/test_edge_runner_main.py
@@ -50,6 +50,34 @@ class EdgeRunnerMainInvokesRun(unittest.TestCase):
         self.assertEqual(os.environ["PGHOST"], "sqlite")
         run.assert_called_once_with()
 
+    @mock.patch("alpha_factory_v1.run.run")
+    @mock.patch("alpha_factory_v1.run.apply_env")
+    @mock.patch("alpha_factory_v1.run.parse_args")
+    @mock.patch("alpha_factory_v1.edge_runner.parse_args")
+    def test_main_uses_env_loglevel(self, edge_parse, run_parse, apply_env, run):
+        args = self._args()
+        args.loglevel = None
+        edge_parse.return_value = args
+        run_parse.return_value = argparse.Namespace()
+        os.environ.pop("PGHOST", None)
+
+        edge_runner.main()
+
+        run_parse.assert_called_once_with([
+            "--dev",
+            "--port",
+            "123",
+            "--metrics-port",
+            "456",
+            "--a2a-port",
+            "789",
+            "--enabled",
+            "A,B",
+            "--cycle",
+            "5",
+        ])
+        apply_env.assert_called_once_with(run_parse.return_value)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid overriding LOGLEVEL when launching via edge_runner
- update CLI defaults to keep loglevel unset unless specified
- adjust unit tests for new behaviour
- check that env loglevel is honoured

## Testing
- `pytest -q`