### PR TITLE
[alpha_factory] clarify offline setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@ The instructions below apply to all contributors and automated agents.
 ## Development Environment
 - Create and activate a **Python&nbsp;3.11 (3.11.x only; 3.12 not yet supported)** virtual environment before running the setup script.
 - Run `./codex/setup.sh` to install the project in editable mode along with minimal runtime dependencies.
-- When offline, run `WHEELHOUSE=/path/to/wheels ./codex/setup.sh`. The same path can be passed to `check_env.py --wheelhouse`.
+- When offline, run `WHEELHOUSE=/path/to/wheels ./codex/setup.sh`. Pass the same
+  path to `check_env.py --wheelhouse` and set `AUTO_INSTALL_MISSING=1` to allow
+  automatic installation of missing packages. Example:
+  `WHEELHOUSE=/media/wheels python check_env.py --auto-install --wheelhouse /media/wheels`
 - After setup, validate with `python check_env.py --auto-install`.
-This installs any missing optional packages from the wheelhouse if provided.
+  This installs any missing optional packages from the wheelhouse if provided.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes. If failures remain, document them in the PR description.
 - Run `python alpha_factory_v1/scripts/preflight.py` or
   `./quickstart.sh --preflight` to verify Docker, git, and required


### PR DESCRIPTION
## Summary
- document AUTO_INSTALL_MISSING=1 for offline setup
- add example check_env usage with wheelhouse

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest::test_check_python_version)*