### PR TITLE
[alpha_factory] add web v1 build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,8 @@ build_web:
 pnpm --dir src/interface/web_client install
 pnpm --dir src/interface/web_client run build
 
+.PHONY: build_web_v1
+build_web_v1:
+pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client install
+pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build
+

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -290,6 +290,7 @@ pnpm install
 pnpm dev            # http://localhost:5173
 # build production assets
 pnpm build          # outputs to src/interface/web_client/dist/
+# or run `make build_web_v1` from the repo root
 # or use `npm install && npm run build`
 ```
 


### PR DESCRIPTION
## Summary
- extend Makefile with `build_web_v1` for the v1 web client
- document usage in the α‑AGI Insight demo README

## Testing
- `python3 check_env.py --auto-install` *(fails: missing packages)*
- `pytest -q` *(fails: command not found)*