### PR TITLE
[alpha_factory] add web client build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,8 @@ python -m http.server --directory dist 9000
 ```
 Alternatively run inside Docker:
 ```bash
+# build the web client first so `dist/` exists
+npm --prefix src/interface/web_client run build
 docker compose build
 docker compose up
 ```

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -11,6 +11,8 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 
 # copy project source
 COPY . /app
+# copy pre-built React bundle if available
+COPY src/interface/web_client/dist/ /app/src/interface/web_client/dist/
 
 # add non-root user
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app

--- a/src/interface/web_client/README.md
+++ b/src/interface/web_client/README.md
@@ -1,8 +1,6 @@
 # React Web Client
 
-This directory contains a small React interface built with [Vite](https://vitejs.dev/).
-It lets you configure simulations, view results and stream live logs from the
-FastAPI server.
+This directory contains a small React interface built with [Vite](https://vitejs.dev/). It lets you configure simulations, view results and stream live logs from the FastAPI server.
 
 ## Setup
 
@@ -13,5 +11,8 @@ npm run dev       # start the development server
 npm run build     # build production assets in `dist/`
 ```
 
-A basic smoke test simply runs `npm test`, which exits successfully if the
-project dependencies are installed.
+The app expects the FastAPI server on `http://localhost:8000`. After running `npm run build`, open `dist/index.html` or copy the `dist/` folder into your container image.
+
+When building the Docker image from the project root, ensure `npm run build` completed so that `src/interface/web_client/dist/` exists. The `infrastructure/Dockerfile` copies this directory automatically.
+
+A basic smoke test simply runs `npm test`, which exits successfully if the project dependencies are installed.


### PR DESCRIPTION
## Summary
- document building the React web client and using the bundle with Docker
- copy the compiled `dist/` assets when building the infrastructure container

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `ruff check .`
- `mypy --config-file mypy.ini .`