### PR TITLE
[alpha_factory] Enhance Insight orchestrator

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -1,8 +1,11 @@
 """Minimal orchestrator for the α‑AGI Insight demo."""
+
 from __future__ import annotations
 
 import asyncio
-from typing import List
+import time
+import contextlib
+from typing import Dict, List
 
 from .agents import (
     planning_agent,
@@ -17,6 +20,38 @@ from .utils import config, messaging, logging
 from .utils.logging import Ledger
 
 
+class AgentRunner:
+    """Wrapper supervising a single agent."""
+
+    def __init__(self, agent: object) -> None:
+        self.agent = agent
+        self.period = getattr(agent, "CYCLE_SECONDS", 1.0)
+        self.capabilities = getattr(agent, "CAPABILITIES", [])
+        self.last_beat = time.time()
+        self.task: asyncio.Task | None = None
+
+    async def loop(self, bus: messaging.A2ABus, ledger: Ledger) -> None:
+        while True:
+            try:
+                await self.agent.run_cycle()
+            except Exception as exc:  # noqa: BLE001
+                logging._log.warning("%s failed: %s", self.agent.name, exc)
+            env = messaging.Envelope(self.agent.name, "orch", {"heartbeat": True}, time.time())
+            ledger.log(env)
+            bus.publish("orch", env)
+            self.last_beat = env.ts
+            await asyncio.sleep(self.period)
+
+    def start(self, bus: messaging.A2ABus, ledger: Ledger) -> None:
+        self.task = asyncio.create_task(self.loop(bus, ledger))
+
+    async def restart(self, bus: messaging.A2ABus, ledger: Ledger) -> None:
+        if self.task:
+            self.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.task
+        self.agent = self.agent.__class__(bus, ledger)
+        self.start(bus, ledger)
 
 
 class Orchestrator:
@@ -27,10 +62,16 @@ class Orchestrator:
         logging.setup()
         self.bus = messaging.A2ABus(self.settings)
         self.ledger = Ledger(self.settings.ledger_path)
-        self.ledger.start_merkle_task()
-        self.agents = self._init_agents()
+        self.ledger.start_merkle_task(3600)
+        self.runners: Dict[str, AgentRunner] = {}
+        self.bus.subscribe("orch", self._on_orch)
+        for agent in self._init_agents():
+            runner = AgentRunner(agent)
+            self.runners[agent.name] = runner
+            self._register(runner)
+        self._monitor_task: asyncio.Task | None = None
 
-    def _init_agents(self) -> List[messaging.Envelope]:
+    def _init_agents(self) -> List[object]:
         agents = [
             planning_agent.PlanningAgent(self.bus, self.ledger),
             research_agent.ResearchAgent(self.bus, self.ledger),
@@ -42,14 +83,49 @@ class Orchestrator:
         ]
         return agents
 
+    def _register(self, runner: AgentRunner) -> None:
+        env = messaging.Envelope(
+            "orch",
+            "system",
+            {"event": "register", "agent": runner.agent.name, "capabilities": runner.capabilities},
+            time.time(),
+        )
+        self.ledger.log(env)
+        self.bus.publish("system", env)
+
+    async def _on_orch(self, env: messaging.Envelope) -> None:
+        if env.payload.get("heartbeat") and env.sender in self.runners:
+            self.runners[env.sender].last_beat = env.ts
+
+    async def _monitor(self) -> None:
+        while True:
+            await asyncio.sleep(2)
+            now = time.time()
+            for r in list(self.runners.values()):
+                if r.task and r.task.done():
+                    await r.restart(self.bus, self.ledger)
+                elif now - r.last_beat > r.period * 5:
+                    logging._log.warning("%s unresponsive – restarting", r.agent.name)
+                    await r.restart(self.bus, self.ledger)
+
     async def run_forever(self) -> None:
         await self.bus.start()
+        for r in self.runners.values():
+            r.start(self.bus, self.ledger)
+        self._monitor_task = asyncio.create_task(self._monitor())
         try:
             while True:
-                for agent in self.agents:
-                    await agent.run_cycle()
                 await asyncio.sleep(0.5)
         finally:
+            if self._monitor_task:
+                self._monitor_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._monitor_task
+            for r in self.runners.values():
+                if r.task:
+                    r.task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await r.task
             await self.bus.stop()
             await self.ledger.stop_merkle_task()
             self.ledger.close()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -57,6 +57,10 @@ class Settings:
     offline: bool = os.getenv("AGI_INSIGHT_OFFLINE", "0") == "1"
     bus_port: int = _env_int("AGI_INSIGHT_BUS_PORT", 6006)
     ledger_path: str = os.getenv("AGI_INSIGHT_LEDGER_PATH", "./ledger/audit.db")
+    broker_url: str | None = os.getenv("AGI_INSIGHT_BROKER_URL")
+    bus_token: str | None = os.getenv("AGI_INSIGHT_BUS_TOKEN")
+    bus_cert: str | None = os.getenv("AGI_INSIGHT_BUS_CERT")
+    bus_key: str | None = os.getenv("AGI_INSIGHT_BUS_KEY")
 
     def __post_init__(self) -> None:
         if not self.openai_api_key:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -1,10 +1,12 @@
 """Simple A2A messaging bus with optional gRPC front-end."""
+
 from __future__ import annotations
 
 import asyncio
 import json
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, List
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from .config import Settings
 
@@ -12,6 +14,11 @@ try:
     import grpc
 except ModuleNotFoundError:  # pragma: no cover - optional
     grpc = None
+
+try:  # pragma: no cover - optional broker
+    from aiokafka import AIOKafkaProducer
+except ModuleNotFoundError:  # pragma: no cover - broker optional
+    AIOKafkaProducer = None
 
 
 @dataclass(slots=True)
@@ -29,11 +36,15 @@ class A2ABus:
         self.settings = settings
         self._subs: Dict[str, List[Callable[[Envelope], Awaitable[None] | None]]] = {}
         self._server: "grpc.aio.Server | None" = None
+        self._producer: Optional[AIOKafkaProducer] = None
 
     def subscribe(self, topic: str, handler: Callable[[Envelope], Awaitable[None] | None]) -> None:
         self._subs.setdefault(topic, []).append(handler)
 
     def publish(self, topic: str, env: Envelope) -> None:
+        if self._producer:
+            data = json.dumps(env.__dict__).encode()
+            asyncio.create_task(self._producer.send_and_wait(topic, data))
         for h in list(self._subs.get(topic, [])):
             try:
                 res = h(env)
@@ -43,11 +54,21 @@ class A2ABus:
                 pass
 
     async def _handle_rpc(self, request: bytes, context: Any) -> bytes:
-        env = Envelope(**json.loads(request.decode()))
+        data = json.loads(request.decode())
+        token = data.pop("token", None)
+        if self.settings.bus_token and token != self.settings.bus_token:
+            if grpc:
+                context.abort(grpc.StatusCode.PERMISSION_DENIED, "unauthenticated")
+            return b"denied"
+        env = Envelope(**data)
         self.publish(env.recipient, env)
         return b"ok"
 
     async def start(self) -> None:
+        if self.settings.broker_url and AIOKafkaProducer:
+            self._producer = AIOKafkaProducer(bootstrap_servers=self.settings.broker_url)
+            await self._producer.start()
+
         if not self.settings.bus_port or grpc is None:
             return
         server = grpc.aio.server()
@@ -59,6 +80,10 @@ class A2ABus:
         service = grpc.method_handlers_generic_handler("bus.Bus", {"Send": method})
         server.add_generic_rpc_handlers((service,))
         creds = None
+        if self.settings.bus_cert and self.settings.bus_key:
+            key = Path(self.settings.bus_key).read_bytes()
+            crt = Path(self.settings.bus_cert).read_bytes()
+            creds = grpc.ssl_server_credentials(((key, crt),))
         if creds:
             server.add_secure_port(f"[::]:{self.settings.bus_port}", creds)
         else:
@@ -70,3 +95,6 @@ class A2ABus:
         if self._server:
             await self._server.stop(0)
             self._server = None
+        if self._producer:
+            await self._producer.stop()
+            self._producer = None

--- a/tests/test_insight_orchestrator_features.py
+++ b/tests/test_insight_orchestrator_features.py
@@ -1,0 +1,80 @@
+import asyncio
+import json
+import os
+import tempfile
+import unittest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+class TestInsightOrchestrator(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.settings = config.Settings(bus_port=0, ledger_path=os.path.join(self.tmp.name, "ledger.db"))
+        self.orch = orchestrator.Orchestrator(self.settings)
+
+    def tearDown(self) -> None:
+        asyncio.run(self.orch.bus.stop())
+        asyncio.run(self.orch.ledger.stop_merkle_task())
+        self.orch.ledger.close()
+        self.tmp.cleanup()
+
+    def test_registration_records(self) -> None:
+        count = self.orch.ledger.conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        self.assertEqual(count, len(self.orch.runners))
+
+
+class TestMessaging(unittest.TestCase):
+    def setUp(self) -> None:
+        self.settings = config.Settings(bus_port=0)
+        self.bus = messaging.A2ABus(self.settings)
+
+    def tearDown(self) -> None:
+        asyncio.run(self.bus.stop())
+
+    def test_publish_subscribe(self) -> None:
+        received = []
+
+        async def handler(env: messaging.Envelope) -> None:
+            received.append(env)
+
+        self.bus.subscribe("x", handler)
+        env = messaging.Envelope("a", "x", {"v": 1}, 0.0)
+        self.bus.publish("x", env)
+        asyncio.run(asyncio.sleep(0.01))
+        self.assertEqual(received[0].payload["v"], 1)
+
+    def test_rpc_auth(self) -> None:
+        self.settings.bus_token = "s3cr3t"
+        bus = messaging.A2ABus(self.settings)
+
+        class Ctx:
+            def abort(self, *_a, **_kw):
+                raise RuntimeError("denied")
+
+        payload = {
+            "sender": "a",
+            "recipient": "b",
+            "payload": {},
+            "ts": 0.0,
+            "token": "s3cr3t",
+        }
+        asyncio.run(bus._handle_rpc(json.dumps(payload).encode(), Ctx()))
+
+
+class TestLedger(unittest.TestCase):
+    def test_merkle_task(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        led = orchestrator.Ledger(os.path.join(tmp.name, "l.db"))
+        env = messaging.Envelope("a", "b", {}, 0.0)
+        led.log(env)
+        asyncio.run(led.broadcast_merkle_root())
+        led.start_merkle_task(0.1)
+        asyncio.run(asyncio.sleep(0.2))
+        asyncio.run(led.stop_merkle_task())
+        tmp.cleanup()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand Insight orchestrator with agent supervision and TLS gRPC bus
- add broker-aware messaging with authentication
- expose new bus/ledger settings
- test registration, routing and ledger operations

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py tests/test_insight_orchestrator_features.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py`
- `python check_env.py --auto-install`
- `pytest -q` *(interrupted after completion)*