### PR TITLE
[alpha_factory] api server fastapi fallback

### DIFF
--- a/tests/test_insight_api_server_no_fastapi.py
+++ b/tests/test_insight_api_server_no_fastapi.py
@@ -1,0 +1,18 @@
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+
+class TestInsightAPIServerNoFastAPI(unittest.TestCase):
+    def test_main_requires_fastapi(self) -> None:
+        mod_name = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server"
+        with mock.patch.dict(sys.modules, {"fastapi": None}):
+            api = importlib.reload(importlib.import_module(mod_name))
+            with self.assertRaises(SystemExit) as cm:
+                api.main([])
+            self.assertIn("FastAPI", str(cm.exception))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- gracefully handle missing `fastapi` in `alpha_agi_insight_v0.api_server`
- add regression test for missing fastapi

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 8 failed, 255 passed, 8 skipped)*