### PR TITLE
[alpha_factory] clarify Python version in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository contains the Alpha-Factory v1 package and demos.
 The instructions below apply to all contributors and automated agents.
 
 ## Development Environment
-- Create and activate a **Python&nbsp;3.11 (3.11.x only; 3.12 not yet supported)** virtual environment before running the setup script.
+- Create and activate a **Python&nbsp;3.11.x** virtual environment before running the setup script.
 - Run `./codex/setup.sh` to install the project in editable mode along with minimal runtime dependencies.
 - When offline, run `WHEELHOUSE=/path/to/wheels ./codex/setup.sh`. Pass the same
   path to `check_env.py --wheelhouse` and set `AUTO_INSTALL_MISSING=1` to allow
@@ -23,7 +23,7 @@ The instructions below apply to all contributors and automated agents.
   `python alpha_factory_v1/quickstart.py --preflight`.
 
 ## Coding Style
-- Use **Python&nbsp;3.11** or newer and include type hints for public APIs.
+- Use **Python&nbsp;3.11.x** and include type hints for public APIs.
 - Indent with 4 spaces and keep lines under 120 characters.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
 for modules, classes and functions.


### PR DESCRIPTION
## Summary
- specify Python 3.11.x requirement in AGENTS guide
- update coding style section wording

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: PreflightTest.test_check_python_version)*