### PR TITLE
[alpha_factory] clarify wheelhouse export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,16 @@ The instructions below apply to all contributors and automated agents.
 ## Development Environment
 - Create and activate a **Python&nbsp;3.11 (3.11.x only; 3.12 not yet supported)** virtual environment before running the setup script.
 - Run `./codex/setup.sh` to install the project in editable mode along with minimal runtime dependencies.
-- When offline, run `WHEELHOUSE=/path/to/wheels ./codex/setup.sh`. The same path can be passed to `check_env.py --wheelhouse`.
-- After setup, validate with `python check_env.py --auto-install`.
-This installs any missing optional packages from the wheelhouse if provided.
+- When offline, export `WHEELHOUSE=/path/to/wheels` first so both
+  `check_env.py --auto-install` and `./codex/setup.sh` install from the
+  local wheelhouse:
+  
+  ```bash
+  export WHEELHOUSE=/path/to/wheels
+  ./codex/setup.sh
+  python check_env.py --auto-install
+  ```
+  This installs any missing optional packages from the wheelhouse if provided.
 - Execute `pytest -q` and ensure the entire suite passes. If failures remain, document them in the PR description.
 - Run `python alpha_factory_v1/scripts/preflight.py` or
   `./quickstart.sh --preflight` to verify Docker, git, and required

--- a/README.md
+++ b/README.md
@@ -475,11 +475,13 @@ python check_env.py --auto-install  # verify & auto-install deps
 ./quickstart.sh               # creates venv, installs deps, launches
 # Use `--wheelhouse /path/to/wheels` to install offline packages when
 # the host has no internet access. `WHEELHOUSE` should point to a
-# directory containing pre-downloaded wheels. Running
-# `python check_env.py --auto-install --wheelhouse /path/to/wheels`
-# installs any missing optional packages. Example offline setup:
+# directory containing pre-downloaded wheels.
+# When offline, export it before running `check_env.py --auto-install`
+# or `./codex/setup.sh` so both tools install from the local wheelhouse.
+# Example offline setup:
 #   export WHEELHOUSE=/media/wheels
-#   python check_env.py --auto-install --wheelhouse $WHEELHOUSE
+#   python check_env.py --auto-install
+#   ./codex/setup.sh
 # open the docs in your browser
 open http://localhost:8000/docs 2>/dev/null || xdg-open http://localhost:8000/docs || start http://localhost:8000/docs
 # Alternatively, ``python alpha_factory_v1/quickstart.py`` provides the same


### PR DESCRIPTION
## Summary
- document using `export WHEELHOUSE=/path/to/wheels` before running setup when offline
- explain exporting WHEELHOUSE in README offline example

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest::test_check_python_version)*