### PR TITLE
[alpha_factory] add pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+        args: ["--line-length", "120"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        args: ["--line-length", "120"]
+      - id: ruff-format
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length", "120"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ This installs any missing optional packages from the wheelhouse if provided.
 for modules, classes and functions.
 - Format code with `black` (line length 120) and run `ruff` or `flake8` for linting, if available.
 - Ensure code is formatted before committing.
+- Install pre‑commit and set up the git hook:
+  1. `pip install pre-commit`
+  2. `pre-commit install`
+  3. Run `pre-commit run --files <paths>` before committing.
+    CI will reject commits that fail these checks.
 
 ## Pull Requests
 - Keep commits focused and descriptive. Use meaningful commit messages.


### PR DESCRIPTION
## Summary
- document pre-commit installation in `AGENTS.md`
- add `.pre-commit-config.yaml` with black, ruff and flake8

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest::test_check_python_version)*
- `pre-commit run --files AGENTS.md .pre-commit-config.yaml` *(fails: pre-commit not installed)*