### PR TITLE
[alpha_factory] add evolutionary runner

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -39,3 +39,8 @@ Each agent implements short cycles of work which the orchestrator invokes sequen
 MATS (Meta-Agentic Tree Search) is an NSGA-II style evolutionary loop that evolves a population of candidate solutions in two objective dimensions. Each individual has a numeric genome and is evaluated by a custom fitness function. Non-dominated sorting and crowding distance ensure that the search explores the trade‑off surface effectively. The resulting Pareto front highlights the best compromises discovered so far.
 
 The demo uses MATS with a toy function `(x^2, y^2)` but the optimiser can be repurposed for arbitrary metrics. Results are visualised either in the Streamlit dashboard or through the REST API.
+
+The helper function `run_evolution` initialises the population and executes the
+NSGA‑II loop for a configurable number of generations. The population size,
+mutation rate and generation count can be adjusted and a random ``seed`` enables
+deterministic runs which is useful for testing and reproducibility.

--- a/tests/test_mats.py
+++ b/tests/test_mats.py
@@ -8,10 +8,22 @@ def test_nsga2_step_evolves_population() -> None:
 
     def fn(genome):
         x, y = genome
-        return x ** 2, y ** 2
+        return x**2, y**2
 
     new = mats.nsga2_step(pop, fn, mu=4)
     assert len(new) == 4
     assert all(ind.fitness is not None for ind in new)
     genomes = {tuple(ind.genome) for ind in new}
     assert len(genomes) >= 1
+
+
+def test_run_evolution_reproducible_and_progress() -> None:
+    def fn(genome: list[float]) -> tuple[float, float]:
+        x, y = genome
+        return x**2, y**2
+
+    pop1 = mats.run_evolution(fn, 2, population_size=4, generations=3, mutation_rate=0.5, seed=123)
+    pop2 = mats.run_evolution(fn, 2, population_size=4, generations=3, mutation_rate=0.5, seed=123)
+
+    assert [ind.genome for ind in pop1] == [ind.genome for ind in pop2]
+    assert any(any(g != 0 for g in ind.genome) for ind in pop1)


### PR DESCRIPTION
## Summary
- add `run_evolution` helper for NSGA-II runs with seeding
- document parameters in DESIGN docs
- test deterministic evolution behaviour

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_registration_records, test_publish_subscribe, test_merkle_task, test_invalid_numeric_fallback, test_server_starts_with_env_port, test_build_rest_none)*