### PR TITLE
[alpha_factory] document strict linting & typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ The instructions below apply to all contributors and automated agents.
 for modules, classes and functions.
 - Format code with `black` (line length 120) and run `ruff` or `flake8` for linting, if available.
 - Ensure code is formatted before committing.
+- Run `ruff` or `flake8` and `mypy --strict` before committing to enforce
+  consistent style and type safety.
 - Run `mypy --config-file mypy.ini .` (or `pyright`) with a **strict** configuration. The
   `mypy.ini` configuration file is located at the repository root.
 - Install pre‑commit and set up the git hook:


### PR DESCRIPTION
## Summary
- emphasize that ruff/flake8 and `mypy --strict` should be run before committing

## Testing
- `python check_env.py --auto-install`
- `python alpha_factory_v1/scripts/preflight.py` *(fails: docker and other deps missing)*
- `pytest -q` *(fails: PreflightTest.test_check_python_version)*
- `pre-commit run --files AGENTS.md` *(fails: command not found)*