### PR TITLE
[alpha_factory] include py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">=3.11,<3.13"
 [tool.setuptools]
 packages = ["alpha_factory_v1", "af_requests"]
 
+[tool.setuptools.package-data]
+"alpha_factory_v1" = ["py.typed"]
+
 [project.scripts]
 alpha-factory = "alpha_factory_v1.run:run"
 governance-sim = "alpha_factory_v1.demos.solving_agi_governance.governance_sim:main"


### PR DESCRIPTION
## Summary
- include `py.typed` file for typing completeness
- list the marker file in `[tool.setuptools.package-data]`

## Testing
- `python check_env.py --auto-install`
- `ruff check .` *(fails: Found 553 errors)*
- `mypy --config-file mypy.ini .` *(fails: Found 2694 errors)*
- `pytest -q`