### PR TITLE
[alpha_factory] handle missing fastapi in static API tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
@@ -3,11 +3,12 @@ import sys
 from pathlib import Path
 
 import pytest
+
+pytest.importorskip("fastapi")
+
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-
-pytest.importorskip("fastapi")
 
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")
@@ -19,4 +20,4 @@ def test_root_serves_index() -> None:
     client = TestClient(api_server.app)
     resp = client.get("/")
     assert resp.status_code == 200
-    assert "<div id=\"root\"></div>" in resp.text
+    assert '<div id="root"></div>' in resp.text


### PR DESCRIPTION
## Summary
- avoid ImportError in `test_api_server_static` when `fastapi` isn't installed

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py`
- `black alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py`
- `pytest -q`