### PR TITLE
[alpha_factory] fix retail demand agent import

### DIFF
--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -38,6 +38,7 @@ import logging
 import math
 import os
 import random
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add missing `import time` to retail_demand_agent
- run ruff to verify no undefined name errors

## Testing
- `ruff check alpha_factory_v1/backend/agents/retail_demand_agent.py`
- `python check_env.py --auto-install`
- `pytest -q`