### PR TITLE
[alpha_factory] update test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ The instructions below apply to all contributors and automated agents.
 - The unit tests rely on `fastapi` and `opentelemetry-api`. Install them via
   `requirements-dev.txt` or ensure `check_env.py` reports no missing packages
   before running `pytest`.
+- If the project is installed without `./codex/setup.sh`, run
+  `pip install -r requirements-dev.txt` to obtain `fastapi` and
+  `opentelemetry-api`.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes. If failures remain, document them in the PR description.
 - See [`alpha_factory_v1/tests/README.md`](alpha_factory_v1/tests/README.md) for test-specific environment variables. `AF_MEMORY_DIR` sets the temporary memory path while `PYTEST_CPU_SOFT_SEC`, `PYTEST_MEM_MB` and `PYTEST_NET_OFF` control CPU time, memory usage and network access. The optional sandboxed runner `python -m alpha_factory_v1.backend.tools.local_pytest` enforces these limits.
 - Run `python alpha_factory_v1/scripts/preflight.py` to confirm the Python version and required tools are available.


### PR DESCRIPTION
## Summary
- add note on installing FastAPI and OpenTelemetry API when `./codex/setup.sh` isn't used

## Testing
- `python check_env.py --auto-install`
- `pytest -q`