### PR TITLE
[alpha_factory] log equity cache write failures

### DIFF
--- a/alpha_factory_v1/backend/risk_management.py
+++ b/alpha_factory_v1/backend/risk_management.py
@@ -34,6 +34,7 @@ risk.enforce_limits()
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 import time
@@ -60,6 +61,8 @@ _CACHE_DIR = Path(os.getenv("ALPHA_DATA_DIR", "/tmp/alphafactory")) / "risk"
 _CACHE_DIR.mkdir(parents=True, exist_ok=True)
 _EQ_CACHE = _CACHE_DIR / "equity_curve.json"
 
+_LOG = logging.getLogger("alpha_factory.risk")
+
 
 def _load_equity_cache() -> List[float]:
     if _EQ_CACHE.exists():
@@ -73,8 +76,11 @@ def _load_equity_cache() -> List[float]:
 def _save_equity_cache(curve: Sequence[float]) -> None:
     try:
         _EQ_CACHE.write_text(json.dumps(curve[-5000:]))  # keep ≤ ~5k pts
-    except Exception:  # pragma: no cover
-        pass
+    except Exception:  # pragma: no cover - best effort persistence
+        _LOG.debug(
+            "Equity cache write failed – continuing without persistence",
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_risk_management.py
+++ b/tests/test_risk_management.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch
+
+import alpha_factory_v1.backend.risk_management as rm
+
+
+class TestRiskManagementCache(unittest.TestCase):
+    def test_save_equity_cache_logs_error(self) -> None:
+        with patch("pathlib.Path.write_text", side_effect=IOError("boom")) as mock_write:
+            with patch.object(rm._LOG, "debug") as mock_log:
+                rm._save_equity_cache([1.0, 2.0])
+                mock_log.assert_called()
+            mock_write.assert_called()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- emit debug logs when saving the risk manager equity cache fails
- cover the log behaviour with a simple unit test

## Testing
- `python check_env.py --auto-install`
- `pytest -q`