### PR TITLE
[alpha_factory] expose Broker class

### DIFF
--- a/alpha_factory_v1/backend/broker/__init__.py
+++ b/alpha_factory_v1/backend/broker/__init__.py
@@ -4,8 +4,10 @@ import os
 _BROKER = os.getenv("ALPHA_BROKER", "sim").lower()
 
 if _BROKER == "alpaca":
-    from .broker_alpaca import AlpacaBroker as Broker  # type: ignore
+    from .broker_alpaca import AlpacaBroker as Broker
 elif _BROKER == "ibkr":
-    from .broker_ibkr import InteractiveBrokersBroker as Broker  # type: ignore
+    from .broker_ibkr import InteractiveBrokersBroker as Broker
 else:
-    from .broker_sim import SimulatedBroker as Broker  # type: ignore
+    from .broker_sim import SimulatedBroker as Broker
+
+__all__ = ["Broker"]


### PR DESCRIPTION
## Summary
- ensure the backend broker module reexports `Broker`
- remove unused `type: ignore` comments

## Testing
- `ruff check alpha_factory_v1/backend/broker/__init__.py`
- `mypy --config-file mypy.ini alpha_factory_v1/backend/broker/__init__.py` *(fails: Found 143 errors in 10 files)*
- `pytest -q`
- `python check_env.py --auto-install`
