### PR TITLE
[alpha_factory] add text-mode option to minimal UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,12 @@ docker compose up
 ```
 Open <http://localhost:9000> in your browser.
 
+If Streamlit isn't installed or you're running on a headless server, use:
+```bash
+python src/interface/minimal_ui.py --text
+```
+to display the forecast results directly in the console.
+
 
 ---
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import argparse
+import sys
 from typing import Any, TYPE_CHECKING, cast
+
+from ..simulation import forecast, sector
 
 try:  # pragma: no cover - optional dependency
     import streamlit as _st
 except Exception:  # pragma: no cover - optional
     _st = None
 st: Any | None = cast(Any, _st)
-
-from ..simulation import forecast, sector
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd
@@ -61,10 +63,20 @@ def _disruption_df(traj: list[Any]) -> "pd.DataFrame":
     return pd.DataFrame({"sector": list(years.keys()), "year": list(years.values())})
 
 
-def main() -> None:  # pragma: no cover - entry point
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - entry point
     """Launch the minimal dashboard or print results."""
-    if st is None:
-        print("Streamlit not installed")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--text",
+        action="store_true",
+        help="Force text-mode output even when Streamlit is installed",
+    )
+    args = parser.parse_args(argv)
+
+    if st is None and not args.text:
+        sys.exit("Streamlit not installed. Re-run with --text for console output.")
+
+    if args.text or st is None:
         traj = _simulate(5, "logistic", 6, 3)
         for record in _disruption_df(traj).to_dict(orient="records"):
             print(f"{record['sector']}: year {record['year']}")

--- a/src/interface/minimal_ui.py
+++ b/src/interface/minimal_ui.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import argparse
 import importlib
+import sys
 from typing import Any, TYPE_CHECKING, cast
 
 try:  # pragma: no cover - optional dependency
@@ -63,10 +65,20 @@ def _disruption_df(traj: list[Any]) -> "pd.DataFrame":
     return pd.DataFrame({"sector": list(years.keys()), "year": list(years.values())})
 
 
-def main() -> None:  # pragma: no cover - entry point
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - entry point
     """Launch the minimal dashboard or print results."""
-    if st is None:
-        print("Streamlit not installed")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--text",
+        action="store_true",
+        help="Force text-mode output even when Streamlit is installed",
+    )
+    args = parser.parse_args(argv)
+
+    if st is None and not args.text:
+        sys.exit("Streamlit not installed. Re-run with --text for console output.")
+
+    if args.text or st is None:
         traj = _simulate(5, "logistic", 6, 3)
         for record in _disruption_df(traj).to_dict(orient="records"):
             print(f"{record['sector']}: year {record['year']}")


### PR DESCRIPTION
## Summary
- exit cleanly when Streamlit is missing
- add `--text` flag for console output
- document headless usage in the README

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `ruff check src/interface/minimal_ui.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py`
- `black src/interface/minimal_ui.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py`
- `mypy --config-file mypy.ini src/interface/minimal_ui.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py --follow-imports=skip`
