### PR TITLE
[alpha_factory] add offline local inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ alpha-agi-insight-offline --episodes 5
 
 This wrapper sets ALPHA_AGI_OFFLINE=true before delegating to the production demo so the search loop never attempts network access.
 
+To run completely offline with a local Llama model set ``AGI_INSIGHT_OFFLINE=1``
+and download a compatible ``.gguf`` weight. For example:
+
+```bash
+mkdir -p ~/.cache/llama
+curl -L -o ~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf \
+  https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-GGUF/resolve/main/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf
+```
+
+Set ``LLAMA_MODEL_PATH`` to the downloaded file and ensure
+``llama-cpp-python`` or ``ctransformers`` is installed. When offline mode is
+enabled the agents automatically use the local model for inference.
+
 
 ### 🎖️ α‑AGI Architect 👁️✨ — Foundational Operational Blueprint
 Empowering Meta‑Agentic visionaries with strategic infrastructure. At the core of α‑AGI Ascension is α‑AGI Architect — the foundational operational framework for scalable global deployment. Rooted in the groundbreaking “Multi‑Agent AI DAO” model, α‑AGI Architect delivers immediate, scalable, and adaptive infrastructure ensuring continuous strategic evolution.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tiny offline LLM interface."""
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, cast
+
+try:  # pragma: no cover - optional dependency
+    from llama_cpp import Llama
+except Exception:  # pragma: no cover - llama-cpp optional
+    Llama = None
+
+try:  # pragma: no cover - optional dependency
+    from ctransformers import AutoModelForCausalLM
+except Exception:  # pragma: no cover - ctransformers optional
+    AutoModelForCausalLM = None
+
+_MODEL: Any | None = None
+_CALL: Callable[[str], str] | None = None
+
+
+def _load_model() -> None:
+    """Load a local model if available, otherwise use an echo stub."""
+    global _MODEL, _CALL
+    model_path = os.getenv(
+        "LLAMA_MODEL_PATH",
+        os.path.expanduser("~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf"),
+    )
+
+    def _wrap(fn: Callable[[str], str]) -> Callable[[str], str]:
+        return fn
+
+    if Llama is not None:
+        try:
+            _MODEL = Llama(model_path=model_path, n_ctx=int(os.getenv("LLAMA_N_CTX", "2048")))
+
+            def call_llama(prompt: str) -> str:
+                out = cast(Any, _MODEL)(prompt)
+                return cast(str, out["choices"][0]["text"]).strip()
+
+            _CALL = _wrap(call_llama)
+            return
+        except Exception:  # pragma: no cover - model load failure
+            _MODEL = None
+    if AutoModelForCausalLM is not None:
+        try:
+            _MODEL = AutoModelForCausalLM.from_pretrained(model_path, model_type="llama")
+
+            def call_ctrans(prompt: str) -> str:
+                return cast(str, cast(Any, _MODEL)(prompt))
+
+            _CALL = _wrap(call_ctrans)
+            return
+        except Exception:  # pragma: no cover - model load failure
+            _MODEL = None
+
+    def call_stub(prompt: str) -> str:
+        return f"[offline] {prompt}"
+
+    _CALL = _wrap(call_stub)
+
+
+def chat(prompt: str) -> str:
+    """Return a completion using the local model or a simple echo."""
+    if _CALL is None:
+        _load_model()
+    assert _CALL is not None
+    try:
+        return _CALL(prompt)
+    except Exception:  # pragma: no cover - runtime error
+        return f"[offline] {prompt}"


### PR DESCRIPTION
## Summary
- provide offline llama-cpp/ctransformers interface
- use local model in PlanningAgent and StrategyAgent when offline
- document offline configuration
- test both online and offline code paths

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py`
- `mypy --config-file mypy.ini --follow-imports=skip alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py`
- `pytest -q`