### PR TITLE
[alpha_factory] add demo docker entrypoint

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -17,7 +17,7 @@ COPY src/interface/web_client/dist /app/src/interface/web_client/dist
 
 # Add non-root user and entrypoint
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app
-COPY infrastructure/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 USER afuser
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Alpha-Factory Insight demo entrypoint
+set -Eeuo pipefail
+
+export PYTHONUNBUFFERED=1
+MODE="${RUN_MODE:-web}"
+
+if [ "$MODE" = "api" ]; then
+    exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server
+elif [ "$MODE" = "web" ]; then
+    exec streamlit run /app/src/interface/web_app.py --server.port 8501 --server.headless true
+else
+    exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli "$@"
+fi


### PR DESCRIPTION
## Summary
- add docker entrypoint for the alpha_agi_insight_v1 demo
- reference script from the demo Dockerfile

## Testing
- `python check_env.py --auto-install`
- `pytest -q`