### PR TITLE
[alpha_factory] Add sandbox execution for CodeGenAgent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -8,6 +8,14 @@ to generate the snippet; otherwise a stub is returned via :meth:`handle`.
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+
 from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
@@ -32,4 +40,71 @@ class CodeGenAgent(BaseAgent):
                 code = await self.oai_ctx.run(prompt=str(analysis))
             except Exception:
                 pass
+        self.execute_in_sandbox(code)
         await self.emit("safety", {"code": code})
+
+    def execute_in_sandbox(self, code: str) -> tuple[str, str]:
+        """Run ``code`` inside a subprocess with resource limits."""
+
+        def _apply_limits() -> None:  # pragma: no cover - platform dependent
+            try:
+                import resource
+
+                resource.setrlimit(resource.RLIMIT_CPU, (2, 2))
+                mem = 128 * 1024 * 1024
+                resource.setrlimit(resource.RLIMIT_AS, (mem, mem))
+            except Exception:
+                pass
+
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+            fh.write(code)
+            code_path = fh.name
+
+        helper = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+        helper.write(
+            "import json,sys,contextlib,io,textwrap,resource\n"
+            "code=open(sys.argv[1]).read()\n"
+            "try:\n"
+            "    resource.setrlimit(resource.RLIMIT_CPU,(2,2))\n"
+            "    resource.setrlimit(resource.RLIMIT_AS,(256*1024*1024,256*1024*1024))\n"
+            "except Exception:\n"
+            "    pass\n"
+            "wrapped='def snippet():\\n'+textwrap.indent(code,'    ')\n"
+            "env={'__builtins__':{'print':print,'range':range,'len':len}}\n"
+            "loc={}\n"
+            "out,err=io.StringIO(),io.StringIO()\n"
+            "with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):\n"
+            "    try:\n"
+            "        exec(compile(wrapped,'<agent>','exec'),env,loc)\n"
+            "        loc['snippet']()\n"
+            "    except Exception as e:\n"
+            "        err.write(type(e).__name__)\n"
+            "print(json.dumps({'stdout':out.getvalue(),'stderr':err.getvalue()}))\n"
+        )
+        helper.flush()
+        helper_path = helper.name
+        helper.close()
+
+        try:
+            proc = subprocess.run(
+                [sys.executable, helper_path, code_path],
+                text=True,
+                capture_output=True,
+                timeout=3,
+                preexec_fn=_apply_limits if os.name == "posix" else None,
+            )
+            try:
+                data = json.loads(proc.stdout or "{}")
+                out = data.get("stdout", "")
+                err = data.get("stderr", "")
+            except json.JSONDecodeError:
+                out, err = proc.stdout, proc.stderr
+        except Exception as exc:  # pragma: no cover - runtime errors
+            out, err = "", str(exc)
+        finally:
+            os.unlink(code_path)
+            os.unlink(helper_path)
+
+        env = messaging.Envelope(self.name, "exec", {"stdout": out, "stderr": err}, time.time())
+        self.ledger.log(env)
+        return out, err


### PR DESCRIPTION
## Summary
- sandbox codegen_agent execution using limited subprocess
- record stdout/stderr in ledger and test sandbox failure

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py tests/test_agents.py`
- `pytest tests/test_agents.py::test_codegen_agent_sandbox_blocks_import -vv`
- `pytest -q tests/test_agents.py`