### PR TITLE
[alpha_factory] fix orchestrator logging

### DIFF
--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -120,12 +120,12 @@ MAX_CYCLE_SEC = int(ENV("MAX_CYCLE_SEC", "30"))
 MODEL_MAX_BYTES = int(ENV("ALPHA_MODEL_MAX_BYTES", str(64 * 1024 * 1024)))
 ENABLED = {s.strip() for s in ENV("ALPHA_ENABLED_AGENTS", "").split(",") if s.strip()}
 
-logging.basicConfig(
-    level=LOGLEVEL,
-    format="%(asctime)s.%(msecs)03d %(levelname)-8s | %(name)s | %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    force=True,
-)
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=LOGLEVEL,
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 log = logging.getLogger("alpha_factory.orchestrator")
 
 # OTEL tracer — noop if lib missing


### PR DESCRIPTION
## Summary
- avoid forcing logging.basicConfig in orchestrator

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `timeout 5 python -m alpha_factory_v1.run --dev --loglevel INFO`