### PR TITLE
[alpha_factory] start ledger task in run loop

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -67,7 +67,6 @@ class Orchestrator:
             wallet=self.settings.solana_wallet,
             broadcast=self.settings.broadcast,
         )
-        self.ledger.start_merkle_task(3600)
         self.runners: Dict[str, AgentRunner] = {}
         self.bus.subscribe("orch", self._on_orch)
         for agent in self._init_agents():
@@ -115,6 +114,7 @@ class Orchestrator:
 
     async def run_forever(self) -> None:
         await self.bus.start()
+        self.ledger.start_merkle_task(3600)
         for r in self.runners.values():
             r.start(self.bus, self.ledger)
         self._monitor_task = asyncio.create_task(self._monitor())


### PR DESCRIPTION
## Summary
- ensure the insight orchestrator only starts the merkle task when running

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py`
- `mypy --config-file mypy.ini .` *(fails: Found 2752 errors)*
- `pytest -q`