### PR TITLE
[alpha_factory] Clarify offline setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,8 +473,13 @@ cd AGI-Alpha-Agent-v0
 ./quickstart.sh --preflight   # optional environment check
 python check_env.py --auto-install  # verify & auto-install deps
 ./quickstart.sh               # creates venv, installs deps, launches
-# Use `--wheelhouse /path/to/wheels` to install offline packages
-# when the host has no internet access.
+# Use `--wheelhouse /path/to/wheels` to install offline packages when
+# the host has no internet access. `WHEELHOUSE` should point to a
+# directory containing pre-downloaded wheels. Running
+# `python check_env.py --auto-install --wheelhouse /path/to/wheels`
+# installs any missing optional packages. Example offline setup:
+#   export WHEELHOUSE=/media/wheels
+#   python check_env.py --auto-install --wheelhouse $WHEELHOUSE
 # open the docs in your browser
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs
 # Alternatively, ``python alpha_factory_v1/quickstart.py`` provides the same


### PR DESCRIPTION
## Summary
- expand offline quickstart tips in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest::test_check_python_version)*