### PR TITLE
[alpha_factory] enhance env file parsing

### DIFF
--- a/alpha_factory_v1/tests/test_cli.py
+++ b/alpha_factory_v1/tests/test_cli.py
@@ -56,14 +56,14 @@ class CliParseTest(unittest.TestCase):
 
     def test_env_file(self):
         with tempfile.NamedTemporaryFile('w', delete=False) as fh:
-            fh.write('FOO=bar\nLOGLEVEL=warning')
+            fh.write('FOO="bar baz"\n#comment\nLOGLEVEL=warning')
             path = fh.name
         args = _parse_with(['--env-file', path, '--loglevel', 'error'])
         for key in ('FOO', 'LOGLEVEL'):
             os.environ.pop(key, None)
         af_run.apply_env(args)
         os.unlink(path)
-        self.assertEqual(os.environ['FOO'], 'bar')
+        self.assertEqual(os.environ['FOO'], 'bar baz')
         self.assertEqual(os.environ['LOGLEVEL'], 'ERROR')
 
 


### PR DESCRIPTION
## Summary
- improve `alpha_factory_v1.run.apply_env` to parse .env files with `python-dotenv` when available
- add `_load_env_file` helper
- support quoted values and comments
- extend CLI test coverage for .env parsing

## Testing
- `pytest -q`