### PR TITLE
[alpha_factory] add bus start/stop info logs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -82,6 +82,11 @@ class A2ABus:
         return b"ok"
 
     async def start(self) -> None:
+        logger.info(
+            "Starting A2ABus (port=%s broker=%s)",
+            self.settings.bus_port,
+            self.settings.broker_url or "disabled",
+        )
         if self.settings.broker_url and AIOKafkaProducer:
             self._producer = AIOKafkaProducer(bootstrap_servers=self.settings.broker_url)
             await self._producer.start()
@@ -106,6 +111,11 @@ class A2ABus:
         self._server = server
 
     async def stop(self) -> None:
+        logger.info(
+            "Stopping A2ABus (port=%s broker=%s)",
+            self.settings.bus_port,
+            self.settings.broker_url or "disabled",
+        )
         if self._server:
             await self._server.stop(0)
             self._server = None

--- a/tests/test_bus_logging.py
+++ b/tests/test_bus_logging.py
@@ -1,0 +1,20 @@
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+def test_bus_logs_start_stop(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    cfg = config.Settings(bus_port=1234, broker_url="kafka:9092")
+    bus = messaging.A2ABus(cfg)
+    with mock.patch.object(messaging, "AIOKafkaProducer", None), \
+         mock.patch.object(messaging, "grpc", None):
+        asyncio.run(bus.start())
+        asyncio.run(bus.stop())
+    messages = [r.message for r in caplog.records]
+    assert any("Starting A2ABus" in m and "1234" in m and "kafka:9092" in m for m in messages)
+    assert any("Stopping A2ABus" in m for m in messages)


### PR DESCRIPTION
## Summary
- log when `A2ABus.start()` and `A2ABus.stop()` are invoked
- add regression test for bus start/stop logging

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py tests/test_bus_logging.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py tests/test_bus_logging.py`
- `pytest -q`