### PR TITLE
[alpha_factory] include extra dev deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ The instructions below apply to all contributors and automated agents.
   - When `WHEELHOUSE` is set, run
     `python check_env.py --auto-install --wheelhouse <path>` so optional packages
     install correctly offline.
+- The unit tests rely on `fastapi` and `opentelemetry-api`. Install them via
+  `requirements-dev.txt` or ensure `check_env.py` reports no missing packages
+  before running `pytest`.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes. If failures remain, document them in the PR description.
 - Run `python alpha_factory_v1/scripts/preflight.py` to confirm the Python version and required tools are available.
 - Before the first launch, run `bash quickstart.sh --preflight` to check

--- a/check_env.py
+++ b/check_env.py
@@ -24,6 +24,8 @@ REQUIRED = [
     "prometheus_client",
     "openai",
     "anthropic",
+    "fastapi",
+    "opentelemetry",
 ]
 
 # Optional integrations that may not be present in restricted environments.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@
 pytest
 prometheus_client
 mypy
+fastapi
+opentelemetry-api


### PR DESCRIPTION
## Summary
- add FastAPI and OTEL API to dev requirements
- check for these packages in `check_env.py`
- document new dev requirements in AGENTS guide

## Testing
- `python check_env.py --auto-install`
- `pytest -q`