### PR TITLE
[alpha_factory] Clarify wheel signing with OpenSSL notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,9 @@ For detailed troubleshooting steps, see [`alpha_factory_v1/scripts/README.md`](a
 
 ### Wheel Signing
 All agent wheels must be signed with the project's ED25519 key before they are
-loaded from `$AGENT_HOT_DIR`.
+loaded from `$AGENT_HOT_DIR`. **OpenSSL** is required to sign and verify wheels.
+Install it with `brew install openssl` on macOS or grab the
+[OpenSSL Windows binaries](https://slproweb.com/products/Win32OpenSSL.html).
 
 Generate the signing key once and capture the base64 public key:
 
@@ -256,6 +258,8 @@ openssl dgst -sha512 -binary <wheel>.whl |
   base64 -w0 > <wheel>.whl.sig
 ```
 
+Keep `<wheel>.whl.sig` next to the wheel inside `$AGENT_HOT_DIR`.
+
 Commit the signature file and add the base64 value to `_WHEEL_SIGS` in
 `alpha_factory_v1/backend/agents/__init__.py`. Wheels without a valid signature
 are ignored at runtime.
@@ -266,6 +270,14 @@ Verify that `<wheel>.whl.sig` matches the wheel:
 ```bash
 openssl dgst -sha512 -binary <wheel>.whl |
   openssl pkeyutl -verify -pubin -inkey "$AGENT_WHEEL_PUBKEY" -sigfile <wheel>.whl.sig
+```
+
+On Windows PowerShell:
+
+```powershell
+Get-Content <wheel>.whl -Encoding Byte |
+  openssl dgst -sha512 -binary |
+  openssl pkeyutl -verify -pubin -inkey $env:AGENT_WHEEL_PUBKEY -sigfile <wheel>.whl.sig
 ```
 
 The orchestrator validates signatures against `_WHEEL_PUBKEY` in `alpha_factory_v1/backend/agents/__init__.py`.

--- a/README.md
+++ b/README.md
@@ -624,12 +624,25 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/cross_industry_alpha_factory
 
 ### 6.3 · Signing Agent Wheels 🔑
 Sign wheels dropped into `$AGENT_HOT_DIR` with the project ED25519 key.
+You need **OpenSSL** to create and verify signatures. Install it with
+`brew install openssl` on macOS or from the
+[OpenSSL Windows binaries](https://slproweb.com/products/Win32OpenSSL.html).
 Generate `<wheel>.whl.sig` via:
 
 ```bash
 openssl dgst -sha512 -binary <wheel>.whl |
   openssl pkeyutl -sign -inkey agent_signing.key |
   base64 -w0 > <wheel>.whl.sig
+```
+
+Keep `<wheel>.whl.sig` next to the wheel in `$AGENT_HOT_DIR`.
+
+Verify the signature (PowerShell example):
+
+```powershell
+Get-Content <wheel>.whl -Encoding Byte |
+  openssl dgst -sha512 -binary |
+  openssl pkeyutl -verify -pubin -inkey $env:AGENT_WHEEL_PUBKEY -sigfile <wheel>.whl.sig
 ```
 
 Add the base64 signature to `_WHEEL_SIGS` in


### PR DESCRIPTION
## Summary
- document the need for OpenSSL when signing agent wheels
- keep `.whl.sig` next to the wheel in `$AGENT_HOT_DIR`
- add PowerShell verification example

## Testing
- `python check_env.py --auto-install`
- `pytest -q`