### PR TITLE
[alpha_factory] Add further reading links

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,16 @@ python -m webbrowser http://localhost:8000/docs
 ```
 
 ## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+This repository is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
 
-Further technical details are documented separately:
-
-- The overall architecture, agent roles and algorithms are explained in [docs/DESIGN.md](docs/DESIGN.md).
-- REST and WebSocket endpoints are listed in [docs/API.md](docs/API.md).
+## Further Reading
+- [docs/DESIGN.md](docs/DESIGN.md) — architecture overview and agent roles.
+- [docs/API.md](docs/API.md) — REST API and CLI endpoints.
 - Release notes are maintained in [docs/CHANGELOG.md](docs/CHANGELOG.md).
-- A demo specific overview can be found in [alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md](alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md).
+- A demo specific overview can be found in
+  [alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md](alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- move doc references under new 'Further Reading' heading

## Testing
- `python check_env.py --auto-install`
- `pytest -q`