### PR TITLE
[alpha_factory] Document pnpm web build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,15 @@ jobs:
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Build web client
+        run: |
+          make build_web
+          test -f src/interface/web_client/dist/index.html
       - name: Build image
         run: |
           docker build -t $DOCKER_IMAGE:ci \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build_web
+build_web:
+pnpm --dir src/interface/web_client install
+pnpm --dir src/interface/web_client run build
+

--- a/README.md
+++ b/README.md
@@ -730,15 +730,13 @@ cd src/interface/web_client
 npm install
 npm run dev       # http://localhost:5173
 # build production assets
-npm run build
-# or pnpm build
+pnpm build
 python -m http.server --directory dist 9000
 ```
 Alternatively run inside Docker:
 ```bash
 # build the web client first so `dist/` exists
-npm --prefix src/interface/web_client install
-npm --prefix src/interface/web_client run build
+make build_web
 docker compose build
 docker compose up
 ```

--- a/src/interface/web_client/README.md
+++ b/src/interface/web_client/README.md
@@ -6,13 +6,13 @@ This directory contains a small React interface built with [Vite](https://vitejs
 
 ```bash
 cd src/interface/web_client
-npm install
-npm run dev       # start the development server
-npm run build     # build production assets in `dist/`
+pnpm install
+pnpm dev        # start the development server
+pnpm build      # build production assets in `dist/`
 ```
 
-The app expects the FastAPI server on `http://localhost:8000`. After running `npm run build`, open `dist/index.html` or copy the `dist/` folder into your container image.
+The app expects the FastAPI server on `http://localhost:8000`. After running `pnpm build`, open `dist/index.html` or copy the `dist/` folder into your container image.
 
-When building the Docker image from the project root, ensure `npm --prefix src/interface/web_client run build` completes so that `src/interface/web_client/dist/` exists. The `infrastructure/Dockerfile` copies this directory automatically.
+When building the Docker image from the project root, ensure `pnpm --dir src/interface/web_client run build` completes so that `src/interface/web_client/dist/` exists. The `infrastructure/Dockerfile` copies this directory automatically.
 
 A basic smoke test simply runs `npm test`, which exits successfully if the project dependencies are installed.


### PR DESCRIPTION
## Summary
- document pnpm build requirement for Docker
- add `build_web` Makefile target
- have CI build the web client before Docker build

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ❌ `pre-commit` *(failed: command not found)*