### PR TITLE
[alpha_factory] clarify Python version requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository contains the Alpha-Factory v1 package and demos.
 The instructions below apply to all contributors and automated agents.
 
 ## Development Environment
-- Create and activate a **Python&nbsp;3.11+** virtual environment before running the setup script.
+- Create and activate a **Python&nbsp;3.11 (3.11.x only; 3.12 not yet supported)** virtual environment before running the setup script.
 - Run `./codex/setup.sh` to install the project in editable mode along with minimal runtime dependencies.
 - When offline, run `WHEELHOUSE=/path/to/wheels ./codex/setup.sh`. The same path can be passed to `check_env.py --wheelhouse`.
 - After setup, validate with `python check_env.py --auto-install`.


### PR DESCRIPTION
## Summary
- clarify Python 3.11 support in contributor guidelines

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest.test_check_python_version)*