### PR TITLE
[alpha_factory] update cli api scripts

### DIFF
--- a/alpha_factory_v1/__init__.py
+++ b/alpha_factory_v1/__init__.py
@@ -16,7 +16,7 @@ try:  # attempt to read the installed package version
 
     __version__ = _version(__name__)
 except Exception:  # pragma: no cover - fallback when not installed
-    __version__ = "1.0.0"
+    __version__ = "1.0.1"
 
 __all__ = ["backend", "demos", "ui", "run", "get_version"]
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -1,14 +1,18 @@
 """FastAPI wrapper to expose the demo over HTTP."""
+
 from __future__ import annotations
 
 try:
     from fastapi import FastAPI
+    import uvicorn
 except Exception:  # pragma: no cover - optional
     FastAPI = None  # type: ignore
+    uvicorn = None  # type: ignore
 
 import asyncio
 
 from .. import orchestrator
+import argparse
 
 app = FastAPI(title="α‑AGI Insight") if FastAPI else None
 
@@ -24,3 +28,20 @@ if app:
         if hasattr(app.state, "task"):
             app.state.task.cancel()
 
+
+def main(argv: list[str] | None = None) -> None:
+    """Launch the α‑AGI Insight API server."""
+
+    if FastAPI is None or uvicorn is None:
+        raise SystemExit("FastAPI is required to run the α‑AGI Insight API.")
+
+    parser = argparse.ArgumentParser(description="Run the α‑AGI Insight API")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port")
+    args = parser.parse_args(argv)
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,17 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alpha-factory-v1"
-version = "1.0.0"
+version = "1.0.1"
 description = "Alpha-Factory v1"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
 
 [tool.setuptools]
-packages = ["alpha_factory_v1", "af_requests"]
+packages = [
+    "alpha_factory_v1",
+    "alpha_factory_v1.demos.alpha_agi_insight_v1",
+    "af_requests",
+]
 
 [tool.setuptools.package-data]
 "alpha_factory_v1" = ["py.typed"]
@@ -35,6 +39,7 @@ alpha-agi-insight-offline = "alpha_factory_v1.demos.alpha_agi_insight_v0.officia
 alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
 alpha-agi-insight-dashboard = "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_dashboard:main"
 alpha-agi-insight-v1 = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli:main"
+alpha-agi-insight-v1-api = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here


### PR DESCRIPTION
## Summary
- include alpha_agi_insight_v1 demo package
- register console script for the v1 demo API server
- bump version to 1.0.1

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/__init__.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py` *(fails: Function is missing a type annotation)*
- `pytest -q` *(fails: 3 failed, 270 passed, 12 skipped)*