### PR TITLE
[alpha_factory] add OPENAI_TIMEOUT_SEC

### DIFF
--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -344,8 +344,9 @@ echo "LOGLEVEL=info" >> .env
 open http://localhost:8000/docs
 ```
 
-No GPU → falls back to GGML Llama‑3‑8B‑Q4.  
+No GPU → falls back to GGML Llama‑3‑8B‑Q4.
 No `OPENAI_API_KEY` → switches to local SBERT + heuristics.
+`OPENAI_TIMEOUT_SEC` sets the OpenAI API request timeout in seconds (default 30).
 
 ---
 

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -126,6 +126,10 @@ class EnergyConfig:
     adk_mesh: bool = bool(os.getenv("ADK_MESH"))
 
 
+# Timeout (seconds) for OpenAI API requests
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
+
 # ---------------------------------------------------------------------------
 # Helpers ---------------------------------------------------------------------
 def _now_iso() -> str:
@@ -348,6 +352,7 @@ class EnergyAgent(AgentBase):
                     model="gpt-4o",
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=150,
+                    timeout=OPENAI_TIMEOUT_SEC,
                 )
                 hedge = json.loads(resp.choices[0].message.content)
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_energy_agent.py
+++ b/tests/test_energy_agent.py
@@ -1,6 +1,10 @@
 import asyncio
+import os
+import types
 import unittest
+from unittest.mock import AsyncMock, patch
 
+from alpha_factory_v1.backend.agents import energy_agent
 from alpha_factory_v1.backend.agents.energy_agent import EnergyAgent
 
 
@@ -15,6 +19,22 @@ class TestEnergyAgentSyncRun(unittest.TestCase):
             self.assertIsInstance(self.agent.hedge_strategy(), str)
 
         asyncio.run(runner())
+
+
+class TestOpenAITimeout(unittest.TestCase):
+    def test_acreate_uses_timeout(self) -> None:
+        response = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="{}"))])
+        openai_mock = types.SimpleNamespace(
+            ChatCompletion=types.SimpleNamespace(acreate=AsyncMock(return_value=response))
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "x"}):
+            with patch.object(energy_agent, "openai", openai_mock):
+                agent = EnergyAgent()
+                agent.cfg.openai_enabled = True
+                asyncio.run(agent._hedge())
+        openai_mock.ChatCompletion.acreate.assert_awaited()
+        kwargs = openai_mock.ChatCompletion.acreate.call_args.kwargs
+        self.assertEqual(kwargs.get("timeout"), energy_agent.OPENAI_TIMEOUT_SEC)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- set `OPENAI_TIMEOUT_SEC` default to 30 seconds in `energy_agent`
- use the timeout with `ChatCompletion.acreate`
- document the new variable
- cover timeout behaviour with unit tests

## Testing
- `ruff check alpha_factory_v1/backend/agents/energy_agent.py tests/test_energy_agent.py`
- `mypy --strict tests/test_energy_agent.py alpha_factory_v1/backend/agents/energy_agent.py --config-file /dev/null` *(fails: Missing type parameters for PathLike and others)*
- `pytest -q tests/test_energy_agent.py`