### PR TITLE
[alpha_factory] fill demo infra files

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -1,5 +1,27 @@
-# Placeholder Dockerfile
+# Demo container for α‑AGI Insight
 FROM python:3.11-slim
+
+# Install build tools for optional native extensions
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
-COPY .. .
-CMD ["python", "-m", "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli"]
+
+# Install Python dependencies for the demo
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+# Copy the project source
+COPY . /app
+COPY src/interface/web_client/dist /app/src/interface/web_client/dist
+
+# Add non-root user and entrypoint
+RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app
+COPY infrastructure/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+USER afuser
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8000 8501 6006
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["web"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-compose.yml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-compose.yml
@@ -1,6 +1,45 @@
 version: '3.9'
 services:
-  insight:
-    build: .
+  orchestrator:
+    build:
+      context: ../../../../
+      dockerfile: alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+    image: alpha-insight:latest
+    env_file:
+      - ../../../../.env
+    environment:
+      RUN_MODE: api
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0}
+      AGI_INSIGHT_BUS_PORT: ${AGI_INSIGHT_BUS_PORT:-6006}
+      AGI_INSIGHT_LEDGER_PATH: ${AGI_INSIGHT_LEDGER_PATH:-./ledger/audit.db}
+    ports:
+      - "8000:8000"
+      - "${AGI_INSIGHT_BUS_PORT:-6006}:6006"
+    restart: unless-stopped
+
+  agents:
+    image: alpha-insight:latest
+    env_file:
+      - ../../../../.env
+    environment:
+      RUN_MODE: cli
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0}
+      AGI_INSIGHT_BUS_PORT: ${AGI_INSIGHT_BUS_PORT:-6006}
+      AGI_INSIGHT_LEDGER_PATH: ${AGI_INSIGHT_LEDGER_PATH:-./ledger/audit.db}
+    depends_on:
+      - orchestrator
+
+  web:
+    image: alpha-insight:latest
+    env_file:
+      - ../../../../.env
+    environment:
+      RUN_MODE: web
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0}
     ports:
       - "8501:8501"
+    depends_on:
+      - orchestrator

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/Chart.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: alpha-insight
+description: Helm chart for the α-AGI Insight demo
+version: 0.1.0
+appVersion: "v1"
+type: application

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
@@ -1,0 +1,9 @@
+This chart deploys the α-AGI Insight demo.
+
+Example usage:
+```bash
+helm upgrade --install insight ./alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart \
+  --set env.OPENAI_API_KEY=<key> \
+  --set env.RUN_MODE=api
+```
+Values such as `service.port` or `image` can be customised via `--set` or a custom values file.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/templates/deployment.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alpha-insight
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: alpha-insight
+  template:
+    metadata:
+      labels:
+        app: alpha-insight
+    spec:
+      containers:
+        - name: orchestrator
+          image: {{ .Values.image }}
+          env:
+            - name: OPENAI_API_KEY
+              value: {{ .Values.env.OPENAI_API_KEY | quote }}
+            - name: RUN_MODE
+              value: {{ .Values.env.RUN_MODE | quote }}
+            - name: AGI_INSIGHT_OFFLINE
+              value: {{ .Values.env.AGI_INSIGHT_OFFLINE | quote }}
+            - name: AGI_INSIGHT_BUS_PORT
+              value: {{ .Values.env.AGI_INSIGHT_BUS_PORT | quote }}
+            - name: AGI_INSIGHT_LEDGER_PATH
+              value: {{ .Values.env.AGI_INSIGHT_LEDGER_PATH | quote }}
+          ports:
+            - containerPort: 8000
+            - containerPort: 8501
+            - containerPort: 6006

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/templates/service.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alpha-insight
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: alpha-insight
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: 8000
+    - name: ui
+      port: {{ .Values.service.uiPort }}
+      targetPort: 8501
+    - name: bus
+      port: {{ .Values.service.busPort }}
+      targetPort: 6006

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/values.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/values.yaml
@@ -1,0 +1,13 @@
+image: alpha-insight:latest
+replicaCount: 1
+env:
+  OPENAI_API_KEY: ""
+  RUN_MODE: api
+  AGI_INSIGHT_OFFLINE: "0"
+  AGI_INSIGHT_BUS_PORT: "6006"
+  AGI_INSIGHT_LEDGER_PATH: "./ledger/audit.db"
+service:
+  type: ClusterIP
+  port: 8000
+  uiPort: 8501
+  busPort: 6006

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/terraform/main_aws.tf
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/terraform/main_aws.tf
@@ -1,1 +1,97 @@
-# Placeholder Terraform script for AWS deployment
+# Example AWS ECS deployment using Fargate
+
+variable "region" { default = "us-east-1" }
+variable "image_tag" { default = "latest" }
+variable "repository_name" { default = "alpha-insight" }
+variable "vpc_id" { default = "vpc-12345" }
+variable "subnets" {
+  type    = list(string)
+  default = ["subnet-12345"]
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_ecr_repository" "insight" {
+  name = var.repository_name
+}
+
+resource "aws_iam_role" "ecs_exec" {
+  name               = "ecsTaskExecutionRole"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_exec" {
+  role       = aws_iam_role.ecs_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_cluster" "insight" {
+  name = "alpha-insight"
+}
+
+resource "aws_ecs_task_definition" "insight" {
+  family                   = "alpha-insight"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.ecs_exec.arn
+  container_definitions = jsonencode([
+    {
+      name      = "orchestrator"
+      image     = "${aws_ecr_repository.insight.repository_url}:${var.image_tag}"
+      essential = true
+      environment = [{ name = "RUN_MODE", value = "api" }]
+      portMappings = [
+        { containerPort = 8000 },
+        { containerPort = 6006 }
+      ]
+    }
+  ])
+}
+
+resource "aws_security_group" "insight" {
+  name   = "alpha-insight"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 6006
+    to_port     = 6006
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_service" "insight" {
+  name            = "alpha-insight"
+  cluster         = aws_ecs_cluster.insight.id
+  task_definition = aws_ecs_task_definition.insight.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = [aws_security_group.insight.id]
+    assign_public_ip = true
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/terraform/main_gcp.tf
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/terraform/main_gcp.tf
@@ -1,1 +1,40 @@
-# Placeholder Terraform script for GCP deployment
+# Example Google Cloud Run deployment
+
+variable "project" { default = "my-project" }
+variable "region" { default = "us-central1" }
+variable "image_tag" { default = "latest" }
+variable "repository_name" { default = "insight" }
+variable "vpc_connector" { default = "" }
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+resource "google_artifact_registry_repository" "insight" {
+  location      = var.region
+  repository_id = var.repository_name
+  format        = "DOCKER"
+}
+
+resource "google_cloud_run_service" "insight" {
+  name     = "alpha-insight"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = "${google_artifact_registry_repository.insight.repository_url}:${var.image_tag}"
+        env = [{ name = "RUN_MODE", value = "api" }]
+        ports { container_port = 8000 }
+        ports { container_port = 6006 }
+      }
+      dynamic "vpc_access" {
+        for_each = var.vpc_connector == "" ? [] : [var.vpc_connector]
+        content {
+          connector = vpc_access.value
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- flesh out alpha_agi_insight_v1 infrastructure
- Dockerfile installs demo requirements
- docker-compose spins up orchestrator, agents and web UI
- add Helm chart with configurable values
- expand Terraform examples for AWS ECS and Google Cloud Run

## Testing
- `python check_env.py --auto-install`
- `pytest -q`