### PR TITLE
[alpha_factory] warn for old compose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,9 @@ The instructions below apply to all contributors and automated agents.
 All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 ## Prerequisites
 - Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**)
-- Docker and Docker Compose
+- Docker and Docker Compose (Compose ≥2.5)
 - Git
-- The script `alpha_factory_v1/scripts/preflight.py` validates these tools.
+- Run `python alpha_factory_v1/scripts/preflight.py` to validate these tools.
 
 ## Development Environment
 - Create and activate a Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**) virtual

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -67,13 +67,22 @@ def check_docker_compose() -> bool:
         banner("docker compose missing", "RED")
         return False
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["docker", "compose", "version"],
             check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
         )
+        output = str(getattr(result, "stdout", "")).strip()
         banner("docker compose available", "GREEN")
+        import re
+
+        match = re.search(r"v?(\d+)\.(\d+)", output)
+        if match:
+            major = int(match.group(1))
+            minor = int(match.group(2))
+            if (major, minor) < (2, 5):
+                banner("docker compose >=2.5 recommended", "YELLOW")
         return True
     except Exception:  # noqa: BLE001
         banner("docker compose missing", "RED")


### PR DESCRIPTION
## Summary
- add warning when docker compose version <2.5 in `preflight.py`
- document Docker Compose minimum version
- instruct running preflight script

## Testing
- `ruff check alpha_factory_v1/scripts/preflight.py`
- `mypy --config-file mypy.ini alpha_factory_v1/scripts/preflight.py`
- `pytest -q`