### PR TITLE
[alpha_factory] enhance demo CLI

### DIFF
--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -19,6 +19,7 @@ better-profanity~=0.7
 httpx~=0.28
 aiohttp~=3.9
 backoff~=2.2
+rich>=13
 
 # ─────────── Observability & task-orchestration ────────────────────────
 prometheus-client~=0.19

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,10 +16,35 @@ def test_agents_status_lists_names() -> None:
         assert "AgentX" in result.output
 
 
+def test_agents_status_watch_stops_on_interrupt() -> None:
+    with patch.object(cli.orchestrator, "Orchestrator") as orch_cls:
+        orch = orch_cls.return_value
+        runner = type(
+            "Runner",
+            (),
+            {"agent": type("Agent", (), {"name": "AgentY"})()},
+        )()
+        orch.runners = {"AgentY": runner}
+        with patch.object(cli.time, "sleep", side_effect=KeyboardInterrupt):
+            result = CliRunner().invoke(cli.main, ["agents-status", "--watch"])
+        assert "AgentY" in result.output
+
+
 def test_show_results_missing(tmp_path) -> None:
     with patch.object(cli.config.CFG, "ledger_path", tmp_path / "ledger.txt"):
         out = CliRunner().invoke(cli.main, ["show-results"])
         assert "No results" in out.output
+
+
+def test_show_results_export_json(tmp_path) -> None:
+    ledger = tmp_path / "audit.db"
+    ledger.touch()
+    with patch.object(cli.config.CFG, "ledger_path", ledger):
+        with patch.object(cli.logging, "Ledger") as led_cls:
+            led = led_cls.return_value
+            led.tail.return_value = [{"ts": 1.0, "sender": "a", "recipient": "b", "payload": {"x": 1}}]
+            res = CliRunner().invoke(cli.main, ["show-results", "--export", "json"])
+            assert res.output.startswith("[")
 
 
 def test_replay_missing(tmp_path) -> None:
@@ -49,3 +74,26 @@ def test_simulate_runs() -> None:
             )
         assert res.exit_code == 0
         aio.run.assert_called_once()
+
+
+def test_simulate_export_csv() -> None:
+    runner = CliRunner()
+    with patch.object(cli, "asyncio"):
+        with patch.object(cli.orchestrator, "Orchestrator"):
+            res = runner.invoke(
+                cli.main,
+                [
+                    "simulate",
+                    "--horizon",
+                    "1",
+                    "--offline",
+                    "--pop-size",
+                    "1",
+                    "--generations",
+                    "1",
+                    "--export",
+                    "csv",
+                ],
+            )
+    assert res.exit_code == 0
+    assert "year,capability,affected" in res.output


### PR DESCRIPTION
## Summary
- add optional rich output with plain fallback
- implement --watch for `agents-status`
- export show-results via `--export`
- support CSV export in simulate tests
- update requirements

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 3 failed, 292 passed, 11 skipped)*
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_cli.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_cli.py` *(fails: 32 errors)*