### PR TITLE
[alpha_factory] Add documentation and module docstrings

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/__init__.py
@@ -1,1 +1,1 @@
-# Demo package
+"""Assets for the Ω‑Lattice business demonstration."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
@@ -1,0 +1,1 @@
+"""Package root for the alpha‑AGI Insight demo modules."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Lightweight agent implementations for the Insight demo."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/__init__.py
@@ -1,0 +1,1 @@
+"""CLI, web UI and API server for the Insight demo."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
@@ -1,0 +1,1 @@
+"""Static files for the optional React front end."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Forecast and evolutionary algorithms used by the demo."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers and configuration for the Insight demo."""

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,34 @@
+# API and CLI Usage
+
+This page documents the REST endpoints provided by the demo API server and the available command line commands.
+
+## REST endpoints
+
+The API is implemented with FastAPI in `src/interface/api_server.py` and exposes three routes when running:
+
+- `POST /simulate` – start a new simulation. The payload accepts the forecast horizon, population size and number of evolutionary generations. A unique simulation ID is returned immediately.
+- `GET /results/{sim_id}` – retrieve the final forecast data and Pareto front once the simulation finishes.
+- `WS  /ws/{sim_id}` – a websocket that streams progress logs while the simulation runs.
+
+Start the server with:
+
+```bash
+python -m src.interface.api_server --host 0.0.0.0 --port 8000
+```
+
+## Command line interface
+
+The CLI lives in `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py`. It groups several commands under one entry point:
+
+```bash
+python cli.py [COMMAND] [OPTIONS]
+```
+
+Available commands are:
+
+- `simulate` – run a forecast and launch the orchestrator. Key options include `--horizon`, `--curve`, `--pop-size` and `--generations`.
+- `show-results` – display the latest ledger entries recorded by the orchestrator.
+- `agents-status` – list currently registered agents.
+- `replay` – replay ledger entries with a small delay for analysis.
+
+The CLI is also installed as the `alpha-agi-bhf` entry point for convenience.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased]
+- Added design overview and API documentation.
+- Initial changelog created.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,34 @@
+# Design Overview
+
+This document outlines the architecture of the Alpha Factory demo included in this repository. It also explains the individual agent roles and the Meta-Agentic Tree Search (MATS) algorithm used for evolutionary optimisation.
+
+## Architecture
+
+The system is composed of a lightweight orchestrator that coordinates a small swarm of agents. Each agent is a micro service with a specific responsibility. The orchestrator exposes both a command line interface and a minimal REST API so the demo can run headless or with a web front end. All communication is performed through simple envelope objects exchanged on an in-memory message bus.
+
+The simulation core consists of two modules:
+
+- `forecast.py` implements a basic capability forecast and a thermodynamic disruption trigger.
+- `mats.py` implements zero-data evolutionary search used to refine candidate innovations.
+
+Both modules are intentionally small so they can be inspected and extended easily.
+
+## Agent roles
+
+Seven agents are bootstrapped by the orchestrator:
+
+1. **PlanningAgent** – builds a high level execution plan.
+2. **ResearchAgent** – gathers background information and assumptions.
+3. **StrategyAgent** – decides which sectors or ideas to pursue.
+4. **MarketAgent** – evaluates potential economic impact.
+5. **CodeGenAgent** – produces runnable code snippets when needed.
+6. **SafetyGuardianAgent** – performs lightweight policy and safety checks.
+7. **MemoryAgent** – persists ledger events for later replay.
+
+Each agent implements short cycles of work which the orchestrator invokes sequentially. The ledger records every envelope processed so the entire run can be replayed for inspection.
+
+## The MATS algorithm
+
+MATS (Meta-Agentic Tree Search) is an NSGA-II style evolutionary loop that evolves a population of candidate solutions in two objective dimensions. Each individual has a numeric genome and is evaluated by a custom fitness function. Non-dominated sorting and crowding distance ensure that the search explores the trade‑off surface effectively. The resulting Pareto front highlights the best compromises discovered so far.
+
+The demo uses MATS with a toy function `(x^2, y^2)` but the optimiser can be repurposed for arbitrary metrics. Results are visualised either in the Streamlit dashboard or through the REST API.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-
+"""Top level utilities used by the small demo interface package."""

--- a/src/interface/__init__.py
+++ b/src/interface/__init__.py
@@ -1,1 +1,1 @@
-
+"""Web and API front ends for running the demo."""


### PR DESCRIPTION
## Summary
- document architecture and Meta-Agentic Tree Search
- describe REST API and CLI options
- start a simple changelog
- add docstrings for public packages

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_orchestrator_env.py::TestOrchestratorEnv::test_invalid_numeric_fallback, test_orchestrator_grpc.py::TestServeGrpc::test_server_starts_with_env_port, test_orchestrator_no_fastapi.py::TestNoFastAPI::test_build_rest_none)*