### PR TITLE
[alpha_factory] run pre-commit right after installing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,15 @@ for modules, classes and functions.
 - Install pre‑commit and set up the git hook:
   1. `pip install pre-commit`
   2. `pre-commit install`
-  3. Run `pre-commit run --all-files` once to populate the cache.
+  3. Run `pre-commit run --all-files` right away to ensure formatting and lint
+     checks succeed and to populate the cache.
   4. Run `pre-commit run --files <paths>` before committing.
     CI will reject commits that fail these checks.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using
     `mypy.ini`.
-  - After setup, run `pre-commit run --all-files` once and
-    `pre-commit run --files <paths>` before every commit.
+  - After setup, run `pre-commit run --all-files` once right away to ensure
+    formatting and lint checks succeed, then run `pre-commit run --files
+    <paths>` before every commit.
 
 ## Pull Requests
 - Keep commits focused and descriptive. Use meaningful commit messages.


### PR DESCRIPTION
## Summary
- clarify that contributors should run `pre-commit run --all-files` immediately after installing the hook

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ❌ `pre-commit run --files AGENTS.md` *(fails: pre-commit not installed)*