### PR TITLE
[alpha_factory] add cryptography dev dep

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ prometheus_client
 mypy
 fastapi
 opentelemetry-api
+cryptography


### PR DESCRIPTION
## Summary
- add `cryptography` to `requirements-dev.txt`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 3 failed, 259 passed)*
- `pre-commit` *(command not found)*