### PR TITLE
[alpha_factory] Add code of conduct link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ The instructions below apply to all contributors and automated agents.
 - [Coding Style](#coding-style)
 - [Pull Requests](#pull-requests)
 - [Troubleshooting](#troubleshooting)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 
+All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 ## Prerequisites
 - Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**)
 - Docker and Docker Compose


### PR DESCRIPTION
## Summary
- add Code of Conduct to quick links
- remind contributors to follow it

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `ruff check .` *(fails: many lint errors)*
- `mypy --config-file mypy.ini .` *(fails: 2688 errors)*
- `pip install pre-commit` *(fails: no network)*