### PR TITLE
[alpha_factory] persist MemoryAgent entries

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -11,14 +11,26 @@ from __future__ import annotations
 from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
+import json
+from pathlib import Path
 
 
 class MemoryAgent(BaseAgent):
     """Persist artefacts produced by other agents."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger", store_path: str | None = None) -> None:
         super().__init__("memory", bus, ledger)
         self.records: list[dict[str, object]] = []
+        self._store = Path(store_path) if store_path else None
+        if self._store and self._store.exists():
+            for line in self._store.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    self.records.append(json.loads(line))
+                except Exception:  # noqa: BLE001 - ignore bad records
+                    pass
 
     async def run_cycle(self) -> None:
         """Periodically report memory size."""
@@ -27,3 +39,6 @@ class MemoryAgent(BaseAgent):
     async def handle(self, env: messaging.Envelope) -> None:
         """Store payload for later retrieval."""
         self.records.append(env.payload)
+        if self._store:
+            with self._store.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(env.payload) + "\n")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -92,7 +92,7 @@ class Orchestrator:
             market_agent.MarketAgent(self.bus, self.ledger),
             codegen_agent.CodeGenAgent(self.bus, self.ledger),
             safety_agent.SafetyGuardianAgent(self.bus, self.ledger),
-            memory_agent.MemoryAgent(self.bus, self.ledger),
+            memory_agent.MemoryAgent(self.bus, self.ledger, self.settings.memory_path),
         ]
         return agents
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -64,6 +64,7 @@ class Settings:
     offline: bool = os.getenv("AGI_INSIGHT_OFFLINE", "0") == "1"
     bus_port: int = _env_int("AGI_INSIGHT_BUS_PORT", 6006)
     ledger_path: str = os.getenv("AGI_INSIGHT_LEDGER_PATH", "./ledger/audit.db")
+    memory_path: str | None = os.getenv("AGI_INSIGHT_MEMORY_PATH")
     broker_url: str | None = os.getenv("AGI_INSIGHT_BROKER_URL")
     bus_token: str | None = os.getenv("AGI_INSIGHT_BUS_TOKEN")
     bus_cert: str | None = os.getenv("AGI_INSIGHT_BUS_CERT")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,21 @@ def test_show_results_export_json(tmp_path) -> None:
             led = led_cls.return_value
             led.tail.return_value = [{"ts": 1.0, "sender": "a", "recipient": "b", "payload": {"x": 1}}]
             res = CliRunner().invoke(cli.main, ["show-results", "--export", "json"])
-            assert res.output.startswith("[")
+        assert res.output.startswith("[")
+
+
+def test_show_memory_missing(tmp_path) -> None:
+    with patch.object(cli.config.CFG, "memory_path", str(tmp_path / "mem.log")):
+        res = CliRunner().invoke(cli.main, ["show-memory"])
+        assert "No memory" in res.output
+
+
+def test_show_memory_export_json(tmp_path) -> None:
+    mem = tmp_path / "mem.log"
+    mem.write_text('{"x":1}\n', encoding="utf-8")
+    with patch.object(cli.config.CFG, "memory_path", str(mem)):
+        res = CliRunner().invoke(cli.main, ["show-memory", "--export", "json"])
+        assert res.output.startswith("[")
 
 
 def test_replay_missing(tmp_path) -> None:

--- a/tests/test_memory_agent_persistence.py
+++ b/tests/test_memory_agent_persistence.py
@@ -1,0 +1,17 @@
+import asyncio
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import memory_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging, logging
+
+
+def test_memory_agent_persists_records(tmp_path):
+    mem_file = tmp_path / "mem.log"
+    cfg = config.Settings(bus_port=0, memory_path=str(mem_file))
+    bus = messaging.A2ABus(cfg)
+    led = logging.Ledger(str(tmp_path / "ledger.db"))
+    agent = memory_agent.MemoryAgent(bus, led, str(mem_file))
+    env = messaging.Envelope("a", "memory", {"v": 1}, 0.0)
+    asyncio.run(agent.handle(env))
+    agent2 = memory_agent.MemoryAgent(bus, led, str(mem_file))
+    assert agent2.records and agent2.records[0]["v"] == 1
+    asyncio.run(bus.stop())
+    led.close()


### PR DESCRIPTION
## Summary
- persist MemoryAgent records to optional JSONL file
- allow configuration of memory path
- expose `show-memory` CLI command
- test persistence and CLI output

## Testing
- `pytest -q tests/test_memory_agent_persistence.py tests/test_cli.py::test_show_memory_missing tests/test_cli.py::test_show_memory_export_json`
- `pytest -q`