### PR TITLE
[alpha_factory] clarify license defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,11 @@ for modules, classes and functions.
   Document any remaining test failures in the PR description.
 - Summarize your changes and test results in the PR body.
 - Title PRs using `[alpha_factory] <Title>`.
-- All contributions are licensed under Apache 2.0.
-- Add an Apache 2.0 header to new source files.
+- All contributions are licensed under Apache 2.0 by default.
+- Some files retain existing MIT license headers; keep whatever license a file
+  already declares when editing it.
+- Add an Apache 2.0 header to new source files unless another license is
+  explicitly stated.
   ```
   # SPDX-License-Identifier: Apache-2.0
   ```

--- a/alpha_factory_v1/backend/agents/finance_agent.py
+++ b/alpha_factory_v1/backend/agents/finance_agent.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 """
 alpha_factory_v1.backend.agents.finance_agent
 =============================================

--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -35,7 +35,7 @@ CLI usage (stand-alone smoke-test)
 
 Copyright & License
 -------------------
-© 2025 Montreal AI — MIT-licensed, like the rest of Alpha-Factory v1.
+© 2025 Montreal AI — Apache 2.0 licensed, like the rest of Alpha-Factory v1.
 """
 
 from __future__ import annotations

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -4,7 +4,7 @@ Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI
 -------------------------------------------------------------------
 Supply‑Chain Domain‑Agent  🌐🚚 — production‑grade implementation
 ===================================================================
-Copyright (c) 2025 Montreal.AI — MIT‑licensed
+Copyright (c) 2025 Montreal.AI — Apache‑2.0 licensed
 
 This module implements **SupplyChainAgent**, an antifragile, cross‑industry
 optimizer that continuously mines global logistics signals to surface *alpha*

--- a/alpha_factory_v1/backend/memory_fabric.py
+++ b/alpha_factory_v1/backend/memory_fabric.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 """
 alpha_factory_v1.backend.memory_fabric
 ======================================

--- a/alpha_factory_v1/backend/memory_vector.py
+++ b/alpha_factory_v1/backend/memory_vector.py
@@ -22,7 +22,7 @@ Design goals
 * **CLI self-test** – ``python -m alpha_factory_v1.backend.memory_vector --demo``
 * **Zero intra-project deps** – drop-in usable in any repo / unit tests.
 
-MIT License © 2025 Montreal AI
+Apache 2.0 License © 2025 Montreal AI
 """
 
 from __future__ import annotations

--- a/alpha_factory_v1/backend/utils/llm_provider.py
+++ b/alpha_factory_v1/backend/utils/llm_provider.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 """
 alpha_factory_v1.backend.utils.llm_provider
 ===========================================

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -125,5 +125,5 @@ Special salute to **[Vincent Boucher](https://www.linkedin.com/in/montrealai/)*
 
 ---
 
-© 2025 MONTREAL.AI — MIT License
+© 2025 MONTREAL.AI — Apache‑2.0 License
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -2,7 +2,7 @@
  AI‑GA Meta‑Evolution Demo
  Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**
  Out‑learn · Out‑think · Out‑strategise · Out‑evolve
- © 2025 MONTREAL.AI   MIT License
+ © 2025 MONTREAL.AI   Apache‑2.0 License
  -------------------------------------------------------------------------------
  Exhaustive README: quick‑start, deep‑dive, SOC‑2 rails, CI/CD, K8s,
  observability, SBOM notice. Rendered as GitHub‑flavoured Markdown.
@@ -306,7 +306,7 @@ spec:
 
 ## ⚖️ License & credits
 
-*Source & assets* © 2025 Montreal.AI, released under the **MIT License**. 
+*Source & assets* © 2025 Montreal.AI, released under the **Apache‑2.0 License**.
 Huge thanks to:
 
 * **Jeff Clune** – visionary behind AI‑GAs 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
@@ -1,5 +1,5 @@
 # alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
-# © 2025 MONTREAL.AI  MIT License
+# © 2025 MONTREAL.AI  Apache-2.0 License
 """MetaEvolver v3.0 (2025‑04‑23)
 =================================
 ✦ **Mission**  Self‑contained, SOC‑2‑aligned neuro‑evolution engine that scales

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -212,7 +212,7 @@ Need help? Open an issue → **@MontrealAI/alpha-factory-core**.
 ## 11  License & citation
 
 ```
-MIT © 2025 MONTREAL.AI
+Apache‑2.0 © 2025 MONTREAL.AI
 ```
 
 Please cite **Alpha-Factory v1 👁️✨ — Multi-Agent AGENTIC α-AGI**:

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -172,4 +172,4 @@ Community PRs welcome!
 ### References
 Clune 2019 · Sutton & Silver 2024 · MuZero 2020 
 
-© 2025 MONTREAL.AI — MIT License
+© 2025 MONTREAL.AI — Apache‑2.0 License

--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -2,7 +2,7 @@
 Era‑of‑Experience Demo
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI
 Out‑learn · Out‑think · Out‑strategise · Out‑execute
-© 2025 MONTREAL.AI   MIT License
+© 2025 MONTREAL.AI   Apache‑2.0 License
 -->
 
 <h1 align="center">🌌 Era of Experience — Your lifelong‑RL playground</h1>
@@ -248,6 +248,6 @@ packages like `pytest` and `openai-agents` are available.
 
 ## 📜 License
 
-MIT. By using this repo you agree to cite **Montreal.AI Alpha‑Factory** if you build on top.
+Apache 2.0. By using this repo you agree to cite **Montreal.AI Alpha‑Factory** if you build on top.
 
 > **Alpha‑Factory** — forging intelligence that *out‑learns, out‑thinks, out‑executes*.

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
-# © 2025 MONTREAL.AI – MIT License
+# © 2025 MONTREAL.AI – Apache-2.0 License
 """
 Era-of-Experience Agent 👁️✨
 ────────────────────────────

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/curiosity_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/curiosity_reward.py
@@ -26,7 +26,7 @@ Implementation details
 
 • Zero third‑party dependencies – standard library only.
 
-© 2025 Montreal.AI   MIT License
+© 2025 Montreal.AI   Apache-2.0 License
 """
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/efficiency_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/efficiency_reward.py
@@ -51,7 +51,7 @@ defaults, tuned for the AGI‑Alpha demo infra, kick in.
 ▸ Explicit `__all__` aids IDEs / static analysers.
 ▸ Lint‑clean (ruff) & typed – good citizens inside larger codebases.
 
-© 2025 Montreal.AI – MIT License
+© 2025 Montreal.AI – Apache-2.0 License
 """
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/energy_balance_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/energy_balance_reward.py
@@ -45,7 +45,7 @@ Public API (required by reward_backends framework)
 --------------------------------------------------
     reward(state, action, result) -> float
 
-© 2025 Montreal.AI – MIT License
+© 2025 Montreal.AI – Apache-2.0 License
 """
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/habit_consistency_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/habit_consistency_reward.py
@@ -50,7 +50,7 @@ Implementation notes
 • **Stateless config**: tweak thresholds via module‑level constants.  
 • **Zero deps**: std‑lib only — works offline, inside minimal containers.
 
-© 2025 Montreal.AI – MIT License
+© 2025 Montreal.AI – Apache-2.0 License
 """
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/novel_solution_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/novel_solution_reward.py
@@ -37,7 +37,7 @@ Returns
 -------
 float ∈ [0.0, 1.0]
 
-© 2025 Montreal.AI   – MIT License
+© 2025 Montreal.AI   – Apache-2.0 License
 """
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/safety_compliance_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/safety_compliance_reward.py
@@ -30,7 +30,7 @@ Implementation details
 * Thread‑safe via a `threading.Lock`
 * Duplicate `request_id`s are ignored (idempotent)
 * Unknown / malformed payload → neutral reward 0.0
-* MIT License
+* Apache‑2.0 License
 
 © 2025 Montreal.AI
 """

--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -4,7 +4,7 @@
 
 [![Docker](https://img.shields.io/badge/Run‑with-Docker-blue?logo=docker)](#one‑command‑docker) 
 [![Colab](https://img.shields.io/badge/Try‑on‑Colab-yellow?logo=googlecolab)](#google‑colab) 
-![License](https://img.shields.io/badge/License-MIT-green)
+![License](https://img.shields.io/badge/License-Apache%202.0-blue)
 
 > **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.
 
@@ -149,6 +149,6 @@ no liability for losses incurred from using this software.
 ---
 
 ## 📜 License
-MIT © 2025 **MONTREAL.AI**
+Apache‑2.0 © 2025 **MONTREAL.AI**
 
 Happy alpha‑hunting 🚀

--- a/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
+++ b/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
@@ -1,5 +1,5 @@
 # alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
-# © 2025 MONTREAL.AI MIT License
+# © 2025 MONTREAL.AI Apache-2.0 License
 """
 Macro-Sentinel entry-point
 ══════════════════════════

--- a/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
+++ b/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
@@ -246,7 +246,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "\u00a9\u00a02025 **MONTREAL.AI** \u2022 MIT License"
+    "\u00a9\u00a02025 **MONTREAL.AI** \u2022 Apache-2.0 License"
    ]
   }
  ],

--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -1,5 +1,5 @@
 # alpha_factory_v1/demos/macro_sentinel/data_feeds.py
-# © 2025 MONTREAL.AI MIT License
+# © 2025 MONTREAL.AI Apache-2.0 License
 """
 Macro-Sentinel — Data Feeds
 ───────────────────────────

--- a/alpha_factory_v1/demos/macro_sentinel/simulation_core.py
+++ b/alpha_factory_v1/demos/macro_sentinel/simulation_core.py
@@ -1,5 +1,5 @@
 # alpha_factory_v1/demos/macro_sentinel/simulation_core.py
-# © 2025 MONTREAL.AI MIT License
+# © 2025 MONTREAL.AI Apache-2.0 License
 """
 simulation_core.py – Macro-Sentinel risk engine
 ───────────────────────────────────────────────

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -2,7 +2,7 @@
   MuZero Planning Demo
   Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**
   Out‑learn · Out‑think · Out‑strategise · Out‑execute
-  © 2025 MONTREAL.AI   MIT License
+  © 2025 MONTREAL.AI   Apache‑2.0 License
 -->
 
 # 🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time

--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -2,7 +2,7 @@
   Self‑Healing Repo Demo
   Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**
   Out‑learn · Out‑think · Out‑debug · Out‑ship
-  © 2025 MONTREAL.AI   MIT License
+  © 2025 MONTREAL.AI   Apache‑2.0 License
 -->
 
 # 🔧 **Self‑Healing Repo** — when CI fails, agents patch

--- a/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
+++ b/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
@@ -1,5 +1,5 @@
 # alpha_factory_v1/demos/self_healing_repo/patcher_core.py
-# © 2025 MONTREAL.AI   MIT License
+# © 2025 MONTREAL.AI   Apache-2.0 License
 """
 patcher_core.py
 ───────────────

--- a/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
+++ b/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
@@ -105,7 +105,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "\u00a9\u00a02025 **MONTREAL.AI** \u2022 MIT License"
+    "\u00a9\u00a02025 **MONTREAL.AI** \u2022 Apache-2.0 License"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- update contribution bullet points to mention legacy MIT headers
- default new files to Apache 2.0 and remind contributors to preserve existing
  licenses
- switch all MIT headers and doc mentions to Apache 2.0

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
