### PR TITLE
[alpha_factory] Lazy log directory

### DIFF
--- a/alpha_factory_v1/backend/__init__.py
+++ b/alpha_factory_v1/backend/__init__.py
@@ -80,11 +80,11 @@ sys.modules["backend.finance_agent"] = _fin_mod
 
 # ──────────────────────── log & CSRF helpers (unchanged) ──────────────────
 LOG_DIR = Path(tempfile.gettempdir()) / "alphafactory"
-LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _read_logs(max_lines: int = 100) -> List[str]:
     """Return the tail of the most-recent log file (≤ *max_lines*)."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_files = sorted(LOG_DIR.glob("*.log"))
     if not log_files:
         return []

--- a/tests/test_log_dir_lazy.py
+++ b/tests/test_log_dir_lazy.py
@@ -1,0 +1,18 @@
+import importlib
+import sys
+import tempfile
+from pathlib import Path
+from unittest import TestCase, mock
+
+
+class TestLogDirLazy(TestCase):
+    def test_log_dir_created_lazily(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch("tempfile.gettempdir", return_value=tmp):
+                sys.modules.pop("alpha_factory_v1.backend", None)
+                backend = importlib.import_module("alpha_factory_v1.backend")
+                log_dir = Path(tmp) / "alphafactory"
+                self.assertFalse(log_dir.exists())
+                backend._read_logs()
+                self.assertTrue(log_dir.exists())
+            sys.modules.pop("alpha_factory_v1.backend", None)


### PR DESCRIPTION
## Summary
- make log directory creation lazy inside `_read_logs`
- add unit test for lazy log directory behavior

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_orchestrator_env.py::TestOrchestratorEnv::test_invalid_numeric_fallback, tests/test_orchestrator_no_fastapi.py::TestNoFastAPI::test_build_rest_none)*