### PR TITLE
[alpha_factory] add ledger logging tests

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,47 @@
+import asyncio
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from unittest import mock
+import pytest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging as insight_logging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
+
+
+def test_compute_merkle_root(tmp_path: Path) -> None:
+    ledger = Ledger(str(tmp_path / "l.db"), broadcast=False)
+    envs = [
+        messaging.Envelope("a", "b", {"v": 1}, 0.0),
+        messaging.Envelope("b", "c", {"v": 2}, 1.0),
+        messaging.Envelope("c", "d", {"v": 3}, 2.0),
+    ]
+    for env in envs:
+        ledger.log(env)
+    computed = ledger.compute_merkle_root()
+    hashes = []
+    for env in envs:
+        data = json.dumps(asdict(env), sort_keys=True).encode()
+        hashes.append(insight_logging.blake3(data).hexdigest())  # type: ignore[attr-defined]
+    manual = insight_logging._merkle_root(hashes)
+    assert computed == manual
+
+
+def test_broadcast_merkle_root_logs_root_when_disabled(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    ledger = Ledger(str(tmp_path / "l.db"), broadcast=False)
+    env = messaging.Envelope("a", "b", {"v": 1}, 0.0)
+    ledger.log(env)
+    root = ledger.compute_merkle_root()
+
+    caplog.set_level(logging.INFO)
+
+    dummy = mock.Mock(side_effect=AssertionError("AsyncClient should not be used"))
+    with mock.patch.object(insight_logging, "AsyncClient", dummy):
+        asyncio.run(ledger.broadcast_merkle_root())
+
+    assert not dummy.called
+    assert any(f"Merkle root {root}" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- test Ledger.compute_merkle_root with manual root calculation
- ensure broadcast_merkle_root logs Merkle root when broadcasting disabled

## Testing
- `ruff check tests/test_logging.py`
- `mypy --config-file mypy.ini tests/test_logging.py`
- `pytest -q tests/test_logging.py`
- `pytest -q` *(fails: tests/test_bus_logging.py::test_bus_logs_start_stop)*