### PR TITLE
[alpha_factory] Reconcile Python versions and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Built atop **OpenAI Agents SDK**, **Google ADK**, **A2A protocol**, and Ant
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
-# Requires Python 3.9–3.12 (<3.13)
+# Requires Python 3.11–3.12 (<3.13)
 ./quickstart.sh
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs
 ```

--- a/alpha_factory_v1/demos/validate_demos.py
+++ b/alpha_factory_v1/demos/validate_demos.py
@@ -1,6 +1,7 @@
+"""Utility to validate demo packages for basic production readiness."""
+
 import os
 import sys
-
 
 DEFAULT_DIR = os.path.dirname(__file__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "alpha-factory-v1"
 version = "1.0.0"
 description = "Alpha-Factory v1"
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.11,<3.13"
 
 [tool.setuptools]
 packages = ["alpha_factory_v1", "requests"]


### PR DESCRIPTION
## Summary
- align README and pyproject requirements with Python 3.11+
- add missing module docstring to `validate_demos`

## Testing
- `./codex/setup.sh` *(fails: could not download setuptools)*
- `python check_env.py --auto-install`
- `pytest -q`