### PR TITLE
[alpha_factory] fix import ordering

### DIFF
--- a/alpha_factory_v1/backend/integrations/neo4j_graph.py
+++ b/alpha_factory_v1/backend/integrations/neo4j_graph.py
@@ -10,6 +10,8 @@ import logging
 import os
 from typing import Iterable, Tuple
 
+import networkx as nx
+
 _LOG = logging.getLogger("alpha_factory.graph")
 _LOG.addHandler(logging.NullHandler())
 
@@ -19,8 +21,6 @@ try:
     _NEO4J_OK = True
 except ModuleNotFoundError:
     _NEO4J_OK = False
-
-import networkx as nx
 
 _URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
 _USER = os.getenv("NEO4J_USER", "neo4j")


### PR DESCRIPTION
## Summary
- move `networkx` import into top block of `neo4j_graph.py`
- keep conditional `neo4j` logic after imports

## Testing
- `ruff check alpha_factory_v1/backend/integrations/neo4j_graph.py`
- `pytest -q`
- `python check_env.py --auto-install`
- `mypy --config-file mypy.ini alpha_factory_v1/backend/integrations/neo4j_graph.py` *(fails: many errors across repo)*
