### PR TITLE
[alpha_factory] add configurable API base for web client

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -21,6 +21,8 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 USER afuser
 
 ENV PYTHONUNBUFFERED=1
+ARG VITE_API_BASE_URL=/
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 EXPOSE 8000 8501 6006
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["web"]

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       RUN_MODE: web                           # start the Streamlit dashboard
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}     # hosted model credential
       AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0} # set 1 for local models
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-/}
     ports:
       - "8501:8501"                           # host:container dashboard port
     depends_on:

--- a/src/interface/web_client/README.md
+++ b/src/interface/web_client/README.md
@@ -11,8 +11,26 @@ pnpm dev        # start the development server
 pnpm build      # build production assets in `dist/`
 ```
 
-The app expects the FastAPI server on `http://localhost:8000`. After running `pnpm build`, open `dist/index.html` or copy the `dist/` folder into your container image.
+Set `VITE_API_BASE_URL` to change the API path prefix at build time:
+
+```bash
+# prepend '/api' to all requests
+VITE_API_BASE_URL=/api pnpm build
+```
+
+The app expects the FastAPI server on `http://localhost:8000` by default. After running `pnpm build`, open `dist/index.html` or copy the `dist/` folder into your container image.
 
 When building the Docker image from the project root, ensure `pnpm --dir src/interface/web_client run build` completes so that `src/interface/web_client/dist/` exists. The `infrastructure/Dockerfile` copies this directory automatically.
 
 A basic smoke test simply runs `npm test`, which exits successfully if the project dependencies are installed.
+
+## Usage with Docker Compose
+
+Set the variable when launching containers:
+
+```yaml
+services:
+  web:
+    environment:
+      VITE_API_BASE_URL: /api
+```

--- a/src/interface/web_client/src/App.tsx
+++ b/src/interface/web_client/src/App.tsx
@@ -21,11 +21,12 @@ interface ResultsResponse {
 export default function App() {
   const [data, setData] = useState<ForecastPoint[]>([]);
   const [population, setPopulation] = useState<PopulationMember[]>([]);
+  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch('/results');
+        const res = await fetch(`${API_BASE}/results`);
         if (res.ok) {
           const body: ResultsResponse = await res.json();
           setData(body.forecast);

--- a/src/interface/web_client/vite.config.ts
+++ b/src/interface/web_client/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   root: '.',
+  envPrefix: 'VITE_',
   build: {
     outDir: 'dist'
   }


### PR DESCRIPTION
## Summary
- support `VITE_API_BASE_URL` in the React web client
- expose the variable through Vite config
- document how to set `VITE_API_BASE_URL`
- pass the variable via docker-compose
- store the value in the demo Docker image

## Testing
- `python check_env.py --auto-install`
- `pytest -q`