### PR TITLE
[alpha_factory] Document test env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,12 @@ Please report security vulnerabilities as described in our [Security Policy](SEC
   `pip install -r requirements-dev.txt` to obtain `fastapi` and
   `opentelemetry-api`.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes. If failures remain, document them in the PR description.
-- See [`alpha_factory_v1/tests/README.md`](alpha_factory_v1/tests/README.md) for test-specific environment variables. `AF_MEMORY_DIR` sets the temporary memory path while `PYTEST_CPU_SOFT_SEC`, `PYTEST_MEM_MB` and `PYTEST_NET_OFF` control CPU time, memory usage and network access. The optional sandboxed runner `python -m alpha_factory_v1.backend.tools.local_pytest` enforces these limits.
+- Test environment variables (see [`alpha_factory_v1/tests/README.md`](alpha_factory_v1/tests/README.md) for details):
+  - `AF_MEMORY_DIR` – temporary memory path.
+  - `PYTEST_CPU_SOFT_SEC` – CPU time limit.
+  - `PYTEST_MEM_MB` – memory cap in MB.
+  - `PYTEST_NET_OFF` – disable network access.
+  - The sandbox runner `python -m alpha_factory_v1.backend.tools.local_pytest` enforces these limits.
 - Run `python alpha_factory_v1/scripts/preflight.py` to confirm the Python version and required tools are available.
 - Before the first launch, run `bash quickstart.sh --preflight` to check
   Docker availability, git, and required packages. After this


### PR DESCRIPTION
## Summary
- list `AF_MEMORY_DIR`, `PYTEST_CPU_SOFT_SEC`, `PYTEST_MEM_MB` and `PYTEST_NET_OFF` near the unit test instructions

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `ruff check .` *(fails: Found 547 errors)*
- `mypy --config-file mypy.ini .` *(fails: Found 2752 errors)*