### PR TITLE
[alpha_factory] Improve Insight demo docstrings

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
@@ -1,2 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Package root for the alpha‑AGI Insight demo modules."""
+"""Entry point for the Insight demo package.
+
+This package exposes lightweight agents, the orchestrator and helper
+utilities used by the α‑AGI Insight example. Interface layers under
+``interface`` provide a CLI, optional Streamlit dashboards and a REST API.
+"""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -1,2 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Lightweight agent implementations for the Insight demo."""
+"""Collection of minimal agents used in the Insight scenario.
+
+The package exposes small, single‑responsibility agents. Each agent
+subclasses :class:`~.base_agent.BaseAgent` and cooperates via the
+:class:`~..utils.messaging.A2ABus`. See individual modules for the
+behaviour of the market, planning and research agents.
+"""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/base_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/base_agent.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared base class for insight agents."""
+"""Base class shared by all Insight demo agents.
+
+The class wires each agent into the :class:`~..utils.messaging.A2ABus` and
+provides helper methods for sending and receiving envelopes. Subclasses
+implement :meth:`handle` to process messages and :meth:`run_cycle` for
+periodic behaviour.
+"""
 from __future__ import annotations
 
 import time
@@ -22,7 +28,7 @@ except Exception:  # pragma: no cover - optional
 
 
 class BaseAgent:
-    """Abstract agent."""
+    """Abstract agent type used by specialised agents."""
 
     name: str
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Code generation agent."""
+"""Agent producing small code samples from market data.
+
+The ``CodeGenAgent`` consumes analysis messages and replies with a candidate
+code snippet. When available, an OpenAI agent context or local model is used
+to generate the snippet; otherwise a stub is returned via :meth:`handle`.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Market analysis agent."""
+"""Agent that translates strategy actions into market analysis.
+
+The market agent periodically emits neutral market data and updates its
+analysis when receiving new strategy information. Generated insights are
+passed to the :class:`CodeGenAgent`.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Memory agent."""
+"""Simple in-memory storage for agent artefacts.
+
+The ``MemoryAgent`` collects payloads from other agents and exposes them via
+its :pyattr:`records` attribute. The :meth:`run_cycle` hook reports the number
+of stored items back to the orchestrator.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Planning agent."""
+"""Agent responsible for proposing research steps.
+
+The planning agent periodically formulates a short plan which guides the
+other agents. It demonstrates integration with both local and remote LLMs
+inside :meth:`run_cycle`.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Research agent."""
+"""Agent that converts a plan into research data.
+
+During each cycle the agent runs a tiny evolutionary loop to estimate
+capability growth. Results are forwarded to the strategy agent via
+:meth:`run_cycle` and :meth:`handle` processes incoming planning messages.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Safety guardian agent."""
+"""Agent performing lightweight safety checks.
+
+The safety agent inspects generated code for obvious issues before data is
+persisted by the :class:`MemoryAgent`. Only minimal pattern checks are
+implemented for demonstration purposes.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Strategy agent."""
+"""Agent composing high level strategy from research results.
+
+The agent consumes ``research`` messages and generates a short action plan
+for the market agent. It can optionally leverage a local or remote LLM during
+:meth:`handle`.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/__init__.py
@@ -1,2 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CLI, web UI and API server for the Insight demo."""
+"""User interfaces for the Insight example.
+
+The ``interface`` package bundles a command line tool, an optional web
+dashboard built with Streamlit and a small FastAPI service for programmatic
+access. Each module exposes a :func:`main` entry point.
+"""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""FastAPI wrapper to expose the demo over HTTP."""
+"""FastAPI server exposing simulation endpoints.
+
+The API allows remote control of the orchestrator and serves progress
+updates over websockets. It is intentionally lean and suitable for local
+testing.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Command line interface for the α‑AGI Insight demo."""
+"""Command line utilities wrapping the Insight components.
+
+Provides commands to run forecast simulations, inspect ledger entries and
+launch the orchestrator. ``click`` is used for argument parsing and the
+console output optionally leverages ``rich`` for nicer tables.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Minimal Streamlit interface for disruption forecasts."""
+"""Tiny Streamlit app visualising forecast results.
+
+The module provides ``main`` which launches a dashboard or prints results in
+text mode. It demonstrates how forecast data can be visualised without any
+backend services.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Interactive dashboard for the α‑AGI Insight demo."""
+"""Full Streamlit dashboard visualising simulation output.
+
+This interface allows interactive control of the forecast parameters and
+renders charts using Plotly. It can fall back to text output when
+Streamlit is unavailable.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
@@ -1,2 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Static files for the optional React front end."""
+"""Bundle of static assets for the example React UI.
+
+The web client is optional and served by :mod:`api_server` when present.
+It contains the compiled JavaScript build artefacts.
+"""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Minimal orchestrator for the α‑AGI Insight demo."""
+"""Central process coordinating all Insight demo agents.
+
+The orchestrator instantiates each agent, relays messages via the
+:class:`~..utils.messaging.A2ABus` and restarts agents when they become
+unresponsive. :meth:`run_forever` starts the event loop and periodic
+health checks.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/__init__.py
@@ -1,2 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Forecast and evolutionary algorithms used by the demo."""
+"""Core simulation routines for the Insight demo.
+
+This package contains a tiny multi-objective evolutionary optimiser along
+with helpers for modelling sector disruption. It is deliberately minimal to
+keep the demonstration lightweight.
+"""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Thermodynamic trigger forecasting."""
+"""Utility functions for projecting sector disruption.
+
+This module implements a very small toy model using a logistic capability
+curve and a thermodynamic trigger based on free energy. The helpers
+``forecast_disruptions`` and ``simulate_years`` drive the demo's forecast
+visualisations.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""NSGA-II style evolutionary optimiser."""
+"""Minimal multi-objective evolutionary algorithm.
+
+This module implements a tiny subset of the NSGA‑II algorithm. The
+``Individual`` dataclass stores genomes and fitness, while
+``run_evolution`` executes several generations of crossover and mutation.
+It is intentionally lightweight and not a full-featured implementation.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Sector state representation."""
+"""Simple container describing a market sector.
+
+Each ``Sector`` tracks energy, entropy and growth parameters alongside a
+``disrupted`` flag used during the forecast simulation.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/__init__.py
@@ -1,2 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Utility helpers and configuration for the Insight demo."""
+"""Miscellaneous utilities supporting the demo codebase.
+
+Submodules include configuration management, logging helpers, a simple
+messaging bus and optional local LLM integration.
+"""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Configuration helpers for the α‑AGI Insight demo."""
+"""Environment driven settings used by the agents and interfaces.
+
+The :class:`Settings` dataclass gathers options from ``.env`` files and
+environment variables. ``CFG`` is the default instance consumed throughout
+the demo.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tiny offline LLM interface."""
+"""Very small wrapper around optional local language models.
+
+The :func:`chat` helper loads a model on demand using either ``llama-cpp`` or
+``ctransformers``. If neither is present an echo implementation is used.
+"""
 from __future__ import annotations
 
 import os

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Logging utilities for tamper-evident message tracking."""
+"""Structured logging and Merkle root broadcasting.
+
+The :class:`Ledger` class appends envelopes to a SQLite database and can
+periodically broadcast the Merkle root to Solana. ``setup`` configures
+standard logging with optional colorization.
+"""
 
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Simple A2A messaging bus with optional gRPC front-end."""
+"""Lightweight pub/sub bus used by the agents.
+
+Envelopes are published to in-memory subscribers and optionally forwarded via
+gRPC or Kafka. Use :class:`A2ABus` to subscribe handlers and to start the
+optional transport servers.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify module descriptions for insight demo packages
- summarize key components in agent, interface and utils modules

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src` *(fails: E402 Module level import not at top of file)*
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src`
- `pytest -q`