### PR TITLE
[alpha_factory] demo setup helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
-.PHONY: build_web
+.PHONY: build_web demo-setup demo-run
 build_web:
-pnpm --dir src/interface/web_client install
-pnpm --dir src/interface/web_client run build
+    pnpm --dir src/interface/web_client install
+    pnpm --dir src/interface/web_client run build
+
+demo-setup:
+    bash scripts/demo_setup.sh
+
+demo-run:
+    @RUN_MODE=${RUN_MODE:-cli}; \
+    if [ "$$RUN_MODE" = "web" ]; then \
+        .venv/bin/python -m streamlit run alpha_factory_v1/demos/alpha_agi_insight_v0/insight_dashboard.py; \
+    else \
+        .venv/bin/python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --episodes 5; \
+    fi
 
 

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -40,6 +40,10 @@ python alpha_factory_v1/quickstart.py
 
 # Or via Docker (no install)
 docker run --pull=always -p 7860:7860 ghcr.io/montrealai/alpha-factory-demos:latest
+
+# With Make
+make demo-setup
+make demo-run        # RUN_MODE=web for dashboard
 ```
 Opens **http://localhost:7860** with a Gradio portal to every demo. Works on macOS, Linux, WSL 2 and Colab.
 

--- a/scripts/demo_setup.sh
+++ b/scripts/demo_setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Simple demo setup helper
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+VENV_DIR=".venv"
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv "$VENV_DIR"
+  "$VENV_DIR/bin/pip" install -U pip
+fi
+"$VENV_DIR/bin/pip" install -r requirements.txt -r requirements-dev.txt
+"$VENV_DIR/bin/python" check_env.py --auto-install
+echo "Demo environment ready. Activate via 'source $VENV_DIR/bin/activate'"


### PR DESCRIPTION
## Summary
- add `demo_setup.sh` helper script
- add `demo-setup` and `demo-run` targets to Makefile
- document Makefile usage in demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ❌ `pre-commit run --files Makefile scripts/demo_setup.sh alpha_factory_v1/demos/README.md` *(failed: pre-commit not installed)*