### PR TITLE
[alpha_factory] add insight demo cli module

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI entry point for the α‑AGI Insight demo."""
+from .src.interface.cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_alpha_agi_insight_v1_main.py
+++ b/tests/test_alpha_agi_insight_v1_main.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestAlphaAgiInsightMainV1(unittest.TestCase):
+    """Verify the v1 demo package entry point."""
+
+    def test_cli_help(self) -> None:
+        result = subprocess.run(
+            [sys.executable, '-m', 'alpha_factory_v1.demos.alpha_agi_insight_v1', '--help'],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('Insight command line interface', result.stdout)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose insight demo v1 as a module so `python -m alpha_factory_v1.demos.alpha_agi_insight_v1` works
- test module entry point

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py tests/test_alpha_agi_insight_v1_main.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py tests/test_alpha_agi_insight_v1_main.py`
- `pytest -q`