### PR TITLE
[alpha_factory] clarify pre-commit hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ for modules, classes and functions.
     CI enforces these checks.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using
     `mypy.ini`.
+  - Hooks are configured in `.pre-commit-config.yaml` at the repository root.
 
 ## Pull Requests
 - Keep commits focused and descriptive. Use meaningful commit messages.


### PR DESCRIPTION
## Summary
- mention the pre-commit configuration file path in AGENTS guidelines

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ❌ `pre-commit run --files AGENTS.md` *(failed: pre-commit not installed)*