### PR TITLE
[alpha_factory] document simulated broker methods

### DIFF
--- a/alpha_factory_v1/backend/broker/broker_sim.py
+++ b/alpha_factory_v1/backend/broker/broker_sim.py
@@ -14,10 +14,26 @@ class SimulatedBroker(TradeBrokerProtocol):
     _ids = itertools.count(1)
 
     def __init__(self, cash: float = 1_000_000.0) -> None:
+        """Initialize the simulated broker.
+
+        Args:
+            cash: Starting cash balance.
+        """
         self.cash = cash
         self.positions: Dict[str, float] = {}
 
     async def submit_order(self, symbol: str, qty: float, side: str, type: str = "market") -> str:
+        """Record an order in memory and update positions.
+
+        Args:
+            symbol: The ticker symbol.
+            qty: Quantity to trade.
+            side: ``"buy"`` or ``"sell"``.
+            type: Order type, unused.
+
+        Returns:
+            Order identifier.
+        """
         qty = float(qty)
         pos = self.positions.get(symbol.upper(), 0.0)
         if side.lower() == "buy":
@@ -30,13 +46,17 @@ class SimulatedBroker(TradeBrokerProtocol):
         return str(oid)
 
     async def get_position(self, symbol: str) -> float:
+        """Return current position for ``symbol``."""
         return self.positions.get(symbol.upper(), 0.0)
 
     async def get_cash(self) -> float:
+        """Return available cash balance."""
         return self.cash
 
     async def __aenter__(self) -> "SimulatedBroker":
+        """Return ``self`` for async context manager support."""
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Async context manager no-op."""
         pass


### PR DESCRIPTION
## Summary
- add Google-style docstrings to `SimulatedBroker` methods

## Testing
- `python check_env.py --auto-install`
- `pytest -q`

The `codex/setup.sh` script failed due to network access restrictions.