### PR TITLE
[alpha_factory] update sys.path in insight tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py
@@ -1,11 +1,10 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 import asyncio
 import pathlib
-import unittest
 from unittest import mock
 from typing import List
 
@@ -112,9 +111,11 @@ def test_strategy_agent_api_uses_oai_ctx(tmp_path: pathlib.Path) -> None:
             return "done"
 
     agent.oai_ctx = Ctx()
+    assert agent.oai_ctx is not None
     env = messaging.Envelope("a", "b", {"research": 1}, 0.0)
 
     async def _run() -> None:
+        assert agent.oai_ctx is not None
         with mock.patch.object(agent.oai_ctx, "run", wraps=agent.oai_ctx.run) as m:
             await agent.handle(env)
             assert m.called

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 # Ensure repository root is on the Python path for subprocess execution
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 os.environ.setdefault("PYTHONPATH", str(REPO_ROOT))
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 from click.testing import CliRunner
 
@@ -18,7 +18,7 @@ def test_simulate_offline(tmp_path: Path) -> None:
     runner = CliRunner()
     from unittest.mock import patch
 
-    with patch.object(cli.config.CFG, "ledger_path", str(led_path)):
+    with patch.object(cli.config.CFG, "ledger_path", str(led_path)):  # type: ignore[attr-defined]
         result = runner.invoke(cli.main, ["simulate", "--horizon", "2", "--offline"])
     assert result.exit_code == 0
     assert "year" in result.output
@@ -33,7 +33,7 @@ def test_show_results_json(tmp_path: Path) -> None:
     runner = CliRunner()
     from unittest.mock import patch
 
-    with patch.object(cli.config.CFG, "ledger_path", str(led_path)):
+    with patch.object(cli.config.CFG, "ledger_path", str(led_path)):  # type: ignore[attr-defined]
         result = runner.invoke(
             cli.main,
             ["show-results", "--limit", "1", "--export", "json"],

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_forecast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_forecast.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast, sector
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_mats.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_mats.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import mats
 


### PR DESCRIPTION
## Summary
- adjust sys.path parent index in `alpha_agi_insight_v1` demo tests
- add assertions for mypy in agent tests
- silence mypy for demo CLI config patch

## Testing
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_forecast.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_mats.py`
- `pytest -q` *(fails: tests/test_af_requests.py::test_fallback_to_internal_shim)*