### PR TITLE
[alpha_factory] add missing tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,31 @@
+import asyncio
+from queue import Queue
+from unittest.mock import patch
+
+from alpha_factory_v1.backend import agents
+from alpha_factory_v1.backend.agents.base import AgentBase
+
+class DummyHB(AgentBase):
+    NAME = "dummy_hb"
+    CAPABILITIES = ["x"]
+
+    async def step(self) -> None:
+        return None
+
+def test_agent_registration_and_heartbeat() -> None:
+    meta = agents.AgentMetadata(
+        name=DummyHB.NAME,
+        cls=DummyHB,
+        version="0.1",
+        capabilities=DummyHB.CAPABILITIES,
+        compliance_tags=[],
+    )
+    q: Queue = Queue()
+    with patch.object(agents, "_HEALTH_Q", q):
+        agents.register_agent(meta)
+        agent = agents.get_agent("dummy_hb")
+        asyncio.run(agent.step())
+        name, _, ok = q.get(timeout=1)
+        assert name == "dummy_hb"
+        assert ok
+    agents.AGENT_REGISTRY.pop("dummy_hb", None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+from click.testing import CliRunner
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
+
+
+def test_agents_status_lists_names() -> None:
+    with patch.object(cli.orchestrator, "Orchestrator") as orch_cls:
+        orch = orch_cls.return_value
+        orch.agents = [type("A", (), {})()]
+        orch.agents[0].__class__.__name__ = "AgentX"
+        result = CliRunner().invoke(cli.main, ["agents-status"])
+        assert "AgentX" in result.output
+
+
+def test_show_results_missing(tmp_path) -> None:
+    with patch.object(cli.config, "Settings") as settings:
+        settings.return_value.ledger_path = tmp_path / "ledger.txt"
+        out = CliRunner().invoke(cli.main, ["show-results"])
+        assert "No results" in out.output
+
+
+def test_replay_missing(tmp_path) -> None:
+    with patch.object(cli.config, "Settings") as settings:
+        settings.return_value.ledger_path = tmp_path / "led.txt"
+        out = CliRunner().invoke(cli.main, ["replay"])
+        assert "No ledger" in out.output
+
+
+def test_simulate_runs() -> None:
+    runner = CliRunner()
+    with patch.object(cli, "asyncio") as aio:
+        aio.run.return_value = None
+        with patch.object(cli.orchestrator, "Orchestrator"):
+            res = runner.invoke(cli.main, ["simulate", "--horizon", "1", "--offline", "--pop-size", "1", "--generations", "1"])
+        assert res.exit_code == 0
+        aio.run.assert_called_once()

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,27 @@
+import math
+import pytest
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast, sector
+from alpha_factory_v1.demos.meta_agentic_agi_v3.core.physics import gibbs
+
+
+def test_logistic_curve_midpoint() -> None:
+    assert forecast.logistic_curve(0.0) == pytest.approx(0.5)
+
+
+def test_thermodynamic_trigger() -> None:
+    sec = sector.Sector("x", energy=1.0, entropy=2.0)
+    assert not forecast.thermodynamic_trigger(sec, 0.1)
+    assert forecast.thermodynamic_trigger(sec, 1.0)
+
+
+def test_simulate_years_length() -> None:
+    secs = [sector.Sector("a")]
+    results = forecast.simulate_years(secs, 3)
+    assert [r.year for r in results] == [1, 2, 3]
+
+
+def test_gibbs_free_energy() -> None:
+    logp = [math.log(0.7), math.log(0.3)]
+    value = gibbs.free_energy(logp, temperature=1.0, task_cost=1.0)
+    entropy = -sum(p * math.log(p) for p in [0.7, 0.3])
+    assert value == pytest.approx(1.0 - entropy)

--- a/tests/test_mats.py
+++ b/tests/test_mats.py
@@ -1,0 +1,17 @@
+import random
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import mats
+
+
+def test_nsga2_step_evolves_population() -> None:
+    random.seed(0)
+    pop = [mats.Individual([0.0, 0.0]) for _ in range(4)]
+
+    def fn(genome):
+        x, y = genome
+        return x ** 2, y ** 2
+
+    new = mats.nsga2_step(pop, fn, mu=4)
+    assert len(new) == 4
+    assert all(ind.fitness is not None for ind in new)
+    genomes = {tuple(ind.genome) for ind in new}
+    assert len(genomes) >= 1


### PR DESCRIPTION
## Summary
- add basic NSGA-II test for mats demo
- exercise forecast utilities and thermodynamic triggers
- validate agent registry heartbeat logic
- cover Insight CLI with click runner
- add CI workflow running `pytest -q`

## Testing
- `ruff check tests/test_mats.py tests/test_forecast.py tests/test_agents.py tests/test_cli.py`
- `mypy --config-file mypy.ini tests/test_mats.py tests/test_forecast.py tests/test_agents.py tests/test_cli.py` *(fails: Found 189 errors in 21 files)*
- `pytest tests/test_agents.py tests/test_mats.py tests/test_forecast.py tests/test_cli.py -q`
- `pytest -q` *(fails: 3 failed, 270 passed, 12 skipped)*
