### PR TITLE
[alpha_factory] Add fallback settings stub

### DIFF
--- a/alpha_factory_v1/tests/test_memory_provider.py
+++ b/alpha_factory_v1/tests/test_memory_provider.py
@@ -1,12 +1,16 @@
 import unittest
 import os
 import logging
+import importlib
+from unittest import mock
+import sys
 
 # Disable noisy logs during import
 logging.disable(logging.CRITICAL)
 
 import alpha_factory_v1.backend.memory_fabric as memf
 from alpha_factory_v1.backend.model_provider import ModelProvider
+
 
 class ModelProviderStubTest(unittest.TestCase):
     def setUp(self):
@@ -19,6 +23,7 @@ class ModelProviderStubTest(unittest.TestCase):
         out = provider.complete("hello")
         self.assertIsInstance(out, str)
         self.assertTrue(out)
+
 
 class MemoryFabricFallbackTest(unittest.TestCase):
     def setUp(self):
@@ -37,12 +42,31 @@ class MemoryFabricFallbackTest(unittest.TestCase):
         self.fabric.add_relation("B", "rel", "C")
         self.assertEqual(self.fabric.find_path("A", "C"), ["A", "B", "C"])
 
+
 class EmbedderFallbackTest(unittest.TestCase):
     def test_hash_embedder(self):
         emb = memf._load_embedder()
         vec = emb("test")
         self.assertEqual(len(vec), memf.CFG.VECTOR_DIM)
         self.assertTrue(all(isinstance(x, (float, int)) for x in vec))
+
+
+class SettingsFallbackTest(unittest.TestCase):
+    def test_no_pydantic_available(self):
+        global memf
+        sys.modules.pop("alpha_factory_v1.backend.memory_fabric", None)
+        importlib.invalidate_caches()
+        with mock.patch.dict(
+            sys.modules,
+            {"pydantic": None, "pydantic_settings": None},
+        ):
+            memf = importlib.import_module("alpha_factory_v1.backend.memory_fabric")
+            self.assertEqual(memf.CFG.PGDATABASE, "memdb")
+            self.assertEqual(memf.BaseSettings.__module__, memf.__name__)
+        # reload original module for other tests
+        sys.modules.pop("alpha_factory_v1.backend.memory_fabric", None)
+        memf = importlib.import_module("alpha_factory_v1.backend.memory_fabric")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement BaseSettings stub in memory_fabric to allow loading without pydantic
- extend memory provider tests to verify stub loading

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
