### PR TITLE
[alpha_factory] Parameterize Solana broadcasting

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -149,6 +149,9 @@ The React dashboard streams year-by-year events via WebSocket and renders:
 | `AGI_INSIGHT_OFFLINE` | Force offline mode | `0` |
 | `AGI_INSIGHT_BUS_PORT` | gRPC bus port | `6006` |
 | `AGI_INSIGHT_LEDGER_PATH` | Audit DB path | `./ledger/audit.db` |
+| `AGI_INSIGHT_BROADCAST` | Enable blockchain broadcasting | `1` |
+| `AGI_INSIGHT_SOLANA_URL` | Solana RPC endpoint | `https://api.testnet.solana.com` |
+| `AGI_INSIGHT_SOLANA_WALLET` | Wallet private key (hex) | _unset_ |
 
 Create `.env` or pass via `docker -e`.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -40,6 +40,7 @@ def main() -> None:
 @click.option("--curve", default="logistic", show_default=True, help="Capability growth curve")
 @click.option("--seed", type=int, help="Random seed")
 @click.option("--offline", is_flag=True, help="Force offline mode")
+@click.option("--no-broadcast", is_flag=True, help="Disable blockchain broadcasting")
 @click.option("--pop-size", default=6, show_default=True, type=int, help="MATS population size")
 @click.option("--generations", default=3, show_default=True, type=int, help="Evolution steps")
 @click.option("--export", type=click.Choice(["json", "csv"]), help="Export results format")
@@ -55,6 +56,7 @@ def simulate(
     export: str | None,
     verbose: bool,
     start_orchestrator: bool,
+    no_broadcast: bool,
 ) -> None:
     """Run the forecast simulation and start the orchestrator."""
     if seed is not None:
@@ -63,6 +65,8 @@ def simulate(
     settings = config.CFG
     if offline:
         settings.offline = True
+    if no_broadcast:
+        settings.broadcast = False
 
     orch = orchestrator.Orchestrator(settings)
     secs = [sector.Sector(f"s{i:02d}") for i in range(pop_size)]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -61,7 +61,12 @@ class Orchestrator:
         self.settings = settings or config.CFG
         logging.setup()
         self.bus = messaging.A2ABus(self.settings)
-        self.ledger = Ledger(self.settings.ledger_path)
+        self.ledger = Ledger(
+            self.settings.ledger_path,
+            rpc_url=self.settings.solana_rpc_url,
+            wallet=self.settings.solana_wallet,
+            broadcast=self.settings.broadcast,
+        )
         self.ledger.start_merkle_task(3600)
         self.runners: Dict[str, AgentRunner] = {}
         self.bus.subscribe("orch", self._on_orch)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -1,4 +1,5 @@
 """Configuration helpers for the α‑AGI Insight demo."""
+
 from __future__ import annotations
 
 import logging
@@ -61,11 +62,16 @@ class Settings:
     bus_token: str | None = os.getenv("AGI_INSIGHT_BUS_TOKEN")
     bus_cert: str | None = os.getenv("AGI_INSIGHT_BUS_CERT")
     bus_key: str | None = os.getenv("AGI_INSIGHT_BUS_KEY")
+    broadcast: bool = os.getenv("AGI_INSIGHT_BROADCAST", "1") == "1"
+    solana_rpc_url: str = os.getenv("AGI_INSIGHT_SOLANA_URL", "https://api.testnet.solana.com")
+    solana_wallet: str | None = os.getenv("AGI_INSIGHT_SOLANA_WALLET")
 
     def __post_init__(self) -> None:
         if not self.openai_api_key:
             _log.warning("OPENAI_API_KEY missing – offline mode enabled")
             self.offline = True
+        if self.offline:
+            self.broadcast = False
 
 
 CFG = Settings()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -49,7 +49,10 @@ class A2ABus:
             try:
                 res = h(env)
                 if asyncio.iscoroutine(res):
-                    asyncio.create_task(res)
+                    try:
+                        asyncio.get_running_loop().create_task(res)
+                    except RuntimeError:  # pragma: no cover - sync context
+                        asyncio.run(res)
             except Exception:  # noqa: BLE001
                 pass
 


### PR DESCRIPTION
## Summary
- allow configuring Solana RPC URL, wallet and broadcast toggle via env vars
- log and gracefully handle missing event loop for Merkle tasks
- add CLI `--no-broadcast` switch
- update docs for new environment variables
- test Merkle root generation and broadcast path with mocked Solana client

## Testing
- `mypy --config-file mypy.ini .` *(fails: Found 2713 errors in 226 files)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 3 failed, 279 passed, 11 skipped)*