### PR TITLE
[alpha_factory] docs and deployment updates

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Root environment template for Alpha-Factory deployments
+# Copy to `.env` and adjust the values before running docker compose or Helm
+
+OPENAI_API_KEY=
+NEO4J_PASSWORD=REPLACE_ME
+RUN_MODE=api   # api | cli | web
+PORT=8000

--- a/README.md
+++ b/README.md
@@ -629,20 +629,28 @@ like `--cycle`, `--loglevel` and `--version`.
 Build the demo containers locally:
 
 ```bash
+cp .env.sample .env
 cd infrastructure
 docker build -t alpha-demo .
-docker compose up
+docker compose up -d
 ```
 
 The Helm chart under `infrastructure/helm-chart` mirrors this Compose
 setup:
 
 ```bash
-helm install alpha-demo ./infrastructure/helm-chart
+helm upgrade --install alpha-demo ./infrastructure/helm-chart \
+  --values ./infrastructure/helm-chart/values.yaml
 ```
 
 Terraform scripts in `infrastructure/terraform` provide GCP and AWS
-examples (`main_gcp.tf`, `main_aws.tf`).
+examples. Initialise and apply with:
+
+```bash
+cd infrastructure/terraform
+terraform init
+terraform apply
+```
 
 | Target | Command | Notes |
 |--------|---------|-------|

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,3 +39,25 @@ Available commands are:
 - `replay` – replay ledger entries with a small delay for analysis.
 
 The CLI is also installed as the `alpha-agi-bhf` entry point for convenience.
+
+### Endpoint Details
+
+**POST `/simulate`**
+
+Start a new simulation run. The JSON body accepts:
+
+- `horizon` – forecast horizon in years.
+- `pop_size` – number of individuals per generation.
+- `generations` – number of evolutionary steps.
+
+Returns a JSON object containing the simulation `id`.
+
+**GET `/results/{sim_id}`**
+
+Retrieve the final forecast and Pareto front for a previously launched simulation.
+
+**WebSocket `/ws/{sim_id}`**
+
+Provides a live feed of progress messages during a running simulation. Clients should close the socket once the final `done` message is received.
+
+The server honours environment variables defined in `.env` such as `PORT` (HTTP port), `OPENAI_API_KEY` and `RUN_MODE`. When `RUN_MODE=web`, a small frontend served at `/` consumes these endpoints via JavaScript.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,3 +7,8 @@ All notable changes to this project are documented in this file.
 - Initial changelog created.
 - Updated API usage examples and expanded design notes.
 - Added Google style docstrings to public modules.
+
+## [0.2.0] - 2024-06-01
+- Expanded design document with data flow, interface and deployment notes.
+- Documented API endpoints in greater detail.
+- Added infrastructure templates for Docker, Helm and Terraform with environment variables.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -44,3 +44,15 @@ The helper function `run_evolution` initialises the population and executes the
 NSGA‑II loop for a configurable number of generations. The population size,
 mutation rate and generation count can be adjusted and a random ``seed`` enables
 deterministic runs which is useful for testing and reproducibility.
+
+## Data flow
+
+Messages traverse the orchestrator in discrete cycles. Each cycle begins with the PlanningAgent emitting a high level goal. Subsequent agents enrich this envelope with research, strategy and market data before the CodeGenAgent proposes executable actions. The SafetyGuardianAgent performs a final policy check and, if approved, the MemoryAgent records the action to the ledger. This deterministic loop makes it easy to trace how a decision emerged from the collective agent swarm.
+
+## Interfaces
+
+The system exposes both a command line interface and a REST/WS API. The CLI is suitable for quick local experiments and supports subcommands for running simulations, replaying ledger events and inspecting agent status. The API server wraps the same orchestrator in a FastAPI application. Clients start a simulation via `POST /simulate`, fetch results with `GET /results/{id}` and stream logs through `WS /ws/{id}`. A lightweight web dashboard consumes these endpoints to visualise progress.
+
+## Deployment model
+
+The repository includes container and infrastructure templates for Docker Compose, Helm and Terraform. Each mode deploys the orchestrator together with optional agents and the web UI. Environment variables configured in `.env` control credentials, ports and runtime options. When running in Kubernetes, the Helm chart maps these variables to pod environment settings. The Terraform examples show how to provision equivalent services on AWS Fargate or Google Cloud Run.

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,5 +1,18 @@
 FROM python:3.11-slim
+
+# install system deps
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
-COPY .. /app
+COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-CMD ["python", "-m", "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final"]
+COPY .. /app
+# add non-root user
+RUN useradd -m afuser
+COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+USER afuser
+
+ENV PYTHONUNBUFFERED=1
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["cli"]

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -3,18 +3,29 @@ services:
   orchestrator:
     build: .
     image: alpha-demo:latest
+    env_file:
+      - ../.env
+    environment:
+      RUN_MODE: api
     ports:
-      - "8000:8000"
+      - "${PORT:-8000}:8000"
+
   agents:
     image: alpha-demo:latest
-    command: ["python", "-m", "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_final"]
+    env_file:
+      - ../.env
+    environment:
+      RUN_MODE: cli
     depends_on:
       - orchestrator
+
   web:
-    image: nginx:alpine
-    volumes:
-      - ../alpha_factory_v1/ui:/usr/share/nginx/html:ro
+    image: alpha-demo:latest
+    env_file:
+      - ../.env
+    environment:
+      RUN_MODE: web
     ports:
-      - "3000:80"
+      - "3000:3000"
     depends_on:
       - orchestrator

--- a/infrastructure/docker-entrypoint.sh
+++ b/infrastructure/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+MODE=${RUN_MODE:-cli}
+if [ "$MODE" = "api" ]; then
+  exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server
+elif [ "$MODE" = "web" ]; then
+  exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_app
+else
+  exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli "$@"
+fi

--- a/infrastructure/helm-chart/README.md
+++ b/infrastructure/helm-chart/README.md
@@ -1,6 +1,9 @@
-This chart deploys the demo orchestrator and UI.
-Install with:
+This chart deploys the orchestrator and optional web UI.
+
 ```bash
 helm upgrade --install alpha-demo ./infrastructure/helm-chart \
-  --set env.OPENAI_API_KEY=<key>
+  --set env.OPENAI_API_KEY=<key> \
+  --set env.RUN_MODE=api
 ```
+
+Values such as `service.port` or `image` can be overridden with `--set` or a custom `values.yaml` file.

--- a/infrastructure/helm-chart/templates/deployment.yaml
+++ b/infrastructure/helm-chart/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: alpha-demo
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: alpha-demo
@@ -14,7 +14,12 @@ spec:
     spec:
       containers:
         - name: orchestrator
-          image: alpha-demo:latest
+          image: {{ .Values.image }}
+          env:
+            - name: OPENAI_API_KEY
+              value: {{ .Values.env.OPENAI_API_KEY | quote }}
+            - name: RUN_MODE
+              value: {{ .Values.env.RUN_MODE | quote }}
           ports:
             - containerPort: 8000
             - containerPort: 3000

--- a/infrastructure/helm-chart/templates/service.yaml
+++ b/infrastructure/helm-chart/templates/service.yaml
@@ -3,13 +3,13 @@ kind: Service
 metadata:
   name: alpha-demo
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   selector:
     app: alpha-demo
   ports:
     - name: http
-      port: 8000
+      port: {{ .Values.service.port }}
       targetPort: 8000
     - name: ui
-      port: 3000
+      port: {{ .Values.service.uiPort }}
       targetPort: 3000

--- a/infrastructure/helm-chart/values.yaml
+++ b/infrastructure/helm-chart/values.yaml
@@ -1,0 +1,9 @@
+image: alpha-demo:latest
+replicaCount: 1
+env:
+  OPENAI_API_KEY: ""
+  RUN_MODE: api
+service:
+  type: ClusterIP
+  port: 8000
+  uiPort: 3000

--- a/infrastructure/terraform/main_aws.tf
+++ b/infrastructure/terraform/main_aws.tf
@@ -1,2 +1,42 @@
-# Example Terraform deployment for AWS Fargate
-# Mirrors the README instructions
+# Simplified AWS Fargate deployment
+variable "region" { default = "us-east-1" }
+variable "openai_api_key" { default = "" }
+
+provider "aws" { region = var.region }
+
+resource "aws_ecs_cluster" "af" {
+  name = "alpha-factory"
+}
+
+# Task definition with environment variables
+resource "aws_ecs_task_definition" "af" {
+  family                   = "alpha-factory"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  container_definitions = jsonencode([
+    {
+      name      = "orchestrator"
+      image     = "alpha-demo:latest"
+      essential = true
+      environment = [
+        { name = "OPENAI_API_KEY", value = var.openai_api_key },
+        { name = "RUN_MODE", value = "api" }
+      ]
+      portMappings = [{ containerPort = 8000 }]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "af" {
+  name            = "alpha-factory"
+  cluster         = aws_ecs_cluster.af.id
+  task_definition = aws_ecs_task_definition.af.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  network_configuration {
+    subnets         = ["subnet-12345"]
+    assign_public_ip = true
+  }
+}

--- a/infrastructure/terraform/main_gcp.tf
+++ b/infrastructure/terraform/main_gcp.tf
@@ -1,2 +1,29 @@
-# Example Terraform deployment for Google Cloud Run
-# Mirrors the README instructions
+# Simplified Google Cloud Run deployment
+variable "project" { default = "my-project" }
+variable "openai_api_key" { default = "" }
+
+provider "google" { project = var.project }
+
+resource "google_cloud_run_service" "af" {
+  name     = "alpha-factory"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "alpha-demo:latest"
+        env = [
+          {
+            name  = "OPENAI_API_KEY"
+            value = var.openai_api_key
+          },
+          {
+            name  = "RUN_MODE"
+            value = "api"
+          }
+        ]
+        ports { container_port = 8000 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand architecture design notes
- extend API documentation
- update changelog for v0.2.0
- add Dockerfile entrypoint and non-root setup
- configure docker-compose, Helm values and Terraform examples
- provide `.env.sample` and update README deployment section

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 6 failed, 276 passed, 11 skipped)*