### PR TITLE
[alpha_factory] serve react dashboard in web mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@ venv/
 # Distribution / packaging
 *.egg-info/
 node_modules/
-src/interface/web_client/dist/
 build/
 dist/
+!src/interface/web_client/dist/
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -671,7 +671,9 @@ npm --prefix src/interface/web_client run build
 docker compose build
 docker compose up
 ```
-Open <http://localhost:9000> in your browser.
+Open <http://localhost:8501> in your browser. When `RUN_MODE=web`, the container
+serves the static files from `src/interface/web_client/dist` using `python -m
+http.server`.
 
 If Streamlit isn't installed or you're running on a headless server, use:
 ```bash

--- a/infrastructure/docker-entrypoint.sh
+++ b/infrastructure/docker-entrypoint.sh
@@ -4,8 +4,14 @@ MODE=${RUN_MODE:-web}
 if [ "$MODE" = "api" ]; then
   exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server
 elif [ "$MODE" = "web" ]; then
-  exec streamlit run /app/src/interface/web_app.py \
-    --server.port 8501 --server.headless true
+  if [ -d /app/src/interface/web_client/dist ]; then
+    cd /app/src/interface/web_client/dist
+    exec python -m http.server 8501
+  else
+    echo "Missing web build, falling back to Streamlit UI" >&2
+    exec streamlit run /app/src/interface/web_app.py \
+      --server.port 8501 --server.headless true
+  fi
 else
   exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli "$@"
 fi

--- a/src/interface/web_client/dist/app.js
+++ b/src/interface/web_client/dist/app.js
@@ -1,0 +1,28 @@
+(function(){
+  const {useState, useEffect} = React;
+  function App(){
+    const [data, setData] = useState([]);
+    useEffect(()=>{
+      fetch('/results')
+        .then(r => r.ok ? r.json() : {forecast: []})
+        .then(d => setData(d.forecast || []))
+        .catch(()=>{});
+    },[]);
+    useEffect(()=>{
+      if(data.length){
+        Plotly.react('timeline',[{
+          x: data.map(p=>p.year),
+          y: data.map(p=>p.capability),
+          mode:'lines+markers',
+          type:'scatter'
+        }],{});
+      }
+    },[data]);
+    return React.createElement('div',null,
+      React.createElement('h1',null,'Disruption Timeline'),
+      React.createElement('div',{id:'timeline',style:{width:'100%',height:300}})
+    );
+  }
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(React.createElement(App));
+})();

--- a/src/interface/web_client/dist/index.html
+++ b/src/interface/web_client/dist/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AGI Dashboard</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-2.24.2.min.js"></script>
+    <script src="app.js" defer></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- include built React bundle
- serve static assets when `RUN_MODE=web`
- update docs for dashboard
- allow tracking built web assets

## Testing
- `python check_env.py --auto-install`
- `pytest -q`