### PR TITLE
[alpha_factory] add design and API docs

### DIFF
--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -34,6 +34,7 @@ def _load_env_file(path: str | os.PathLike[str]) -> Mapping[str, str]:
 
 
 def parse_args() -> argparse.Namespace:
+    """Return command line arguments for the launcher."""
     ap = argparse.ArgumentParser(description="Alpha-Factory launcher")
     ap.add_argument("--dev", action="store_true", help="Enable dev mode")
     ap.add_argument("--env-file", help="Load environment variables from file")
@@ -57,6 +58,14 @@ def parse_args() -> argparse.Namespace:
 
 
 def apply_env(args: argparse.Namespace) -> None:
+    """Apply command line options to ``os.environ``.
+
+    Args:
+        args: Parsed command line arguments.
+
+    Returns:
+        None
+    """
     env_file = args.env_file
     if env_file is None and Path(".env").is_file():
         env_file = ".env"
@@ -78,12 +87,14 @@ def apply_env(args: argparse.Namespace) -> None:
 
 
 def run() -> None:
+    """Entry point used by the ``alpha-factory`` console script."""
     args = parse_args()
     if args.version:
         print(__version__)
         return
     if args.list_agents:
         from .backend.agents import list_agents
+
         for name in list_agents():
             print(name)
         return
@@ -92,6 +103,7 @@ def run() -> None:
         return
     apply_env(args)
     from .backend.orchestrator import Orchestrator
+
     Orchestrator().run_forever()
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,13 @@ The CLI lives in `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.
 python cli.py [COMMAND] [OPTIONS]
 ```
 
+For example, to run a three‑generation simulation with six agents for a
+five‑year horizon:
+
+```bash
+python cli.py simulate --horizon 5 --pop-size 6 --generations 3
+```
+
 Available commands are:
 
 - `simulate` – run a forecast and launch the orchestrator. Key options include `--horizon`, `--curve`, `--pop-size` and `--generations`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 - Added design overview and API documentation.
 - Initial changelog created.
+- Updated API usage examples and expanded design notes.
+- Added Google style docstrings to public modules.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -6,6 +6,13 @@ This document outlines the architecture of the Alpha Factory demo included in th
 
 The system is composed of a lightweight orchestrator that coordinates a small swarm of agents. Each agent is a micro service with a specific responsibility. The orchestrator exposes both a command line interface and a minimal REST API so the demo can run headless or with a web front end. All communication is performed through simple envelope objects exchanged on an in-memory message bus.
 
+### Orchestrator
+
+The orchestrator manages message routing between agents and persists every
+interaction in a ledger. This ledger can be replayed to analyse decision steps or
+to visualise the overall run. Agents are invoked sequentially in short cycles so
+the system remains deterministic and easy to debug.
+
 The simulation core consists of two modules:
 
 - `forecast.py` implements a basic capability forecast and a thermodynamic disruption trigger.

--- a/src/interface/web_app.py
+++ b/src/interface/web_app.py
@@ -1,4 +1,5 @@
 """Streamlit dashboard for AGI simulations."""
+
 from __future__ import annotations
 
 import time
@@ -20,19 +21,22 @@ else:
     SectorModule = Any
     MatsModule = Any
 
-forecast = importlib.import_module(
-    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.forecast"
-)
-sector = importlib.import_module(
-    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.sector"
-)
-mats = importlib.import_module(
-    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.mats"
-)
+forecast = importlib.import_module("alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.forecast")
+sector = importlib.import_module("alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.sector")
+mats = importlib.import_module("alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.mats")
 
 
 def _run_simulation(horizon: int, pop_size: int, generations: int) -> None:
-    """Execute the simulation and update charts live."""
+    """Execute the simulation and update charts live.
+
+    Args:
+        horizon: Number of years to forecast.
+        pop_size: Size of the MATS population.
+        generations: Number of evolutionary steps.
+
+    Returns:
+        None
+    """
     if st is None:
         print("Streamlit not installed")
         return
@@ -66,7 +70,11 @@ def _run_simulation(horizon: int, pop_size: int, generations: int) -> None:
 
 
 def main() -> None:  # pragma: no cover - entry point
-    """Streamlit entry point."""
+    """Streamlit entry point.
+
+    Returns:
+        None
+    """
     if st is None:
         print("Streamlit not installed")
         return


### PR DESCRIPTION
## Summary
- detail orchestrator in design doc
- show CLI example in API usage
- track changes in changelog
- add Google-style docstrings to interface modules
- document CLI helpers in `run.py`

## Testing
- `ruff check docs src alpha_factory_v1/run.py`
- `mypy --config-file mypy.ini .` *(fails: Found 2715 errors)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 3 failed, 270 passed, 12 skipped)*