### PR TITLE
[alpha_factory] remove unused imports

### DIFF
--- a/alpha_factory_v1/backend/mcp_bridge.py
+++ b/alpha_factory_v1/backend/mcp_bridge.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from typing import Dict, List, TypedDict
+from typing import List, TypedDict
 
 try:
     import httpx  # type: ignore

--- a/alpha_factory_v1/backend/memory_vector.py
+++ b/alpha_factory_v1/backend/memory_vector.py
@@ -32,10 +32,8 @@ import logging
 import os
 import queue
 import random
-import sqlite3
 import sys
 import time
-from pathlib import Path
 from typing import Iterable, List, Sequence, Tuple
 
 try:  # NumPy optional – provide pure Python fallback


### PR DESCRIPTION
## Summary
- drop unused Dict import from MCP bridge
- drop unused sqlite3 and Path imports from memory_vector

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `ruff check alpha_factory_v1/backend/mcp_bridge.py alpha_factory_v1/backend/memory_vector.py`
- ❌ `pre-commit run --files alpha_factory_v1/backend/mcp_bridge.py alpha_factory_v1/backend/memory_vector.py` *(failed: pre-commit not installed)*