### PR TITLE
[alpha_factory] add mypy strict requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ This installs any missing optional packages from the wheelhouse if provided.
 for modules, classes and functions.
 - Format code with `black` (line length 120) and run `ruff` or `flake8` for linting, if available.
 - Ensure code is formatted before committing.
+- Run `mypy --config-file mypy.ini .` (or `pyright`) with a **strict** configuration. The
+  `mypy.ini` configuration file is located at the repository root.
 - Install pre‑commit and set up the git hook:
   1. `pip install pre-commit`
   2. `pre-commit install`

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.11
+strict = True
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- add guidance to run `mypy` with `strict` mode
- include minimal `mypy.ini` at project root

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest::test_check_python_version)*