### PR TITLE
[alpha_factory] add offline tests and ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          pip install .
+      - name: Lint and type check
+        run: pre-commit run --all-files
+      - name: Test
+        run: |
+          python check_env.py --auto-install
+          pytest -q

--- a/tests/test_aiga_evolver_agent_logic.py
+++ b/tests/test_aiga_evolver_agent_logic.py
@@ -1,0 +1,29 @@
+import asyncio
+from unittest import TestCase, mock
+
+from alpha_factory_v1.backend.agents import aiga_evolver_agent as mod
+
+
+class TestEvolverAgentLogic(TestCase):
+    def test_disabled_when_deps_missing(self) -> None:
+        with mock.patch.object(mod, "MetaEvolver", None), \
+             mock.patch.object(mod, "CurriculumEnv", None):
+            agent = mod.AIGAEvolverAgent()
+            self.assertIsNone(agent.evolver)
+            asyncio.run(agent.step())
+
+    def test_step_publishes_best(self) -> None:
+        class Dummy:
+            def __init__(self) -> None:
+                self.gen = 2
+                self.best_fitness = 0.5
+
+            def run_generations(self, _n: int) -> None:
+                pass
+
+        with mock.patch.object(mod, "MetaEvolver", lambda *a, **k: Dummy()), \
+             mock.patch.object(mod, "CurriculumEnv", object), \
+             mock.patch.object(mod, "_publish") as pub:
+            agent = mod.AIGAEvolverAgent()
+            asyncio.run(agent.step())
+            pub.assert_called_with("aiga.best", {"gen": 2, "fitness": 0.5})

--- a/tests/test_forecast_functions.py
+++ b/tests/test_forecast_functions.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast
+
+
+class TestForecastFunctions(TestCase):
+    def test_curve_helpers(self) -> None:
+        self.assertEqual(forecast.linear_curve(-1.0), 0.0)
+        self.assertEqual(forecast.linear_curve(2.0), 1.0)
+        self.assertAlmostEqual(forecast.exponential_curve(0.0), 0.0)
+        self.assertAlmostEqual(forecast.exponential_curve(1.0), 1.0)
+        self.assertAlmostEqual(
+            forecast.capability_growth(0.5, curve="linear"), 0.5
+        )
+        val = forecast.capability_growth(0.2, curve="exponential")
+        self.assertGreaterEqual(val, 0.0)
+        self.assertLessEqual(val, 1.0)
+
+    def test_innovation_gain_positive(self) -> None:
+        gain = forecast._innovation_gain(pop_size=2, generations=1)
+        self.assertGreater(gain, 0.0)
+        self.assertLess(gain, 0.1)

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,0 +1,49 @@
+import asyncio
+import types
+from unittest import TestCase, mock
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+class TestMessageBus(TestCase):
+    def test_start_without_optional_dependencies(self) -> None:
+        cfg = config.Settings(bus_port=0)
+        with mock.patch.object(messaging, "AIOKafkaProducer", None), \
+             mock.patch.object(messaging, "grpc", None):
+            bus = messaging.A2ABus(cfg)
+            asyncio.run(bus.start())
+            asyncio.run(bus.stop())
+
+    def test_kafka_publish(self) -> None:
+        events: list[object] = []
+
+        class Prod:
+            def __init__(self, bootstrap_servers: str) -> None:
+                events.append(bootstrap_servers)
+
+            async def start(self) -> None:
+                events.append("start")
+
+            async def send_and_wait(self, topic: str, data: bytes) -> None:
+                events.append((topic, data))
+
+            async def stop(self) -> None:
+                events.append("stop")
+
+        cfg = config.Settings(bus_port=0, broker_url="k:1")
+        with mock.patch.object(messaging, "AIOKafkaProducer", Prod):
+            bus = messaging.A2ABus(cfg)
+            asyncio.run(bus.start())
+            env = types.SimpleNamespace(sender="a", recipient="b", payload={}, ts=0.0)
+
+            async def _send() -> None:
+                bus.publish("b", env)
+                await asyncio.sleep(0)
+
+            asyncio.run(_send())
+            asyncio.run(bus.stop())
+
+        self.assertEqual(events[0:2], ["k:1", "start"])
+        self.assertIn("stop", events)
+        sent = [e for e in events if isinstance(e, tuple)][0]
+        self.assertEqual(sent[0], "b")

--- a/tests/test_run_cli_options.py
+++ b/tests/test_run_cli_options.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from unittest import TestCase, mock
+
+from alpha_factory_v1 import run
+
+
+class TestRunCLI(TestCase):
+    def test_apply_env(self) -> None:
+        argv = ["prog", "--dev", "--port", "123", "--metrics-port", "9", "--a2a-port", "5", "--enabled", "A", "--loglevel", "debug"]
+        with mock.patch.object(sys, "argv", argv):
+            args = run.parse_args()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            run.apply_env(args)
+            self.assertEqual(os.environ["DEV_MODE"], "true")
+            self.assertEqual(os.environ["PORT"], "123")
+            self.assertEqual(os.environ["METRICS_PORT"], "9")
+            self.assertEqual(os.environ["A2A_PORT"], "5")
+            self.assertEqual(os.environ["ALPHA_ENABLED_AGENTS"], "A")
+            self.assertEqual(os.environ["LOGLEVEL"], "DEBUG")


### PR DESCRIPTION
## Summary
- remove skip in finance agent test
- add tests for the evolver agent, CLI env parsing, forecast helpers and message bus
- run tests in CI on every push

## Testing
- `mypy --config-file mypy.ini tests/test_aiga_evolver_agent_logic.py tests/test_run_cli_options.py tests/test_forecast_functions.py tests/test_message_bus.py`
- `pytest -q`
