### PR TITLE
[alpha_factory] add container infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,24 @@ Alpha‑Factory on air‑gapped or resource‑constrained devices. The script
 forwards to `alpha_factory_v1.edge_runner` and exposes additional flags
 like `--cycle`, `--loglevel` and `--version`.
 
+Build the demo containers locally:
+
+```bash
+cd infrastructure
+docker build -t alpha-demo .
+docker compose up
+```
+
+The Helm chart under `infrastructure/helm-chart` mirrors this Compose
+setup:
+
+```bash
+helm install alpha-demo ./infrastructure/helm-chart
+```
+
+Terraform scripts in `infrastructure/terraform` provide GCP and AWS
+examples (`main_gcp.tf`, `main_aws.tf`).
+
 | Target | Command | Notes |
 |--------|---------|-------|
 | **Docker Compose** | `docker compose up -d` | Kafka, Prometheus, Grafana |

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY .. /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["python", "-m", "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final"]

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  orchestrator:
+    build: .
+    image: alpha-demo:latest
+    ports:
+      - "8000:8000"
+  agents:
+    image: alpha-demo:latest
+    command: ["python", "-m", "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final"]
+    depends_on:
+      - orchestrator
+  web:
+    image: nginx:alpine
+    volumes:
+      - ../alpha_factory_v1/ui:/usr/share/nginx/html:ro
+    ports:
+      - "3000:80"
+    depends_on:
+      - orchestrator

--- a/infrastructure/helm-chart/Chart.yaml
+++ b/infrastructure/helm-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: alpha-demo
+description: Helm chart for the Alpha Factory demo
+version: 0.1.0
+appVersion: "v0"
+type: application

--- a/infrastructure/helm-chart/README.md
+++ b/infrastructure/helm-chart/README.md
@@ -1,0 +1,6 @@
+This chart deploys the demo orchestrator and UI.
+Install with:
+```bash
+helm upgrade --install alpha-demo ./infrastructure/helm-chart \
+  --set env.OPENAI_API_KEY=<key>
+```

--- a/infrastructure/helm-chart/templates/deployment.yaml
+++ b/infrastructure/helm-chart/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alpha-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alpha-demo
+  template:
+    metadata:
+      labels:
+        app: alpha-demo
+    spec:
+      containers:
+        - name: orchestrator
+          image: alpha-demo:latest
+          ports:
+            - containerPort: 8000
+            - containerPort: 3000

--- a/infrastructure/helm-chart/templates/service.yaml
+++ b/infrastructure/helm-chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alpha-demo
+spec:
+  type: ClusterIP
+  selector:
+    app: alpha-demo
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+    - name: ui
+      port: 3000
+      targetPort: 3000

--- a/infrastructure/terraform/main_aws.tf
+++ b/infrastructure/terraform/main_aws.tf
@@ -1,0 +1,2 @@
+# Example Terraform deployment for AWS Fargate
+# Mirrors the README instructions

--- a/infrastructure/terraform/main_gcp.tf
+++ b/infrastructure/terraform/main_gcp.tf
@@ -1,0 +1,2 @@
+# Example Terraform deployment for Google Cloud Run
+# Mirrors the README instructions


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose example under `infrastructure`
- provide minimal Helm chart and Terraform examples
- document how to build and run the demo containers

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: TestOrchestratorEnv::test_invalid_numeric_fallback, TestServeGrpc::test_server_starts_with_env_port, TestNoFastAPI::test_build_rest_none)*