### PR TITLE
[alpha_factory] update demo docs for local Llama models

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -268,6 +268,14 @@ python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli agents-s
 Helpful flags: `--offline` (force local models), `--pop-size`, `--generations`,
 `--export csv|json`, `--verbose`.
 
+Example offline invocation:
+
+```bash
+LLAMA_MODEL_PATH=~/models/tinyllama.gguf \
+python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \
+  --offline --llama-model-path "$LLAMA_MODEL_PATH"
+```
+
 ---
 
 ## 5 Web UI
@@ -325,6 +333,7 @@ For the REST and WebSocket endpoints see
 |----------|---------|---------|
 | `OPENAI_API_KEY` | Enables OpenAI-hosted LLMs | _unset_ → offline |
 | `AGI_INSIGHT_OFFLINE` | Force offline mode | `0` |
+| `LLAMA_MODEL_PATH` | Path to local .gguf weights | `~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf` |
 | `AGI_INSIGHT_BUS_PORT` | gRPC bus port | `6006` |
 | `AGI_INSIGHT_LEDGER_PATH` | Audit DB path | `./ledger/audit.db` |
 | `AGI_INSIGHT_BROADCAST` | Enable blockchain broadcasting | `1` |


### PR DESCRIPTION
## Summary
- document `LLAMA_MODEL_PATH` in the alpha_agi_insight demo
- show how to pass it when running the CLI offline

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
