### PR TITLE
[alpha_factory] Add orchestrator CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 #   pip install -e .
 #   alpha-factory --list-agents
 #   alpha-asi-demo --demo   # launch the α‑ASI world‑model UI
+#   alpha-agi-insight-v1 orchestrator   # run the Insight orchestrator
 #
 # Or install directly from GitHub for a quick test:
 #   pip install git+https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -244,6 +244,19 @@ def agents_status(watch: bool) -> None:
         pass
 
 
+@main.command(name="orchestrator")
+@click.option("--verbose", is_flag=True, help="Verbose output")
+def run_orchestrator(verbose: bool) -> None:
+    """Run the orchestrator until interrupted."""
+    orch = orchestrator.Orchestrator()
+    if verbose and console is not None:
+        console.log("Starting orchestrator … press Ctrl+C to stop")
+    try:
+        asyncio.run(orch.run_forever())
+    except KeyboardInterrupt:  # pragma: no cover - interactive
+        pass
+
+
 @main.command()
 def replay() -> None:
     """Replay ledger events with a short delay.

--- a/tests/test_bus_logging.py
+++ b/tests/test_bus_logging.py
@@ -16,5 +16,5 @@ def test_bus_logs_start_stop(caplog: pytest.LogCaptureFixture) -> None:
         asyncio.run(bus.start())
         asyncio.run(bus.stop())
     messages = [r.message for r in caplog.records]
-    assert any("Starting A2ABus" in m and "1234" in m and "kafka:9092" in m for m in messages)
-    assert any("Stopping A2ABus" in m for m in messages)
+    assert any("A2ABus.start()" in m and "1234" in m and "kafka:9092" in m for m in messages)
+    assert any("A2ABus.stop()" in m for m in messages)

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -70,3 +70,12 @@ def test_agents_status_lists_all_agents(tmp_path) -> None:
 
 def test_plain_table_handles_no_rows() -> None:
     assert cli._plain_table(["h1", "h2"], []) == "h1 | h2"
+
+
+def test_orchestrator_command_runs() -> None:
+    runner = CliRunner()
+    with patch.object(cli, "asyncio") as aio:
+        with patch.object(cli.orchestrator, "Orchestrator"):
+            res = runner.invoke(cli.main, ["orchestrator"])
+            assert res.exit_code == 0
+        aio.run.assert_called_once()


### PR DESCRIPTION
## Summary
- add `orchestrator` subcommand to the insight CLI
- document the new command in the README
- include orchestrator CLI test
- fix bus logging test for current messages

## Testing
- `python check_env.py --auto-install`
- `pytest -q`