### PR TITLE
[alpha_factory] remove default Neo4j password

### DIFF
--- a/alpha_factory_v1/.env.sample
+++ b/alpha_factory_v1/.env.sample
@@ -24,7 +24,7 @@ FRED_API_KEY=
 NEWSAPI_KEY=
 NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
-NEO4J_PASSWORD=password
+NEO4J_PASSWORD=changeme
 
 # ─── Agent runtime options ───────────────────────────────────────────
 LLM_PROVIDER=openai         # openai | ollama | anthropic | mistral | together

--- a/alpha_factory_v1/helm/alpha-factory/values.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/values.yaml
@@ -24,7 +24,7 @@ env:
   NEWSAPI_KEY: ""
   NEO4J_URI: bolt://neo4j:7687
   NEO4J_USER: neo4j
-  NEO4J_PASSWORD: password
+  NEO4J_PASSWORD: changeme
   LLM_PROVIDER: openai
   MODEL_NAME: gpt-4-turbo
   PORT: "8000"


### PR DESCRIPTION
## Summary
- replace default Neo4j password in `.env.sample` and Helm chart
- enforce explicit password in `neo4j_graph.py`

## Testing
- `python alpha_factory_v1/scripts/preflight.py --help` *(fails: docker missing)*
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit run --files alpha_factory_v1/.env.sample alpha_factory_v1/backend/integrations/neo4j_graph.py alpha_factory_v1/helm/alpha-factory/values.yaml` *(fails: pre-commit not installed)*
- `flake8 alpha_factory_v1/backend/integrations/neo4j_graph.py` *(fails: flake8 not installed)*
- `mypy --config-file mypy.ini alpha_factory_v1/backend/integrations/neo4j_graph.py` *(fails: numerous errors)*