### PR TITLE
[alpha_factory] improve streamlit simulation UI

### DIFF
--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -74,3 +74,7 @@ noaa-sdk==0.1.21
 # ─────────── Local model fallbacks (no API-key mode) ───────────────────
 llama-cpp-python>=0.2.37    # GGML Llama-3-8B-Q4 CPU inference
 ctransformers==0.2.27
+
+# ─────────── Web UI & visualisation ───────────────────────────────────
+streamlit>=1.35
+plotly>=5.21

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,22 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+from src.interface import web_app
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast, sector, mats  # type: ignore[import]
+
+
+def test_timeline_df() -> None:
+    secs = [sector.Sector("a"), sector.Sector("b")]
+    traj = forecast.forecast_disruptions(secs, 2, pop_size=2, generations=1)
+    df = web_app.timeline_df(traj)
+    assert set(df.columns) == {"year", "sector", "energy", "disrupted"}
+    assert len(df) == 4
+
+
+def test_pareto_df() -> None:
+    pop = [mats.Individual([0.0, 0.0]), mats.Individual([1.0, 1.0])]
+    pop[0].rank = 0
+    pop[1].rank = 1
+    df = web_app.pareto_df(pop)
+    assert set(df.columns) == {"x", "y", "rank"}
+    assert len(df) == 2


### PR DESCRIPTION
## Summary
- overhaul `web_app.py` with progress UI and Plotly visualisations
- add Streamlit and Plotly deps
- expose helpers for chart dataframes
- cover new helpers in tests

## Testing
- `ruff format src/interface/web_app.py tests/test_web_app.py`
- `ruff check src/interface/web_app.py tests/test_web_app.py`
- `black src/interface/web_app.py tests/test_web_app.py`
- `mypy --config-file mypy.ini src/interface/web_app.py`
- `pytest -q` *(fails: test_orchestrator_env.py, test_orchestrator_grpc.py, test_orchestrator_no_fastapi.py)*
