### PR TITLE
[alpha_factory] add insight web client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 build/
 dist/
 !src/interface/web_client/dist/
+!alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/
 
 # Logs
 *.log

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -296,6 +296,10 @@ pnpm build          # outputs to src/interface/web_client/dist/
 The built dashboard lives under `src/interface/web_client/dist/` and is copied
 into the demo container.
 
+The React client exposes an input form for **horizon**, **population size** and
+**generations**. It listens to `/ws/progress` events and updates Plotly charts in
+real-time as the simulation runs.
+
 ```bash
 # build and launch containers
 docker compose build

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -15,9 +15,13 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 
 # Copy the project source
 COPY . /app
-RUN pnpm --dir src/interface/web_client install \
-    && pnpm --dir src/interface/web_client run build \
-    && rm -rf src/interface/web_client/node_modules
+RUN pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client install \
+    && pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
+    && rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+
+# copy built assets
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/ \
+    /app/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/
 
 # Add non-root user and entrypoint
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
@@ -1,0 +1,14 @@
+# React Web Client
+
+This directory contains the Vite-based React dashboard for the α‑AGI Insight demo. It communicates with the FastAPI backend and visualises progress in real time.
+
+## Setup
+
+```bash
+cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
+pnpm install
+pnpm dev        # start the development server
+pnpm build      # production build in `dist/`
+```
+
+The app expects the API server on `http://localhost:8000`. When building the Docker image from the project root, ensure `pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build` completes so that `dist/` exists. The infrastructure Dockerfile copies this directory automatically.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
@@ -1,0 +1,37 @@
+(function(){
+  const {useState, useEffect} = React;
+  const API_TOKEN = 'demo-token';
+  function App(){
+    const [horizon,setHorizon]=useState(5);
+    const [pop,setPop]=useState(6);
+    const [gen,setGen]=useState(3);
+    const [runId,setRunId]=useState(null);
+    const [years,setYears]=useState([]);
+    const [caps,setCaps]=useState([]);
+    async function start(e){
+      e.preventDefault();
+      const res=await fetch('/simulate',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+API_TOKEN},body:JSON.stringify({horizon, pop_size:pop, generations:gen})});
+      const d=await res.json();
+      setRunId(d.id);setYears([]);setCaps([]);
+    }
+    useEffect(()=>{
+      if(!runId)return;
+      const ws=new WebSocket('ws://'+location.host+'/ws/progress');
+      ws.onopen=()=>ws.send('ready');
+      ws.onmessage=ev=>{try{const m=JSON.parse(ev.data);if(m.id===runId){setYears(y=>y.concat(m.year));setCaps(c=>c.concat(m.capability));}}catch{}}
+      return ()=>ws.close();
+    },[runId]);
+    useEffect(()=>{if(years.length){Plotly.react('chart',[{x:years,y:caps,mode:'lines+markers',type:'scatter'}],{margin:{t:20}});}},[years,caps]);
+    return React.createElement('div',null,
+      React.createElement('h2',null,'\u03B1\u2011AGI Insight'),
+      React.createElement('form',{onSubmit:start,style:{marginBottom:'1em'}},
+        React.createElement('label',null,'Horizon',React.createElement('input',{type:'number',value:horizon,onChange:e=>setHorizon(+e.target.value)})),
+        React.createElement('label',null,' Population',React.createElement('input',{type:'number',value:pop,onChange:e=>setPop(+e.target.value)})),
+        React.createElement('label',null,' Generations',React.createElement('input',{type:'number',value:gen,onChange:e=>setGen(+e.target.value)})),
+        React.createElement('button',{type:'submit'},'Run')
+      ),
+      React.createElement('div',{id:'chart',style:{width:'100%',height:400}})
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+})();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AGI Insight Dashboard</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-2.24.2.min.js"></script>
+    <script src="app.js" defer></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AGI Insight Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agi-insight-client",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"Running smoke test\" && exit 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "plotly.js-dist": "^2.24.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.0",
+    "vite": "^4.2.0"
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/App.tsx
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/App.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import Plotly from 'plotly.js-dist';
+
+interface ProgressMsg {
+  id: string;
+  year: number;
+  capability: number;
+}
+
+const API_TOKEN = import.meta.env.VITE_API_TOKEN || 'demo-token';
+
+export default function App() {
+  const [horizon, setHorizon] = useState(5);
+  const [popSize, setPopSize] = useState(6);
+  const [generations, setGenerations] = useState(3);
+  const [runId, setRunId] = useState<string | null>(null);
+  const [years, setYears] = useState<number[]>([]);
+  const [caps, setCaps] = useState<number[]>([]);
+
+  async function start(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/simulate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_TOKEN}`,
+      },
+      body: JSON.stringify({ horizon, pop_size: popSize, generations }),
+    });
+    const data = await res.json();
+    setRunId(data.id);
+    setYears([]);
+    setCaps([]);
+  }
+
+  useEffect(() => {
+    if (!runId) return;
+    const ws = new WebSocket(`ws://${window.location.host}/ws/progress`);
+    ws.onopen = () => ws.send('ready');
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data) as ProgressMsg;
+        if (msg.id === runId) {
+          setYears((y) => [...y, msg.year]);
+          setCaps((c) => [...c, msg.capability]);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    return () => ws.close();
+  }, [runId]);
+
+  useEffect(() => {
+    if (years.length) {
+      Plotly.react('chart', [
+        { x: years, y: caps, mode: 'lines+markers', type: 'scatter' },
+      ], { margin: { t: 20 } });
+    }
+  }, [years, caps]);
+
+  return (
+    <div>
+      <h2>α‑AGI Insight</h2>
+      <form onSubmit={start} style={{ marginBottom: '1em' }}>
+        <label>
+          Horizon
+          <input type="number" value={horizon} onChange={(e) => setHorizon(Number(e.target.value))} />
+        </label>
+        <label>
+          Population
+          <input type="number" value={popSize} onChange={(e) => setPopSize(Number(e.target.value))} />
+        </label>
+        <label>
+          Generations
+          <input type="number" value={generations} onChange={(e) => setGenerations(Number(e.target.value))} />
+        </label>
+        <button type="submit">Run</button>
+      </form>
+      <div id="chart" style={{ width: '100%', height: 400 }} />
+    </div>
+  );
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.node.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/vite.config.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.',
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- build a Vite-based React dashboard under the insight demo
- stream `/ws/progress` updates and display Plotly charts
- update Dockerfile and README
- keep built assets committed

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_fallback_to_internal_shim)*
- `pre-commit` *(failed to install: no network)*