### PR TITLE
[alpha_factory] add docs to portfolio/tracer

### DIFF
--- a/alpha_factory_v1/backend/portfolio.py
+++ b/alpha_factory_v1/backend/portfolio.py
@@ -42,11 +42,13 @@ class Fill:
     side: str
 
     def to_json(self) -> str:
+        """Serialize the fill to a compact JSON string."""
         return json.dumps(asdict(self), separators=(",", ":"))
 
 
 class Portfolio:
     def __init__(self, db_path: Path = DB_PATH) -> None:
+        """Initialize the portfolio and load any persisted fills."""
         self._db_path = db_path
         self._positions: Dict[str, float] = {}
 
@@ -106,6 +108,7 @@ class Portfolio:
             self._db_path.write_text("")
 
     async def arecord_fill(self, symbol: str, qty: float, price: float, side: str) -> None:
+        """Async wrapper around :meth:`record_fill`."""
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self.record_fill, symbol, qty, price, side)
 

--- a/alpha_factory_v1/backend/tracer.py
+++ b/alpha_factory_v1/backend/tracer.py
@@ -44,6 +44,12 @@ class Tracer:
     """Capture and persist execution spans."""
 
     def __init__(self, memory: Any, *, enabled: bool | None = None) -> None:
+        """Create a tracer backed by ``memory``.
+
+        Args:
+            memory: Object exposing a ``write`` method used to persist spans.
+            enabled: Override the ``AF_TRACING`` environment variable if set.
+        """
         self.mem = memory
         if enabled is None:
             enabled = os.getenv("AF_TRACING", "true").lower() != "false"


### PR DESCRIPTION
## Summary
- document JSON serialization in Fill dataclass
- document Portfolio initialization and async record helper
- document Tracer initialization

## Testing
- `ruff check alpha_factory_v1/backend/portfolio.py alpha_factory_v1/backend/tracer.py`
- `mypy --strict --ignore-missing-imports --follow-imports=skip -m alpha_factory_v1.backend.portfolio -m alpha_factory_v1.backend.tracer` *(fails: Module has no attribute errors in portfolio.py)*