### PR TITLE
[alpha_factory] docs: expand design and api docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4,12 +4,13 @@ This page documents the REST endpoints provided by the demo API server and the a
 
 ## REST endpoints
 
-The API is implemented with FastAPI in `src/interface/api_server.py` and exposes three routes when running.
-The orchestrator boots in the background when the server starts and is gracefully shut down on exit:
+The API is implemented with FastAPI in `src/interface/api_server.py`.  Three routes
+are available.  The orchestrator boots in the background when the server starts and
+is gracefully shut down on exit:
 
-- `POST /simulate` – start a new simulation. The payload accepts the forecast horizon, population size and number of evolutionary generations. A unique simulation ID is returned immediately.
-- `GET /results/{sim_id}` – retrieve the final forecast data and Pareto front once the simulation finishes.
-- `WS  /ws/{sim_id}` – a websocket that streams progress logs while the simulation runs.
+- `POST /simulate` – start a new simulation.
+- `GET /results/{sim_id}` – fetch final forecast data.
+- `WS  /ws/{sim_id}` – stream progress logs while the simulation runs.
 
 Start the server with:
 
@@ -45,20 +46,44 @@ The CLI is also installed as the `alpha-agi-bhf` entry point for convenience.
 
 **POST `/simulate`**
 
-Start a new simulation run. The JSON body accepts:
+Start a new simulation. Send a JSON payload with the following fields:
 
-- `horizon` – forecast horizon in years.
-- `pop_size` – number of individuals per generation.
-- `generations` – number of evolutionary steps.
+- `horizon` – forecast horizon in years
+- `pop_size` – number of individuals per generation
+- `generations` – number of evolutionary steps
 
-Returns a JSON object containing the simulation `id`.
+```json
+{
+  "horizon": 5,
+  "pop_size": 6,
+  "generations": 3
+}
+```
+
+The response contains the generated simulation identifier:
+
+```json
+{"id": "<sim_id>"}
+```
 
 **GET `/results/{sim_id}`**
 
-Retrieve the final forecast and Pareto front for a previously launched simulation.
+Return the final forecast and Pareto front for an earlier run.
+
+Example response:
+
+```json
+{
+  "forecast": [{"year": 1, "capability": 0.1}],
+  "pareto": [[0.0, 0.0], [0.5, 0.2]],
+  "logs": ["Year 1: 0 affected"]
+}
+```
 
 **WebSocket `/ws/{sim_id}`**
 
-Provides a live feed of progress messages during a running simulation. Clients should close the socket once the final `done` message is received.
+Streams progress messages during a running simulation. Messages are plain text lines
+such as `"Year 1: 0 affected"` or `"Generation 2"`. Close the socket once all
+messages have been received.
 
 The server honours environment variables defined in `.env` such as `PORT` (HTTP port), `OPENAI_API_KEY` and `RUN_MODE`. When `RUN_MODE=web`, a small frontend served at `/` consumes these endpoints via JavaScript.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project are documented in this file.
 - Added Google style docstrings to public modules.
 - Linked documentation from the README for easier navigation.
 
+## [1.0.1] - 2025-05-25
+- Packaged the React web client and served static assets from the API server.
+- Added asynchronous API tests and new CLI flags.
+- Improved container orchestration scripts and default Docker compose files.
+
 ## [0.2.0] - 2024-06-01
 - Expanded design document with data flow, interface and deployment notes.
 - Documented API endpoints in greater detail.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -4,7 +4,19 @@ This document outlines the architecture of the Alpha Factory demo included in th
 
 ## Architecture
 
-The system is composed of a lightweight orchestrator that coordinates a small swarm of agents. Each agent is a micro service with a specific responsibility. The orchestrator exposes both a command line interface and a minimal REST API so the demo can run headless or with a web front end. All communication is performed through simple envelope objects exchanged on an in-memory message bus.
+The demo consists of a lightweight orchestrator and a handful of specialised agents.  All
+components communicate through a simple in-memory message bus using envelope objects.
+The orchestrator exposes both a command line interface and a small REST API so the
+simulation can run headless or with a web frontend.
+
+### Simulation engine
+
+Two tiny modules implement the core of the simulation:
+
+- `forecast.py` – generates a capability forecast and triggers thermodynamic disruption.
+- `mats.py` – performs a zero‑data evolutionary search to refine potential innovations.
+
+Both modules are intentionally concise and easy to extend.
 
 ### Orchestrator
 
@@ -13,12 +25,13 @@ interaction in a ledger. This ledger can be replayed to analyse decision steps o
 to visualise the overall run. Agents are invoked sequentially in short cycles so
 the system remains deterministic and easy to debug.
 
-The simulation core consists of two modules:
 
-- `forecast.py` implements a basic capability forecast and a thermodynamic disruption trigger.
-- `mats.py` implements zero-data evolutionary search used to refine candidate innovations.
+### Message bus
 
-Both modules are intentionally small so they can be inspected and extended easily.
+Messages are dispatched in short deterministic cycles.  Agents read an envelope,
+mutate its contents and pass it back to the orchestrator which then forwards it
+to the next participant.  Each interaction is stored in a ledger so that runs
+can be replayed or inspected later.
 
 ## Agent roles
 


### PR DESCRIPTION
## Summary
- fill out DESIGN.md with simulation engine and message bus details
- add request/response examples to API.md
- update CHANGELOG for version 1.0.1

## Testing
- `python check_env.py --auto-install`
- `pytest -q`