### PR TITLE
[alpha_factory] Skip optional UI dist copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ npm install
 npm run dev       # http://localhost:5173
 # build production assets
 npm run build
+# or pnpm build
 python -m http.server --directory dist 9000
 ```
 Alternatively run inside Docker:

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -11,7 +11,6 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 
 # copy project source
 COPY . /app
-COPY src/interface/web_client/dist /app/src/interface/web_client/dist
 
 # add non-root user
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app


### PR DESCRIPTION
## Summary
- avoid copying non-existent web_client dist in Dockerfile
- mention `pnpm build` in the dashboard instructions

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit run --files infrastructure/Dockerfile README.md` *(fails: command not found)*