### PR TITLE
[alpha_factory] log local LLM load failures

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
@@ -6,6 +6,7 @@ The :func:`chat` helper loads a model on demand using either ``llama-cpp`` or
 """
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Callable, cast
 
@@ -18,6 +19,8 @@ try:  # pragma: no cover - optional dependency
     from ctransformers import AutoModelForCausalLM
 except Exception:  # pragma: no cover - ctransformers optional
     AutoModelForCausalLM = None
+
+_log = logging.getLogger(__name__)
 
 _MODEL: Any | None = None
 _CALL: Callable[[str], str] | None = None
@@ -44,7 +47,8 @@ def _load_model() -> None:
 
             _CALL = _wrap(call_llama)
             return
-        except Exception:  # pragma: no cover - model load failure
+        except Exception as exc:  # pragma: no cover - model load failure
+            _log.warning("Failed to load Llama model: %s", exc)
             _MODEL = None
     if AutoModelForCausalLM is not None:
         try:
@@ -55,7 +59,8 @@ def _load_model() -> None:
 
             _CALL = _wrap(call_ctrans)
             return
-        except Exception:  # pragma: no cover - model load failure
+        except Exception as exc:  # pragma: no cover - model load failure
+            _log.warning("Failed to load ctransformers model: %s", exc)
             _MODEL = None
 
     def call_stub(prompt: str) -> str:

--- a/tests/test_local_llm_logging.py
+++ b/tests/test_local_llm_logging.py
@@ -1,0 +1,16 @@
+import logging
+from unittest import mock
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import local_llm
+
+
+def test_load_model_warning(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(local_llm, "_MODEL", None)
+    monkeypatch.setattr(local_llm, "_CALL", None)
+    monkeypatch.setattr(local_llm, "Llama", mock.Mock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(local_llm, "AutoModelForCausalLM", None)
+
+    local_llm._load_model()
+
+    assert any("boom" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- warn when local model initialization fails and include the exception message
- test that failed load emits a warning

## Testing
- `python check_env.py --auto-install`
- `pytest -q`

`pre-commit` couldn't be run because it wasn't installed in this environment.