### PR TITLE
[alpha_factory] update quickstart python requirement

### DIFF
--- a/alpha_factory_v1/quickstart.sh
+++ b/alpha_factory_v1/quickstart.sh
@@ -44,7 +44,7 @@ header
 # check python version
 python3 - <<'PY'
 import sys
-req = (3, 9)
+req = (3, 11)
 max_py = (3, 12)
 if sys.version_info < req or sys.version_info >= max_py:
     sys.exit(f"Python {req[0]}.{req[1]}+ and <{max_py[0]}.{max_py[1]} required")


### PR DESCRIPTION
## Summary
- require Python 3.11 in `quickstart.sh`

## Testing
- `./codex/setup.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q`