### PR TITLE
[alpha_factory] improve password checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ Please report security vulnerabilities as described in our [Security Policy](SEC
   [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md)
   for additional guidance.
 - Verify `.env` is ignored by running `git status` (it should appear untracked). The repository's `.gitignore` already includes `.env`.
+- Store secrets in environment variables or Docker secrets instead of code to keep them out of version control.
 - Set `AF_TRACING=true` to enable tracing (default) or `false` to disable it. See
   [`alpha_factory_v1/backend/tracer.py`](alpha_factory_v1/backend/tracer.py).
 

--- a/README.md
+++ b/README.md
@@ -511,9 +511,10 @@ python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
 ### .env Setup & Security
 Before running the orchestrator, copy `alpha_factory_v1/.env.sample` to `.env` and
 replace all placeholder values with strong secrets. The sample sets
-`NEO4J_PASSWORD=REPLACE_ME` as a placeholder—configure passwords for services
-like Neo4j and Postgres and **never deploy with the defaults**. The orchestrator
-will refuse to start if `NEO4J_PASSWORD` remains `REPLACE_ME` or is missing.
+`NEO4J_PASSWORD=REPLACE_ME` as a placeholder—generate a random password for
+services like Neo4j and Postgres using `openssl rand -base64 18` or a similar
+tool and **never deploy with the defaults**. The orchestrator will refuse to
+start if `NEO4J_PASSWORD` remains `REPLACE_ME` or is missing.
 
 ### Finance Demo Quick‑Start
 

--- a/alpha_factory_v1/.env.sample
+++ b/alpha_factory_v1/.env.sample
@@ -24,7 +24,7 @@ FRED_API_KEY=
 NEWSAPI_KEY=
 NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
-NEO4J_PASSWORD=REPLACE_ME     # must be a strong secret; orchestrator refuses to start if unchanged
+NEO4J_PASSWORD=REPLACE_ME     # generate a strong secret (e.g. openssl rand -base64 18); orchestrator refuses to start if unchanged
 
 # ─── Agent runtime options ───────────────────────────────────────────
 LLM_PROVIDER=openai         # openai | ollama | anthropic | mistral | together

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -473,6 +473,14 @@ async def _hb_watch(runners: Dict[str, AgentRunner]) -> None:
 
 # ───────────────────────────── main() ────────────────────────────────
 async def _main() -> None:
+    # ─── Basic startup checks ───────────────────────────────────────
+    if os.getenv("NEO4J_PASSWORD") == "REPLACE_ME":
+        log.error(
+            "NEO4J_PASSWORD is set to the default 'REPLACE_ME'. "
+            "Edit .env or your Docker secrets to configure a strong password."
+        )
+        sys.exit(1)
+
     # ─── Discover/instantiate agents ─────────────────────────────────
     avail = list_agents()
     names = [n for n in avail if not ENABLED or n in ENABLED]


### PR DESCRIPTION
## Summary
- detect `NEO4J_PASSWORD=REPLACE_ME` at orchestrator start
- highlight generating a strong Neo4j password in README and `.env.sample`
- note secret management best practices in `AGENTS.md`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_orchestrator_env, test_orchestrator_grpc, test_orchestrator_no_fastapi)*