### PR TITLE
[alpha_factory] handle empty rows in plain table

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -26,7 +26,11 @@ console = Console() if Console else None
 
 
 def _plain_table(headers: Iterable[str], rows: Iterable[Iterable[Any]]) -> str:
-    cols = [list(map(str, col)) for col in zip(*([headers] + list(rows)))]
+    rows = list(rows)
+    if not rows:
+        return " | ".join(map(str, headers))
+
+    cols = [list(map(str, col)) for col in zip(*([headers] + rows))]
     widths = [max(len(item) for item in col) for col in cols]
     line = "-+-".join("-" * w for w in widths)
     header = " | ".join(h.ljust(widths[i]) for i, h in enumerate(headers))

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -44,3 +44,7 @@ def test_agents_status_lists_all_agents(tmp_path) -> None:
             result = CliRunner().invoke(cli.main, ["agents-status"])
     for name in orch.runners.keys():
         assert name in result.output
+
+
+def test_plain_table_handles_no_rows() -> None:
+    assert cli._plain_table(["h1", "h2"], []) == "h1 | h2"


### PR DESCRIPTION
## Summary
- fix plain table to return just the header when there are no data rows
- add a regression test for empty results

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
