### PR TITLE
[alpha_factory] mount web UI and enable CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ for instructions and example volume mounts.
 | `AGI_INSIGHT_BUS_TOKEN` | _(empty)_ | Shared secret for bus authentication. |
 | `AGI_INSIGHT_ALLOW_INSECURE` | `0` | Set to `1` to run the bus without TLS when no certificate is provided. |
 | `API_TOKEN` | `REPLACE_ME_TOKEN` | Bearer token required by the REST API. |
+| `API_CORS_ORIGINS` | `*` | Comma-separated list of allowed CORS origins. |
 
 The values above mirror `.env.sample`. When running the stack with Docker
 Compose, adjust the environment section of
@@ -755,7 +756,8 @@ docker compose up
 ```
 Open <http://localhost:8501> in your browser. When `RUN_MODE=web`, the container
 serves the static files from `src/interface/web_client/dist` using `python -m
-http.server`.
+http.server`. The FastAPI demo also mounts this folder at `/` when present so the
+dashboard is reachable without additional tooling.
 
 The dashboard now plots a 3‑D scatter chart of effectiveness vs. risk vs.
 complexity from the final population.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+pytest.importorskip("fastapi")
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+
+def test_root_serves_index() -> None:
+    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
+
+    client = TestClient(api_server.app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "<div id=\"root\"></div>" in resp.text

--- a/docs/API.md
+++ b/docs/API.md
@@ -157,4 +157,4 @@ wscat -c "ws://localhost:8000/ws/progress" \
   -H "Authorization: Bearer $API_TOKEN"
 ```
 
-The server honours environment variables defined in `.env` such as `PORT` (HTTP port), `OPENAI_API_KEY` and `RUN_MODE`. When `RUN_MODE=web`, a small frontend served at `/` consumes these endpoints via JavaScript.
+The server honours environment variables defined in `.env` such as `PORT` (HTTP port) and `OPENAI_API_KEY`. When a prebuilt React dashboard exists under `src/interface/web_client/dist`, it is automatically served at the root path (`/`). CORS headers are configured via `API_CORS_ORIGINS` (default `"*"`).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,6 +170,7 @@ def test_replay_existing(tmp_path) -> None:
             ),
         ):
             led = led_cls.return_value
+            led.__enter__.return_value = led
             led.tail.return_value = [{"ts": 0.0, "sender": "a", "recipient": "b", "payload": {"x": 1}}]
             out = CliRunner().invoke(cli.main, ["replay"])
             assert "a -> b" in out.output

--- a/tests/test_cli_runner_ext.py
+++ b/tests/test_cli_runner_ext.py
@@ -103,6 +103,7 @@ def test_replay_outputs_rows(tmp_path) -> None:
     with patch.object(cli.config.CFG, "ledger_path", path):
         with patch.object(cli.logging, "Ledger") as led_cls, patch.object(cli.time, "sleep", return_value=None):
             led = led_cls.return_value
+            led.__enter__.return_value = led
             led.tail.return_value = [SAMPLE_LEDGER_ROW]
             res = CliRunner().invoke(cli.main, ["replay"])
     assert "a -> b" in res.output


### PR DESCRIPTION
## Summary
- serve web_client/dist at `/` in Insight demo API server
- allow CORS via API_CORS_ORIGINS
- document static serving and CORS settings
- test FastAPI root serves React index
- fix CLI replay mocks for tests

## Testing
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py`
- `pytest -q`