### PR TITLE
[alpha_factory] JSON logging and DuckDB ledger

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -389,6 +389,8 @@ local development or customization. See the
 | `AGI_INSIGHT_ALLOW_INSECURE` | Allow non‑TLS bus (`1` to enable) | `0` |
 | `AGI_INSIGHT_LEDGER_PATH` | Audit DB path | `./ledger/audit.db` |
 | `AGI_INSIGHT_MEMORY_PATH` | Path used by `MemoryAgent` for persistent storage | _unset_ |
+| `AGI_INSIGHT_JSON_LOGS` | Emit JSON formatted console logs (`1` to enable) | `0` |
+| `AGI_INSIGHT_DB` | Ledger backend (`sqlite` or `duckdb`) | `sqlite` |
 | `AGI_INSIGHT_BROADCAST` | Enable blockchain broadcasting | `1` |
 | `AGI_INSIGHT_SOLANA_URL` | Solana RPC endpoint | `https://api.testnet.solana.com` |
 | `AGI_INSIGHT_SOLANA_WALLET` | Wallet private key (hex) | _unset_ |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -70,13 +70,14 @@ class Orchestrator:
 
     def __init__(self, settings: config.Settings | None = None) -> None:
         self.settings = settings or config.CFG
-        insight_logging.setup()
+        insight_logging.setup(json_logs=self.settings.json_logs)
         self.bus = messaging.A2ABus(self.settings)
         self.ledger = Ledger(
             self.settings.ledger_path,
             rpc_url=self.settings.solana_rpc_url,
             wallet=self.settings.solana_wallet,
             broadcast=self.settings.broadcast,
+            db=self.settings.db_type,
         )
         self.runners: Dict[str, AgentRunner] = {}
         self.bus.subscribe("orch", self._on_orch)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -77,6 +77,8 @@ class Settings:
     model_name: str = os.getenv("AGI_MODEL_NAME", "gpt-4o-mini")
     temperature: float = float(os.getenv("AGI_TEMPERATURE", "0.2"))
     context_window: int = _env_int("AGI_CONTEXT_WINDOW", 8192)
+    json_logs: bool = os.getenv("AGI_INSIGHT_JSON_LOGS", "0") == "1"
+    db_type: str = os.getenv("AGI_INSIGHT_DB", "sqlite")
 
     def __post_init__(self) -> None:
         if not self.openai_api_key:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Expanded API documentation with `curl` and WebSocket examples.
 - Additional CLI notes and help command reference.
 - Documented `AGI_INSIGHT_MEMORY_PATH` for persistent storage configuration.
+- Optional JSON console logging and DuckDB ledger support.
 
 ## [1.0.2] - 2025-06-30
 - Documented CLI and FastAPI usage with example commands.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -45,3 +45,15 @@ def test_broadcast_merkle_root_logs_root_when_disabled(
 
     assert not dummy.called
     assert any(f"Merkle root {root}" in r.getMessage() for r in caplog.records)
+
+
+def test_json_console_formatting(capsys: pytest.CaptureFixture[str]) -> None:
+    logging.getLogger().handlers.clear()
+    insight_logging.setup(json_logs=True)
+    log = logging.getLogger("jtest")
+    log.info("hello")
+    captured = capsys.readouterr()
+    out = (captured.err or captured.out).strip()
+    data = json.loads(out)
+    assert data["msg"] == "hello"
+    assert data["lvl"] == "INFO"


### PR DESCRIPTION
## Summary
- add optional JSON console logging
- switch ledger backend to DuckDB when `AGI_INSIGHT_DB=duckdb`
- expose `json_logs` and `db_type` settings
- document new options
- test JSON logging output

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
