### PR TITLE
[alpha_factory] Clean trailing whitespace in AIGA README

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -213,9 +213,9 @@ agent is published over the A2A protocol for orchestration by external controlle
 └────────────────────────────────────────┘
 ```
 
-* **MetaEvolver** – pop 24, tournament‑k 3, elitism 2, novelty bonus toggle 
-* **EvoNet** – arbitrary hidden layers, activation ∈ {relu,tanh,sigmoid}, optional Hebbian ΔW 
-* **CurriculumEnv** – 12 × 12 grid, DFS solvability check, energy budget, genome auto‑mutation 
+* **MetaEvolver** – pop 24, tournament‑k 3, elitism 2, novelty bonus toggle
+* **EvoNet** – arbitrary hidden layers, activation ∈ {relu,tanh,sigmoid}, optional Hebbian ΔW
+* **CurriculumEnv** – 12 × 12 grid, DFS solvability check, energy budget, genome auto‑mutation
 
 ---
 
@@ -228,15 +228,15 @@ agent is published over the A2A protocol for orchestration by external controlle
 | `aiga_generations_total` | Counter |
 | `aiga_curriculum_stage` | 0–3 |
 
-Enable profile `telemetry` to autopush → Prometheus → Grafana. 
+Enable profile `telemetry` to autopush → Prometheus → Grafana.
 `docker compose --profile telemetry up`.
 
 ---
 
 ## 🧪 Tests & CI
 
-* **Coverage ≥ 90 %** in < 0.5 s (`pytest -q`) 
-* GitHub Actions → lint → test → build → Cosign sign 
+* **Coverage ≥ 90 %** in < 0.5 s (`pytest -q`)
+* GitHub Actions → lint → test → build → Cosign sign
 * **SBOM** via *Syft* (SPDX v3) per release
 
 ---
@@ -270,9 +270,9 @@ spec:
 
 ## 🛡 SOC‑2 & supply‑chain
 
-* Cosign‑signed images (`cosign verify …`) 
-* Runs **non‑root UID 1001**, read‑only code volume 
-* Secrets via K8s / Docker *secrets* (never baked into layers) 
+* Cosign‑signed images (`cosign verify …`)
+* Runs **non‑root UID 1001**, read‑only code volume
+* Secrets via K8s / Docker *secrets* (never baked into layers)
 * Dependencies hashed (Poetry lock) & validated at runtime 
 * SBOM exported; SLSA level 2 pipeline
 


### PR DESCRIPTION
## Summary
- trim trailing whitespace in `aiga_meta_evolution/README.md`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/README.md` *(fails: `pre-commit` not installed)*