### PR TITLE
[alpha_factory] orchestrator fastapi fallback

### DIFF
--- a/tests/test_orchestrator_no_fastapi.py
+++ b/tests/test_orchestrator_no_fastapi.py
@@ -1,0 +1,17 @@
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+
+class TestNoFastAPI(unittest.TestCase):
+    def test_build_rest_none(self) -> None:
+        mod_name = "alpha_factory_v1.backend.orchestrator"
+        with mock.patch.dict(sys.modules, {"fastapi": None}):
+            orch = importlib.reload(importlib.import_module(mod_name))
+            self.assertIsNone(orch._build_rest({}))
+        importlib.reload(orch)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- add fallback stubs when FastAPI isn't installed
- avoid File evaluation if FastAPI is missing
- ensure `_build_rest` quickly returns None when FastAPI isn't available
- test that import without FastAPI succeeds

## Testing
- `python check_env.py --auto-install`
- `pytest -q`