### PR TITLE
[alpha_factory] add apache headers to insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Package root for the alpha‑AGI Insight demo modules."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Lightweight agent implementations for the Insight demo."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/base_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/base_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Shared base class for insight agents."""
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Code generation agent."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Market analysis agent."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Memory agent."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Planning agent."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Research agent."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Safety guardian agent."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Strategy agent."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI, web UI and API server for the Insight demo."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """FastAPI wrapper to expose the demo over HTTP."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Command line interface for the α‑AGI Insight demo."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Minimal Streamlit interface for disruption forecasts."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Interactive dashboard for the α‑AGI Insight demo."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Static files for the optional React front end."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Minimal orchestrator for the α‑AGI Insight demo."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Forecast and evolutionary algorithms used by the demo."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Thermodynamic trigger forecasting."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """NSGA-II style evolutionary optimiser."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Sector state representation."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Utility helpers and configuration for the Insight demo."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Configuration helpers for the α‑AGI Insight demo."""
 
 from __future__ import annotations
@@ -63,9 +64,7 @@ class Settings:
     bus_cert: str | None = os.getenv("AGI_INSIGHT_BUS_CERT")
     bus_key: str | None = os.getenv("AGI_INSIGHT_BUS_KEY")
     broadcast: bool = os.getenv("AGI_INSIGHT_BROADCAST", "1") == "1"
-    solana_rpc_url: str = os.getenv(
-        "AGI_INSIGHT_SOLANA_URL", "https://api.testnet.solana.com"
-    )
+    solana_rpc_url: str = os.getenv("AGI_INSIGHT_SOLANA_URL", "https://api.testnet.solana.com")
     solana_wallet: str | None = os.getenv("AGI_INSIGHT_SOLANA_WALLET")
     solana_wallet_file: str | None = os.getenv("AGI_INSIGHT_SOLANA_WALLET_FILE")
 
@@ -77,9 +76,7 @@ class Settings:
             self.broadcast = False
         if not self.solana_wallet and self.solana_wallet_file:
             try:
-                self.solana_wallet = (
-                    Path(self.solana_wallet_file).read_text(encoding="utf-8").strip()
-                )
+                self.solana_wallet = Path(self.solana_wallet_file).read_text(encoding="utf-8").strip()
             except Exception as exc:  # pragma: no cover - optional
                 _log.warning("Failed to load wallet file %s: %s", self.solana_wallet_file, exc)
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Logging utilities for tamper-evident message tracking."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Simple A2A messaging bus with optional gRPC front-end."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add Apache headers to alpha_agi_insight_v1 demo modules

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit run --files <paths>` *(fails: `pre-commit` not found)*