### PR TITLE
[alpha_factory] add llama path option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,6 +10,8 @@ RUN_MODE=api
 PORT=8000
 # Set to 1 to force local models only
 AGI_INSIGHT_OFFLINE=0
+# Path to local Llama model (optional)
+LLAMA_MODEL_PATH=
 # gRPC bus port for agent coordination
 AGI_INSIGHT_BUS_PORT=6006
 # SQLite ledger path used by the Insight demo

--- a/README.md
+++ b/README.md
@@ -72,7 +72,14 @@ curl -L -o ~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf \
 
 Set ``LLAMA_MODEL_PATH`` to the downloaded file and ensure
 ``llama-cpp-python`` or ``ctransformers`` is installed. When offline mode is
-enabled the agents automatically use the local model for inference.
+enabled the agents automatically use the local model for inference. You can
+also provide the path directly when running ``simulate``:
+
+```bash
+python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \
+  --offline --llama-model-path ~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf
+```
+
 Set ``AGI_INSIGHT_OFFLINE=1`` in your `.env` to force this behaviour even when
 API keys are present.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import random
 import time
 from pathlib import Path
@@ -72,6 +73,7 @@ def main() -> None:
 @click.option("--seed", type=int, help="Random seed")
 @click.option("--offline", is_flag=True, help="Force offline mode")
 @click.option("--no-broadcast", is_flag=True, help="Disable blockchain broadcasting")
+@click.option("--llama-model-path", type=click.Path(), help="Path to local Llama model")
 @click.option("--pop-size", default=6, show_default=True, type=int, help="MATS population size")
 @click.option("--generations", default=3, show_default=True, type=int, help="Evolution steps")
 @click.option("--export", type=click.Choice(["json", "csv"]), help="Export results format")
@@ -88,10 +90,14 @@ def simulate(
     verbose: bool,
     start_orchestrator: bool,
     no_broadcast: bool,
+    llama_model_path: str | None,
 ) -> None:
     """Run the forecast simulation and start the orchestrator."""
     if seed is not None:
         random.seed(seed)
+
+    if llama_model_path is not None:
+        os.environ["LLAMA_MODEL_PATH"] = str(llama_model_path)
 
     settings = config.CFG
     if offline:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 from click.testing import CliRunner
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
@@ -70,10 +71,13 @@ def test_simulate_runs() -> None:
                     "--generations",
                     "1",
                     "--start-orchestrator",
+                    "--llama-model-path",
+                    "model.gguf",
                 ],
             )
-        assert res.exit_code == 0
+            assert res.exit_code == 0
         aio.run.assert_called_once()
+        assert os.environ.get("LLAMA_MODEL_PATH") == "model.gguf"
 
 
 def test_simulate_export_csv() -> None:

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 from click.testing import CliRunner
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
@@ -22,6 +23,25 @@ def test_simulate_without_flag_does_not_start() -> None:
             )
         assert res.exit_code == 0
         aio.run.assert_not_called()
+
+
+def test_simulate_sets_llama_path() -> None:
+    runner = CliRunner()
+    with patch.object(cli, "asyncio"):
+        with patch.object(cli.orchestrator, "Orchestrator"):
+            result = runner.invoke(
+                cli.main,
+                [
+                    "simulate",
+                    "--horizon",
+                    "1",
+                    "--offline",
+                    "--llama-model-path",
+                    "weights.bin",
+                ],
+            )
+    assert result.exit_code == 0
+    assert os.environ.get("LLAMA_MODEL_PATH") == "weights.bin"
 
 
 def test_show_results_table(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add `--llama-model-path` flag to the Insight CLI
- expose llama env var in `.env.sample`
- document how to pass a local model path
- test that the new flag sets `LLAMA_MODEL_PATH`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
