### PR TITLE
[alpha_factory] adjust tests bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,11 @@ Install the optional test dependencies with:
 pip install -r requirements-dev.txt
 ```
 
+Install the project in editable mode so tests resolve imports:
+```bash
+pip install -e .
+```
+
 <a name="62-marketplace-demo-example"></a>
 ### 6.2 · Marketplace Demo Example 🛒
 A minimal snippet queues the sample job once the orchestrator is running:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# 🧪 Root Test Suite
+
+These integration tests expect the `alpha_factory_v1` package to be importable. When running from the repository root without installation, set `PYTHONPATH` so Python can locate the source tree:
+
+```bash
+export PYTHONPATH=$(pwd)
+python -m pytest -q tests
+```
+
+Alternatively install the package in editable mode first:
+
+```bash
+pip install -e .
+pytest -q
+```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,11 @@
-# test package
+"""Helper to import the project when not installed."""
+
+from importlib.util import find_spec
+from pathlib import Path
+import sys
+
+# Allow tests to run from the repository without installing the package
+if find_spec("alpha_factory_v1") is None:
+    ROOT = Path(__file__).resolve().parents[3]
+    if str(ROOT) not in sys.path:
+        sys.path.append(str(ROOT))


### PR DESCRIPTION
## Summary
- ensure tests modify `sys.path` when package isn't installed
- document running tests from repo root
- clarify test install instructions in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q`