### PR TITLE
[alpha_factory] add container health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,12 @@ serves the static files from `src/interface/web_client/dist` using `python -m
 http.server`. The FastAPI demo also mounts this folder at `/` when present so the
 dashboard is reachable without additional tooling.
 
+Once running, Docker Compose marks the services **healthy** when:
+
+- `http://localhost:8000/runs` responds with `{"ids": []}` (or listed run IDs) for the
+  orchestrator container.
+- `http://localhost:8501/` returns status `200` for the web container.
+
 The dashboard now plots a 3‑D scatter chart of effectiveness vs. risk vs.
 complexity from the final population.
 

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -23,6 +23,11 @@ USER afuser
 ENV PYTHONUNBUFFERED=1
 ARG VITE_API_BASE_URL=/
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
+# verify the API server is responsive
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD \
+  curl -fsS http://localhost:8000/runs || exit 1
+
 EXPOSE 8000 8501 6006
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["web"]

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -1,4 +1,9 @@
 version: '3.9'
+
+x-healthcheck: &default_healthcheck
+  interval: 30s
+  timeout: 5s
+  retries: 3
 services:
   orchestrator:
     build:
@@ -17,6 +22,9 @@ services:
       - "${PORT:-8000}:8000"                 # host:container REST API port
       - "${AGI_INSIGHT_BUS_PORT:-6006}:6006" # host:container gRPC bus
     restart: unless-stopped              # restart policy
+    healthcheck:
+      <<: *default_healthcheck
+      test: ["CMD", "curl", "-sf", "http://localhost:8000/runs"]
 
   agents:
     image: alpha-demo:latest             # reuse the demo image
@@ -44,3 +52,6 @@ services:
       - "8501:8501"                           # host:container dashboard port
     depends_on:
       - orchestrator                     # wait for orchestrator
+    healthcheck:
+      <<: *default_healthcheck
+      test: ["CMD", "curl", "-sf", "http://localhost:8501/"]


### PR DESCRIPTION
## Summary
- add health check to the demo Dockerfile
- ping `/runs` from docker-compose
- document health statuses in the README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 14 errors)*
