### PR TITLE
[alpha_factory] add alpha-agi-insight-v1 cli

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -1,28 +1,114 @@
-"""Command line interface for the insight demo."""
+"""Command line interface for the α‑AGI Insight demo."""
+
 from __future__ import annotations
 
-import argparse
 import asyncio
+import json
+import random
+import time
+from pathlib import Path
+
+import click
 
 from .. import orchestrator
-from ..simulation import sector, forecast
+from ..simulation import forecast, sector
+from ..utils import config
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description="Run α‑AGI Insight simulation")
-    p.add_argument("--horizon", type=int, default=5)
-    return p
+@click.group()
+def main() -> None:
+    """α‑AGI Insight command line interface."""
 
 
-async def main(argv: list[str] | None = None) -> None:
-    args = _build_parser().parse_args(argv)
+@main.command()
+@click.option("--horizon", default=5, show_default=True, type=int, help="Forecast horizon in years")
+@click.option("--curve", default="logistic", show_default=True, help="Capability growth curve")
+@click.option("--seed", type=int, help="Random seed")
+@click.option("--offline", is_flag=True, help="Force offline mode")
+@click.option("--pop-size", default=6, show_default=True, type=int, help="MATS population size")
+@click.option("--generations", default=3, show_default=True, type=int, help="Evolution steps")
+@click.option("--export", type=click.Choice(["json", "csv"]), help="Export results format")
+@click.option("--verbose", is_flag=True, help="Verbose output")
+def simulate(
+    horizon: int,
+    curve: str,
+    seed: int | None,
+    offline: bool,
+    pop_size: int,
+    generations: int,
+    export: str | None,
+    verbose: bool,
+) -> None:
+    """Run the forecast simulation and start the orchestrator."""
+    if seed is not None:
+        random.seed(seed)
+
+    settings = config.Settings()
+    if offline:
+        settings.offline = True
+
+    orch = orchestrator.Orchestrator(settings)
+    secs = [sector.Sector(f"s{i:02d}") for i in range(pop_size)]
+    results = forecast.simulate_years(secs, horizon)
+
+    if export == "json":
+        data = [
+            {
+                "year": r.year,
+                "capability": r.capability,
+                "affected": [s.name for s in r.affected],
+            }
+            for r in results
+        ]
+        click.echo(json.dumps(data))
+    elif export == "csv":
+        lines = ["year,capability,affected"]
+        for r in results:
+            lines.append(f"{r.year},{r.capability},{'|'.join(s.name for s in r.affected)}")
+        click.echo("\n".join(lines))
+    else:
+        for r in results:
+            click.echo(f"{r.year}: {r.capability:.2f} → {[s.name for s in r.affected]}")
+
+    if verbose:
+        click.echo("Starting orchestrator … press Ctrl+C to stop")
+
+    try:
+        asyncio.run(orch.run_forever())
+    except KeyboardInterrupt:  # pragma: no cover - interactive
+        pass
+
+
+@main.command("show-results")
+def show_results() -> None:
+    """Display the last ledger entries."""
+    path = Path(config.Settings().ledger_path)
+    if not path.exists():
+        click.echo("No results found")
+        return
+    for line in path.read_text(encoding="utf-8").splitlines()[-10:]:
+        click.echo(line)
+
+
+@main.command("agents-status")
+def agents_status() -> None:
+    """List registered agents."""
     orch = orchestrator.Orchestrator()
-    secs = [sector.Sector("s%02d" % i) for i in range(3)]
-    sim = forecast.simulate_years(secs, args.horizon)
-    for pt in sim:
-        print(pt)
-    await orch.run_forever()
+    for agent in orch.agents:
+        click.echo(agent.__class__.__name__)
+
+
+@main.command()
+def replay() -> None:
+    """Replay ledger entries with small delay."""
+    path = Path(config.Settings().ledger_path)
+    if not path.exists():
+        click.echo("No ledger to replay")
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        click.echo(line)
+        time.sleep(0.1)
 
 
 if __name__ == "__main__":  # pragma: no cover
-    asyncio.run(main())
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.offi
 alpha-agi-insight-offline = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_zero_data:main"
 alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
 alpha-agi-insight-dashboard = "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_dashboard:main"
+alpha-agi-insight-v1 = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- add click-based CLI for alpha_agi_insight_v1 demo
- register `alpha-agi-insight-v1` console script

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_orchestrator_env.py::TestOrchestratorEnv::test_invalid_numeric_fallback, tests/test_orchestrator_grpc.py::TestServeGrpc::test_server_starts_with_env_port, tests/test_orchestrator_no_fastapi.py::TestNoFastAPI::test_build_rest_none)*