### PR TITLE
[alpha_factory] secure sandbox for SafeExec

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi/agents/agent_base.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi/agents/agent_base.py
@@ -27,6 +27,7 @@ Key capabilities
 
 Apache‑2.0 © 2025 MONTREAL.AI
 """
+
 from __future__ import annotations
 
 import os, sys, time, json, uuid, math, json, pathlib, logging, importlib, hashlib
@@ -47,15 +48,19 @@ logging.basicConfig(level=os.environ.get("ALPHAF_FACTORY_LOGLEVEL", "INFO"))
 # Helper utilities
 # ---------------------------------------------------------------------------
 
+
 def _sha(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()[:10]
+
 
 def _utcnow_ms() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + f".{int((time.time()%1)*1000):03d}Z"
 
+
 def _str_tkn(text: str) -> int:
     # naïve token estimate ≈‑ 1 token / 4 chars in English
-    return max(1, math.ceil(len(text)/4))
+    return max(1, math.ceil(len(text) / 4))
+
 
 # ---------------------------------------------------------------------------
 # Rate limiter (token bucket, per‑second)
@@ -78,7 +83,9 @@ class RateLimiter:
             sleep = (cost - self._allow) / self._tps + 1e-3
             time.sleep(sleep)
 
+
 GLOBAL_LIMITER = RateLimiter(float(os.getenv("ALPHA_TPS", 3)))
+
 
 # ---------------------------------------------------------------------------
 # LM Provider adapter
@@ -94,14 +101,16 @@ class LMClient:
         "llama": None,  # local
     }
 
-    def __init__(self,
-                 endpoint: str = "openai:gpt-4o",
-                 temperature: float = 0.2,
-                 max_tokens: int = 2048,
-                 context_len: int = 8192,
-                 stream: bool = False,
-                 timeout: int = 120,
-                 **extra):
+    def __init__(
+        self,
+        endpoint: str = "openai:gpt-4o",
+        temperature: float = 0.2,
+        max_tokens: int = 2048,
+        context_len: int = 8192,
+        stream: bool = False,
+        timeout: int = 120,
+        **extra,
+    ):
         self.endpoint = endpoint
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -116,7 +125,7 @@ class LMClient:
     def _parse(self, ep: str):
         if ":" not in ep:
             raise ValueError("Endpoint must be <backend>:<model>")
-        return ep.split(":",1)
+        return ep.split(":", 1)
 
     def _init_backend(self):
         back = self._backend
@@ -129,13 +138,13 @@ class LMClient:
         if back == "gemini":
             mod = importlib.import_module("google.generativeai")
             return mod.GenerativeModel(self._model)
-        if back in ("mistral","llama"):
+        if back in ("mistral", "llama"):
             mod = importlib.import_module("llama_cpp")
             return mod.Llama(model_path=self._model, n_ctx=self.context_len)
         raise NotImplementedError(back)
 
     # .................................
-    def chat(self, msgs: List[Dict[str,str]], **kw) -> str:
+    def chat(self, msgs: List[Dict[str, str]], **kw) -> str:
         merged = dict(temperature=self.temperature, max_tokens=self.max_tokens, **kw)
         attempts = 0
         while True:
@@ -149,15 +158,18 @@ class LMClient:
                     return rsp.content[0].text
                 if self._backend == "gemini":
                     return self._client.generate_content(msgs[-1]["content"], **merged).text
-                if self._backend in ("mistral","llama"):
-                    prompt = "".join(f"<{m['role']}> {m['content']}" for m in msgs)+"\n<assistant> "
-                    out = self._client(prompt, max_tokens=self.max_tokens, temperature=self.temperature, stop=["</assistant>"])
+                if self._backend in ("mistral", "llama"):
+                    prompt = "".join(f"<{m['role']}> {m['content']}" for m in msgs) + "\n<assistant> "
+                    out = self._client(
+                        prompt, max_tokens=self.max_tokens, temperature=self.temperature, stop=["</assistant>"]
+                    )
                     return out["choices"][0]["text"].strip()
             except Exception as e:
                 attempts += 1
                 wait = min(60, 2**attempts)
                 LOGGER.warning("LM error %s; retry in %.1fs", e, wait)
                 time.sleep(wait)
+
 
 # ---------------------------------------------------------------------------
 # Lineage tracer & UI stub
@@ -172,6 +184,7 @@ class LineageTracer:
             json.dump({"ts": _utcnow_ms(), "event": event, **payload}, fp, ensure_ascii=False)
             fp.write("\n")
 
+
 # ---------------------------------------------------------------------------
 # Multi‑objective scorer
 # ---------------------------------------------------------------------------
@@ -182,49 +195,52 @@ class ObjectiveWeights:
     carbon: float = 0.2
     risk: float = 0.3
 
-    def score(self, metrics: Dict[str,float]) -> float:
+    def score(self, metrics: Dict[str, float]) -> float:
         return (
-            self.latency * (1/ (1+metrics.get("latency",0))) +
-            self.cost    * (1/ (1+metrics.get("cost",0))) +
-            self.carbon  * (1/ (1+metrics.get("carbon",0))) +
-            self.risk    * (1- metrics.get("risk",0))
+            self.latency * (1 / (1 + metrics.get("latency", 0)))
+            + self.cost * (1 / (1 + metrics.get("cost", 0)))
+            + self.carbon * (1 / (1 + metrics.get("carbon", 0)))
+            + self.risk * (1 - metrics.get("risk", 0))
         )
+
 
 # ---------------------------------------------------------------------------
 # Agent base‑class
 # ---------------------------------------------------------------------------
 class Agent:
-    def __init__(self,
-                 name: str,
-                 role: str = "autonomous‑agent",
-                 provider: str | None = None,
-                 objectives: Optional[ObjectiveWeights] = None,
-                 lineage_dir: str | pathlib.Path = "./lineage",
-                 rate_limit_tps: float = 3.0):
+    def __init__(
+        self,
+        name: str,
+        role: str = "autonomous‑agent",
+        provider: str | None = None,
+        objectives: Optional[ObjectiveWeights] = None,
+        lineage_dir: str | pathlib.Path = "./lineage",
+        rate_limit_tps: float = 3.0,
+    ):
         self.name = name
         self.role = role
         self.id = f"{name}-{_sha(uuid.uuid4().hex)}"
         self.objectives = objectives or ObjectiveWeights()
         self.lm = LMClient(provider or os.getenv("ALPHA_PROVIDER", "openai:gpt-4o"))
-        self.tracer = LineageTracer(pathlib.Path(lineage_dir)/f"{self.id}.jsonl")
+        self.tracer = LineageTracer(pathlib.Path(lineage_dir) / f"{self.id}.jsonl")
         self.tracer.log("init", role=role, provider=self.lm.endpoint)
         GLOBAL_LIMITER._tps = rate_limit_tps
 
     # .................................................................
-    def _estimate_cost(self, prompt_tokens:int, completion_tokens:int) -> float:
-        price = float(os.getenv("ALPHA_USD_PER_M", 0.01)) # user override
-        return ((prompt_tokens+completion_tokens)/1_000_000)*price
+    def _estimate_cost(self, prompt_tokens: int, completion_tokens: int) -> float:
+        price = float(os.getenv("ALPHA_USD_PER_M", 0.01))  # user override
+        return ((prompt_tokens + completion_tokens) / 1_000_000) * price
 
-    def run(self, prompt: str, context: Optional[Iterable[Dict[str,str]]]=None, **kw) -> Dict[str,Any]:
-        ctx: List[Dict[str,str]] = list(context or [])
-        ctx.append({"role":"user", "content": prompt})
+    def run(self, prompt: str, context: Optional[Iterable[Dict[str, str]]] = None, **kw) -> Dict[str, Any]:
+        ctx: List[Dict[str, str]] = list(context or [])
+        ctx.append({"role": "user", "content": prompt})
         t0 = time.perf_counter()
         output = self.lm.chat(ctx, **kw)
-        latency = time.perf_counter()-t0
+        latency = time.perf_counter() - t0
         tokens_in = _str_tkn(prompt)
         tokens_out = _str_tkn(output)
-        cost = self._estimate_cost(tokens_in,tokens_out)
-        carbon = cost*0.00015 # placeholder multiplier (avg kgCO2 per $ cloud)
+        cost = self._estimate_cost(tokens_in, tokens_out)
+        carbon = cost * 0.00015  # placeholder multiplier (avg kgCO2 per $ cloud)
         risk = self._risk_assess(prompt, output)
         metrics = dict(latency=latency, cost=cost, carbon=carbon, risk=risk)
         score = self.objectives.score(metrics)
@@ -232,27 +248,35 @@ class Agent:
         return {"response": output, "metrics": metrics, "score": score}
 
     # .................................................................
-    def _risk_assess(self, prompt:str, response:str) -> float:
+    def _risk_assess(self, prompt: str, response: str) -> float:
         # toy heuristic: long responses & code carry more risk
-        return min(1.0, 0.1 + 0.9*(len(response)/4000))
+        return min(1.0, 0.1 + 0.9 * (len(response) / 4000))
 
     # .................................................................
-    def __call__(self, prompt:str, **kw):
+    def __call__(self, prompt: str, **kw):
         return self.run(prompt, **kw)
+
 
 # ---------------------------------------------------------------------------
 # Sandbox utilities for dynamic code exec (optional)
 # ---------------------------------------------------------------------------
 class SafeExec:
-    """Run untrusted python code under CPU/ram constraints."""
-    def __init__(self, cpu_sec:int=2, mem_mb:int=128):
+    """Run untrusted Python under CPU/ram limits using a restricted sandbox.
+
+    The code executes with :mod:`RestrictedPython` if installed.  When the
+    package is unavailable, a tiny ``__builtins__`` dictionary containing only
+    ``print``, ``range`` and ``len`` is provided.  Dangerous functions such as
+    ``open`` or ``__import__`` are therefore inaccessible.
+    """
+
+    def __init__(self, cpu_sec: int = 2, mem_mb: int = 128):
         self.cpu_sec = cpu_sec
         self.mem_mb = mem_mb
 
     def __enter__(self):
         if resource:
             resource.setrlimit(resource.RLIMIT_CPU, (self.cpu_sec, self.cpu_sec))
-            resource.setrlimit(resource.RLIMIT_AS, (self.mem_mb*1024*1024, self.mem_mb*1024*1024))
+            resource.setrlimit(resource.RLIMIT_AS, (self.mem_mb * 1024 * 1024, self.mem_mb * 1024 * 1024))
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -261,12 +285,21 @@ class SafeExec:
         return False  # do not suppress
 
     def run(self, code: str, func_name: str, *args, **kw):
-        loc: Dict[str,Any] = {}
+        """Execute ``code`` safely and run ``func_name`` with ``args``."""
+        loc: Dict[str, Any] = {}
         with self:
-            exec(code, {}, loc)
+            try:
+                RP = importlib.import_module("RestrictedPython")
+                compiled = RP.compile_restricted_exec(code)
+                sec_builtins = RP.Guards.safe_builtins.copy()
+                exec(compiled, {"__builtins__": sec_builtins}, loc)
+            except Exception:
+                safe_builtins = {"print": print, "range": range, "len": len}
+                exec(compile(code, "<sandbox>", "exec"), {"__builtins__": safe_builtins}, loc)
         if func_name not in loc:
             raise AttributeError(f"{func_name} not found")
         return loc[func_name](*args, **kw)
+
 
 # ---------------------------------------------------------------------------
 # Simple lineage viewer (optional)
@@ -278,8 +311,10 @@ VIEW_HTML = """<!doctype html>
 <h2>Lineage log</h2>
 <pre hx-get="/log" hx-trigger="load, every 2s"></pre>"""
 
-def serve_lineage(path: pathlib.Path, port: int=8000):
+
+def serve_lineage(path: pathlib.Path, port: int = 8000):
     import flask, threading
+
     app = flask.Flask("lineage-viewer")
 
     @app.route("/")
@@ -297,6 +332,7 @@ def serve_lineage(path: pathlib.Path, port: int=8000):
     th.start()
     LOGGER.info("Lineage viewer at http://localhost:%d", port)
     return th
+
 
 # ---------------------------------------------------------------------------
 # Example usage

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/agents/agent_base.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/agents/agent_base.py
@@ -27,6 +27,7 @@ Key capabilities
 
 Apache‑2.0 © 2025 MONTREAL.AI
 """
+
 from __future__ import annotations
 
 import os, sys, time, json, uuid, math, json, pathlib, logging, importlib, hashlib
@@ -47,15 +48,19 @@ logging.basicConfig(level=os.environ.get("ALPHAF_FACTORY_LOGLEVEL", "INFO"))
 # Helper utilities
 # ---------------------------------------------------------------------------
 
+
 def _sha(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()[:10]
+
 
 def _utcnow_ms() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + f".{int((time.time()%1)*1000):03d}Z"
 
+
 def _str_tkn(text: str) -> int:
     # naïve token estimate ≈‑ 1 token / 4 chars in English
-    return max(1, math.ceil(len(text)/4))
+    return max(1, math.ceil(len(text) / 4))
+
 
 # ---------------------------------------------------------------------------
 # Rate limiter (token bucket, per‑second)
@@ -78,7 +83,9 @@ class RateLimiter:
             sleep = (cost - self._allow) / self._tps + 1e-3
             time.sleep(sleep)
 
+
 GLOBAL_LIMITER = RateLimiter(float(os.getenv("ALPHA_TPS", 3)))
+
 
 # ---------------------------------------------------------------------------
 # LM Provider adapter
@@ -94,14 +101,16 @@ class LMClient:
         "llama": None,  # local
     }
 
-    def __init__(self,
-                 endpoint: str = "openai:gpt-4o",
-                 temperature: float = 0.2,
-                 max_tokens: int = 2048,
-                 context_len: int = 8192,
-                 stream: bool = False,
-                 timeout: int = 120,
-                 **extra):
+    def __init__(
+        self,
+        endpoint: str = "openai:gpt-4o",
+        temperature: float = 0.2,
+        max_tokens: int = 2048,
+        context_len: int = 8192,
+        stream: bool = False,
+        timeout: int = 120,
+        **extra,
+    ):
         self.endpoint = endpoint
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -116,7 +125,7 @@ class LMClient:
     def _parse(self, ep: str):
         if ":" not in ep:
             raise ValueError("Endpoint must be <backend>:<model>")
-        return ep.split(":",1)
+        return ep.split(":", 1)
 
     def _init_backend(self):
         back = self._backend
@@ -129,13 +138,13 @@ class LMClient:
         if back == "gemini":
             mod = importlib.import_module("google.generativeai")
             return mod.GenerativeModel(self._model)
-        if back in ("mistral","llama"):
+        if back in ("mistral", "llama"):
             mod = importlib.import_module("llama_cpp")
             return mod.Llama(model_path=self._model, n_ctx=self.context_len)
         raise NotImplementedError(back)
 
     # .................................
-    def chat(self, msgs: List[Dict[str,str]], **kw) -> str:
+    def chat(self, msgs: List[Dict[str, str]], **kw) -> str:
         merged = dict(temperature=self.temperature, max_tokens=self.max_tokens, **kw)
         attempts = 0
         while True:
@@ -149,15 +158,18 @@ class LMClient:
                     return rsp.content[0].text
                 if self._backend == "gemini":
                     return self._client.generate_content(msgs[-1]["content"], **merged).text
-                if self._backend in ("mistral","llama"):
-                    prompt = "".join(f"<{m['role']}> {m['content']}" for m in msgs)+"\n<assistant> "
-                    out = self._client(prompt, max_tokens=self.max_tokens, temperature=self.temperature, stop=["</assistant>"])
+                if self._backend in ("mistral", "llama"):
+                    prompt = "".join(f"<{m['role']}> {m['content']}" for m in msgs) + "\n<assistant> "
+                    out = self._client(
+                        prompt, max_tokens=self.max_tokens, temperature=self.temperature, stop=["</assistant>"]
+                    )
                     return out["choices"][0]["text"].strip()
             except Exception as e:
                 attempts += 1
                 wait = min(60, 2**attempts)
                 LOGGER.warning("LM error %s; retry in %.1fs", e, wait)
                 time.sleep(wait)
+
 
 # ---------------------------------------------------------------------------
 # Lineage tracer & UI stub
@@ -172,6 +184,7 @@ class LineageTracer:
             json.dump({"ts": _utcnow_ms(), "event": event, **payload}, fp, ensure_ascii=False)
             fp.write("\n")
 
+
 # ---------------------------------------------------------------------------
 # Multi‑objective scorer
 # ---------------------------------------------------------------------------
@@ -182,49 +195,52 @@ class ObjectiveWeights:
     carbon: float = 0.2
     risk: float = 0.3
 
-    def score(self, metrics: Dict[str,float]) -> float:
+    def score(self, metrics: Dict[str, float]) -> float:
         return (
-            self.latency * (1/ (1+metrics.get("latency",0))) +
-            self.cost    * (1/ (1+metrics.get("cost",0))) +
-            self.carbon  * (1/ (1+metrics.get("carbon",0))) +
-            self.risk    * (1- metrics.get("risk",0))
+            self.latency * (1 / (1 + metrics.get("latency", 0)))
+            + self.cost * (1 / (1 + metrics.get("cost", 0)))
+            + self.carbon * (1 / (1 + metrics.get("carbon", 0)))
+            + self.risk * (1 - metrics.get("risk", 0))
         )
+
 
 # ---------------------------------------------------------------------------
 # Agent base‑class
 # ---------------------------------------------------------------------------
 class Agent:
-    def __init__(self,
-                 name: str,
-                 role: str = "autonomous‑agent",
-                 provider: str | None = None,
-                 objectives: Optional[ObjectiveWeights] = None,
-                 lineage_dir: str | pathlib.Path = "./lineage",
-                 rate_limit_tps: float = 3.0):
+    def __init__(
+        self,
+        name: str,
+        role: str = "autonomous‑agent",
+        provider: str | None = None,
+        objectives: Optional[ObjectiveWeights] = None,
+        lineage_dir: str | pathlib.Path = "./lineage",
+        rate_limit_tps: float = 3.0,
+    ):
         self.name = name
         self.role = role
         self.id = f"{name}-{_sha(uuid.uuid4().hex)}"
         self.objectives = objectives or ObjectiveWeights()
         self.lm = LMClient(provider or os.getenv("ALPHA_PROVIDER", "openai:gpt-4o"))
-        self.tracer = LineageTracer(pathlib.Path(lineage_dir)/f"{self.id}.jsonl")
+        self.tracer = LineageTracer(pathlib.Path(lineage_dir) / f"{self.id}.jsonl")
         self.tracer.log("init", role=role, provider=self.lm.endpoint)
         GLOBAL_LIMITER._tps = rate_limit_tps
 
     # .................................................................
-    def _estimate_cost(self, prompt_tokens:int, completion_tokens:int) -> float:
-        price = float(os.getenv("ALPHA_USD_PER_M", 0.01)) # user override
-        return ((prompt_tokens+completion_tokens)/1_000_000)*price
+    def _estimate_cost(self, prompt_tokens: int, completion_tokens: int) -> float:
+        price = float(os.getenv("ALPHA_USD_PER_M", 0.01))  # user override
+        return ((prompt_tokens + completion_tokens) / 1_000_000) * price
 
-    def run(self, prompt: str, context: Optional[Iterable[Dict[str,str]]]=None, **kw) -> Dict[str,Any]:
-        ctx: List[Dict[str,str]] = list(context or [])
-        ctx.append({"role":"user", "content": prompt})
+    def run(self, prompt: str, context: Optional[Iterable[Dict[str, str]]] = None, **kw) -> Dict[str, Any]:
+        ctx: List[Dict[str, str]] = list(context or [])
+        ctx.append({"role": "user", "content": prompt})
         t0 = time.perf_counter()
         output = self.lm.chat(ctx, **kw)
-        latency = time.perf_counter()-t0
+        latency = time.perf_counter() - t0
         tokens_in = _str_tkn(prompt)
         tokens_out = _str_tkn(output)
-        cost = self._estimate_cost(tokens_in,tokens_out)
-        carbon = cost*0.00015 # placeholder multiplier (avg kgCO2 per $ cloud)
+        cost = self._estimate_cost(tokens_in, tokens_out)
+        carbon = cost * 0.00015  # placeholder multiplier (avg kgCO2 per $ cloud)
         risk = self._risk_assess(prompt, output)
         metrics = dict(latency=latency, cost=cost, carbon=carbon, risk=risk)
         score = self.objectives.score(metrics)
@@ -232,27 +248,35 @@ class Agent:
         return {"response": output, "metrics": metrics, "score": score}
 
     # .................................................................
-    def _risk_assess(self, prompt:str, response:str) -> float:
+    def _risk_assess(self, prompt: str, response: str) -> float:
         # toy heuristic: long responses & code carry more risk
-        return min(1.0, 0.1 + 0.9*(len(response)/4000))
+        return min(1.0, 0.1 + 0.9 * (len(response) / 4000))
 
     # .................................................................
-    def __call__(self, prompt:str, **kw):
+    def __call__(self, prompt: str, **kw):
         return self.run(prompt, **kw)
+
 
 # ---------------------------------------------------------------------------
 # Sandbox utilities for dynamic code exec (optional)
 # ---------------------------------------------------------------------------
 class SafeExec:
-    """Run untrusted python code under CPU/ram constraints."""
-    def __init__(self, cpu_sec:int=2, mem_mb:int=128):
+    """Run untrusted Python under CPU/ram limits using a restricted sandbox.
+
+    The code executes with :mod:`RestrictedPython` if installed.  When the
+    package is unavailable, a tiny ``__builtins__`` dictionary containing only
+    ``print``, ``range`` and ``len`` is provided.  Dangerous functions such as
+    ``open`` or ``__import__`` are therefore inaccessible.
+    """
+
+    def __init__(self, cpu_sec: int = 2, mem_mb: int = 128):
         self.cpu_sec = cpu_sec
         self.mem_mb = mem_mb
 
     def __enter__(self):
         if resource:
             resource.setrlimit(resource.RLIMIT_CPU, (self.cpu_sec, self.cpu_sec))
-            resource.setrlimit(resource.RLIMIT_AS, (self.mem_mb*1024*1024, self.mem_mb*1024*1024))
+            resource.setrlimit(resource.RLIMIT_AS, (self.mem_mb * 1024 * 1024, self.mem_mb * 1024 * 1024))
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -261,12 +285,21 @@ class SafeExec:
         return False  # do not suppress
 
     def run(self, code: str, func_name: str, *args, **kw):
-        loc: Dict[str,Any] = {}
+        """Execute ``code`` safely and run ``func_name`` with ``args``."""
+        loc: Dict[str, Any] = {}
         with self:
-            exec(code, {}, loc)
+            try:
+                RP = importlib.import_module("RestrictedPython")
+                compiled = RP.compile_restricted_exec(code)
+                sec_builtins = RP.Guards.safe_builtins.copy()
+                exec(compiled, {"__builtins__": sec_builtins}, loc)
+            except Exception:
+                safe_builtins = {"print": print, "range": range, "len": len}
+                exec(compile(code, "<sandbox>", "exec"), {"__builtins__": safe_builtins}, loc)
         if func_name not in loc:
             raise AttributeError(f"{func_name} not found")
         return loc[func_name](*args, **kw)
+
 
 # ---------------------------------------------------------------------------
 # Simple lineage viewer (optional)
@@ -278,8 +311,10 @@ VIEW_HTML = """<!doctype html>
 <h2>Lineage log</h2>
 <pre hx-get="/log" hx-trigger="load, every 2s"></pre>"""
 
-def serve_lineage(path: pathlib.Path, port: int=8000):
+
+def serve_lineage(path: pathlib.Path, port: int = 8000):
     import flask, threading
+
     app = flask.Flask("lineage-viewer")
 
     @app.route("/")
@@ -297,6 +332,7 @@ def serve_lineage(path: pathlib.Path, port: int=8000):
     th.start()
     LOGGER.info("Lineage viewer at http://localhost:%d", port)
     return th
+
 
 # ---------------------------------------------------------------------------
 # Example usage

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/agents/agent_base.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/agents/agent_base.py
@@ -27,6 +27,7 @@ Key capabilities
 
 Apache‑2.0 © 2025 MONTREAL.AI
 """
+
 from __future__ import annotations
 
 import os, sys, time, json, uuid, math, json, pathlib, logging, importlib, hashlib
@@ -47,15 +48,19 @@ logging.basicConfig(level=os.environ.get("ALPHAF_FACTORY_LOGLEVEL", "INFO"))
 # Helper utilities
 # ---------------------------------------------------------------------------
 
+
 def _sha(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()[:10]
+
 
 def _utcnow_ms() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + f".{int((time.time()%1)*1000):03d}Z"
 
+
 def _str_tkn(text: str) -> int:
     # naïve token estimate ≈‑ 1 token / 4 chars in English
-    return max(1, math.ceil(len(text)/4))
+    return max(1, math.ceil(len(text) / 4))
+
 
 # ---------------------------------------------------------------------------
 # Rate limiter (token bucket, per‑second)
@@ -78,7 +83,9 @@ class RateLimiter:
             sleep = (cost - self._allow) / self._tps + 1e-3
             time.sleep(sleep)
 
+
 GLOBAL_LIMITER = RateLimiter(float(os.getenv("ALPHA_TPS", 3)))
+
 
 # ---------------------------------------------------------------------------
 # LM Provider adapter
@@ -94,14 +101,16 @@ class LMClient:
         "llama": None,  # local
     }
 
-    def __init__(self,
-                 endpoint: str = "openai:gpt-4o",
-                 temperature: float = 0.2,
-                 max_tokens: int = 2048,
-                 context_len: int = 8192,
-                 stream: bool = False,
-                 timeout: int = 120,
-                 **extra):
+    def __init__(
+        self,
+        endpoint: str = "openai:gpt-4o",
+        temperature: float = 0.2,
+        max_tokens: int = 2048,
+        context_len: int = 8192,
+        stream: bool = False,
+        timeout: int = 120,
+        **extra,
+    ):
         self.endpoint = endpoint
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -116,7 +125,7 @@ class LMClient:
     def _parse(self, ep: str):
         if ":" not in ep:
             raise ValueError("Endpoint must be <backend>:<model>")
-        return ep.split(":",1)
+        return ep.split(":", 1)
 
     def _init_backend(self):
         back = self._backend
@@ -129,13 +138,13 @@ class LMClient:
         if back == "gemini":
             mod = importlib.import_module("google.generativeai")
             return mod.GenerativeModel(self._model)
-        if back in ("mistral","llama"):
+        if back in ("mistral", "llama"):
             mod = importlib.import_module("llama_cpp")
             return mod.Llama(model_path=self._model, n_ctx=self.context_len)
         raise NotImplementedError(back)
 
     # .................................
-    def chat(self, msgs: List[Dict[str,str]], **kw) -> str:
+    def chat(self, msgs: List[Dict[str, str]], **kw) -> str:
         merged = dict(temperature=self.temperature, max_tokens=self.max_tokens, **kw)
         attempts = 0
         while True:
@@ -149,15 +158,18 @@ class LMClient:
                     return rsp.content[0].text
                 if self._backend == "gemini":
                     return self._client.generate_content(msgs[-1]["content"], **merged).text
-                if self._backend in ("mistral","llama"):
-                    prompt = "".join(f"<{m['role']}> {m['content']}" for m in msgs)+"\n<assistant> "
-                    out = self._client(prompt, max_tokens=self.max_tokens, temperature=self.temperature, stop=["</assistant>"])
+                if self._backend in ("mistral", "llama"):
+                    prompt = "".join(f"<{m['role']}> {m['content']}" for m in msgs) + "\n<assistant> "
+                    out = self._client(
+                        prompt, max_tokens=self.max_tokens, temperature=self.temperature, stop=["</assistant>"]
+                    )
                     return out["choices"][0]["text"].strip()
             except Exception as e:
                 attempts += 1
                 wait = min(60, 2**attempts)
                 LOGGER.warning("LM error %s; retry in %.1fs", e, wait)
                 time.sleep(wait)
+
 
 # ---------------------------------------------------------------------------
 # Lineage tracer & UI stub
@@ -172,6 +184,7 @@ class LineageTracer:
             json.dump({"ts": _utcnow_ms(), "event": event, **payload}, fp, ensure_ascii=False)
             fp.write("\n")
 
+
 # ---------------------------------------------------------------------------
 # Multi‑objective scorer
 # ---------------------------------------------------------------------------
@@ -182,49 +195,52 @@ class ObjectiveWeights:
     carbon: float = 0.2
     risk: float = 0.3
 
-    def score(self, metrics: Dict[str,float]) -> float:
+    def score(self, metrics: Dict[str, float]) -> float:
         return (
-            self.latency * (1/ (1+metrics.get("latency",0))) +
-            self.cost    * (1/ (1+metrics.get("cost",0))) +
-            self.carbon  * (1/ (1+metrics.get("carbon",0))) +
-            self.risk    * (1- metrics.get("risk",0))
+            self.latency * (1 / (1 + metrics.get("latency", 0)))
+            + self.cost * (1 / (1 + metrics.get("cost", 0)))
+            + self.carbon * (1 / (1 + metrics.get("carbon", 0)))
+            + self.risk * (1 - metrics.get("risk", 0))
         )
+
 
 # ---------------------------------------------------------------------------
 # Agent base‑class
 # ---------------------------------------------------------------------------
 class Agent:
-    def __init__(self,
-                 name: str,
-                 role: str = "autonomous‑agent",
-                 provider: str | None = None,
-                 objectives: Optional[ObjectiveWeights] = None,
-                 lineage_dir: str | pathlib.Path = "./lineage",
-                 rate_limit_tps: float = 3.0):
+    def __init__(
+        self,
+        name: str,
+        role: str = "autonomous‑agent",
+        provider: str | None = None,
+        objectives: Optional[ObjectiveWeights] = None,
+        lineage_dir: str | pathlib.Path = "./lineage",
+        rate_limit_tps: float = 3.0,
+    ):
         self.name = name
         self.role = role
         self.id = f"{name}-{_sha(uuid.uuid4().hex)}"
         self.objectives = objectives or ObjectiveWeights()
         self.lm = LMClient(provider or os.getenv("ALPHA_PROVIDER", "openai:gpt-4o"))
-        self.tracer = LineageTracer(pathlib.Path(lineage_dir)/f"{self.id}.jsonl")
+        self.tracer = LineageTracer(pathlib.Path(lineage_dir) / f"{self.id}.jsonl")
         self.tracer.log("init", role=role, provider=self.lm.endpoint)
         GLOBAL_LIMITER._tps = rate_limit_tps
 
     # .................................................................
-    def _estimate_cost(self, prompt_tokens:int, completion_tokens:int) -> float:
-        price = float(os.getenv("ALPHA_USD_PER_M", 0.01)) # user override
-        return ((prompt_tokens+completion_tokens)/1_000_000)*price
+    def _estimate_cost(self, prompt_tokens: int, completion_tokens: int) -> float:
+        price = float(os.getenv("ALPHA_USD_PER_M", 0.01))  # user override
+        return ((prompt_tokens + completion_tokens) / 1_000_000) * price
 
-    def run(self, prompt: str, context: Optional[Iterable[Dict[str,str]]]=None, **kw) -> Dict[str,Any]:
-        ctx: List[Dict[str,str]] = list(context or [])
-        ctx.append({"role":"user", "content": prompt})
+    def run(self, prompt: str, context: Optional[Iterable[Dict[str, str]]] = None, **kw) -> Dict[str, Any]:
+        ctx: List[Dict[str, str]] = list(context or [])
+        ctx.append({"role": "user", "content": prompt})
         t0 = time.perf_counter()
         output = self.lm.chat(ctx, **kw)
-        latency = time.perf_counter()-t0
+        latency = time.perf_counter() - t0
         tokens_in = _str_tkn(prompt)
         tokens_out = _str_tkn(output)
-        cost = self._estimate_cost(tokens_in,tokens_out)
-        carbon = cost*0.00015 # placeholder multiplier (avg kgCO2 per $ cloud)
+        cost = self._estimate_cost(tokens_in, tokens_out)
+        carbon = cost * 0.00015  # placeholder multiplier (avg kgCO2 per $ cloud)
         risk = self._risk_assess(prompt, output)
         metrics = dict(latency=latency, cost=cost, carbon=carbon, risk=risk)
         score = self.objectives.score(metrics)
@@ -232,27 +248,35 @@ class Agent:
         return {"response": output, "metrics": metrics, "score": score}
 
     # .................................................................
-    def _risk_assess(self, prompt:str, response:str) -> float:
+    def _risk_assess(self, prompt: str, response: str) -> float:
         # toy heuristic: long responses & code carry more risk
-        return min(1.0, 0.1 + 0.9*(len(response)/4000))
+        return min(1.0, 0.1 + 0.9 * (len(response) / 4000))
 
     # .................................................................
-    def __call__(self, prompt:str, **kw):
+    def __call__(self, prompt: str, **kw):
         return self.run(prompt, **kw)
+
 
 # ---------------------------------------------------------------------------
 # Sandbox utilities for dynamic code exec (optional)
 # ---------------------------------------------------------------------------
 class SafeExec:
-    """Run untrusted python code under CPU/ram constraints."""
-    def __init__(self, cpu_sec:int=2, mem_mb:int=128):
+    """Run untrusted Python under CPU/ram limits using a restricted sandbox.
+
+    The code executes with :mod:`RestrictedPython` if installed.  When the
+    package is unavailable, a tiny ``__builtins__`` dictionary containing only
+    ``print``, ``range`` and ``len`` is provided.  Dangerous functions such as
+    ``open`` or ``__import__`` are therefore inaccessible.
+    """
+
+    def __init__(self, cpu_sec: int = 2, mem_mb: int = 128):
         self.cpu_sec = cpu_sec
         self.mem_mb = mem_mb
 
     def __enter__(self):
         if resource:
             resource.setrlimit(resource.RLIMIT_CPU, (self.cpu_sec, self.cpu_sec))
-            resource.setrlimit(resource.RLIMIT_AS, (self.mem_mb*1024*1024, self.mem_mb*1024*1024))
+            resource.setrlimit(resource.RLIMIT_AS, (self.mem_mb * 1024 * 1024, self.mem_mb * 1024 * 1024))
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -261,12 +285,21 @@ class SafeExec:
         return False  # do not suppress
 
     def run(self, code: str, func_name: str, *args, **kw):
-        loc: Dict[str,Any] = {}
+        """Execute ``code`` safely and run ``func_name`` with ``args``."""
+        loc: Dict[str, Any] = {}
         with self:
-            exec(code, {}, loc)
+            try:
+                RP = importlib.import_module("RestrictedPython")
+                compiled = RP.compile_restricted_exec(code)
+                sec_builtins = RP.Guards.safe_builtins.copy()
+                exec(compiled, {"__builtins__": sec_builtins}, loc)
+            except Exception:
+                safe_builtins = {"print": print, "range": range, "len": len}
+                exec(compile(code, "<sandbox>", "exec"), {"__builtins__": safe_builtins}, loc)
         if func_name not in loc:
             raise AttributeError(f"{func_name} not found")
         return loc[func_name](*args, **kw)
+
 
 # ---------------------------------------------------------------------------
 # Simple lineage viewer (optional)
@@ -278,8 +311,10 @@ VIEW_HTML = """<!doctype html>
 <h2>Lineage log</h2>
 <pre hx-get="/log" hx-trigger="load, every 2s"></pre>"""
 
-def serve_lineage(path: pathlib.Path, port: int=8000):
+
+def serve_lineage(path: pathlib.Path, port: int = 8000):
     import flask, threading
+
     app = flask.Flask("lineage-viewer")
 
     @app.route("/")
@@ -297,6 +332,7 @@ def serve_lineage(path: pathlib.Path, port: int=8000):
     th.start()
     LOGGER.info("Lineage viewer at http://localhost:%d", port)
     return th
+
 
 # ---------------------------------------------------------------------------
 # Example usage

--- a/tests/test_safe_exec_security.py
+++ b/tests/test_safe_exec_security.py
@@ -1,0 +1,34 @@
+import unittest
+
+from alpha_factory_v1.demos.meta_agentic_agi.agents import agent_base
+from alpha_factory_v1.demos.meta_agentic_agi.agents.agent_base import SafeExec
+
+
+class TestSafeExecSecurity(unittest.TestCase):
+    def test_open_blocked(self):
+        agent_base.resource = None
+        agent_base.signal = None
+        se = SafeExec()
+        code = """\
+
+def transform(x):
+    return open('foo', 'w')
+"""
+        with self.assertRaises(NameError):
+            se.run(code, "transform", 0)
+
+    def test_import_system_blocked(self):
+        agent_base.resource = None
+        agent_base.signal = None
+        se = SafeExec()
+        code = """\
+
+def transform(x):
+    return __import__('os').system('echo hi')
+"""
+        with self.assertRaises(NameError):
+            se.run(code, "transform", 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden SafeExec by using RestrictedPython if present
- fallback to minimal builtin sandbox when RestrictedPython isn't installed
- clarify sandbox security model in SafeExec docstring
- add tests ensuring dangerous calls are blocked

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_safe_exec_security.py -q`
- `pytest -q` *(failed: process was killed)*
- `ruff check alpha_factory_v1/demos/meta_agentic_agi/agents/agent_base.py alpha_factory_v1/demos/meta_agentic_agi_v2/agents/agent_base.py alpha_factory_v1/demos/meta_agentic_agi_v3/agents/agent_base.py` *(errors from existing code)*
- `mypy --config-file mypy.ini tests/test_safe_exec_security.py` *(errors from existing code)*