### PR TITLE
[alpha_factory] implement demo agent behaviors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -1,15 +1,29 @@
 """Code generation agent."""
+
 from __future__ import annotations
 
 from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
 
 
 class CodeGenAgent(BaseAgent):
-    def __init__(self, bus, ledger) -> None:
+    """Generate code snippets from market analysis."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
         super().__init__("codegen", bus, ledger)
 
     async def run_cycle(self) -> None:
-        pass
+        """No-op background loop."""
+        return None
 
-    async def handle(self, env):
-        pass
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Translate market insight into executable code."""
+        analysis = env.payload.get("analysis", "")
+        code = "print('alpha')"
+        if self.oai_ctx and not self.bus.settings.offline:
+            try:  # pragma: no cover
+                code = await self.oai_ctx.run(prompt=str(analysis))
+            except Exception:
+                pass
+        await self.emit("safety", {"code": code})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
@@ -1,15 +1,29 @@
 """Market analysis agent."""
+
 from __future__ import annotations
 
 from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
 
 
 class MarketAgent(BaseAgent):
-    def __init__(self, bus, ledger) -> None:
+    """Analyse markets and forward results to the code generator."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
         super().__init__("market", bus, ledger)
 
     async def run_cycle(self) -> None:
-        pass
+        """Emit a periodic market snapshot."""
+        await self.emit("codegen", {"analysis": "neutral"})
 
-    async def handle(self, env):
-        pass
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Process strategy input and compute market impact."""
+        strategy = env.payload.get("strategy")
+        analysis = f"impact of {strategy}"
+        if self.oai_ctx and not self.bus.settings.offline:
+            try:  # pragma: no cover
+                analysis = await self.oai_ctx.run(prompt=str(strategy))
+            except Exception:
+                pass
+        await self.emit("codegen", {"analysis": analysis})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -1,15 +1,23 @@
 """Memory agent."""
+
 from __future__ import annotations
 
 from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
 
 
 class MemoryAgent(BaseAgent):
-    def __init__(self, bus, ledger) -> None:
+    """Persist artefacts produced by other agents."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
         super().__init__("memory", bus, ledger)
+        self.records: list[dict[str, object]] = []
 
     async def run_cycle(self) -> None:
-        pass
+        """Periodically report memory size."""
+        await self.emit("orch", {"stored": len(self.records)})
 
-    async def handle(self, env):
-        pass
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Store payload for later retrieval."""
+        self.records.append(env.payload)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
@@ -1,15 +1,28 @@
 """Planning agent."""
+
 from __future__ import annotations
 
 from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
 
 
 class PlanningAgent(BaseAgent):
-    def __init__(self, bus, ledger) -> None:
+    """Generate research plans for downstream agents."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
         super().__init__("planning", bus, ledger)
 
     async def run_cycle(self) -> None:
-        await self.emit("research", {"plan": "collect data"})
+        """Emit a high level research request."""
+        plan = "collect baseline metrics"
+        if self.oai_ctx and not self.bus.settings.offline:
+            try:  # pragma: no cover - SDK optional
+                plan = await self.oai_ctx.run(prompt="plan research task")
+            except Exception:
+                plan = "collect baseline metrics"
+        await self.emit("research", {"plan": plan})
 
-    async def handle(self, env):
-        pass
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Log incoming feedback for future planning."""
+        self.ledger.log(env)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -1,15 +1,34 @@
 """Research agent."""
+
 from __future__ import annotations
 
+import random
+
 from .base_agent import BaseAgent
+from ..simulation import forecast, sector
+from ..utils import messaging
+from ..utils.logging import Ledger
 
 
 class ResearchAgent(BaseAgent):
-    def __init__(self, bus, ledger) -> None:
+    """Perform simple research based on plans from :class:`PlanningAgent`."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
         super().__init__("research", bus, ledger)
 
     async def run_cycle(self) -> None:
-        pass
+        """Periodic sweep using a tiny evolutionary loop."""
+        secs = [sector.Sector(f"s{i}") for i in range(3)]
+        results = forecast.simulate_years(secs, 1)
+        await self.emit("strategy", {"research": results[0].capability})
 
-    async def handle(self, env):
-        pass
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Process planning requests and emit research results."""
+        plan = env.payload.get("plan", "")
+        cap = random.random()
+        if self.oai_ctx and not self.bus.settings.offline:
+            try:  # pragma: no cover
+                cap = float(await self.oai_ctx.run(prompt=str(plan)))
+            except Exception:
+                pass
+        await self.emit("strategy", {"research": cap})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
@@ -1,15 +1,24 @@
 """Safety guardian agent."""
+
 from __future__ import annotations
 
 from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
 
 
 class SafetyGuardianAgent(BaseAgent):
-    def __init__(self, bus, ledger) -> None:
+    """Validate generated code before persistence."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
         super().__init__("safety", bus, ledger)
 
     async def run_cycle(self) -> None:
-        pass
+        """No-op periodic check."""
+        return None
 
-    async def handle(self, env):
-        pass
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Simple pattern-based validation."""
+        code = env.payload.get("code", "")
+        status = "blocked" if "import os" in code else "ok"
+        await self.emit("memory", {"code": code, "status": status})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
@@ -1,15 +1,29 @@
 """Strategy agent."""
+
 from __future__ import annotations
 
 from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
 
 
 class StrategyAgent(BaseAgent):
-    def __init__(self, bus, ledger) -> None:
+    """Turn research output into actionable strategy."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
         super().__init__("strategy", bus, ledger)
 
     async def run_cycle(self) -> None:
-        pass
+        """No-op periodic loop."""
+        return None
 
-    async def handle(self, env):
-        pass
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Compose a strategy from research results."""
+        val = env.payload.get("research")
+        strat = {"action": f"monitor {val}"}
+        if self.oai_ctx and not self.bus.settings.offline:
+            try:  # pragma: no cover
+                strat["action"] = await self.oai_ctx.run(prompt=str(val))
+            except Exception:
+                pass
+        await self.emit("market", {"strategy": strat})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py
@@ -1,24 +1,45 @@
-import pytest
-pytestmark = pytest.mark.skip("demo")
+import asyncio
+import pathlib
+from typing import List
 
-if False:  # type: ignore
-    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (
-        planning_agent,
-        research_agent,
-        strategy_agent,
-        market_agent,
-        codegen_agent,
-        safety_agent,
-        memory_agent,
-    )
-    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging, config
-    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.orchestrator import Ledger
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (
+    planning_agent,
+    research_agent,
+    strategy_agent,
+    market_agent,
+    codegen_agent,
+    safety_agent,
+    memory_agent,
+)
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
 
 
-async def test_agents_cycle() -> None:
+def test_agent_pipeline(tmp_path: pathlib.Path) -> None:
     settings = config.Settings()
+    settings.ledger_path = str(tmp_path / "ledger.db")
     bus = messaging.A2ABus(settings)
     ledger = Ledger(settings.ledger_path)
+
+    plan_msgs: List[messaging.Envelope] = []
+    bus.subscribe("research", plan_msgs.append)
+
+    strat_msgs: List[messaging.Envelope] = []
+    bus.subscribe("strategy", strat_msgs.append)
+
+    market_msgs: List[messaging.Envelope] = []
+    bus.subscribe("market", market_msgs.append)
+
+    code_msgs: List[messaging.Envelope] = []
+    bus.subscribe("codegen", code_msgs.append)
+
+    safety_in: List[messaging.Envelope] = []
+    bus.subscribe("safety", safety_in.append)
+
+    memory_msgs: List[messaging.Envelope] = []
+    bus.subscribe("memory", memory_msgs.append)
+
+    mem_agent = memory_agent.MemoryAgent(bus, ledger)
     agents = [
         planning_agent.PlanningAgent(bus, ledger),
         research_agent.ResearchAgent(bus, ledger),
@@ -26,7 +47,30 @@ async def test_agents_cycle() -> None:
         market_agent.MarketAgent(bus, ledger),
         codegen_agent.CodeGenAgent(bus, ledger),
         safety_agent.SafetyGuardianAgent(bus, ledger),
-        memory_agent.MemoryAgent(bus, ledger),
+        mem_agent,
     ]
-    for a in agents:
-        await a.run_cycle()
+
+    async def _run() -> None:
+        await agents[0].run_cycle()
+        assert plan_msgs, "planning agent did not emit research plan"
+
+        await agents[1].handle(plan_msgs[0])
+        assert strat_msgs, "research agent did not emit strategy payload"
+
+        await agents[2].handle(strat_msgs[0])
+        assert market_msgs, "strategy agent did not emit market analysis"
+
+        await agents[3].handle(market_msgs[0])
+        assert code_msgs, "market agent did not emit code generation task"
+
+        await agents[4].handle(code_msgs[0])
+        assert safety_in, "codegen agent did not emit safety event"
+
+        await agents[5].handle(safety_in[0])
+        assert memory_msgs, "safety agent did not emit memory payload"
+
+        await mem_agent.handle(memory_msgs[0])
+        assert mem_agent.records, "memory agent did not store payload"
+        ledger.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add simple behaviours for planning, research, strategy, market, codegen, safety and memory agents
- wire optional OpenAI and ADK usage with offline fallbacks
- store envelopes using dataclass `asdict`
- test demo agent message pipeline

## Testing
- `python check_env.py --auto-install`
- `ruff format` & `ruff check`
- `mypy --config-file mypy.ini ...`
- `pytest -q`