### PR TITLE
[alpha_factory] implement insight API endpoints

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -8,38 +8,232 @@ testing.
 
 from __future__ import annotations
 
-import typing as t
-
-try:
-    import fastapi
-except Exception:  # pragma: no cover - optional
-    fastapi = t.cast(t.Any, None)
-
-try:
-    import uvicorn
-except Exception:  # pragma: no cover - optional
-    uvicorn = t.cast(t.Any, None)
-
-FastAPI = fastapi.FastAPI if fastapi is not None else None
-
-import asyncio
-
-from .. import orchestrator
 import argparse
+import asyncio
+import contextlib
+import importlib
+import json
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Any, List, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from typing import Protocol
+
+    class ForecastTrajectoryPoint(Protocol):
+        year: int
+        capability: float
+        sectors: List[Any]
+
+    ForecastModule = Any
+    SectorModule = Any
+    MatsModule = Any
+else:
+    ForecastModule = Any
+    SectorModule = Any
+    MatsModule = Any
+    ForecastTrajectoryPoint = Any  # type: ignore[assignment]
+
+forecast = importlib.import_module(
+    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.forecast"
+)
+sector = importlib.import_module(
+    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.sector"
+)
+
+_IMPORT_ERROR: Exception | None
+try:
+    from fastapi import FastAPI, HTTPException, WebSocket, Request, Depends
+    from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+    from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+    from starlette.responses import Response
+    from pydantic import BaseModel
+    import uvicorn
+except Exception as exc:  # pragma: no cover - optional
+    FastAPI = None  # type: ignore
+    HTTPException = None  # type: ignore
+    BaseModel = object  # type: ignore
+    WebSocket = Any  # type: ignore
+    uvicorn = None  # type: ignore
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
 
 app = FastAPI(title="α‑AGI Insight") if FastAPI is not None else None
 
 if app is not None:
-    orch = orchestrator.Orchestrator()
+    app_f: FastAPI = app
+    _orch: Any | None = None
 
     @app.on_event("startup")
     async def _start() -> None:
-        app.state.task = asyncio.create_task(orch.run_forever())
+        global _orch
+        orch_mod = importlib.import_module(
+            "alpha_factory_v1.demos.alpha_agi_insight_v1.src.orchestrator"
+        )
+        _orch = orch_mod.Orchestrator()
+        app_f.state.task = asyncio.create_task(_orch.run_forever())
+        _load_results()
 
     @app.on_event("shutdown")
     async def _stop() -> None:
-        if hasattr(app.state, "task"):
-            app.state.task.cancel()
+        global _orch
+        task = getattr(app_f.state, "task", None)
+        if task:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        _orch = None
+
+    API_TOKEN = os.getenv("API_TOKEN")
+    if not API_TOKEN:
+        raise RuntimeError("API_TOKEN environment variable must be set")
+
+    security = HTTPBearer()
+
+    class SimpleRateLimiter(BaseHTTPMiddleware):
+        def __init__(self, app: FastAPI, limit: int = 60, window: int = 60) -> None:
+            super().__init__(app)
+            self.limit = int(os.getenv("API_RATE_LIMIT", str(limit)))
+            self.window = window
+            self.counters: dict[str, tuple[int, float]] = {}
+            self.lock = asyncio.Lock()
+
+        async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+            ip = request.client.host if request.client else "unknown"
+            now = time.time()
+            async with self.lock:
+                count, start = self.counters.get(ip, (0, now))
+                if now - start > self.window:
+                    count = 0
+                    start = now
+                count += 1
+                self.counters[ip] = (count, start)
+                if count > self.limit:
+                    return Response("Too Many Requests", status_code=429)
+            return await call_next(request)
+
+    async def verify_token(
+        credentials: HTTPAuthorizationCredentials = Depends(security),
+    ) -> None:
+        if credentials.credentials != API_TOKEN:
+            raise HTTPException(status_code=403, detail="Invalid token")
+
+    app.add_middleware(SimpleRateLimiter)
+
+    _simulations: dict[str, ResultsResponse] = {}
+    _progress_ws: Set[Any] = set()
+    _results_dir = Path(
+        os.getenv("SIM_RESULTS_DIR", os.path.join(os.getenv("ALPHA_DATA_DIR", "/tmp/alphafactory"), "simulations"))
+    )
+    _results_dir.mkdir(parents=True, exist_ok=True)
+
+    def _load_results() -> None:
+        for f in _results_dir.glob("*.json"):
+            try:
+                data = json.loads(f.read_text())
+                res = ResultsResponse(**data)
+            except Exception:
+                continue
+            _simulations[res.id] = res
+
+    def _save_result(result: ResultsResponse) -> None:
+        path = _results_dir / f"{result.id}.json"
+        path.write_text(result.json())
+
+    class SimRequest(BaseModel):
+        """Payload for the ``/simulate`` endpoint."""
+
+        horizon: int = 5
+        pop_size: int = 6
+        generations: int = 3
+
+    class ForecastPoint(BaseModel):
+        """Single year forecast entry."""
+
+        year: int
+        capability: float
+
+    class SimStartResponse(BaseModel):
+        """Identifier returned when launching a simulation."""
+
+        id: str
+
+    class ResultsResponse(BaseModel):
+        """Stored simulation outcome."""
+
+        id: str
+        forecast: list[ForecastPoint]
+
+    class RunsResponse(BaseModel):
+        """List of available run identifiers."""
+
+        ids: list[str]
+
+    async def _background_run(sim_id: str, cfg: SimRequest) -> None:
+        secs = [sector.Sector(f"s{i:02d}") for i in range(cfg.pop_size)]
+        traj: list[ForecastTrajectoryPoint] = []
+        for year in range(1, cfg.horizon + 1):
+            t = year / cfg.horizon
+            cap = forecast.capability_growth(t)
+            for sec in secs:
+                if not sec.disrupted:
+                    sec.energy *= 1.0 + sec.growth
+                    if forecast.thermodynamic_trigger(sec, cap):
+                        sec.disrupted = True
+                        sec.energy += forecast._innovation_gain(cfg.pop_size, cfg.generations)
+            snapshot = [sector.Sector(s.name, s.energy, s.entropy, s.growth, s.disrupted) for s in secs]
+            point = forecast.TrajectoryPoint(year, cap, snapshot)
+            traj.append(point)
+            for ws in list(_progress_ws):
+                try:
+                    await ws.send_json({"id": sim_id, "year": year, "capability": cap})
+                except Exception:
+                    _progress_ws.discard(ws)
+            await asyncio.sleep(0)
+        result = ResultsResponse(
+            id=sim_id,
+            forecast=[ForecastPoint(year=p.year, capability=p.capability) for p in traj],
+        )
+        _simulations[sim_id] = result
+        _save_result(result)
+
+    _load_results()
+
+    @app.post("/simulate", response_model=SimStartResponse)
+    async def simulate(req: SimRequest, _: None = Depends(verify_token)) -> SimStartResponse:
+        sim_id = secrets.token_hex(8)
+        asyncio.create_task(_background_run(sim_id, req))
+        return SimStartResponse(id=sim_id)
+
+    @app.get("/results/{sim_id}", response_model=ResultsResponse)
+    async def get_results(sim_id: str, _: None = Depends(verify_token)) -> ResultsResponse:
+        result = _simulations.get(sim_id)
+        if result is None:
+            raise HTTPException(status_code=404)
+        return result
+
+    @app.get("/runs", response_model=RunsResponse)
+    async def list_runs(_: None = Depends(verify_token)) -> RunsResponse:
+        return RunsResponse(ids=list(_simulations.keys()))
+
+    @app.websocket("/ws/progress")
+    async def ws_progress(websocket: WebSocket) -> None:
+        auth = websocket.headers.get("authorization")
+        if not auth or not auth.startswith("Bearer ") or auth.split(" ", 1)[1] != API_TOKEN:
+            await websocket.close(code=1008)
+            return
+        await websocket.accept()
+        _progress_ws.add(websocket)
+        try:
+            while True:
+                await websocket.receive_text()
+        except Exception:
+            pass
+        finally:
+            _progress_ws.discard(websocket)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
@@ -1,6 +1,7 @@
 import os
 import socket
 import subprocess
+import threading
 import sys
 import time
 from pathlib import Path
@@ -10,16 +11,19 @@ import pytest
 # Ensure repository root is on the Python path for subprocess execution
 REPO_ROOT = Path(__file__).resolve().parents[3]
 os.environ.setdefault("PYTHONPATH", str(REPO_ROOT))
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 fastapi = pytest.importorskip("fastapi")
 httpx = pytest.importorskip("httpx")
 uvicorn = pytest.importorskip("uvicorn")
+websockets = pytest.importorskip("websockets.sync.client")
 
 
 def _free_port() -> int:
     with socket.socket() as s:
         s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+        return int(s.getsockname()[1])
 
 
 def test_docs_available() -> None:
@@ -49,6 +53,82 @@ def test_docs_available() -> None:
         else:
             raise AssertionError("server failed to start")
         assert r.status_code == 200
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_simulation_endpoints() -> None:
+    port = _free_port()
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    cmd = [
+        sys.executable,
+        "-m",
+        "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+    url = f"http://127.0.0.1:{port}"
+    headers = {"Authorization": "Bearer test-token"}
+    try:
+        for _ in range(50):
+            try:
+                r = httpx.get(url + "/runs", headers=headers)
+                if r.status_code == 200:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.1)
+        else:
+            raise AssertionError("server failed to start")
+
+        progress: list[str] = []
+
+        def _listen() -> None:
+            ws_url = f"ws://127.0.0.1:{port}/ws/progress"
+            with websockets.connect(ws_url, additional_headers=headers) as ws:
+                try:
+                    while True:
+                        msg = ws.recv()
+                        progress.append(msg)
+                        if progress:
+                            break
+                except Exception:
+                    pass
+
+        th = threading.Thread(target=_listen, daemon=True)
+        th.start()
+
+        r = httpx.post(
+            url + "/simulate",
+            json={"horizon": 1, "pop_size": 2, "generations": 1},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        sim_id = r.json()["id"]
+
+        for _ in range(100):
+            r = httpx.get(f"{url}/results/{sim_id}", headers=headers)
+            if r.status_code == 200:
+                data = r.json()
+                break
+            time.sleep(0.05)
+        else:
+            raise AssertionError("Timed out waiting for results")
+
+        th.join(timeout=5)
+        assert progress
+        assert "forecast" in data
+        r_runs = httpx.get(url + "/runs", headers=headers)
+        assert r_runs.status_code == 200
+        assert sim_id in r_runs.json().get("ids", [])
     finally:
         proc.terminate()
         try:


### PR DESCRIPTION
## Summary
- extend Insight demo API server with /simulate, /results, /runs and WebSocket progress
- exercise new routes in subprocess test

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py`
- `pytest -q`