### PR TITLE
[alpha_factory] package web client assets

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -11,6 +11,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 
 # copy project source
 COPY . /app
+COPY src/interface/web_client/dist /app/src/interface/web_client/dist
 
 # add non-root user
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app

--- a/infrastructure/docker-entrypoint.sh
+++ b/infrastructure/docker-entrypoint.sh
@@ -4,7 +4,7 @@ MODE=${RUN_MODE:-cli}
 if [ "$MODE" = "api" ]; then
   exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server
 elif [ "$MODE" = "web" ]; then
-  exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_app
+  exec python -m http.server 3000 --directory /app/src/interface/web_client/dist
 else
   exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli "$@"
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,12 @@ packages = [
     "alpha_factory_v1",
     "alpha_factory_v1.demos.alpha_agi_insight_v1",
     "af_requests",
+    "src",
 ]
 
 [tool.setuptools.package-data]
 "alpha_factory_v1" = ["py.typed"]
+"src.interface.web_client" = ["dist/**"]
 
 [project.scripts]
 alpha-factory = "alpha_factory_v1.run:run"

--- a/src/interface/web_client/__init__.py
+++ b/src/interface/web_client/__init__.py
@@ -1,0 +1,1 @@
+"""Built React front-end for the AGI demo."""


### PR DESCRIPTION
## Summary
- package frontend assets under `src/interface/web_client/dist`
- copy built assets into the demo image and expose them via a simple HTTP server

## Testing
- `ruff check src/interface/web_client/__init__.py`
- `mypy --config-file mypy.ini src/interface/web_client/__init__.py`
- `pytest -q` *(fails: 3 failed, 292 passed, 11 skipped)*