### PR TITLE
[alpha_factory] Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Report a reproducible defect in the project
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots or logs**
+If applicable, add screenshots or paste logs to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Ubuntu 22.04]
+- Python version: `python --version`
+- Additional context
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an improvement or new capability
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear description of the problem or motivation for the feature.
+
+**Describe the solution you'd like**
+Provide a concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+Explain any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Summary
+- Provide a concise description of your changes.
+
+# Checks
+- [ ] I ran `pre-commit run --files <paths>`
+- [ ] I ran `python check_env.py --auto-install`
+- [ ] I ran `pytest -q` and documented any failures below
+
+# Testing
+Describe the outcome of the checks and tests here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ for modules, classes and functions.
 - Summarize your changes and test results in the PR body.
 - Title PRs using `[alpha_factory] <Title>`.
 - All contributions are licensed under Apache 2.0.
+- Use the issue templates under `.github/ISSUE_TEMPLATE` for bug reports and feature requests.
+- Follow the pull request template to confirm linting, type checks and tests pass.
 
 ### PR Message Guidelines
 - Keep the subject line concise and under 72 characters.


### PR DESCRIPTION
## Summary
- add bug report and feature request templates under `.github/ISSUE_TEMPLATE`
- create pull request template referencing required checks
- mention templates in `AGENTS.md`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
