### PR TITLE
[alpha_factory] docs: note Apache license in PR guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ for modules, classes and functions.
   Document any remaining test failures in the PR description.
 - Summarize your changes and test results in the PR body.
 - Title PRs using `[alpha_factory] <Title>`.
+- All contributions are licensed under Apache 2.0.
 
 ### PR Message Guidelines
 - Keep the subject line concise and under 72 characters.


### PR DESCRIPTION
## Summary
- clarify that Pull Request contributions are licensed under Apache 2.0

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest.test_check_python_version)*
- `pre-commit run --files AGENTS.md` *(fails: pre-commit not installed)*