### PR TITLE
[alpha_factory] add cli parse args tests

### DIFF
--- a/tests/test_edge_runner_cli.py
+++ b/tests/test_edge_runner_cli.py
@@ -1,6 +1,10 @@
+import os
 import subprocess
 import sys
 import unittest
+from unittest.mock import patch
+
+from alpha_factory_v1 import edge_runner
 
 
 class TestEdgeRunnerCLI(unittest.TestCase):
@@ -14,6 +18,22 @@ class TestEdgeRunnerCLI(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0)
         self.assertIn("usage", result.stdout.lower())
+
+
+class TestParseArgs(unittest.TestCase):
+    """Validate :func:`edge_runner.parse_args` behavior."""
+
+    def test_cli_args_override_env(self) -> None:
+        env = {"PORT": "1111", "METRICS_PORT": "2222", "A2A_PORT": "3333", "CYCLE": "4"}
+        argv = ["--port", "9000", "--metrics-port", "9001", "--agents", "X,Y"]
+        with patch.dict(os.environ, env, clear=True):
+            args = edge_runner.parse_args(argv)
+        self.assertEqual(args.port, 9000)
+        self.assertEqual(args.metrics_port, 9001)
+        self.assertEqual(args.agents, "X,Y")
+        # Unspecified flags fall back to environment defaults
+        self.assertEqual(args.a2a_port, 3333)
+        self.assertEqual(args.cycle, 4)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- expand `tests/test_edge_runner_cli.py` to exercise `edge_runner.parse_args`
- verify CLI arguments override environment defaults

## Testing
- `pytest -q tests/test_edge_runner_cli.py`
- `pytest -q`