### PR TITLE
[alpha_factory] clean up backend imports

### DIFF
--- a/alpha_factory_v1/backend/muzero_engine.py
+++ b/alpha_factory_v1/backend/muzero_engine.py
@@ -28,7 +28,6 @@ import importlib
 import logging
 import os
 import random
-import time
 from pathlib import Path
 from typing import Any, List, Sequence, Tuple
 

--- a/alpha_factory_v1/backend/planner_agent.py
+++ b/alpha_factory_v1/backend/planner_agent.py
@@ -4,6 +4,8 @@ import random
 import re
 from typing import Any, Dict, List
 
+from .agent_base import AgentBase
+
 
 _JSON_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
@@ -15,8 +17,6 @@ def _extract_json(text: str) -> Dict[str, Any]:
         raise ValueError("no JSON object found")
     return json.loads(match.group(0))
 
-
-from .agent_base import AgentBase
 
 
 class PlannerAgent(AgentBase):

--- a/alpha_factory_v1/backend/risk.py
+++ b/alpha_factory_v1/backend/risk.py
@@ -1,4 +1,5 @@
-import os, math
+import os
+import math
 
 MAX_PCT_CAPITAL = float(os.getenv("MAX_PCT_CAPITAL", "0.05"))  # 5 %
 ACCOUNT_EQUITY = float(os.getenv("ACCOUNT_EQUITY", "100000"))  # $100k demo


### PR DESCRIPTION
## Summary
- drop unused `time` import from MuZero engine
- reorder PlannerAgent imports
- split risk module imports

## Testing
- `ruff check alpha_factory_v1/backend/muzero_engine.py alpha_factory_v1/backend/planner_agent.py alpha_factory_v1/backend/risk.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: KeyboardInterrupt after tests complete)*