### PR TITLE
[alpha_factory] enforce openai_agents version

### DIFF
--- a/tests/test_preflight_openai_agents_version.py
+++ b/tests/test_preflight_openai_agents_version.py
@@ -1,0 +1,55 @@
+import importlib
+import types
+import unittest
+from typing import Any
+from unittest import mock
+
+from alpha_factory_v1.scripts import preflight
+
+
+class TestPreflightOpenAIAgentsVersion(unittest.TestCase):
+    def test_old_version_fails(self) -> None:
+        fake_mod = types.SimpleNamespace(__version__="0.0.13")
+        orig_import_module = importlib.import_module
+        orig_find_spec = importlib.util.find_spec
+
+        def _fake_import(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == "openai_agents":
+                return fake_mod
+            return orig_import_module(name, *args, **kwargs)
+
+        def _fake_find_spec(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == "openai_agents":
+                return object()
+            return orig_find_spec(name, *args, **kwargs)
+
+        with (
+            mock.patch("importlib.import_module", side_effect=_fake_import),
+            mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
+        ):
+            self.assertFalse(preflight.check_openai_agents_version())
+
+    def test_new_version_ok(self) -> None:
+        fake_mod = types.SimpleNamespace(__version__="0.0.15")
+        orig_import_module = importlib.import_module
+        orig_find_spec = importlib.util.find_spec
+
+        def _fake_import(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == "openai_agents":
+                return fake_mod
+            return orig_import_module(name, *args, **kwargs)
+
+        def _fake_find_spec(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == "openai_agents":
+                return object()
+            return orig_find_spec(name, *args, **kwargs)
+
+        with (
+            mock.patch("importlib.import_module", side_effect=_fake_import),
+            mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
+        ):
+            self.assertTrue(preflight.check_openai_agents_version())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend preflight checks to validate `openai_agents.__version__`
- fail preflight when the detected version is older than 0.0.14
- add unit tests covering this behavior

## Testing
- `ruff check alpha_factory_v1/scripts/preflight.py tests/test_preflight_openai_agents_version.py`
- `mypy --config-file mypy.ini alpha_factory_v1/scripts/preflight.py tests/test_preflight_openai_agents_version.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_orchestrator_env.py::TestOrchestratorEnv::test_invalid_numeric_fallback, test_orchestrator_grpc.py::TestServeGrpc::test_server_starts_with_env_port, test_orchestrator_no_fastapi.py::TestNoFastAPI::test_build_rest_none)*
