### PR TITLE
[alpha_factory] package web_client dist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,19 @@ requires-python = ">=3.11,<3.13"
 packages = [
     "alpha_factory_v1",
     "alpha_factory_v1.demos.alpha_agi_insight_v1",
+    "alpha_factory_v1.demos.alpha_agi_insight_v1.src",
+    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface",
+    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_client",
     "af_requests",
     "src",
+    "src.interface",
+    "src.interface.web_client",
 ]
 
 [tool.setuptools.package-data]
 "alpha_factory_v1" = ["py.typed"]
 "src.interface.web_client" = ["dist/**"]
+"alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_client" = ["dist/**"]
 
 [project.scripts]
 alpha-factory = "alpha_factory_v1.run:run"


### PR DESCRIPTION
## Summary
- include `src.interface.web_client` and `alpha_agi_insight_v1` web assets in packages
- expand package list for nested interface modules
- verify installation works

## Testing
- `python check_env.py --auto-install`
- `pip install . --no-build-isolation`
- `pytest -q`