### PR TITLE
[alpha_factory] enhance demo CLI

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -7,12 +7,27 @@ import json
 import random
 import time
 from pathlib import Path
+from typing import Any, Iterable, List
 
 import click
 
 from .. import orchestrator
 from ..simulation import forecast, sector
-from ..utils import config
+from ..utils import config, logging
+
+
+def _pretty_table(headers: Iterable[str], rows: Iterable[Iterable[Any]]) -> str:
+    cols = [list(map(str, col)) for col in zip(*([headers] + list(rows)))]
+    widths = [max(len(item) for item in col) for col in cols]
+    line = "-+-".join("-" * w for w in widths)
+    header = " | ".join(h.ljust(widths[i]) for i, h in enumerate(headers))
+    data_lines = [" | ".join(str(val).ljust(widths[i]) for i, val in enumerate(row)) for row in rows]
+    return "\n".join([header, line, *data_lines])
+
+
+def _format_results(res: List[forecast.ForecastPoint]) -> str:
+    rows = [(r.year, f"{r.capability:.2f}", ",".join(s.name for s in r.affected)) for r in res]
+    return _pretty_table(["year", "capability", "affected"], rows)
 
 
 @click.group()
@@ -29,6 +44,7 @@ def main() -> None:
 @click.option("--generations", default=3, show_default=True, type=int, help="Evolution steps")
 @click.option("--export", type=click.Choice(["json", "csv"]), help="Export results format")
 @click.option("--verbose", is_flag=True, help="Verbose output")
+@click.option("--start-orchestrator", is_flag=True, help="Run orchestrator after simulation")
 def simulate(
     horizon: int,
     curve: str,
@@ -38,6 +54,7 @@ def simulate(
     generations: int,
     export: str | None,
     verbose: bool,
+    start_orchestrator: bool,
 ) -> None:
     """Run the forecast simulation and start the orchestrator."""
     if seed is not None:
@@ -74,27 +91,33 @@ def simulate(
             lines.append(f"{r.year},{r.capability},{'|'.join(s.name for s in r.affected)}")
         click.echo("\n".join(lines))
     else:
-        for r in results:
-            click.echo(f"{r.year}: {r.capability:.2f} → {[s.name for s in r.affected]}")
+        click.echo(_format_results(results))
 
-    if verbose:
+    if start_orchestrator and verbose:
         click.echo("Starting orchestrator … press Ctrl+C to stop")
 
-    try:
-        asyncio.run(orch.run_forever())
-    except KeyboardInterrupt:  # pragma: no cover - interactive
-        pass
+    if start_orchestrator:
+        try:
+            asyncio.run(orch.run_forever())
+        except KeyboardInterrupt:  # pragma: no cover - interactive
+            pass
 
 
 @main.command("show-results")
-def show_results() -> None:
+@click.option("--limit", default=10, show_default=True, type=int, help="Entries to display")
+def show_results(limit: int) -> None:
     """Display the last ledger entries."""
     path = Path(config.CFG.ledger_path)
     if not path.exists():
         click.echo("No results found")
         return
-    for line in path.read_text(encoding="utf-8").splitlines()[-10:]:
-        click.echo(line)
+    led = logging.Ledger(str(path))
+    rows = led.tail(limit)
+    if not rows:
+        click.echo("No results found")
+        return
+    data = [(f"{r['ts']:.2f}", r["sender"], r["recipient"], json.dumps(r["payload"])) for r in rows]
+    click.echo(_pretty_table(["ts", "sender", "recipient", "payload"], data))
 
 
 @main.command("agents-status")
@@ -112,8 +135,10 @@ def replay() -> None:
     if not path.exists():
         click.echo("No ledger to replay")
         return
-    for line in path.read_text(encoding="utf-8").splitlines():
-        click.echo(line)
+    led = logging.Ledger(str(path))
+    for row in led.tail(1000):
+        msg = f"{row['ts']:.2f} {row['sender']} -> {row['recipient']} {json.dumps(row['payload'])}"
+        click.echo(msg)
         time.sleep(0.1)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,19 @@ def test_simulate_runs() -> None:
     with patch.object(cli, "asyncio") as aio:
         aio.run.return_value = None
         with patch.object(cli.orchestrator, "Orchestrator"):
-            res = runner.invoke(cli.main, ["simulate", "--horizon", "1", "--offline", "--pop-size", "1", "--generations", "1"])
+            res = runner.invoke(
+                cli.main,
+                [
+                    "simulate",
+                    "--horizon",
+                    "1",
+                    "--offline",
+                    "--pop-size",
+                    "1",
+                    "--generations",
+                    "1",
+                    "--start-orchestrator",
+                ],
+            )
         assert res.exit_code == 0
         aio.run.assert_called_once()

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+from click.testing import CliRunner
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
+
+
+def test_simulate_without_flag_does_not_start() -> None:
+    runner = CliRunner()
+    with patch.object(cli, "asyncio") as aio:
+        with patch.object(cli.orchestrator, "Orchestrator"):
+            res = runner.invoke(
+                cli.main,
+                [
+                    "simulate",
+                    "--horizon",
+                    "1",
+                    "--offline",
+                    "--pop-size",
+                    "1",
+                    "--generations",
+                    "1",
+                ],
+            )
+        assert res.exit_code == 0
+        aio.run.assert_not_called()
+
+
+def test_show_results_table(tmp_path) -> None:
+    ledger = tmp_path / "audit.db"
+    ledger.touch()
+    with patch.object(cli.config.CFG, "ledger_path", ledger):
+        with patch.object(cli.logging, "Ledger") as led_cls:
+            led = led_cls.return_value
+            led.tail.return_value = [{"ts": 1.0, "sender": "a", "recipient": "b", "payload": {"x": 1}}]
+            res = CliRunner().invoke(cli.main, ["show-results"])
+            assert "sender" in res.output
+            assert "a" in res.output


### PR DESCRIPTION
## Summary
- add coloredlog support and ledger tail helper
- pretty table printer and optional orchestrator start
- expose ledger table via CLI commands
- adjust CLI tests
- cover CLI start logic

## Testing
- `black alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py tests/test_cli.py tests/test_demo_cli.py`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py tests/test_cli.py tests/test_demo_cli.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py tests/test_cli.py tests/test_demo_cli.py` *(fails: unused-ignore, attr-defined, etc.)*
- `pytest -q` *(fails: 6 failed, 276 passed)*
