### PR TITLE
[alpha_factory] add signed wheel verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,3 +134,17 @@ for modules, classes and functions.
 - Missing optional packages can cause test failures; run `python check_env.py --auto-install`.
 
 For detailed troubleshooting steps, see [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md).
+
+### Wheel Signing
+All agent wheels must be signed with the project's ED25519 key before they are
+loaded from `$AGENT_HOT_DIR`. Generate `<wheel>.whl.sig` with:
+
+```bash
+openssl dgst -sha512 -binary <wheel>.whl |
+  openssl pkeyutl -sign -inkey agent_signing.key |
+  base64 -w0 > <wheel>.whl.sig
+```
+
+Commit the signature file and add the base64 value to `_WHEEL_SIGS` in
+`alpha_factory_v1/backend/agents/__init__.py`. Wheels without a valid signature
+are ignored at runtime.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ flowchart TD
 
 ---
 
+---
+
 ## Deploy Now
 Open‑source framework for immediate strategic action: **[github.com/MontrealAI/AGI-Alpha-Agent-v0](https://github.com/MontrealAI/AGI-Alpha-Agent-v0)**
 
@@ -579,6 +581,22 @@ git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/cross_industry_alpha_factory
 ./deploy_alpha_factory_cross_industry_demo.sh
 ```
+
+---
+
+### 6.3 · Signing Agent Wheels 🔑
+Sign wheels dropped into `$AGENT_HOT_DIR` with the project ED25519 key.
+Generate `<wheel>.whl.sig` via:
+
+```bash
+openssl dgst -sha512 -binary <wheel>.whl |
+  openssl pkeyutl -sign -inkey agent_signing.key |
+  base64 -w0 > <wheel>.whl.sig
+```
+
+Add the base64 signature to `_WHEEL_SIGS` in
+`alpha_factory_v1/backend/agents/__init__.py`. Wheels failing verification are
+ignored.
 
 ---
 

--- a/tests/test_wheel_signature.py
+++ b/tests/test_wheel_signature.py
@@ -1,0 +1,38 @@
+import base64
+import unittest
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from alpha_factory_v1.backend import agents as agents_mod
+
+
+class TestWheelSignature(unittest.TestCase):
+    def test_verify_wheel(self) -> None:
+        priv = Ed25519PrivateKey.generate()
+        pub_b64 = base64.b64encode(
+            priv.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        ).decode()
+        wheel = Path("test.whl")
+        wheel.write_bytes(b"demo")
+        sig = base64.b64encode(priv.sign(b"demo")).decode()
+        sig_file = Path("test.whl.sig")
+        sig_file.write_text(sig)
+        orig_pub = agents_mod._WHEEL_PUBKEY
+        orig_sigs = agents_mod._WHEEL_SIGS.copy()
+        try:
+            agents_mod._WHEEL_PUBKEY = pub_b64
+            agents_mod._WHEEL_SIGS = {wheel.name: sig}
+            self.assertTrue(agents_mod._verify_wheel(wheel))
+        finally:
+            agents_mod._WHEEL_PUBKEY = orig_pub
+            agents_mod._WHEEL_SIGS = orig_sigs
+            wheel.unlink()
+            sig_file.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- verify agent wheels before installation
- reject hotdir wheels that fail signature validation
- fetch and validate wheel signatures when using ADK
- document wheel signing workflow for contributors
- test verifying wheel signatures

## Testing
- `ruff check alpha_factory_v1/backend/agents/__init__.py tests/test_wheel_signature.py`
- `mypy --config-file mypy.ini alpha_factory_v1/backend/agents/__init__.py tests/test_wheel_signature.py` *(fails: many missing type hints)*
- `pytest -q` *(fails: TestOrchestratorEnv.test_invalid_numeric_fallback and related orchestrator tests)*
- `python check_env.py --auto-install`