### PR TITLE
[alpha_factory] add CORS support in api server

### DIFF
--- a/alpha_factory_v1/.env.sample
+++ b/alpha_factory_v1/.env.sample
@@ -35,6 +35,7 @@ TRACE_WS_PORT=8088          # Trace‑graph WebSocket port
 LOGLEVEL=INFO               # DEBUG | INFO | WARNING | ERROR
 API_TOKEN=REPLACE_ME_TOKEN  # bearer token for the demo API
 API_RATE_LIMIT=60           # requests per minute per IP
+API_CORS_ORIGINS=*          # comma-separated CORS origins for the API
 ALPHA_KAFKA_BROKER=
 ALPHA_DATA_DIR=/data
 

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -39,6 +39,7 @@ try:
     from fastapi import FastAPI, HTTPException, WebSocket, Request, Depends
     from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
     from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+    from fastapi.middleware.cors import CORSMiddleware
     from starlette.responses import Response
     from pydantic import BaseModel
     import uvicorn
@@ -91,6 +92,14 @@ if app is not None:
 
     app_f: FastAPI = app
     app_f.add_middleware(SimpleRateLimiter)
+    origins = [o.strip() for o in os.getenv("API_CORS_ORIGINS", "*").split(",") if o.strip()]
+    app_f.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     _orch: Any | None = None
 
     @app.on_event("startup")

--- a/tests/test_api_server_cors.py
+++ b/tests/test_api_server_cors.py
@@ -1,0 +1,35 @@
+import asyncio
+import os
+from typing import Any, cast
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+fastapi = pytest.importorskip("fastapi")
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+os.environ.setdefault("API_CORS_ORIGINS", "http://example.com")
+
+
+async def make_client() -> tuple[AsyncClient, Any]:
+    from src.interface import api_server
+
+    transport = ASGITransport(app=cast(Any, api_server.app))
+    client = AsyncClient(base_url="http://test", transport=transport)
+    return client, api_server
+
+
+def test_cors_headers() -> None:
+    async def run() -> None:
+        client, _ = await make_client()
+        async with client:
+            headers = {
+                "Authorization": "Bearer test-token",
+                "Origin": "http://example.com",
+            }
+            r = await client.get("/runs", headers=headers)
+            assert r.status_code == 200
+            assert r.headers.get("access-control-allow-origin") == "http://example.com"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- configure FastAPI CORS middleware via API_CORS_ORIGINS env var
- document API_CORS_ORIGINS in .env sample
- test CORS headers on the API server

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/interface/api_server.py alpha_factory_v1/.env.sample tests/test_api_server_cors.py` *(fails: `pre-commit: command not found`)*
- `pytest -q tests/test_api_server_cors.py`