### PR TITLE
[alpha_factory] docs: add pip check note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ Please report security vulnerabilities as described in our [Security Policy](SEC
    WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
      python check_env.py --auto-install
    ```
+   - Run `pip check` to verify package integrity. If problems occur, rerun `python check_env.py --auto-install --wheelhouse <path>` to reinstall.
+
    See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md)
    for additional offline tips.
 - After setup, validate with `python check_env.py --auto-install`.


### PR DESCRIPTION
## Summary
- mention running `pip check` when installing from a wheelhouse
- advise rerunning `check_env.py` with `--wheelhouse` if needed

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit run --files AGENTS.md` *(fails: command not found)*