### PR TITLE
[alpha_factory] add return type for muzero cli test

### DIFF
--- a/tests/test_muzero_cli.py
+++ b/tests/test_muzero_cli.py
@@ -1,7 +1,7 @@
 import subprocess, sys
 
 
-def test_cli_help():
+def test_cli_help() -> None:
     result = subprocess.run([
         sys.executable,
         '-m', 'alpha_factory_v1.demos.muzero_planning',


### PR DESCRIPTION
## Summary
- add explicit `-> None` return type for `test_cli_help`

## Testing
- `mypy tests` *(fails: Found 968 errors)*