### PR TITLE
[alpha_factory] improve contributor guide and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ The instructions below apply to all contributors and automated agents.
 - After setup, validate with `python check_env.py --auto-install`.
   This installs any missing optional packages from the wheelhouse if provided.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes. If failures remain, document them in the PR description.
+- Run `python alpha_factory_v1/scripts/preflight.py` to confirm the Python version and required tools are available.
 - Before the first launch, run `bash quickstart.sh --preflight` to check
   Docker availability, git, and required packages. After this
   verification, run `./quickstart.sh` to launch the project. The script
@@ -49,6 +50,7 @@ for modules, classes and functions.
 ## Pull Requests
 - Keep commits focused and descriptive. Use meaningful commit messages.
 - Ensure `git status` shows a clean working tree before committing.
+- Remove stray build artifacts with `git clean -fd` if needed.
 - Run `python check_env.py --auto-install` and `pytest -q` before committing. \
   Document any remaining test failures in the PR description.
 - Summarize your changes and test results in the PR body.

--- a/alpha_factory_v1/tests/test_preflight.py
+++ b/alpha_factory_v1/tests/test_preflight.py
@@ -8,60 +8,60 @@ from alpha_factory_v1.scripts import preflight
 
 
 class PreflightTest(unittest.TestCase):
-    def test_banner_colours(self):
-        with mock.patch('builtins.print') as p:
-            preflight.banner('msg', 'RED')
+    def test_banner_colours(self) -> None:
+        with mock.patch("builtins.print") as p:
+            preflight.banner("msg", "RED")
             p.assert_called_once()
             args, _ = p.call_args
-            self.assertIn('msg', args[0])
-            self.assertIn(preflight.COLORS['RED'], args[0])
-            self.assertIn(preflight.COLORS['RESET'], args[0])
+            self.assertIn("msg", args[0])
+            self.assertIn(preflight.COLORS["RED"], args[0])
+            self.assertIn(preflight.COLORS["RESET"], args[0])
 
-    def test_check_python_version(self):
-        with mock.patch.object(sys, 'version_info', (3, 9)):
+    def test_check_python_version(self) -> None:
+        with mock.patch.object(sys, "version_info", (3, 11)):
             self.assertTrue(preflight.check_python())
-        with mock.patch.object(sys, 'version_info', (3, 8)):
+        with mock.patch.object(sys, "version_info", (3, 10)):
             self.assertFalse(preflight.check_python())
 
-    def test_check_cmd(self):
-        with mock.patch('shutil.which', return_value='/bin/foo'):
-            self.assertTrue(preflight.check_cmd('foo'))
-        with mock.patch('shutil.which', return_value=None):
-            self.assertFalse(preflight.check_cmd('foo'))
+    def test_check_cmd(self) -> None:
+        with mock.patch("shutil.which", return_value="/bin/foo"):
+            self.assertTrue(preflight.check_cmd("foo"))
+        with mock.patch("shutil.which", return_value=None):
+            self.assertFalse(preflight.check_cmd("foo"))
 
-    def test_check_docker_daemon(self):
-        with mock.patch('shutil.which', return_value=None):
+    def test_check_docker_daemon(self) -> None:
+        with mock.patch("shutil.which", return_value=None):
             self.assertFalse(preflight.check_docker_daemon())
-        with mock.patch('shutil.which', return_value='/bin/docker'):
-            with mock.patch('subprocess.run') as run:
+        with mock.patch("shutil.which", return_value="/bin/docker"):
+            with mock.patch("subprocess.run") as run:
                 run.return_value = mock.Mock(returncode=0)
                 self.assertTrue(preflight.check_docker_daemon())
-            with mock.patch('subprocess.run', side_effect=Exception):
+            with mock.patch("subprocess.run", side_effect=Exception):
                 self.assertFalse(preflight.check_docker_daemon())
 
-    def test_check_docker_compose(self):
-        with mock.patch('shutil.which', return_value=None):
+    def test_check_docker_compose(self) -> None:
+        with mock.patch("shutil.which", return_value=None):
             self.assertFalse(preflight.check_docker_compose())
-        with mock.patch('shutil.which', return_value='/bin/docker'):
-            with mock.patch('subprocess.run') as run:
+        with mock.patch("shutil.which", return_value="/bin/docker"):
+            with mock.patch("subprocess.run") as run:
                 run.return_value = mock.Mock(returncode=0)
                 self.assertTrue(preflight.check_docker_compose())
-            with mock.patch('subprocess.run', side_effect=Exception):
+            with mock.patch("subprocess.run", side_effect=Exception):
                 self.assertFalse(preflight.check_docker_compose())
 
-    def test_check_pkg(self):
-        with mock.patch('importlib.util.find_spec', return_value=object()):
-            self.assertTrue(preflight.check_pkg('x'))
-        with mock.patch('importlib.util.find_spec', return_value=None):
-            self.assertFalse(preflight.check_pkg('y'))
+    def test_check_pkg(self) -> None:
+        with mock.patch("importlib.util.find_spec", return_value=object()):
+            self.assertTrue(preflight.check_pkg("x"))
+        with mock.patch("importlib.util.find_spec", return_value=None):
+            self.assertFalse(preflight.check_pkg("y"))
 
-    def test_ensure_dir(self):
+    def test_ensure_dir(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'd'
+            path = Path(tmp) / "d"
             preflight.ensure_dir(path)
             self.assertTrue(path.exists())
 
-    def test_main_success_and_failure(self):
+    def test_main_success_and_failure(self) -> None:
         with mock.patch.multiple(
             preflight,
             check_python=lambda: True,
@@ -87,5 +87,5 @@ class PreflightTest(unittest.TestCase):
                 preflight.main()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- adjust `test_preflight` to expect Python 3.11
- add return type hints to satisfy mypy strict mode
- document running preflight and cleaning artifacts in `AGENTS.md`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `mypy --config-file mypy.ini alpha_factory_v1/tests/test_preflight.py`
