### PR TITLE
[alpha_factory] fix type hints for self-healing demo

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
@@ -1,9 +1,11 @@
 # diff_utils.py
-import re, subprocess
+import re
+import subprocess
 
 ALLOWED_PATHS = ["alpha_factory_v1", "src", "tests"]  # example allowed directories
 
-def parse_and_validate_diff(diff_text: str) -> str:
+
+def parse_and_validate_diff(diff_text: str) -> str | None:
     """Verify the LLM's output is a valid unified diff and meets safety criteria."""
     if not diff_text:
         return None
@@ -23,6 +25,7 @@ def parse_and_validate_diff(diff_text: str) -> str:
                     return None
     # (Additional checks: e.g., diff length, certain forbidden content can be added here.)
     return diff_text
+
 
 def apply_diff(diff_text: str, repo_dir: str) -> bool:
     """Apply the unified diff to the repo_dir. Returns True if applied successfully."""

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/sandbox.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/sandbox.py
@@ -1,12 +1,9 @@
 # sandbox.py (pseudo-code)
-import subprocess, os
+import subprocess
 
-def run_in_docker(image: str, repo_dir: str, command: str) -> (int, str):
+
+def run_in_docker(image: str, repo_dir: str, command: str) -> tuple[int, str]:
     """Run a command inside a Docker container mounted with the repo_dir."""
-    cmd = [
-        "docker", "run", "--rm",
-        "-v", f"{repo_dir}:/app", "-w", "/app",
-        image
-    ] + command.split()
+    cmd = ["docker", "run", "--rm", "-v", f"{repo_dir}:/app", "-w", "/app", image] + command.split()
     result = subprocess.run(cmd, capture_output=True, text=True)
     return result.returncode, result.stdout + result.stderr

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/test_runner.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/test_runner.py
@@ -1,26 +1,34 @@
 # test_runner.py
-import subprocess, os, shlex
+import subprocess
+import os
+
 
 class BaseTestRunner:
-    def __init__(self, repo_dir):
+    def __init__(self, repo_dir: str) -> None:
         self.repo_dir = repo_dir
-    def run_tests(self) -> (bool, str):
+
+    def run_tests(self) -> tuple[bool, str]:
         """Run tests and return (success, output)."""
         raise NotImplementedError
+
     def extract_failure_log(self, full_output: str) -> str:
         """Extract the relevant failure section from output (e.g., last traceback)."""
         # Default implementation: return last 50 lines if failure
         lines = full_output.strip().splitlines()
         return "\n".join(lines[-50:])  # last 50 lines as guess
 
+
 class PytestRunner(BaseTestRunner):
-    def run_tests(self):
+    def run_tests(self) -> tuple[bool, str]:
         try:
             # Run pytest, capturing output
             result = subprocess.run(
                 ["pytest", "-q", "--color=no"],  # quiet, no color codes
                 cwd=self.repo_dir,
-                check=True, capture_output=True, text=True, timeout=300
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=300,
             )
             return (True, result.stdout + result.stderr)
         except subprocess.CalledProcessError as e:
@@ -30,12 +38,12 @@ class PytestRunner(BaseTestRunner):
         except subprocess.TimeoutExpired:
             return (False, "Test run timed out.")
 
+
 def get_default_runner(repo_dir: str) -> BaseTestRunner:
     """Determine the appropriate test runner based on project files (pytest, npm, etc.)"""
     # Simple heuristic: if pytest available, use PytestRunner.
     # Could be extended to detect package.json for npm, pom.xml for Maven, etc.
-    if os.path.exists(os.path.join(repo_dir, "pytest.ini")) or \
-       os.path.exists(os.path.join(repo_dir, "pyproject.toml")):
+    if os.path.exists(os.path.join(repo_dir, "pytest.ini")) or os.path.exists(os.path.join(repo_dir, "pyproject.toml")):
         return PytestRunner(repo_dir)
     # Future: other runner detections...
     return PytestRunner(repo_dir)


### PR DESCRIPTION
## Summary
- update run_in_docker return type
- annotate BaseTestRunner.run_tests and PytestRunner.run_tests
- allow None result in parse_and_validate_diff

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/demos/self_healing_repo/agent_core/sandbox.py alpha_factory_v1/demos/self_healing_repo/agent_core/test_runner.py alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/self_healing_repo/agent_core/sandbox.py alpha_factory_v1/demos/self_healing_repo/agent_core/test_runner.py alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py`
- `pytest -q` *(fails: ImportError in orchestrator tests)*