### PR TITLE
[alpha_factory] expose latest simulation data

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -322,8 +322,15 @@ The React dashboard streams year-by-year events via WebSocket and renders:
 * **MATS Pareto front** evolution,
 * real-time **agent logs**.
 
-For the REST and WebSocket endpoints see
-[docs/API.md](docs/API.md).
+Typical REST endpoints:
+
+- `POST /simulate` – launch a new run.
+- `GET /results` – latest completed run.
+- `GET /results/{id}` – specific run data.
+- `GET /population/{id}` – MATS population only.
+- `WS  /ws/progress` – live progress updates.
+
+For details see [docs/API.md](docs/API.md).
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,12 +4,14 @@ This page documents the REST endpoints provided by the demo API server and the a
 
 ## REST endpoints
 
-The API is implemented with FastAPI in `src/interface/api_server.py`. Three
-routes are available. The orchestrator boots in the background when the server
-starts and is gracefully shut down on exit:
+The API is implemented with FastAPI in `src/interface/api_server.py`. The
+orchestrator boots in the background when the server starts and is gracefully
+shut down on exit. Available endpoints are:
 
 - `POST /simulate` – start a new simulation.
+- `GET /results` – most recent simulation data.
 - `GET /results/{sim_id}` – fetch final forecast data.
+- `GET /population/{sim_id}` – retrieve only the population list.
 - `WS  /ws/progress` – stream progress logs while the simulation runs.
 
 ## Authentication
@@ -110,6 +112,19 @@ The response contains the generated simulation identifier:
 
 ```json
 {"id": "<sim_id>"}
+```
+
+**GET `/results`**
+
+Return the most recent simulation results. The payload matches
+``GET /results/{sim_id}``.
+
+```json
+{
+  "id": "<sim_id>",
+  "forecast": [{"year": 1, "capability": 0.1}],
+  "population": [{"effectiveness": 0.5, "risk": 0.2, "complexity": 0.3, "rank": 0}]
+}
 ```
 
 **GET `/results/{sim_id}`**

--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -60,6 +60,10 @@ def test_simulate_curve_subprocess() -> None:
             time.sleep(0.05)
         assert r.status_code == 200
 
+        r_latest = httpx.get(f"{url}/results", headers=headers)
+        assert r_latest.status_code == 200
+        assert r_latest.json()["id"] == sim_id
+
         r_pop = httpx.get(f"{url}/population/{sim_id}", headers=headers)
         assert r_pop.status_code == 200
         pop = r_pop.json()


### PR DESCRIPTION
## Summary
- extend API server `ResultsResponse` to optionally include `population`
- keep the final MATS population and store the latest run
- expose new `/results` and `/population/{id}` routes
- update React docs and README with new endpoints
- verify endpoints with updated subprocess test

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
