### PR TITLE
[alpha_factory] remove obsolete noqa comment

### DIFF
--- a/alpha_factory_v1/backend/trace_ws.py
+++ b/alpha_factory_v1/backend/trace_ws.py
@@ -151,7 +151,7 @@ def attach(app) -> None:  # noqa: D401
     router = APIRouter()
 
     @router.websocket("/ws/trace")
-    async def _trace_ws(ws: WebSocket):  # noqa: WPS430
+    async def _trace_ws(ws: WebSocket):
         """
         WebSocket stream with race‑free, CSRF‑checked loop.
 


### PR DESCRIPTION
## Summary
- clean up unused noqa in `trace_ws`

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/backend/trace_ws.py`
- `pytest -q`

Pre-commit could not be run because the environment lacked `pre-commit`.