### PR TITLE
[alpha_factory] secure api with token and rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,9 @@ replace all placeholder values with strong secrets. The sample sets
 services like Neo4j and Postgres using `openssl rand -base64 18` or a similar
 tool and **never deploy with the defaults**. The orchestrator will refuse to
 start if `NEO4J_PASSWORD` remains `REPLACE_ME` or is missing.
+Set `API_TOKEN` to a strong secret so that the REST API can authenticate
+incoming requests. Clients must send `Authorization: Bearer <token>`. Use
+`API_RATE_LIMIT` to limit requests per minute per IP (default `60`).
 Avoid storing private keys directly in `.env`. Instead set
 `AGI_INSIGHT_SOLANA_WALLET_FILE` to a file containing your hex-encoded wallet
 key and keep that file readable only by the orchestrator.

--- a/alpha_factory_v1/.env.sample
+++ b/alpha_factory_v1/.env.sample
@@ -33,6 +33,8 @@ PORT=8000                   # REST API port
 PROM_PORT=9090              # Prometheus exporter port
 TRACE_WS_PORT=8088          # Trace‑graph WebSocket port
 LOGLEVEL=INFO               # DEBUG | INFO | WARNING | ERROR
+API_TOKEN=REPLACE_ME_TOKEN  # bearer token for the demo API
+API_RATE_LIMIT=60           # requests per minute per IP
 ALPHA_KAFKA_BROKER=
 ALPHA_DATA_DIR=/data
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,9 @@ is gracefully shut down on exit:
 - `GET /results/{sim_id}` – fetch final forecast data.
 - `WS  /ws/{sim_id}` – stream progress logs while the simulation runs.
 
+All endpoints require a bearer token. Set `API_TOKEN` in `.env` and include
+`Authorization: Bearer <token>` with each request.
+
 Start the server with:
 
 ```bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Updated API usage examples and expanded design notes.
 - Added Google style docstrings to public modules.
 - Linked documentation from the README for easier navigation.
+- API server now enforces bearer token auth and simple rate limiting.
 
 ## [1.0.1] - 2025-05-25
 - Packaged the React web client and served static assets from the API server.


### PR DESCRIPTION
## Summary
- protect API endpoints with HTTP bearer token
- add simple in-memory rate limiter
- document new API_TOKEN and API_RATE_LIMIT settings
- update unit tests for authentication

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ⚠️ `pre-commit` not installed (no network access)
