### PR TITLE
[alpha_factory] add bus TLS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ of a real general intelligence. Use at your own risk.
 - Release notes are maintained in [docs/CHANGELOG.md](docs/CHANGELOG.md).
 - A demo specific overview can be found in
   [alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md](alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md).
+- TLS setup for the agent bus is documented in
+  [alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md](alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md).
 
 ---
 ## Contributing
@@ -562,6 +564,10 @@ incoming requests. Clients must send `Authorization: Bearer <token>`. Use
 Avoid storing private keys directly in `.env`. Instead set
 `AGI_INSIGHT_SOLANA_WALLET_FILE` to a file containing your hex-encoded wallet
 key and keep that file readable only by the orchestrator.
+To enable secure gRPC transport set `AGI_INSIGHT_BUS_CERT`,
+`AGI_INSIGHT_BUS_KEY` and `AGI_INSIGHT_BUS_TOKEN`.
+See [bus_tls.md](alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md)
+for instructions and example volume mounts.
 
 #### Supported Environment Variables
 
@@ -574,6 +580,9 @@ key and keep that file readable only by the orchestrator.
 | `AGI_INSIGHT_OFFLINE` | `0` | Set to `1` to force local inference models. |
 | `AGI_INSIGHT_BUS_PORT` | `6006` | gRPC bus port used by the demo. |
 | `AGI_INSIGHT_LEDGER_PATH` | `./ledger/audit.db` | Path to the local audit ledger. |
+| `AGI_INSIGHT_BUS_CERT` | _(empty)_ | Path to the gRPC bus certificate. |
+| `AGI_INSIGHT_BUS_KEY` | _(empty)_ | Private key matching `AGI_INSIGHT_BUS_CERT`. |
+| `AGI_INSIGHT_BUS_TOKEN` | _(empty)_ | Shared secret for bus authentication. |
 
 ### Finance Demo Quick‑Start
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -1,0 +1,53 @@
+# Bus TLS Setup
+
+The Insight demo uses a gRPC message bus for communication between agents. When `AGI_INSIGHT_BUS_CERT` and `AGI_INSIGHT_BUS_KEY` are provided the bus requires TLS and authenticates requests with `AGI_INSIGHT_BUS_TOKEN`.
+
+## Generating a Self-Signed Certificate
+
+Use `openssl` to create a private key and certificate valid for one year:
+
+```bash
+mkdir -p certs
+openssl req -x509 -newkey rsa:4096 -nodes \
+  -keyout certs/bus.key \
+  -out certs/bus.crt \
+  -days 365 \
+  -subj "/CN=localhost"
+```
+
+Set the environment variables to the generated paths:
+
+```
+AGI_INSIGHT_BUS_CERT=/path/to/certs/bus.crt
+AGI_INSIGHT_BUS_KEY=/path/to/certs/bus.key
+AGI_INSIGHT_BUS_TOKEN=change_this_token
+```
+
+## Docker and Docker Compose
+
+Place `bus.crt` and `bus.key` under `./certs` next to `docker-compose.yml` and mount the directory:
+
+```yaml
+services:
+  orchestrator:
+    volumes:
+      - ./certs:/certs:ro
+```
+
+Inside the container reference the mounted files:
+
+```
+AGI_INSIGHT_BUS_CERT=/certs/bus.crt
+AGI_INSIGHT_BUS_KEY=/certs/bus.key
+AGI_INSIGHT_BUS_TOKEN=<token>
+```
+
+For a single container run use:
+
+```bash
+docker run -v $(pwd)/certs:/certs:ro \
+  -e AGI_INSIGHT_BUS_CERT=/certs/bus.crt \
+  -e AGI_INSIGHT_BUS_KEY=/certs/bus.key \
+  -e AGI_INSIGHT_BUS_TOKEN=<token> \
+  alpha-demo
+```


### PR DESCRIPTION
## Summary
- document TLS instructions for the demo bus
- reference the new doc from the README
- list bus env vars needed for secure mode

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
