### PR TITLE
[alpha_factory] add env template for insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/.env.example
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/.env.example
@@ -1,0 +1,34 @@
+#######################################################################
+#  \u03b1-AGI Insight Demo – Environment Settings
+#  Copy to `.env` and tweak values as needed. All variables have defaults.
+#######################################################################
+
+# Optional OpenAI key (leave blank for offline mode)
+OPENAI_API_KEY=
+
+# Force offline mode (0/1)
+AGI_INSIGHT_OFFLINE=0
+
+# gRPC bus port
+AGI_INSIGHT_BUS_PORT=6006
+
+# Ledger database path
+AGI_INSIGHT_LEDGER_PATH=./ledger/audit.db
+
+# Broadcast events to blockchain (0/1)
+AGI_INSIGHT_BROADCAST=1
+
+# Solana RPC endpoint
+AGI_INSIGHT_SOLANA_URL=https://api.testnet.solana.com
+
+# Hex-encoded private key (use AGI_INSIGHT_SOLANA_WALLET_FILE instead)
+AGI_INSIGHT_SOLANA_WALLET=
+
+# Path to file containing the wallet key
+AGI_INSIGHT_SOLANA_WALLET_FILE=/path/to/wallet.key
+
+# Folder for simulation results
+SIM_RESULTS_DIR=$ALPHA_DATA_DIR/simulations
+
+# Bearer token for the API server
+API_TOKEN=REPLACE_ME_TOKEN

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -333,7 +333,7 @@ For the REST and WebSocket endpoints see
 | `SIM_RESULTS_DIR` | Folder for simulation JSON results | `$ALPHA_DATA_DIR/simulations` |
 | `API_TOKEN` | Bearer token required by the REST API | `REPLACE_ME_TOKEN` |
 
-Create `.env` or pass via `docker -e`. Store wallet keys outside of `.env` and
+Copy `.env.example` to `.env` (or pass via `docker -e`). Store wallet keys outside of `.env` and
 use `AGI_INSIGHT_SOLANA_WALLET_FILE` to reference the file containing the
 hex-encoded private key.
 The API server stores simulation results as JSON files under `SIM_RESULTS_DIR`.


### PR DESCRIPTION
## Summary
- add `.env.example` for Alpha AGI Insight demo
- tell users to copy the template before running

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_bus_logging.py::test_bus_logs_start_stop)*