### PR TITLE
[alpha_factory] skip fastapi tests when dependency missing

### DIFF
--- a/alpha_factory_v1/tests/test_alpha_asi_world_model.py
+++ b/alpha_factory_v1/tests/test_alpha_asi_world_model.py
@@ -1,19 +1,23 @@
 import unittest
 import time
 
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi is required for ASI world model tests")
+
 try:
-    from alpha_factory_v1.demos.alpha_asi_world_model import alpha_asi_world_model_demo as demo
+    from alpha_factory_v1.demos.alpha_asi_world_model import (
+        alpha_asi_world_model_demo as demo,
+    )
     from alpha_factory_v1.demos.alpha_asi_world_model import run_headless
+
     dependencies_available = True
 except Exception:
     demo = None
     run_headless = None
     dependencies_available = False
 
-try:
-    from fastapi.testclient import TestClient
-except ImportError:  # pragma: no cover - fastapi optional
-    TestClient = None
+from fastapi.testclient import TestClient
 
 
 class TestAlphaASIWorldModel(unittest.TestCase):
@@ -37,8 +41,8 @@ class TestAlphaASIWorldModel(unittest.TestCase):
         self.assertGreater(len(orch.learners[0].buffer), 0)
 
     def test_rest_endpoints(self):
-        if not dependencies_available or TestClient is None:
-            self.skipTest("fastapi or dependencies missing")
+        if not dependencies_available:
+            self.skipTest("demo dependencies missing")
         with TestClient(demo.app) as client:
             res = client.get("/agents")
             self.assertEqual(res.status_code, 200)

--- a/alpha_factory_v1/tests/test_orchestrator_rest.py
+++ b/alpha_factory_v1/tests/test_orchestrator_rest.py
@@ -2,12 +2,12 @@ import unittest
 import time
 from types import SimpleNamespace
 
-from alpha_factory_v1.backend.orchestrator import _build_rest
+import pytest
 
-try:
-    from fastapi.testclient import TestClient
-except ModuleNotFoundError:  # pragma: no cover - allow unittest fallback
-    TestClient = None  # type: ignore
+pytest.importorskip("fastapi", reason="fastapi is required for REST API tests")
+from fastapi.testclient import TestClient
+
+from alpha_factory_v1.backend.orchestrator import _build_rest
 
 
 class DummyRunner:
@@ -19,7 +19,6 @@ class DummyRunner:
         self.spec = None
 
 
-@unittest.skipIf(TestClient is None, "fastapi not installed")
 class BuildRestTest(unittest.TestCase):
     def test_basic_routes(self):
         runners = {"foo": DummyRunner()}
@@ -43,7 +42,6 @@ class DummyAgent:
         self.loaded = path
 
 
-@unittest.skipIf(TestClient is None, "fastapi not installed")
 class UpdateModelTest(unittest.TestCase):
     def _make_client(self):
         runner = DummyRunner()

--- a/tests/test_orchestrator_rest.py
+++ b/tests/test_orchestrator_rest.py
@@ -4,6 +4,9 @@ import zipfile
 import unittest
 from unittest import mock
 
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi is required for REST API tests")
 from fastapi.testclient import TestClient
 
 from alpha_factory_v1.backend import orchestrator


### PR DESCRIPTION
## Summary
- skip REST API tests if `fastapi` is not available

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: TestOrchestratorEnv::test_invalid_numeric_fallback, TestServeGrpc::test_server_starts_with_env_port, TestNoFastAPI::test_build_rest_none)*