### PR TITLE
[alpha_factory] fix: use tempfile dir for logs

### DIFF
--- a/alpha_factory_v1/backend/__init__.py
+++ b/alpha_factory_v1/backend/__init__.py
@@ -25,6 +25,7 @@ import sys
 import types
 from pathlib import Path
 from typing import List
+import tempfile
 import json
 import secrets
 
@@ -78,7 +79,7 @@ sys.modules["backend.finance_agent"] = _fin_mod
 
 
 # ──────────────────────── log & CSRF helpers (unchanged) ──────────────────
-LOG_DIR = Path("/tmp/alphafactory")
+LOG_DIR = Path(tempfile.gettempdir()) / "alphafactory"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- switch log directory to `Path(tempfile.gettempdir()) / "alphafactory"`
- import `tempfile` for log path

## Testing
- `black alpha_factory_v1/backend/__init__.py --check`
- `ruff check alpha_factory_v1/backend/__init__.py`
- `mypy --strict alpha_factory_v1/backend/__init__.py` *(fails: missing type hints in many modules)*
- `pytest -q`