### PR TITLE
[alpha_factory] add insight demo env template

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/.env.sample
@@ -1,20 +1,17 @@
 #======================================================================
 #  α‑AGI Insight v1 — environment template
-#  Copy to `.env` and adjust values for your deployment.
+#  Copy to `.env` in this directory before running docker compose.
 #  Never commit real secrets to version control.
 #======================================================================
 
 # ─── Core settings ──────────────────────────────────────────────────
-OPENAI_API_KEY=                 # OpenAI API key for hosted models
-AGI_INSIGHT_OFFLINE=0           # set to 1 to run fully offline
-AGI_INSIGHT_BUS_PORT=6006       # gRPC event bus port
-AGI_INSIGHT_LEDGER_PATH=./ledger/audit.db  # path to audit ledger
-AGI_INSIGHT_BROADCAST=1         # 1 to broadcast events to the UI
-AGI_INSIGHT_SOLANA_URL=https://api.testnet.solana.com  # Solana RPC endpoint
-AGI_INSIGHT_SOLANA_WALLET=      # base58 wallet address
-AGI_INSIGHT_SOLANA_WALLET_FILE= # file containing wallet keypair
-
-# ─── API server ─────────────────────────────────────────────────────
-API_TOKEN=REPLACE_ME_TOKEN      # bearer token for the REST API
-API_RATE_LIMIT=60               # requests per minute per client
-SIM_RESULTS_DIR=                # folder for simulation results (defaults to $ALPHA_DATA_DIR/simulations)
+OPENAI_API_KEY=
+AGI_INSIGHT_OFFLINE=0
+AGI_INSIGHT_BUS_PORT=6006
+AGI_INSIGHT_LEDGER_PATH=./ledger/audit.db
+AGI_INSIGHT_BROADCAST=1
+AGI_INSIGHT_SOLANA_URL=https://api.testnet.solana.com
+AGI_INSIGHT_SOLANA_WALLET=
+AGI_INSIGHT_SOLANA_WALLET_FILE=/path/to/wallet.key
+SIM_RESULTS_DIR=$ALPHA_DATA_DIR/simulations
+API_TOKEN=REPLACE_ME_TOKEN


### PR DESCRIPTION
## Summary
- provide `.env.sample` for the alpha_agi_insight_v1 demo

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_bus_logging.py::test_bus_logs_start_stop)*