### PR TITLE
[alpha_factory] Add MemoryFabric embedder fallback test

### DIFF
--- a/tests/test_memory_fabric_fallback.py
+++ b/tests/test_memory_fabric_fallback.py
@@ -1,0 +1,23 @@
+import importlib
+import math
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+class TestMemoryFabricEmbedderFallback(unittest.TestCase):
+    def test_hashing_path_when_deps_missing(self) -> None:
+        os.environ.pop("OPENAI_API_KEY", None)
+        sys.modules.pop("alpha_factory_v1.backend.memory_fabric", None)
+        importlib.invalidate_caches()
+        with mock.patch.dict(sys.modules, {"openai": None, "sentence_transformers": None}):
+            memf = importlib.import_module("alpha_factory_v1.backend.memory_fabric")
+            vec = memf._EMBED("text")
+        self.assertEqual(len(vec), memf.CFG.VECTOR_DIM)
+        norm = math.sqrt(sum(x * x for x in vec))
+        self.assertAlmostEqual(norm, 1.0, places=5)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression test ensuring `_load_embedder` hashes text when openai and sentence_transformers are unavailable

## Testing
- `ruff check tests/test_memory_fabric_fallback.py`
- `mypy --config-file mypy.ini tests/test_memory_fabric_fallback.py`
- `pytest -q tests/test_memory_fabric_fallback.py`
