### PR TITLE
[alpha_factory] Add license header to entrypoint

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 # Alpha-Factory Insight demo entrypoint
 set -Eeuo pipefail
 


### PR DESCRIPTION
## Summary
- add missing Apache license header to alpha_agi_insight_v1 entrypoint script

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_af_requests.py::test_fallback_to_internal_shim)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh` *(fails: pre-commit not installed)*