### PR TITLE
[alpha_factory] update wheel signing guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist/
 .env
 *.env
 
+# Key files
+*.key
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,10 @@ openssl genpkey -algorithm ed25519 -out agent_signing.key
 openssl pkey -in agent_signing.key -pubout -outform DER | base64 -w0
 ```
 
+Store `agent_signing.key` **outside** the repository and never commit it. The
+root `.gitignore` now ignores `*.key` so automated agents and human
+contributors avoid including the private key in pull requests.
+
 Store the public key in the `AGENT_WHEEL_PUBKEY` environment variable so
 `alpha_factory_v1/backend/agents/__init__.py` can verify signatures.
 


### PR DESCRIPTION
# Summary
- ignore `*.key` in .gitignore
- warn not to commit `agent_signing.key`

# Checks
- [ ] I ran `pre-commit run --files .gitignore AGENTS.md` *(failed: command not found)*
- [x] I ran `python check_env.py --auto-install`
- [x] I ran `pytest -q`