### PR TITLE
[alpha_factory] add minimal insight web client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 build/
 dist/
 !src/interface/web_client/dist/
+!alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/
 
 # Logs
 *.log

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -295,7 +295,7 @@ uvicorn src/interface/api_server:app --reload --port 8000
 # or via the CLI
 python -m alpha_factory_v1.demos.alpha_agi_insight_v1 api-server
 # frontend
-cd src/interface/web_client
+cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
 pnpm install
 pnpm dev            # http://localhost:5173
 # build production assets
@@ -304,7 +304,7 @@ pnpm build          # outputs to src/interface/web_client/dist/
 # or use `npm install && npm run build`
 ```
 
-The built dashboard lives under `src/interface/web_client/dist/` and is copied
+The built dashboard lives under `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/` and is copied
 into the demo container.
 
 The React client exposes an input form for **horizon**, **population size** and
@@ -339,7 +339,7 @@ Install [Node.js](https://nodejs.org/) **≥ 20** and
 From the repository root run:
 
 ```bash
-cd src/interface/web_client
+cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
 pnpm install && pnpm build
 ```
 
@@ -353,7 +353,7 @@ Launch the container stack afterwards or serve `dist/` with any static server,
 e.g. `python -m http.server --directory dist 8080`.
 
 For advanced options see
-[src/interface/web_client/README.md](../../../src/interface/web_client/README.md).
+[src/interface/web_client/README.md](src/interface/web_client/README.md).
 
 For details see [docs/API.md](docs/API.md).
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -15,13 +15,13 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 
 # Copy the project source
 COPY . /app
-RUN pnpm --dir src/interface/web_client install \
-    && pnpm --dir src/interface/web_client run build \
-    && rm -rf src/interface/web_client/node_modules
+RUN pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client install \
+    && pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
+    && rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
 
 # copy built assets
-COPY src/interface/web_client/dist/ \
-    /app/src/interface/web_client/dist/
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/ \
+    /app/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/
 
 # Add non-root user and entrypoint
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -316,7 +316,8 @@ if app is not None:
         finally:
             _progress_ws.discard(websocket)
 
-    web_dist = Path(__file__).resolve().parents[5] / "src" / "interface" / "web_client" / "dist"
+    # Serve the minimal React dashboard bundled with this demo
+    web_dist = Path(__file__).resolve().parent / "web_client" / "dist"
     if web_dist.is_dir():
         app.mount("/", StaticFiles(directory=str(web_dist), html=True), name="static")
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
@@ -1,0 +1,21 @@
+# Alpha AGI Insight Web Client
+
+This directory contains a minimal React application built with [Vite](https://vitejs.dev/).
+It connects to the API server at `/ws/progress` and logs messages to the console.
+
+## Development
+
+```bash
+cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
+pnpm install
+pnpm dev       # open http://localhost:5173
+```
+
+## Build
+
+```bash
+pnpm build  # outputs static files in dist/
+```
+
+The production bundle lives under `dist/` and is served automatically by the API
+server when present.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal React dashboard for α‑AGI Insight."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
@@ -1,0 +1,13 @@
+(function () {
+  const { useEffect } = React;
+  function App() {
+    useEffect(() => {
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+      const ws = new WebSocket(`${proto}://${location.host}/ws/progress`);
+      ws.onmessage = (e) => console.log(e.data);
+      return () => ws.close();
+    }, []);
+    return React.createElement('div', null, 'α‑AGI Insight Demo');
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+})();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>α‑AGI Insight</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="app.js" defer></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>α‑AGI Insight</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agi-insight-web-client",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.0",
+    "vite": "^4.2.0"
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom/client';
+
+function App() {
+  useEffect(() => {
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${proto}://${location.host}/ws/progress`);
+    ws.onmessage = (ev) => console.log(ev.data);
+    return () => ws.close();
+  }, []);
+  return <div>α‑AGI Insight Demo</div>;
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.node.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/vite.config.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.',
+  envPrefix: 'VITE_',
+  build: { outDir: 'dist' }
+});


### PR DESCRIPTION
## Summary
- add a tiny React client under `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client`
- mount the new build path in `api_server`
- adjust insight Dockerfile to build and copy the new `dist/`
- document build steps in the demo README
- allow Git to track the new dist folder

## Testing
- `python check_env.py --auto-install`
- `pytest -q`