### PR TITLE
[alpha_factory] add API token docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -331,6 +331,7 @@ For the REST and WebSocket endpoints see
 | `AGI_INSIGHT_SOLANA_WALLET` | Wallet private key (hex) | _unset_ |
 | `AGI_INSIGHT_SOLANA_WALLET_FILE` | Path to wallet key file | _unset_ |
 | `SIM_RESULTS_DIR` | Folder for simulation JSON results | `$ALPHA_DATA_DIR/simulations` |
+| `API_TOKEN` | Bearer token required by the REST API | `REPLACE_ME_TOKEN` |
 
 Create `.env` or pass via `docker -e`. Store wallet keys outside of `.env` and
 use `AGI_INSIGHT_SOLANA_WALLET_FILE` to reference the file containing the

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,11 +12,20 @@ starts and is gracefully shut down on exit:
 - `GET /results/{sim_id}` – fetch final forecast data.
 - `WS  /ws/progress` – stream progress logs while the simulation runs.
 
-### Authentication
+## Authentication
 
-All requests must include an `Authorization: Bearer $API_TOKEN` header. Set
-`API_TOKEN` inside your `.env` file or pass `-e API_TOKEN=yourtoken` when
-launching the Docker image.
+All requests must include an `Authorization: Bearer $API_TOKEN` header so the
+server can verify the caller. Define `API_TOKEN` in your `.env` file:
+
+```bash
+API_TOKEN=mysecret
+```
+
+or pass the variable when launching Docker:
+
+```bash
+docker run -e API_TOKEN=mysecret <image>
+```
 
 Start the server with:
 


### PR DESCRIPTION
## Summary
- document how to pass `API_TOKEN` to the server in docs/API.md
- list `API_TOKEN` in the Insight demo configuration table

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ⚠️ `pre-commit` not installed so hooks were not run