### PR TITLE
[alpha_factory] add retry logging decorator

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -19,6 +19,7 @@ import time
 from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
+from ..utils.retry import with_retry
 
 
 class CodeGenAgent(BaseAgent):
@@ -37,7 +38,7 @@ class CodeGenAgent(BaseAgent):
         code = "print('alpha')"
         if self.oai_ctx and not self.bus.settings.offline:
             try:  # pragma: no cover
-                code = await self.oai_ctx.run(prompt=str(analysis))
+                code = await with_retry(self.oai_ctx.run)(prompt=str(analysis))
             except Exception:
                 pass
         self.execute_in_sandbox(code)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
+from ..utils.retry import with_retry
 
 
 class MarketAgent(BaseAgent):
@@ -29,7 +30,7 @@ class MarketAgent(BaseAgent):
         analysis = f"impact of {strategy}"
         if self.oai_ctx and not self.bus.settings.offline:
             try:  # pragma: no cover
-                analysis = await self.oai_ctx.run(prompt=str(strategy))
+                analysis = await with_retry(self.oai_ctx.run)(prompt=str(strategy))
             except Exception:
                 pass
         await self.emit("codegen", {"analysis": analysis})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
+from ..utils.retry import with_retry
 
 
 class PlanningAgent(BaseAgent):
@@ -26,12 +27,12 @@ class PlanningAgent(BaseAgent):
             try:
                 from ..utils import local_llm
 
-                plan = local_llm.chat("plan research task", self.bus.settings)
+                plan = with_retry(local_llm.chat)("plan research task", self.bus.settings)
             except Exception:  # pragma: no cover - model optional
                 plan = "collect baseline metrics"
         elif self.oai_ctx:
             try:  # pragma: no cover - SDK optional
-                plan = await self.oai_ctx.run(prompt="plan research task")
+                plan = await with_retry(self.oai_ctx.run)(prompt="plan research task")
             except Exception:
                 plan = "collect baseline metrics"
         await self.emit("research", {"plan": plan})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -14,6 +14,7 @@ from .base_agent import BaseAgent
 from ..simulation import forecast, sector
 from ..utils import messaging
 from ..utils.logging import Ledger
+from ..utils.retry import with_retry
 
 
 class ResearchAgent(BaseAgent):
@@ -44,7 +45,7 @@ class ResearchAgent(BaseAgent):
         cap = random.random()
         if self.oai_ctx and not self.bus.settings.offline:
             try:  # pragma: no cover
-                cap = float(await self.oai_ctx.run(prompt=str(plan)))
+                cap = float(await with_retry(self.oai_ctx.run)(prompt=str(plan)))
             except Exception:
                 pass
         await self.emit("strategy", {"research": cap})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
+from ..utils.retry import with_retry
 
 
 class StrategyAgent(BaseAgent):
@@ -31,12 +32,12 @@ class StrategyAgent(BaseAgent):
             try:
                 from ..utils import local_llm
 
-                strat["action"] = local_llm.chat(str(val), self.bus.settings)
+                strat["action"] = with_retry(local_llm.chat)(str(val), self.bus.settings)
             except Exception:  # pragma: no cover - model optional
                 pass
         elif self.oai_ctx:
             try:  # pragma: no cover
-                strat["action"] = await self.oai_ctx.run(prompt=str(val))
+                strat["action"] = await with_retry(self.oai_ctx.run)(prompt=str(val))
             except Exception:
                 pass
         await self.emit("market", {"strategy": strat})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/retry.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/retry.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Callable, TypeVar, Any
+
+try:  # pragma: no cover - optional dependency
+    import backoff
+except Exception:  # pragma: no cover - fallback if missing
+    backoff = None
+
+from .logging import _log
+import asyncio
+import inspect
+import time
+
+T = TypeVar("T")
+
+
+def with_retry(func: Callable[..., T], *, max_tries: int = 3) -> Callable[..., T]:
+    """Wrap *func* with exponential backoff and logging."""
+
+    def _log_retry(details: dict[str, Any]) -> None:
+        _log.warning(
+            "Retry %d/%d for %s due to %s",
+            details["tries"],
+            max_tries,
+            getattr(details.get("target"), "__name__", "call"),
+            details.get("exception"),
+        )
+
+    if backoff is not None:
+        return backoff.on_exception(
+            backoff.expo,
+            Exception,
+            max_tries=max_tries,
+            jitter=backoff.full_jitter,
+            on_backoff=_log_retry,
+        )(func)
+
+    is_async = inspect.iscoroutinefunction(func)
+
+    if is_async:
+
+        async def wrapper(*args: Any, **kwargs: Any) -> T:
+            for attempt in range(max_tries):
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as exc:  # pragma: no cover - runtime errors
+                    if attempt + 1 >= max_tries:
+                        raise
+                    _log_retry(
+                        {
+                            "tries": attempt + 1,
+                            "exception": exc,
+                            "target": func,
+                        }
+                    )
+                    await asyncio.sleep(2**attempt * 0.1)
+
+        return wrapper
+
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        for attempt in range(max_tries):
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # pragma: no cover - runtime errors
+                if attempt + 1 >= max_tries:
+                    raise
+                _log_retry(
+                    {
+                        "tries": attempt + 1,
+                        "exception": exc,
+                        "target": func,
+                    }
+                )
+                time.sleep(2**attempt * 0.1)
+
+    return wrapper


### PR DESCRIPTION
## Summary
- add `with_retry` utility with optional backoff
- retry local/remote model calls across agents
- log each retry attempt

## Testing
- `python check_env.py --auto-install`
- `pytest -q`