### PR TITLE
[alpha_factory] update env instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,9 @@ The instructions below apply to all contributors and automated agents.
 - On Windows or systems without Bash, run
   `python alpha_factory_v1/quickstart.py --preflight`.
 - Copy `alpha_factory_v1/.env.sample` to `.env` and add secrets such as
-  `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`.
+  `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`. Replace `NEO4J_PASSWORD=changeme`
+  with a strong secret— the orchestrator fails to start if this variable is
+  missing or left at the default.
 - **Never commit** `.env` or other secrets. See
   [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md)
   for additional guidance.


### PR DESCRIPTION
## Summary
- instruct contributors to set `NEO4J_PASSWORD` in `.env`
- warn that the orchestrator fails if it's missing or unchanged

## Testing
- `python check_env.py --auto-install`
- `pytest -q`