### PR TITLE
[alpha_factory] allow insecure bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,8 @@ Avoid storing private keys directly in `.env`. Instead set
 `AGI_INSIGHT_SOLANA_WALLET_FILE` to a file containing your hex-encoded wallet
 key and keep that file readable only by the orchestrator.
 To enable secure gRPC transport set `AGI_INSIGHT_BUS_CERT`,
-`AGI_INSIGHT_BUS_KEY` and `AGI_INSIGHT_BUS_TOKEN`.
+`AGI_INSIGHT_BUS_KEY` and `AGI_INSIGHT_BUS_TOKEN`. If these values are
+omitted and `AGI_INSIGHT_ALLOW_INSECURE=1`, the bus starts without TLS.
 See [bus_tls.md](alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md)
 for instructions and example volume mounts.
 
@@ -617,6 +618,7 @@ for instructions and example volume mounts.
 | `AGI_INSIGHT_BUS_CERT` | _(empty)_ | Path to the gRPC bus certificate. |
 | `AGI_INSIGHT_BUS_KEY` | _(empty)_ | Private key matching `AGI_INSIGHT_BUS_CERT`. |
 | `AGI_INSIGHT_BUS_TOKEN` | _(empty)_ | Shared secret for bus authentication. |
+| `AGI_INSIGHT_ALLOW_INSECURE` | `0` | Set to `1` to run the bus without TLS when no certificate is provided. |
 | `API_TOKEN` | `REPLACE_ME_TOKEN` | Bearer token required by the REST API. |
 
 The values above mirror `.env.sample`. When running the stack with Docker

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -68,6 +68,7 @@ class Settings:
     bus_token: str | None = os.getenv("AGI_INSIGHT_BUS_TOKEN")
     bus_cert: str | None = os.getenv("AGI_INSIGHT_BUS_CERT")
     bus_key: str | None = os.getenv("AGI_INSIGHT_BUS_KEY")
+    allow_insecure: bool = os.getenv("AGI_INSIGHT_ALLOW_INSECURE", "0") == "1"
     broadcast: bool = os.getenv("AGI_INSIGHT_BROADCAST", "1") == "1"
     solana_rpc_url: str = os.getenv("AGI_INSIGHT_SOLANA_URL", "https://api.testnet.solana.com")
     solana_wallet: str | None = os.getenv("AGI_INSIGHT_SOLANA_WALLET")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -94,8 +94,6 @@ class A2ABus:
 
         if not self.settings.bus_port or grpc is None:
             return
-        if not (self.settings.bus_cert and self.settings.bus_key):
-            raise RuntimeError("AGI_INSIGHT_BUS_CERT and AGI_INSIGHT_BUS_KEY are required")
         server = grpc.aio.server()
         method = grpc.unary_unary_rpc_method_handler(
             self._handle_rpc,
@@ -104,10 +102,15 @@ class A2ABus:
         )
         service = grpc.method_handlers_generic_handler("bus.Bus", {"Send": method})
         server.add_generic_rpc_handlers((service,))
-        key = Path(self.settings.bus_key).read_bytes()
-        crt = Path(self.settings.bus_cert).read_bytes()
-        creds = grpc.ssl_server_credentials(((key, crt),))
-        server.add_secure_port(f"[::]:{self.settings.bus_port}", creds)
+        if self.settings.bus_cert and self.settings.bus_key:
+            key = Path(self.settings.bus_key).read_bytes()
+            crt = Path(self.settings.bus_cert).read_bytes()
+            creds = grpc.ssl_server_credentials(((key, crt),))
+            server.add_secure_port(f"[::]:{self.settings.bus_port}", creds)
+        elif self.settings.allow_insecure:
+            server.add_insecure_port(f"[::]:{self.settings.bus_port}")
+        else:
+            raise RuntimeError("AGI_INSIGHT_BUS_CERT and AGI_INSIGHT_BUS_KEY are required")
         await server.start()
         self._server = server
 


### PR DESCRIPTION
## Summary
- allow insecure gRPC bus when AGI_INSIGHT_ALLOW_INSECURE=1
- document AGI_INSIGHT_ALLOW_INSECURE in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_bus_logging.py::test_bus_logs_start_stop)*