### PR TITLE
[alpha_factory] openai runtime cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ alpha-agi-bhf --episodes 5
 
 When API keys are configured the program automatically uses the OpenAI Agents
 runtime. Otherwise it falls back to the local Meta‑Agentic Tree Search.
+The orchestrator also cleans up the OpenAI runtime on exit to release resources.
 
 For production use, invoke the **official demo** which automatically
 checks the environment, selects the best runtime and optionally starts the

--- a/alpha_factory_v1/docs/alpha_agi_agent.md
+++ b/alpha_factory_v1/docs/alpha_agi_agent.md
@@ -119,6 +119,7 @@ from alpha_factory_v1.backend.agents.finance import FinanceAgent
 rt = AgentRuntime(api_key=None)           # Works offline
 rt.register(FinanceAgent(ens="finance.demo.a.agent.agi.eth"))
 rt.serve()
+# The orchestrator shuts down the runtime automatically on exit
 ```
 
 ---

--- a/tests/test_oai_runtime.py
+++ b/tests/test_oai_runtime.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest import mock
+
+from alpha_factory_v1.backend import orchestrator
+
+
+class TestOAIRuntime(unittest.TestCase):
+    def test_shutdown_called_on_exit(self) -> None:
+        orchestrator._OAI._runtime = None
+        orchestrator._OAI._hooked = False
+        stub = mock.MagicMock()
+        handlers = []
+        with mock.patch.object(orchestrator, "AgentRuntime", return_value=stub, create=True):
+            with mock.patch.object(orchestrator.atexit, "register", side_effect=lambda h: handlers.append(h)) as reg:
+                self.assertIs(orchestrator._OAI.runtime(), stub)
+                reg.assert_called_once()
+        self.assertEqual(len(handlers), 1)
+        handlers[0]()
+        stub.shutdown.assert_called_once()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- automatically close the OpenAI Agents runtime when the orchestrator exits
- document runtime cleanup in README and docs
- test shutdown hook

## Testing
- `python check_env.py --auto-install`
- `pytest -q`