### PR TITLE
[alpha_factory] ignore env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ dist/
 
 # Logs
 *.log
+# Environment configuration files
+.env
+*.env
 


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude `.env` secrets

## Testing
- `pre-commit run --files .gitignore` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pytest -q`
