### PR TITLE
[alpha_factory] update env sample instructions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -334,7 +334,7 @@ For the REST and WebSocket endpoints see
 | `SIM_RESULTS_DIR` | Folder for simulation JSON results | `$ALPHA_DATA_DIR/simulations` |
 | `API_TOKEN` | Bearer token required by the REST API | `REPLACE_ME_TOKEN` |
 
-Copy `.env.example` to `.env` (or pass via `docker -e`). Store wallet keys outside of `.env` and
+Before running the demo, copy `.env.sample` to `.env` (or pass variables via `docker -e`). Store wallet keys outside of `.env` and
 use `AGI_INSIGHT_SOLANA_WALLET_FILE` to reference the file containing the
 hex-encoded private key.
 The API server stores simulation results as JSON files under `SIM_RESULTS_DIR`.


### PR DESCRIPTION
## Summary
- fix README for insight demo to reference `.env.sample`
- clarify copying the env file before running the demo

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_bus_logging.py::test_bus_logs_start_stop)*
- `pre-commit` *(failed to run: pre-commit not installed and no internet access)*