### PR TITLE
[alpha_factory] add bus startup logging

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -30,6 +30,7 @@ except ModuleNotFoundError:  # pragma: no cover - broker optional
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass(slots=True)
 class Envelope:
     sender: str
@@ -83,7 +84,7 @@ class A2ABus:
 
     async def start(self) -> None:
         logger.info(
-            "Starting A2ABus (port=%s broker=%s)",
+            "A2ABus.start() called: port=%s broker=%s",
             self.settings.bus_port,
             self.settings.broker_url or "disabled",
         )
@@ -112,7 +113,7 @@ class A2ABus:
 
     async def stop(self) -> None:
         logger.info(
-            "Stopping A2ABus (port=%s broker=%s)",
+            "A2ABus.stop() called: port=%s broker=%s",
             self.settings.bus_port,
             self.settings.broker_url or "disabled",
         )

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+from typing import Any
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
 
@@ -26,3 +28,19 @@ def test_publish_to_async_subscriber() -> None:
     asyncio.run(run())
     assert len(received) == 1
     assert received[0].payload["v"] == 42
+
+
+def test_start_stop_logging(caplog: Any) -> None:
+    """Bus start and stop should emit informative log messages."""
+    bus = messaging.A2ABus(config.Settings(bus_port=0, broker_url="kafka:9092"))
+
+    async def run() -> None:
+        await bus.start()
+        await bus.stop()
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(run())
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("A2ABus.start()" in m for m in messages)
+    assert any("A2ABus.stop()" in m for m in messages)


### PR DESCRIPTION
## Summary
- log when A2ABus starts and stops with port and broker info
- test that these log messages appear

## Testing
- `python check_env.py --auto-install`
- `black alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py tests/test_messaging.py`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py tests/test_messaging.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py tests/test_messaging.py`
- `PYTHONPATH=$(pwd) pytest -q tests/test_messaging.py`