### PR TITLE
[alpha_factory] fix: use timezone-aware timestamps

### DIFF
--- a/alpha_factory_v1/backend/memory.py
+++ b/alpha_factory_v1/backend/memory.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 _log = logging.getLogger("alpha_factory.memory")
@@ -41,7 +41,9 @@ class Memory:
     def write(self, agent: str, kind: str, data) -> None:
         """Append one structured record to disk."""
         record = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            "ts": datetime.now(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z"),
             "agent": agent,
             "kind": kind,
             "data": data,

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -102,7 +102,7 @@ async def experience_stream() -> AsyncIterator[Dict[str, Any]]:
 
     while True:
         uid += 1
-        now = dt.datetime.utcnow().isoformat()
+        now = dt.datetime.now(dt.timezone.utc).isoformat()
         if random.random() < .6:
             kind, payload = "health", {"activity": random.choice(health)}
         else:

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/education_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/education_reward.py
@@ -85,7 +85,7 @@ def reward(state: Any, action: Any, result: Any) -> float:
     if now is None:
         import datetime as _dt
 
-        now = _dt.datetime.utcnow()
+        now = _dt.datetime.now(_dt.timezone.utc)
 
     # ------------------------------------------------------------------------
     # 1) Detect if the *result* represents a bona‑fide learning activity

--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -197,7 +197,7 @@ def _fanout(evt: Dict[str, Any]):
 async def stream_macro_events(live: bool = False) -> AsyncIterator[Dict[str, Any]]:
     idx = 0
     while True:
-        evt = {"timestamp": dt.datetime.utcnow().isoformat()}
+        evt = {"timestamp": dt.datetime.now(dt.timezone.utc).isoformat()}
         if live:
             speech = await _latest_fed_speech() or OFF_FED[idx]["text"]
             y10    = await _fred_latest(FRED_10Y)  or float(OFF_YIELD[idx]["10y"])


### PR DESCRIPTION
## Summary
- resolve `datetime.utcnow()` deprecation warnings
- ensure all generated timestamps use UTC

## Testing
- `python alpha_factory_v1/scripts/preflight.py`
- `python check_env.py --auto-install`
- `pytest -q`
