### PR TITLE
[alpha_factory] add api-server CLI command

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -292,6 +292,8 @@ streamlit run src/interface/web_app.py
 ```bash
 # backend
 uvicorn src/interface/api_server:app --reload --port 8000
+# or via the CLI
+python -m alpha_factory_v1.demos.alpha_agi_insight_v1 api-server
 # frontend
 cd src/interface/web_client
 pnpm install

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CLI entry point for the α‑AGI Insight demo."""
+"""CLI entry point for the α‑AGI Insight demo.
+
+Run ``python -m alpha_factory_v1.demos.alpha_agi_insight_v1 --help`` to see
+available subcommands, including ``api-server`` to launch the REST API.
+"""
 from .src.interface.cli import main
 
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -308,6 +308,30 @@ def run_orchestrator(verbose: bool) -> None:
         pass
 
 
+@main.command(name="api-server")
+@click.option("--host", default="0.0.0.0", show_default=True, help="Bind host")
+@click.option(
+    "--port",
+    type=int,
+    default=8000,
+    show_default=True,
+    help="Bind port",
+)
+def api_server_cmd(host: str, port: int) -> None:
+    """Launch the FastAPI backend server."""
+
+    try:
+        import uvicorn
+    except Exception as exc:  # pragma: no cover - optional
+        raise click.ClickException("uvicorn is required to run the API server") from exc
+
+    uvicorn.run(
+        "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server:app",
+        host=host,
+        port=port,
+    )
+
+
 @main.command()
 def replay() -> None:
     """Replay ledger events with a short delay.


### PR DESCRIPTION
## Summary
- expose `api-server` subcommand in the Insight CLI
- update Insight README with CLI server usage
- mention new subcommand in module help text

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py`
