### PR TITLE
[alpha_factory] add TLS cert helper script

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -4,7 +4,9 @@ The Insight demo uses a gRPC message bus for communication between agents. When 
 
 ## Generating a Self-Signed Certificate
 
-Use `openssl` to create a private key and certificate valid for one year:
+Use `openssl` to create a private key and certificate valid for one year. Run
+`infrastructure/gen_bus_certs.sh` to execute these commands automatically and
+print the environment variables, or run them manually:
 
 ```bash
 mkdir -p certs

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/gen_bus_certs.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/gen_bus_certs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# gen_bus_certs.sh -- generate a self-signed certificate for the Insight bus
+set -euo pipefail
+
+mkdir -p certs
+openssl req -x509 -newkey rsa:4096 -nodes \
+  -keyout certs/bus.key \
+  -out certs/bus.crt \
+  -days 365 \
+  -subj "/CN=localhost"
+
+printf 'AGI_INSIGHT_BUS_CERT=%s/certs/bus.crt\n' "$(pwd)"
+printf 'AGI_INSIGHT_BUS_KEY=%s/certs/bus.key\n' "$(pwd)"
+printf 'AGI_INSIGHT_BUS_TOKEN=change_this_token\n'


### PR DESCRIPTION
## Summary
- add `gen_bus_certs.sh` for creating demo bus certificates
- document the script in `bus_tls.md`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_bus_logging.py::test_bus_logs_start_stop)*
- `pre-commit` *(failed to run: pre-commit not installed and network access blocked)*