### PR TITLE
[alpha_factory] Document wheel signing key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,19 @@ For detailed troubleshooting steps, see [`alpha_factory_v1/scripts/README.md`](a
 
 ### Wheel Signing
 All agent wheels must be signed with the project's ED25519 key before they are
-loaded from `$AGENT_HOT_DIR`. Generate `<wheel>.whl.sig` with:
+loaded from `$AGENT_HOT_DIR`.
+
+Generate the signing key once and capture the base64 public key:
+
+```bash
+openssl genpkey -algorithm ed25519 -out agent_signing.key
+openssl pkey -in agent_signing.key -pubout -outform DER | base64 -w0
+```
+
+Store the public key in the `AGENT_WHEEL_PUBKEY` environment variable so
+`alpha_factory_v1/backend/agents/__init__.py` can verify signatures.
+
+Generate `<wheel>.whl.sig` with:
 
 ```bash
 openssl dgst -sha512 -binary <wheel>.whl |


### PR DESCRIPTION
## Summary
- document how to generate the wheel signing key
- mention storing the public key in `AGENT_WHEEL_PUBKEY`

## Testing
- `ruff check .` *(fails: found 547 errors)*
- `mypy --config-file mypy.ini .` *(fails: Found 2752 errors)*
- `pytest -q`