### PR TITLE
[alpha_factory] Add central config for Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -43,7 +43,7 @@ def simulate(
     if seed is not None:
         random.seed(seed)
 
-    settings = config.Settings()
+    settings = config.CFG
     if offline:
         settings.offline = True
 
@@ -82,7 +82,7 @@ def simulate(
 @main.command("show-results")
 def show_results() -> None:
     """Display the last ledger entries."""
-    path = Path(config.Settings().ledger_path)
+    path = Path(config.CFG.ledger_path)
     if not path.exists():
         click.echo("No results found")
         return
@@ -101,7 +101,7 @@ def agents_status() -> None:
 @main.command()
 def replay() -> None:
     """Replay ledger entries with small delay."""
-    path = Path(config.Settings().ledger_path)
+    path = Path(config.CFG.ledger_path)
     if not path.exists():
         click.echo("No ledger to replay")
         return

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -40,7 +40,7 @@ class Orchestrator:
     """Bootstraps agents and routes envelopes."""
 
     def __init__(self, settings: config.Settings | None = None) -> None:
-        self.settings = settings or config.Settings()
+        self.settings = settings or config.CFG
         logging.setup()
         self.bus = messaging.A2ABus(self.settings)
         self.ledger = Ledger(self.settings.ledger_path)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -1,8 +1,45 @@
 """Configuration helpers for the α‑AGI Insight demo."""
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+
+_log = logging.getLogger(__name__)
+
+
+def _load_env_file(path: str | os.PathLike[str]) -> Dict[str, str]:
+    """Return key/value pairs from ``path``.
+
+    Falls back to a minimal parser when :mod:`python_dotenv` is unavailable.
+    """
+    try:  # pragma: no cover - optional dependency
+        from dotenv import dotenv_values
+
+        return {k: v for k, v in dotenv_values(path).items() if v is not None}
+    except Exception:  # noqa: BLE001 - any import/parsing error falls back
+        pass
+
+    data: Dict[str, str] = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k.strip()] = v.strip().strip('"')
+    return data
+
+
+def _load_dotenv(path: str = ".env") -> None:
+    if Path(path).is_file():
+        for k, v in _load_env_file(path).items():
+            os.environ.setdefault(k, v)
+
+
+_load_dotenv()
 
 
 def _env_int(name: str, default: int) -> int:
@@ -20,3 +57,11 @@ class Settings:
     offline: bool = os.getenv("AGI_INSIGHT_OFFLINE", "0") == "1"
     bus_port: int = _env_int("AGI_INSIGHT_BUS_PORT", 6006)
     ledger_path: str = os.getenv("AGI_INSIGHT_LEDGER_PATH", "./ledger/audit.db")
+
+    def __post_init__(self) -> None:
+        if not self.openai_api_key:
+            _log.warning("OPENAI_API_KEY missing – offline mode enabled")
+            self.offline = True
+
+
+CFG = Settings()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,15 +13,13 @@ def test_agents_status_lists_names() -> None:
 
 
 def test_show_results_missing(tmp_path) -> None:
-    with patch.object(cli.config, "Settings") as settings:
-        settings.return_value.ledger_path = tmp_path / "ledger.txt"
+    with patch.object(cli.config.CFG, "ledger_path", tmp_path / "ledger.txt"):
         out = CliRunner().invoke(cli.main, ["show-results"])
         assert "No results" in out.output
 
 
 def test_replay_missing(tmp_path) -> None:
-    with patch.object(cli.config, "Settings") as settings:
-        settings.return_value.ledger_path = tmp_path / "led.txt"
+    with patch.object(cli.config.CFG, "ledger_path", tmp_path / "led.txt"):
         out = CliRunner().invoke(cli.main, ["replay"])
         assert "No ledger" in out.output
 


### PR DESCRIPTION
## Summary
- centralize α‑AGI Insight configuration
- use shared settings across orchestrator and CLI
- warn and enable offline mode when `OPENAI_API_KEY` is unset
- update CLI tests for new configuration object

## Testing
- `python3 check_env.py --auto-install` *(fails: could not install packages)*
- `pytest -q` *(fails: command not found)*