### PR TITLE
[alpha_factory] support multiobjective MATS

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/forecast.py
@@ -65,13 +65,23 @@ def thermodynamic_trigger(sector: Sector, capability: float) -> bool:
 def _innovation_gain(pop_size: int = 6, generations: int = 1) -> float:
     """Return a small gain from a short MATS run."""
 
-    def fn(genome: list[float]) -> tuple[float, float]:
+    def fn(genome: list[float]) -> tuple[float, float, float]:
         x, y = genome
-        return x**2, y**2
+        effectiveness = x**2
+        negative_evar = y**2
+        complexity = (x + y) ** 2
+        return effectiveness, negative_evar, complexity
 
-    pop = mats.run_evolution(fn, 2, population_size=pop_size, generations=generations, seed=42)
-    best = min(pop, key=lambda ind: sum(ind.fitness or (0.0, 0.0)))
-    return 0.1 / (1.0 + sum(best.fitness or (0.0, 0.0)))
+    pop = mats.run_evolution(
+        fn,
+        2,
+        population_size=pop_size,
+        generations=generations,
+        seed=42,
+    )
+    m = len(pop[0].fitness or ())
+    best = min(pop, key=lambda ind: sum(ind.fitness or (0.0,) * m))
+    return 0.1 / (1.0 + sum(best.fitness or (0.0,) * m))
 
 
 def forecast_disruptions(

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
@@ -17,7 +17,7 @@ from typing import Callable, List, Tuple
 @dataclass(slots=True)
 class Individual:
     genome: List[float]
-    fitness: Tuple[float, float] | None = None
+    fitness: Tuple[float, ...] | None = None
     crowd: float = 0.0
     rank: int = 0
 
@@ -25,7 +25,7 @@ class Individual:
 Population = List[Individual]
 
 
-def evaluate(pop: Population, fn: Callable[[List[float]], Tuple[float, float]]) -> None:
+def evaluate(pop: Population, fn: Callable[[List[float]], Tuple[float, ...]]) -> None:
     """Assign fitness scores using ``fn``."""
 
     for ind in pop:
@@ -41,7 +41,7 @@ def _crowding(pop: Population) -> None:
     for ind in pop:
         ind.crowd = 0.0
     for i in range(m):
-        pop.sort(key=lambda x: (x.fitness or (0.0, 0.0))[i])
+        pop.sort(key=lambda x: (x.fitness or (0.0,) * m)[i])
         first_fit = pop[0].fitness
         last_fit = pop[-1].fitness
         assert first_fit is not None and last_fit is not None
@@ -100,7 +100,7 @@ def _non_dominated_sort(pop: Population) -> List[Population]:
 
 def _evolve_step(
     pop: Population,
-    fn: Callable[[List[float]], Tuple[float, float]],
+    fn: Callable[[List[float]], Tuple[float, ...]],
     *,
     rng: random.Random,
     mutation_rate: float,
@@ -133,7 +133,7 @@ def _evolve_step(
 
 
 def run_evolution(
-    fn: Callable[[List[float]], Tuple[float, float]],
+    fn: Callable[[List[float]], Tuple[float, ...]],
     genome_length: int,
     *,
     population_size: int = 20,

--- a/tests/test_mats.py
+++ b/tests/test_mats.py
@@ -33,3 +33,13 @@ def test_run_evolution_different_seeds() -> None:
     pop2 = mats.run_evolution(fn, 2, population_size=3, generations=1, seed=2)
 
     assert [ind.genome for ind in pop1] != [ind.genome for ind in pop2]
+
+
+def test_run_evolution_three_objectives() -> None:
+    def fn(genome: list[float]) -> tuple[float, float, float]:
+        x, y = genome
+        return x**2, y**2, (x + y) ** 2
+
+    pop = mats.run_evolution(fn, 2, population_size=4, generations=2, seed=42)
+
+    assert all(len(ind.fitness or ()) == 3 for ind in pop)


### PR DESCRIPTION
## Summary
- allow `fitness` tuples of any length in MATS
- update crowding, non-dominated sort, and evolution utilities to use the provided objective count
- compute three-objective innovation gain in forecast
- test MATS with three-objective optimisation

## Testing
- `python check_env.py --auto-install`
- `pytest -q`