### PR TITLE
[alpha_factory] update TL;DR to show venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Built atop **OpenAI Agents SDK**, **Google ADK**, **A2A protocol**, and Ant
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
+python3 -m venv .venv
+source .venv/bin/activate
 # Install runtime dependencies
 pip install -r requirements.txt
 # Requires Python 3.11–3.12 (<3.13)


### PR DESCRIPTION
## Summary
- create and activate `.venv` in the TL;DR section of the README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_fallback_to_internal_shim)*
- `pre-commit run --files README.md` *(fails: could not install pre-commit due to lack of network access)*