### PR TITLE
[alpha_factory] clarify API token docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ for instructions and example volume mounts.
 | `AGI_INSIGHT_BUS_CERT` | _(empty)_ | Path to the gRPC bus certificate. |
 | `AGI_INSIGHT_BUS_KEY` | _(empty)_ | Private key matching `AGI_INSIGHT_BUS_CERT`. |
 | `AGI_INSIGHT_BUS_TOKEN` | _(empty)_ | Shared secret for bus authentication. |
+| `API_TOKEN` | `REPLACE_ME_TOKEN` | Bearer token required by the REST API. |
 
 ### Finance Demo Quick‑Start
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,8 +12,11 @@ starts and is gracefully shut down on exit:
 - `GET /results/{sim_id}` – fetch final forecast data.
 - `WS  /ws/progress` – stream progress logs while the simulation runs.
 
-All endpoints require a bearer token. Set `API_TOKEN` in `.env` and include
-`Authorization: Bearer <token>` with each request.
+### Authentication
+
+All requests must include an `Authorization: Bearer $API_TOKEN` header. Set
+`API_TOKEN` inside your `.env` file or pass `-e API_TOKEN=yourtoken` when
+launching the Docker image.
 
 Start the server with:
 


### PR DESCRIPTION
## Summary
- document required Authorization header in docs/API.md
- list `API_TOKEN` under Supported Environment Variables

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit` *(failed: command not found)*