### PR TITLE
[alpha_factory] fix import warnings

### DIFF
--- a/alpha_factory_v1/__init__.py
+++ b/alpha_factory_v1/__init__.py
@@ -12,7 +12,7 @@ import importlib
 from typing import Any
 
 try:  # attempt to read the installed package version
-    from importlib.metadata import PackageNotFoundError, version as _version
+    from importlib.metadata import version as _version
 
     __version__ = _version(__name__)
 except Exception:  # pragma: no cover - fallback when not installed

--- a/alpha_factory_v1/backend/__init__.py
+++ b/alpha_factory_v1/backend/__init__.py
@@ -23,6 +23,10 @@ import importlib
 import logging
 import sys
 import types
+from pathlib import Path
+from typing import List
+import json
+import secrets
 
 _LOG = logging.getLogger("alphafactory.startup")
 
@@ -74,11 +78,7 @@ _fin_mod = importlib.import_module(".agents.finance_agent", __name__)
 sys.modules.setdefault(__name__ + ".finance_agent", _fin_mod)
 sys.modules["backend.finance_agent"] = _fin_mod
 
-# ────────────────────────── standard library deps ─────────────────────────
-import json
-import secrets
-from pathlib import Path
-from typing import List
+
 
 # ──────────────────────── log & CSRF helpers (unchanged) ──────────────────
 LOG_DIR = Path("/tmp/alphafactory")

--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -44,7 +44,6 @@ import asyncio
 import logging
 import os
 import signal
-import sys
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, Mapping, Optional

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -44,11 +44,10 @@ import json
 import logging
 import os
 import re
-import textwrap
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional
 
 # ────────────────────────────────────────────────────────────────────────────
 # Soft‑optional deps (never crash at import)                                  
@@ -102,7 +101,6 @@ except ModuleNotFoundError:  # pragma: no cover
 # ────────────────────────────────────────────────────────────────────────────
 from backend.agent_base import AgentBase  # type: ignore
 from backend.agents import AgentMetadata, register_agent  # type: ignore
-from backend.orchestrator import _publish  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -36,7 +36,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 try:
     import networkx as nx  # type: ignore

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -40,12 +40,11 @@ import os
 import random
 import re
 import sqlite3
-import time
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 # ---------------------------------------------------------------------------
 # Optional dependencies (soft imports — never crash)                        |

--- a/alpha_factory_v1/backend/memory_fabric.py
+++ b/alpha_factory_v1/backend/memory_fabric.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 # ───────────────────────── stdlib ░─────────────────────────
 import asyncio
 import contextlib
-import dataclasses
 import hashlib
 import json
 import logging
@@ -48,7 +47,7 @@ import os
 import sqlite3
 import threading
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
@@ -60,7 +59,8 @@ except ModuleNotFoundError:  # pragma: no cover - optional dep
 with contextlib.suppress(ModuleNotFoundError):
     from sentence_transformers import SentenceTransformer  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
-    import psycopg2, psycopg2.extras  # type: ignore
+    import psycopg2  # type: ignore
+    import psycopg2.extras  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
     import faiss  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
@@ -323,7 +323,7 @@ class _VectorStore:
                 self._evict_if_needed(agent)
                 self._apply_ttl_pg()
             elif self._mode == "faiss":
-                if h in (meta_h := {m[1] for m in self._meta}):
+                if h in {m[1] for m in self._meta}:
                     return
                 self._faiss.add(vec.reshape(1, -1))
                 self._vectors.append(vec)

--- a/alpha_factory_v1/backend/memory_graph.py
+++ b/alpha_factory_v1/backend/memory_graph.py
@@ -37,7 +37,6 @@ $ python -m alpha_factory_v1.backend.memory_graph --verbose
 from __future__ import annotations
 
 # ───────────────────────── stdlib & typing ──────────────────────────
-import json
 import logging
 import os
 import pathlib
@@ -45,7 +44,7 @@ import random
 import threading
 import time
 from contextlib import contextmanager
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 # ─────────────────── optional third-party imports ───────────────────
 try:

--- a/alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py
@@ -19,14 +19,14 @@ Additions v2.0 (relative to v1.1)
 The environment remains lightweight (<350 LoC) and free of external deps.
 """
 from __future__ import annotations
-import json, zlib
+import json
+import zlib
 from dataclasses import dataclass, asdict
 from typing import Any, Tuple, Dict, List
 
 import numpy as np
 import gymnasium as gym
 from gymnasium import spaces
-from scipy.ndimage import binary_dilation  # allowed, in SciPy core
 
 Coord = Tuple[int, int]
 Grid  = np.ndarray
@@ -199,7 +199,8 @@ class CurriculumEnv(gym.Env):
             raise NotImplementedError
         lut = {0: " ", 1: "#"}
         board = ["".join(lut[c] for c in row) for row in self.grid]
-        ay, ax = self.agent; gy, gx = self.goal
+        ay, ax = self.agent
+        gy, gx = self.goal
         board[ay] = board[ay][:ax] + "A" + board[ay][ax + 1:]
         board[gy] = board[gy][:gx] + "G" + board[gy][gx + 1:]
         return "\n".join(board)

--- a/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
@@ -12,12 +12,19 @@
 """
 from __future__ import annotations
 
-import copy, dataclasses as dc, hashlib, json, logging, math, os, pathlib, random
+import copy
+import dataclasses as dc
+import hashlib
+import json
+import logging
+import math
+import os
+import pathlib
+import random
 import contextlib
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import datetime, timezone
 from functools import cached_property
-from importlib import import_module
 from typing import Callable, List, Tuple
 
 try:
@@ -216,7 +223,8 @@ class MetaEvolver:
             with torch.no_grad():
                 a = net(torch.tensor(obs, dtype=torch.float32, device=Device)).argmax().item()
             obs, rew, done, truncated, _ = env.step(a)
-            total += rew; bc.append(obs)
+            total += rew
+            bc.append(obs)
             if done or truncated:
                 break
         bc_vec = np.mean(bc, axis=0)
@@ -237,7 +245,8 @@ class MetaEvolver:
             with torch.no_grad():
                 a = net(torch.tensor(obs, dtype=torch.float32, device=Device)).argmax().item()
             obs, rew, done, truncated, _ = env.step(a)
-            total += rew; bc.append(obs)
+            total += rew
+            bc.append(obs)
             if done or truncated:
                 break
         bc_vec = np.mean(bc, axis=0)
@@ -293,10 +302,13 @@ class MetaEvolver:
             if scores[best_idx] > self._best_fitness:
                 self._best_fitness = scores[best_idx]
                 self.best_genome = self.population[best_idx]
-            avg = float(np.mean(scores)); self.history.append((self.gen, avg))
-            if _fitness_gauge: _fitness_gauge.set(avg)
+            avg = float(np.mean(scores))
+            self.history.append((self.gen, avg))
+            if _fitness_gauge:
+                _fitness_gauge.set(avg)
             LOG.info("gen=%d avg=%.3f best=%.2f", self.gen, avg, self._best_fitness)
-            if _A2A: _A2A.sendjson({"gen": self.gen, "avg": avg, "sha": self.population_sha()})
+            if _A2A:
+                _A2A.sendjson({"gen": self.gen, "avg": avg, "sha": self.population_sha()})
             elite_idx = sorted(range(self.pop_size), key=lambda i: scores[i], reverse=True)[:self.elitism]
             new_pop = [self.population[i] for i in elite_idx]
             while len(new_pop) < self.pop_size:
@@ -319,7 +331,8 @@ class MetaEvolver:
             "ts": datetime.now(timezone.utc).isoformat()
         }
         p = self.ckpt_dir / f"gen_{self.gen:04d}.json.tmp"
-        p.write_text(json.dumps(data)); p.replace(p.with_suffix(""))
+        p.write_text(json.dumps(data))
+        p.replace(p.with_suffix(""))
 
     def save(self) -> None:
         """Public wrapper for checkpoint persistence."""


### PR DESCRIPTION
## Summary
- clean unused imports and fix improper import placement
- resolve semicolons and colons in meta evolver
- adjust curriculum environment imports

## Testing
- `ruff check alpha_factory_v1/__init__.py alpha_factory_v1/backend/__init__.py alpha_factory_v1/backend/agents/ping_agent.py alpha_factory_v1/backend/agents/policy_agent.py alpha_factory_v1/backend/agents/supply_chain_agent.py alpha_factory_v1/backend/agents/talent_match_agent.py alpha_factory_v1/backend/memory_graph.py alpha_factory_v1/backend/memory_fabric.py alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py`
- `pytest -q`