### PR TITLE
[alpha_factory] Add safe arithmetic evaluator

### DIFF
--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
@@ -9,6 +9,7 @@ Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the co
 3. Phantom wallet gating requiring a configurable token balance.
 4. Integrated agent chat backed by a language model.
 5. Agentic tree search explorer for open-ended strategy discovery.
+6. Built-in arithmetic evaluator for the `Calculate` tool (supports +, -, *, /, and power).
 
 ```bash
 ./deploy_sovereign_agentic_agialpha_agent_v0.sh


### PR DESCRIPTION
## Summary
- allow simple arithmetic without eval
- document new feature in demo README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/deploy_sovereign_agentic_agialpha_agent_v0.sh alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md` *(fails: `pre-commit: command not found`)*
- `python check_env.py --auto-install`
- `pytest -q`