### PR TITLE
[alpha_factory] add MemoryFabric context manager

### DIFF
--- a/alpha_factory_v1/tests/test_memory_provider.py
+++ b/alpha_factory_v1/tests/test_memory_provider.py
@@ -27,9 +27,13 @@ class ModelProviderStubTest(unittest.TestCase):
 
 class MemoryFabricFallbackTest(unittest.TestCase):
     def setUp(self):
-        self.fabric = memf.MemoryFabric()
+        self._cm = memf.MemoryFabric()
+        self.fabric = self._cm.__enter__()
         # Avoid metrics context when Prometheus is absent
         memf._MET_V_SRCH = None
+
+    def tearDown(self):
+        self._cm.__exit__(None, None, None)
 
     def test_vector_ram_mode(self):
         self.assertEqual(self.fabric.vector._mode, "ram")

--- a/tests/test_memory_fabric_sqlite.py
+++ b/tests/test_memory_fabric_sqlite.py
@@ -10,11 +10,12 @@ class TestMemoryFabricSQLiteClose(unittest.TestCase):
     def setUp(self):
         os.environ["VECTOR_STORE_USE_SQLITE"] = "true"
         os.environ.pop("PGHOST", None)
-        self.fabric = memf.MemoryFabric()
+        self._cm = memf.MemoryFabric()
+        self.fabric = self._cm.__enter__()
         memf._MET_V_SRCH = None
 
     def tearDown(self):
-        self.fabric.close()
+        self._cm.__exit__(None, None, None)
         os.environ.pop("VECTOR_STORE_USE_SQLITE", None)
 
     def test_close_closes_connection(self):
@@ -40,8 +41,8 @@ class TestMemoryFabricSQLiteWarning(unittest.TestCase):
         os.environ.pop("PGHOST", None)
         with mock.patch.object(memf, "np", None, create=True):
             with self.assertLogs("AlphaFactory.MemoryFabric", level="WARNING") as cm:
-                fabric = memf.MemoryFabric()
-                fabric.close()
+                with memf.MemoryFabric() as fabric:
+                    pass
         os.environ.pop("VECTOR_STORE_USE_SQLITE", None)
         self.assertTrue(any("numpy required for SQLite" in msg for msg in cm.output))
 


### PR DESCRIPTION
## Summary
- add context manager (`__enter__`/`__exit__`) to `MemoryFabric`
- document `with MemoryFabric()` usage
- expose exports via `__all__`
- update tests to open `MemoryFabric` via context manager

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError in orchestrator tests)*
- `mypy --config-file mypy.ini alpha_factory_v1/backend/memory_fabric.py alpha_factory_v1/tests/test_memory_provider.py tests/test_memory_fabric_sqlite.py` *(fails: many type errors)*