### PR TITLE
[alpha_factory] tolerant orchestrator env parsing

### DIFF
--- a/alpha_factory_v1/backend/README.md
+++ b/alpha_factory_v1/backend/README.md
@@ -39,5 +39,6 @@ This starts the orchestrator in development mode, using in-memory stubs for Kafk
 
 - Optional dependencies are soft-imported; missing libraries will disable related features without crashing the service.
 - The gRPC server starts automatically when `A2A_PORT` is set and shuts down cleanly on exit.
+- Numeric environment variables are parsed leniently; invalid values fall back to the defaults above.
 - See `../requirements.txt` for the full dependency list.
 

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -108,16 +108,27 @@ except ModuleNotFoundError:  # pragma: no cover
 
 # ────────────────────────── configuration ─────────────────────────────
 ENV = os.getenv
+
+
+def _env_int(name: str, default: int) -> int:
+    """Return ``int`` environment value or ``default`` if conversion fails."""
+
+    try:
+        return int(ENV(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
 DEV_MODE = ENV("DEV_MODE", "false").lower() == "true" or "--dev" in sys.argv
 LOGLEVEL = ENV("LOGLEVEL", "INFO").upper()
-PORT = int(ENV("PORT", "8000"))
-METRICS_PORT = int(ENV("METRICS_PORT", "0"))
-A2A_PORT = int(ENV("A2A_PORT", "0"))
+PORT = _env_int("PORT", 8000)
+METRICS_PORT = _env_int("METRICS_PORT", 0)
+A2A_PORT = _env_int("A2A_PORT", 0)
 SSL_DISABLE = ENV("INSECURE_DISABLE_TLS", "false").lower() == "true"
 KAFKA_BROKER = None if DEV_MODE else ENV("ALPHA_KAFKA_BROKER")
-CYCLE_DEFAULT = int(ENV("ALPHA_CYCLE_SECONDS", "60"))
-MAX_CYCLE_SEC = int(ENV("MAX_CYCLE_SEC", "30"))
-MODEL_MAX_BYTES = int(ENV("ALPHA_MODEL_MAX_BYTES", str(64 * 1024 * 1024)))
+CYCLE_DEFAULT = _env_int("ALPHA_CYCLE_SECONDS", 60)
+MAX_CYCLE_SEC = _env_int("MAX_CYCLE_SEC", 30)
+MODEL_MAX_BYTES = _env_int("ALPHA_MODEL_MAX_BYTES", 64 * 1024 * 1024)
 ENABLED = {s.strip() for s in ENV("ALPHA_ENABLED_AGENTS", "").split(",") if s.strip()}
 
 if not logging.getLogger().handlers:

--- a/tests/test_orchestrator_env.py
+++ b/tests/test_orchestrator_env.py
@@ -1,0 +1,31 @@
+import importlib
+import os
+import unittest
+from unittest import mock
+
+
+class TestOrchestratorEnv(unittest.TestCase):
+    def test_invalid_numeric_fallback(self) -> None:
+        env = {
+            "DEV_MODE": "true",
+            "PORT": "foo",
+            "METRICS_PORT": "bar",
+            "A2A_PORT": "baz",
+            "ALPHA_CYCLE_SECONDS": "qux",
+            "MAX_CYCLE_SEC": "zap",
+            "ALPHA_MODEL_MAX_BYTES": "oops",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            orch = importlib.reload(
+                importlib.import_module("alpha_factory_v1.backend.orchestrator")
+            )
+        self.assertEqual(orch.PORT, 8000)
+        self.assertEqual(orch.METRICS_PORT, 0)
+        self.assertEqual(orch.A2A_PORT, 0)
+        self.assertEqual(orch.CYCLE_DEFAULT, 60)
+        self.assertEqual(orch.MAX_CYCLE_SEC, 30)
+        self.assertEqual(orch.MODEL_MAX_BYTES, 64 * 1024 * 1024)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow fallback integer env parsing for orchestrator like edge runner
- test invalid numeric env values
- document that numeric env vars are parsed leniently

## Testing
- `python check_env.py --auto-install`
- `pytest -q`