### PR TITLE
[alpha_factory] handle missing opentelemetry

### DIFF
--- a/alpha_factory_v1/backend/governance.py
+++ b/alpha_factory_v1/backend/governance.py
@@ -128,7 +128,10 @@ class Governance:
 # │ 2.  Decision telemetry & credential emission                           │
 # ╰────────────────────────────────────────────────────────────────────────╯
 # Optional‑import OpenTelemetry (keeps repo usable without it)
-_ot_trace_spec = importlib.util.find_spec("opentelemetry.trace")
+try:  # pragma: no cover - optional dependency
+    _ot_trace_spec = importlib.util.find_spec("opentelemetry.trace")
+except ModuleNotFoundError:  # pragma: no cover - missing package
+    _ot_trace_spec = None
 if _ot_trace_spec:
     from opentelemetry import trace as _trace  # type: ignore
     _tracer = _trace.get_tracer("alpha_factory")


### PR DESCRIPTION
## Summary
- avoid `ModuleNotFoundError` when `opentelemetry` isn't installed

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `mypy --config-file mypy.ini alpha_factory_v1/backend/governance.py` *(fails: found 140 errors in 7 files)*