### PR TITLE
[alpha_factory] add curve parameter to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Example:
 
 ```bash
 python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \
-  --offline --llama-model-path "$LLAMA_MODEL_PATH"
+  --curve linear --offline --llama-model-path "$LLAMA_MODEL_PATH"
 ```
 
 Produces output similar to:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -149,6 +149,7 @@ if app is not None:
         horizon: int = 5
         pop_size: int = 6
         generations: int = 3
+        curve: str = "logistic"
 
     class ForecastPoint(BaseModel):
         """Single year forecast entry."""
@@ -177,7 +178,7 @@ if app is not None:
         traj: list[ForecastTrajectoryPoint] = []
         for year in range(1, cfg.horizon + 1):
             t = year / cfg.horizon
-            cap = forecast.capability_growth(t)
+            cap = forecast.capability_growth(t, cfg.curve)
             for sec in secs:
                 if not sec.disrupted:
                     sec.energy *= 1.0 + sec.growth

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ Once the server is running you can trigger a forecast using `curl`:
 curl -X POST http://localhost:8000/simulate \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"horizon": 5, "pop_size": 6, "generations": 3}'
+  -d '{"horizon": 5, "pop_size": 6, "generations": 3, "curve": "linear"}'
 ```
 
 Retrieve the results when the run finishes:
@@ -95,12 +95,14 @@ Start a new simulation. Send a JSON payload with the following fields:
 - `horizon` – forecast horizon in years
 - `pop_size` – number of individuals per generation
 - `generations` – number of evolutionary steps
+- `curve` – capability growth curve (`logistic`, `linear`, `exponential`)
 
 ```json
 {
   "horizon": 5,
   "pop_size": 6,
-  "generations": 3
+  "generations": 3,
+  "curve": "logistic"
 }
 ```
 

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -150,6 +150,7 @@ class SimRequest(BaseModel):
     horizon: int = 5
     pop_size: int = 6
     generations: int = 3
+    curve: str = "logistic"
 
 
 class ForecastPoint(BaseModel):
@@ -210,7 +211,7 @@ async def _background_run(sim_id: str, cfg: SimRequest) -> None:
     traj: list[ForecastTrajectoryPoint] = []
     for year in range(1, cfg.horizon + 1):
         t = year / cfg.horizon
-        cap = forecast.capability_growth(t)
+        cap = forecast.capability_growth(t, cfg.curve)
         for sec in secs:
             if not sec.disrupted:
                 sec.energy *= 1.0 + sec.growth

--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -1,0 +1,63 @@
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_simulate_curve_subprocess() -> None:
+    port = _free_port()
+    env = os.environ.copy()
+    cmd = [
+        sys.executable,
+        "-m",
+        "src.interface.api_server",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+    proc = subprocess.Popen(cmd, env=env)
+    url = f"http://127.0.0.1:{port}"
+    headers = {"Authorization": "Bearer test-token"}
+    try:
+        for _ in range(50):
+            try:
+                r = httpx.get(f"{url}/runs", headers=headers)
+                if r.status_code == 200:
+                    break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            proc.terminate()
+            raise AssertionError("server did not start")
+        r = httpx.post(
+            f"{url}/simulate",
+            json={"horizon": 1, "pop_size": 2, "generations": 1, "curve": "linear"},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        sim_id = r.json()["id"]
+        for _ in range(400):
+            r = httpx.get(f"{url}/results/{sim_id}", headers=headers)
+            if r.status_code == 200:
+                break
+            time.sleep(0.05)
+        assert r.status_code == 200
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)


### PR DESCRIPTION
## Summary
- expose `curve` parameter in SimRequest
- use custom curve in background forecast run
- document REST API curve parameter
- show `--curve` usage in README
- add regression test for posting with non-default curve

## Testing
- `python check_env.py --auto-install`
- `pytest -q`