### PR TITLE
[alpha_factory] docs: note web_client build steps

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -281,9 +281,22 @@ streamlit run src/interface/web_app.py
 ```bash
 # backend
 uvicorn src/interface/api_server:app --reload --port 8000
-# frontend (if you want to rebuild)
+# frontend
 cd src/interface/web_client
-pnpm install && pnpm dev
+pnpm install
+pnpm dev            # http://localhost:5173
+# build production assets
+pnpm build          # outputs to src/interface/web_client/dist/
+# or use `npm install && npm run build`
+```
+
+The built dashboard lives under `src/interface/web_client/dist/` and is copied
+into the demo container.
+
+```bash
+# build and launch containers
+docker compose build
+docker compose up
 ```
 
 The React dashboard streams year-by-year events via WebSocket and renders:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -2,7 +2,9 @@
 FROM python:3.11-slim
 
 # Install build tools for optional native extensions
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential nodejs npm \
+    && npm install -g pnpm \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -13,7 +15,9 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 
 # Copy the project source
 COPY . /app
-COPY src/interface/web_client/dist /app/src/interface/web_client/dist
+RUN pnpm --dir src/interface/web_client install \
+    && pnpm --dir src/interface/web_client run build \
+    && rm -rf src/interface/web_client/node_modules
 
 # Add non-root user and entrypoint
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app


### PR DESCRIPTION
## Summary
- clarify how to build the React dashboard
- build React client automatically in demo Dockerfile

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
