### PR TITLE
[alpha_factory] Add API endpoint summary

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -293,6 +293,9 @@ The React dashboard streams year-by-year events via WebSocket and renders:
 * **MATS Pareto front** evolution,
 * real-time **agent logs**.
 
+For the REST and WebSocket endpoints see
+[docs/API.md](docs/API.md).
+
 ---
 
 ## 6 Configuration

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -1,0 +1,11 @@
+# API Overview
+
+This demo exposes a minimal REST and WebSocket interface implemented in `src/interface/api_server.py`. All requests must include `Authorization: Bearer $API_TOKEN`.
+
+| Endpoint | Query/Path Params | Payload | Example Response |
+|---------|------------------|---------|-----------------|
+| **POST `/simulate`** | – | `{ "horizon": 5, "pop_size": 6, "generations": 3 }` | `{ "id": "d4e5f6a7" }` |
+| **GET `/results/{sim_id}`** | `sim_id` (path) | – | `{ "id": "d4e5f6a7", "forecast": [{"year": 1, "capability": 0.1}] }` |
+| **GET `/runs`** | – | – | `{ "ids": ["d4e5f6a7"] }` |
+| **WS `/ws/progress`** | – | N/A | `{"id": "d4e5f6a7", "year": 1, "capability": 0.1}` |
+


### PR DESCRIPTION
## Summary
- document REST and WebSocket endpoints used by the demo
- link the new API overview from the Web UI section

## Testing
- `python check_env.py --auto-install`
- `pytest -q`