### PR TITLE
[alpha_factory] Document numpy requirement for SQLite store

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Cells with \(Δ\mathcal F < 0\) glow 🔵 on Grafana; Ω‑Agents race to harves
 
 * Agents query `mem.search("supply shock beta>0.2")`  
 * Planner asks Neo4j: `MATCH (a)-[:CAUSES]->(b) WHERE b.delta_alpha > 5e6 RETURN path`
+* SQLite vector store fallback requires `numpy`
 
 ---
 

--- a/tests/test_memory_fabric_sqlite.py
+++ b/tests/test_memory_fabric_sqlite.py
@@ -1,6 +1,7 @@
 import os
 import sqlite3
 import unittest
+from unittest import mock
 
 import alpha_factory_v1.backend.memory_fabric as memf
 
@@ -31,6 +32,18 @@ class TestMemoryFabricSQLiteClose(unittest.TestCase):
         self.assertIsNone(self.fabric.vector._sql)
         with self.assertRaises(sqlite3.ProgrammingError):
             conn.execute("SELECT 1")
+
+
+class TestMemoryFabricSQLiteWarning(unittest.TestCase):
+    def test_warn_without_numpy(self) -> None:
+        os.environ["VECTOR_STORE_USE_SQLITE"] = "true"
+        os.environ.pop("PGHOST", None)
+        with mock.patch.object(memf, "np", None, create=True):
+            with self.assertLogs("AlphaFactory.MemoryFabric", level="WARNING") as cm:
+                fabric = memf.MemoryFabric()
+                fabric.close()
+        os.environ.pop("VECTOR_STORE_USE_SQLITE", None)
+        self.assertTrue(any("numpy required for SQLite" in msg for msg in cm.output))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- mention numpy requirement in README
- warn when numpy missing but SQLite requested
- test warning logic in MemoryFabric

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: orchestrator env/grpc/no_fastapi)*