### PR TITLE
[alpha_factory] Add documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ python -m webbrowser http://localhost:8000/docs
 ## Disclaimer
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
+Further technical details are documented separately:
+
+- The overall architecture, agent roles and algorithms are explained in [docs/DESIGN.md](docs/DESIGN.md).
+- REST and WebSocket endpoints are listed in [docs/API.md](docs/API.md).
+- Release notes are maintained in [docs/CHANGELOG.md](docs/CHANGELOG.md).
+
 ---
 
 ## 📜 Table of Contents

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 - Initial changelog created.
 - Updated API usage examples and expanded design notes.
 - Added Google style docstrings to public modules.
+- Linked documentation from the README for easier navigation.
 
 ## [0.2.0] - 2024-06-01
 - Expanded design document with data flow, interface and deployment notes.


### PR DESCRIPTION
## Summary
- cross-link design, API, and changelog docs from the README
- note new documentation links in changelog

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 3 failed, 289 passed)*
- `mypy --config-file mypy.ini .` *(fails: found 2731 errors)*