### PR TITLE
[alpha_factory] add model settings to Insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/base_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/base_agent.py
@@ -35,7 +35,23 @@ class BaseAgent:
         self.name = name
         self.bus = bus
         self.ledger = ledger
-        self.oai_ctx = AgentContext() if AgentContext is not None else None
+        if AgentContext is not None:
+            try:
+                self.oai_ctx = AgentContext(
+                    model=bus.settings.model_name,
+                    temperature=bus.settings.temperature,
+                    context_window=bus.settings.context_window,
+                )
+            except TypeError:
+                try:
+                    self.oai_ctx = AgentContext(
+                        model=bus.settings.model_name,
+                        temperature=bus.settings.temperature,
+                    )
+                except Exception:
+                    self.oai_ctx = AgentContext()
+        else:
+            self.oai_ctx = None
         self.adk = ADKAdapter() if ADKAdapter.is_available() else None
         self.mcp = MCPAdapter() if MCPAdapter.is_available() else None
         self.bus.subscribe(name, self._on_envelope)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
@@ -26,7 +26,7 @@ class PlanningAgent(BaseAgent):
             try:
                 from ..utils import local_llm
 
-                plan = local_llm.chat("plan research task")
+                plan = local_llm.chat("plan research task", self.bus.settings)
             except Exception:  # pragma: no cover - model optional
                 plan = "collect baseline metrics"
         elif self.oai_ctx:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
@@ -31,7 +31,7 @@ class StrategyAgent(BaseAgent):
             try:
                 from ..utils import local_llm
 
-                strat["action"] = local_llm.chat(str(val))
+                strat["action"] = local_llm.chat(str(val), self.bus.settings)
             except Exception:  # pragma: no cover - model optional
                 pass
         elif self.oai_ctx:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -74,6 +74,9 @@ def main() -> None:
 @click.option("--offline", is_flag=True, help="Force offline mode")
 @click.option("--no-broadcast", is_flag=True, help="Disable blockchain broadcasting")
 @click.option("--llama-model-path", type=click.Path(), help="Path to local Llama model")
+@click.option("--model", "model_name", help="Model name for AgentContext/local models")
+@click.option("--temperature", type=float, help="Model temperature")
+@click.option("--context-window", type=int, help="Context window size")
 @click.option("--sectors-file", type=click.Path(exists=True), help="JSON file with sector definitions")
 @click.option("--sectors", default=6, show_default=True, type=int, help="Number of sectors")
 @click.option("--pop-size", default=6, show_default=True, type=int, help="MATS population size")
@@ -95,6 +98,9 @@ def simulate(
     start_orchestrator: bool,
     no_broadcast: bool,
     llama_model_path: str | None,
+    model_name: str | None,
+    temperature: float | None,
+    context_window: int | None,
 ) -> None:
     """Run a forecast simulation.
 
@@ -112,6 +118,9 @@ def simulate(
         start_orchestrator: Launch orchestrator after the run.
         no_broadcast: Disable ledger broadcasting.
         llama_model_path: Path to a local Llama model.
+        model_name: Model identifier for LLM calls.
+        temperature: Sampling temperature for completions.
+        context_window: Prompt context window size.
 
     Returns:
         None
@@ -127,6 +136,12 @@ def simulate(
         settings.offline = True
     if no_broadcast:
         settings.broadcast = False
+    if model_name is not None:
+        settings.model_name = model_name
+    if temperature is not None:
+        settings.temperature = temperature
+    if context_window is not None:
+        settings.context_window = context_window
 
     orch = orchestrator.Orchestrator(settings)
     if sectors_file:
@@ -297,9 +312,19 @@ def agents_status(watch: bool) -> None:
 
 @main.command(name="orchestrator")
 @click.option("--verbose", is_flag=True, help="Verbose output")
-def run_orchestrator(verbose: bool) -> None:
+@click.option("--model", "model_name", help="Model name for AgentContext/local models")
+@click.option("--temperature", type=float, help="Model temperature")
+@click.option("--context-window", type=int, help="Context window size")
+def run_orchestrator(verbose: bool, model_name: str | None, temperature: float | None, context_window: int | None) -> None:
     """Run the orchestrator until interrupted."""
-    orch = orchestrator.Orchestrator()
+    settings = config.CFG
+    if model_name is not None:
+        settings.model_name = model_name
+    if temperature is not None:
+        settings.temperature = temperature
+    if context_window is not None:
+        settings.context_window = context_window
+    orch = orchestrator.Orchestrator(settings)
     if verbose and console is not None:
         console.log("Starting orchestrator … press Ctrl+C to stop")
     try:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -74,6 +74,9 @@ class Settings:
     solana_rpc_url: str = os.getenv("AGI_INSIGHT_SOLANA_URL", "https://api.testnet.solana.com")
     solana_wallet: str | None = os.getenv("AGI_INSIGHT_SOLANA_WALLET")
     solana_wallet_file: str | None = os.getenv("AGI_INSIGHT_SOLANA_WALLET_FILE")
+    model_name: str = os.getenv("AGI_MODEL_NAME", "gpt-4o-mini")
+    temperature: float = float(os.getenv("AGI_TEMPERATURE", "0.2"))
+    context_window: int = _env_int("AGI_CONTEXT_WINDOW", 8192)
 
     def __post_init__(self) -> None:
         if not self.openai_api_key:

--- a/tests/test_local_llm_logging.py
+++ b/tests/test_local_llm_logging.py
@@ -11,6 +11,6 @@ def test_load_model_warning(monkeypatch, caplog):
     monkeypatch.setattr(local_llm, "Llama", mock.Mock(side_effect=RuntimeError("boom")))
     monkeypatch.setattr(local_llm, "AutoModelForCausalLM", None)
 
-    local_llm._load_model()
+    local_llm._load_model(local_llm.config.CFG)
 
     assert any("boom" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- expose `model_name`, `temperature` and `context_window` in Insight `Settings`
- initialise `AgentContext` and local models with these options
- allow overriding via CLI flags `--model`, `--temperature` and `--context-window`
- adapt tests for updated `local_llm` helpers

## Testing
- `python check_env.py --auto-install`
- `pytest -q`