### PR TITLE
[alpha_factory] close Ledger after CLI commands

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -198,12 +198,20 @@ def show_results(limit: int, export: str | None) -> None:
     if not path.exists():
         click.echo("No results found")
         return
-    led = logging.Ledger(str(path))
-    rows = led.tail(limit)
-    if not rows:
-        click.echo("No results found")
-        return
-    data = [(f"{r['ts']:.2f}", r["sender"], r["recipient"], json.dumps(r["payload"])) for r in rows]
+    with logging.Ledger(str(path)) as led:
+        rows = led.tail(limit)
+        if not rows:
+            click.echo("No results found")
+            return
+        data = [
+            (
+                f"{r['ts']:.2f}",
+                r["sender"],
+                r["recipient"],
+                json.dumps(r["payload"]),
+            )
+            for r in rows
+        ]
     if export == "json":
         items = [
             {
@@ -311,11 +319,11 @@ def replay() -> None:
     if not path.exists():
         click.echo("No ledger to replay")
         return
-    led = logging.Ledger(str(path))
-    for row in led.tail(1000):
-        msg = f"{row['ts']:.2f} {row['sender']} -> {row['recipient']} {json.dumps(row['payload'])}"
-        click.echo(msg)
-        time.sleep(0.1)
+    with logging.Ledger(str(path)) as led:
+        for row in led.tail(1000):
+            msg = f"{row['ts']:.2f} {row['sender']} -> {row['recipient']} {json.dumps(row['payload'])}"
+            click.echo(msg)
+            time.sleep(0.1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
@@ -189,3 +189,11 @@ class Ledger:
         if self.conn:
             self.conn.close()
             self.conn = None
+
+    def __enter__(self) -> "Ledger":
+        """Return ``self`` for context manager support."""
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        """Ensure the database connection is closed."""
+        self.close()


### PR DESCRIPTION
## Summary
- ensure show-results and replay CLI commands close their ledgers
- enable context manager support in Ledger
- test that the ledger is closed in show-results and replay

## Testing
- `ruff check tests/test_demo_cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py`
- `mypy --config-file mypy.ini tests/test_demo_cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py` *(fails: Module "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli" does not explicitly export attribute "orchestrator" and others)*
- `pytest -q tests/test_demo_cli.py`