### PR TITLE
[alpha_factory] add disruption forecasting

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -19,8 +19,8 @@ class ResearchAgent(BaseAgent):
     async def run_cycle(self) -> None:
         """Periodic sweep using a tiny evolutionary loop."""
         secs = [sector.Sector(f"s{i}") for i in range(3)]
-        results = forecast.simulate_years(secs, 1)
-        await self.emit("strategy", {"research": results[0].capability})
+        traj = forecast.forecast_disruptions(secs, 1)
+        await self.emit("strategy", {"research": traj[0].capability})
 
     async def handle(self, env: messaging.Envelope) -> None:
         """Process planning requests and emit research results."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -49,7 +49,14 @@ def simulate(
 
     orch = orchestrator.Orchestrator(settings)
     secs = [sector.Sector(f"s{i:02d}") for i in range(pop_size)]
-    results = forecast.simulate_years(secs, horizon)
+    trajectory = forecast.forecast_disruptions(
+        secs,
+        horizon,
+        curve=curve,
+        pop_size=pop_size,
+        generations=generations,
+    )
+    results = [forecast.ForecastPoint(t.year, t.capability, [s for s in t.sectors if s.disrupted]) for t in trajectory]
 
     if export == "json":
         data = [

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
@@ -1,4 +1,5 @@
 """Thermodynamic trigger forecasting."""
+
 from __future__ import annotations
 
 import math
@@ -6,6 +7,7 @@ from dataclasses import dataclass
 from typing import Iterable, List
 
 from .sector import Sector
+from . import mats
 
 
 @dataclass(slots=True)
@@ -15,19 +17,88 @@ class ForecastPoint:
     affected: List[Sector]
 
 
+@dataclass(slots=True)
+class TrajectoryPoint:
+    """Detailed snapshot for a single year."""
+
+    year: int
+    capability: float
+    sectors: List[Sector]
+
+
 def logistic_curve(t: float, k: float = 1.0, x0: float = 0.0) -> float:
     return 1.0 / (1.0 + math.exp(-k * (t - x0)))
 
 
+def linear_curve(t: float) -> float:
+    return max(0.0, min(1.0, t))
+
+
+def exponential_curve(t: float, k: float = 3.0) -> float:
+    scale = math.exp(k) - 1.0
+    return min(1.0, (math.exp(k * t) - 1.0) / scale)
+
+
+def capability_growth(t: float, curve: str = "logistic") -> float:
+    if curve == "linear":
+        return linear_curve(t)
+    if curve == "exponential":
+        return exponential_curve(t)
+    return logistic_curve(10.0 * t)
+
+
+def free_energy(sector: Sector, capability: float) -> float:
+    return sector.energy - capability * sector.entropy
+
+
 def thermodynamic_trigger(sector: Sector, capability: float) -> bool:
-    delta_g = sector.energy - capability * sector.entropy
-    return delta_g < 0
+    return free_energy(sector, capability) < 0
+
+
+def _innovation_gain(pop_size: int = 6, generations: int = 1) -> float:
+    """Return a small gain from a short MATS run."""
+
+    def fn(genome: list[float]) -> tuple[float, float]:
+        x, y = genome
+        return x**2, y**2
+
+    pop = mats.run_evolution(fn, 2, population_size=pop_size, generations=generations, seed=42)
+    best = min(pop, key=lambda ind: sum(ind.fitness or (0.0, 0.0)))
+    return 0.1 / (1.0 + sum(best.fitness or (0.0, 0.0)))
+
+
+def forecast_disruptions(
+    sectors: Iterable[Sector],
+    horizon: int,
+    curve: str = "logistic",
+    *,
+    pop_size: int = 6,
+    generations: int = 1,
+) -> List[TrajectoryPoint]:
+    """Simulate sector trajectories and disruption events."""
+
+    secs = list(sectors)
+    results: List[TrajectoryPoint] = []
+    for year in range(1, horizon + 1):
+        t = year / horizon
+        cap = capability_growth(t, curve)
+        affected: List[Sector] = []
+        for sec in secs:
+            if not sec.disrupted:
+                sec.energy *= 1.0 + sec.growth
+                if thermodynamic_trigger(sec, cap):
+                    sec.disrupted = True
+                    sec.energy += _innovation_gain(pop_size, generations)
+                    affected.append(sec)
+        snapshot = [Sector(s.name, s.energy, s.entropy, s.growth, s.disrupted) for s in secs]
+        results.append(TrajectoryPoint(year, cap, snapshot))
+    return results
 
 
 def simulate_years(sectors: Iterable[Sector], horizon: int) -> List[ForecastPoint]:
     results: List[ForecastPoint] = []
-    for year in range(1, horizon + 1):
-        cap = logistic_curve(year / horizon * 10.0)
-        affected = [s for s in sectors if thermodynamic_trigger(s, cap)]
-        results.append(ForecastPoint(year, cap, affected))
+    traj = forecast_disruptions(sectors, horizon)
+    for point in traj:
+        affected = [s for s in point.sectors if s.disrupted]
+        results.append(ForecastPoint(point.year, point.capability, affected))
     return results

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
@@ -1,4 +1,5 @@
 """Sector state representation."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -6,6 +7,10 @@ from dataclasses import dataclass
 
 @dataclass(slots=True)
 class Sector:
+    """Simple sector state used by the simulation."""
+
     name: str
     energy: float = 1.0
     entropy: float = 1.0
+    growth: float = 0.05
+    disrupted: bool = False

--- a/src/interface/web_app.py
+++ b/src/interface/web_app.py
@@ -12,8 +12,6 @@ except Exception:  # pragma: no cover - optional
 import importlib
 from typing import Any, TYPE_CHECKING
 
-from ..utils import CFG
-
 if TYPE_CHECKING:  # pragma: no cover - typing only
     ForecastModule = Any
     SectorModule = Any
@@ -50,11 +48,12 @@ def _run_simulation(horizon: int, pop_size: int, generations: int) -> None:
     pareto_area = st.empty()
     log_box = st.empty()
 
-    results = forecast.simulate_years(secs, horizon)
-    for res in results:
-        capability_chart.add_rows({"capability": [res.capability]})
-        sector_chart.add_rows({"affected": [len(res.affected)]})
-        st.session_state.logs.append(f"Year {res.year}: {len(res.affected)} affected")
+    traj = forecast.forecast_disruptions(secs, horizon, generations=generations, pop_size=pop_size)
+    for t in traj:
+        affected = [s for s in t.sectors if s.disrupted]
+        capability_chart.add_rows({"capability": [t.capability]})
+        sector_chart.add_rows({"affected": [len(affected)]})
+        st.session_state.logs.append(f"Year {t.year}: {len(affected)} affected")
         log_box.text("\n".join(st.session_state.logs[-20:]))
         time.sleep(0.1)
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -20,6 +20,17 @@ def test_simulate_years_length() -> None:
     assert [r.year for r in results] == [1, 2, 3]
 
 
+def test_baseline_growth_and_disruption() -> None:
+    sec = sector.Sector("x", energy=1.0, entropy=2.0, growth=0.1)
+    traj = forecast.forecast_disruptions([sec], 2, curve="linear", pop_size=2, generations=1)
+    first = traj[0].sectors[0]
+    second = traj[1].sectors[0]
+    assert first.energy == pytest.approx(1.1)
+    assert not first.disrupted
+    assert second.disrupted
+    assert second.energy > 1.1 * 1.1
+
+
 def test_gibbs_free_energy() -> None:
     logp = [math.log(0.7), math.log(0.3)]
     value = gibbs.free_energy(logp, temperature=1.0, task_cost=1.0)


### PR DESCRIPTION
## Summary
- allow Sector to track baseline growth and disruption
- add capability curve options and free energy calculation
- update CLI/API/web UI to use new disruption forecast
- record innovation gains when AGI capability crosses the trigger
- test baseline growth and disruption logging

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py src/interface/api_server.py src/interface/web_app.py tests/test_forecast.py`
- `mypy --config-file mypy.ini .` *(fails: Found 2705 errors)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 6 failed, 274 passed, 11 skipped)*