### PR TITLE
[alpha_factory] Add broker module docstring

### DIFF
--- a/alpha_factory_v1/backend/broker/__init__.py
+++ b/alpha_factory_v1/backend/broker/__init__.py
@@ -1,4 +1,9 @@
 # backend/broker/__init__.py
+"""Broker selection factory.
+
+Chooses the broker via ``ALPHA_BROKER``; the simulated broker is used by default.
+"""
+
 import os
 
 _BROKER = os.getenv("ALPHA_BROKER", "sim").lower()


### PR DESCRIPTION
## Summary
- document broker selection in `alpha_factory_v1/backend/broker/__init__.py`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_invalid_numeric_fallback, test_server_starts_with_env_port, test_build_rest_none)*
- `ruff check alpha_factory_v1/backend/broker/__init__.py`
- `black --check alpha_factory_v1/backend/broker/__init__.py`
- `mypy --config-file mypy.ini alpha_factory_v1/backend/broker/__init__.py` *(fails: several errors in unrelated files)*