### PR TITLE
[alpha_factory] centralize lint config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,15 +3,12 @@ repos:
     rev: 23.11.0
     hooks:
       - id: black
-        args: ["--line-length", "120"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.1
     hooks:
       - id: ruff
-        args: ["--line-length", "120"]
       - id: ruff-format
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
       - id: flake8
-        args: ["--max-line-length", "120"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ The instructions below apply to all contributors and automated agents.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
 for modules, classes and functions.
 - Format code with `black` (line length 120) and run `ruff` or `flake8` for linting, if available.
+- `pyproject.toml` contains the configuration for `black`, `ruff` and `flake8`.
+  Adjust lint settings there if needed.
 - Ensure code is formatted before committing.
 - Run `ruff` or `flake8` and `mypy --strict` before committing to enforce
   consistent style and type safety.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,13 @@ alpha-agi-insight-dashboard = "alpha_factory_v1.demos.alpha_agi_insight_v0.insig
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here
+
+[tool.black]
+line-length = 120
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.flake8]
+max-line-length = 120


### PR DESCRIPTION
## Summary
- consolidate black, ruff, and flake8 settings in `pyproject.toml`
- simplify `.pre-commit-config.yaml` by using config file defaults
- document lint configuration location in `AGENTS.md`

## Testing
- `pytest -q` *(fails: PreflightTest::test_check_python_version)*
- `pre-commit run --files AGENTS.md pyproject.toml .pre-commit-config.yaml` *(fails: command not found)*