### PR TITLE
[alpha_factory] fix agents-status command

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -128,8 +128,8 @@ def show_results(limit: int) -> None:
 def agents_status() -> None:
     """List registered agents."""
     orch = orchestrator.Orchestrator()
-    for agent in orch.agents:
-        click.echo(agent.__class__.__name__)
+    for runner in orch.runners.values():
+        click.echo(runner.agent.name)
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,12 @@ from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
 def test_agents_status_lists_names() -> None:
     with patch.object(cli.orchestrator, "Orchestrator") as orch_cls:
         orch = orch_cls.return_value
-        orch.agents = [type("A", (), {})()]
-        orch.agents[0].__class__.__name__ = "AgentX"
+        runner = type(
+            "Runner",
+            (),
+            {"agent": type("Agent", (), {"name": "AgentX"})()},
+        )()
+        orch.runners = {"AgentX": runner}
         result = CliRunner().invoke(cli.main, ["agents-status"])
         assert "AgentX" in result.output
 

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -34,3 +34,13 @@ def test_show_results_table(tmp_path) -> None:
             res = CliRunner().invoke(cli.main, ["show-results"])
             assert "sender" in res.output
             assert "a" in res.output
+
+
+def test_agents_status_lists_all_agents(tmp_path) -> None:
+    path = tmp_path / "audit.db"
+    with patch.object(cli.config.CFG, "ledger_path", str(path)):
+        orch = cli.orchestrator.Orchestrator()
+        with patch.object(cli.orchestrator, "Orchestrator", return_value=orch):
+            result = CliRunner().invoke(cli.main, ["agents-status"])
+    for name in orch.runners.keys():
+        assert name in result.output


### PR DESCRIPTION
## Summary
- fix CLI to iterate over runners
- update CLI unit tests
- test printing real agent names

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_invalid_numeric_fallback, test_server_starts_with_env_port, test_build_rest_none)*