### PR TITLE
[alpha_factory] bump preflight python floor

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -12,7 +12,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-MIN_PY = (3, 9)
+MIN_PY = (3, 11)
 MAX_PY = (3, 13)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
 


### PR DESCRIPTION
## Summary
- raise MIN_PY to Python 3.11 in preflight checks

## Testing
- `python check_env.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry', '_MissingSDK' object is not callable)*