### PR TITLE
[alpha_factory] Clarify PYTHONPATH usage for Insight demo tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -347,7 +347,12 @@ All containers are x86-64/arm64 multi-arch and GPU-aware (CUDA 12).
 
 ## 8 Testing
 
+Running the suite directly from the repository root requires Python to locate
+the `alpha_factory_v1` package. Either install the project or export
+`PYTHONPATH=$(pwd)` before invoking `pytest`:
+
 ```bash
+export PYTHONPATH=$(pwd)  # if running from the repo root without installation
 pytest -q          # unit + integration suite
 pytest -m e2e      # full 5-year forecast smoke-test
 ```


### PR DESCRIPTION
## Summary
- clarify that running tests from the Insight demo requires PYTHONPATH
- show updated command example

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_af_requests.py::test_fallback_to_internal_shim)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/README.md` *(fails: pre-commit not installed)*