### PR TITLE
[alpha_factory] feat: configurable secret backend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,3 +16,11 @@ LLAMA_MODEL_PATH=
 AGI_INSIGHT_BUS_PORT=6006
 # SQLite ledger path used by the Insight demo
 AGI_INSIGHT_LEDGER_PATH=./ledger/audit.db
+# Optional secret backend: vault | aws | gcp
+AGI_INSIGHT_SECRET_BACKEND=
+# HashiCorp Vault settings
+VAULT_ADDR=
+VAULT_TOKEN=
+# AWS/GCP secret names for OPENAI_API_KEY
+OPENAI_API_KEY_SECRET_ID=
+

--- a/README.md
+++ b/README.md
@@ -621,6 +621,10 @@ for instructions and example volume mounts.
 | `AGI_INSIGHT_OFFLINE` | `0` | Set to `1` to force local inference models. |
 | `AGI_INSIGHT_BUS_PORT` | `6006` | gRPC bus port used by the demo. |
 | `AGI_INSIGHT_LEDGER_PATH` | `./ledger/audit.db` | Path to the local audit ledger. |
+| `AGI_INSIGHT_SECRET_BACKEND` | _(empty)_ | Set to `vault`, `aws` or `gcp` to load secrets from an external manager. |
+| `VAULT_ADDR`/`VAULT_TOKEN` | _(empty)_ | Connection details for HashiCorp Vault when using the `vault` backend. |
+| `AWS_REGION`/`OPENAI_API_KEY_SECRET_ID` | _(empty)_ | AWS Secrets Manager region and secret ID when using the `aws` backend. |
+| `GCP_PROJECT_ID`/`OPENAI_API_KEY_SECRET_ID` | _(empty)_ | GCP project and secret name when using the `gcp` backend. |
 | `AGI_INSIGHT_BUS_CERT` | _(empty)_ | Path to the gRPC bus certificate. |
 | `AGI_INSIGHT_BUS_KEY` | _(empty)_ | Private key matching `AGI_INSIGHT_BUS_CERT`. |
 | `AGI_INSIGHT_BUS_TOKEN` | _(empty)_ | Shared secret for bus authentication. |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Expanded API documentation with `curl` and WebSocket examples.
 - Additional CLI notes and help command reference.
 - Documented `AGI_INSIGHT_MEMORY_PATH` for persistent storage configuration.
+- Configurable secret backend for HashiCorp Vault and cloud managers via `AGI_INSIGHT_SECRET_BACKEND`.
 - Optional JSON console logging and DuckDB ledger support.
 - Aggregated forecast endpoint `/insight` and OpenAPI schema exposure.
 

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -15,6 +15,11 @@ services:
     environment:
       RUN_MODE: api                           # container start mode
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}     # hosted model credential
+      AGI_INSIGHT_SECRET_BACKEND: ${AGI_INSIGHT_SECRET_BACKEND:-}
+      VAULT_ADDR: ${VAULT_ADDR:-}
+      VAULT_TOKEN: ${VAULT_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-}
+      OPENAI_API_KEY_SECRET_ID: ${OPENAI_API_KEY_SECRET_ID:-}
       AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0} # set 1 for local models
       AGI_INSIGHT_BUS_PORT: ${AGI_INSIGHT_BUS_PORT:-6006} # gRPC event bus port
       AGI_INSIGHT_LEDGER_PATH: ${AGI_INSIGHT_LEDGER_PATH:-./ledger/audit.db} # audit ledger path
@@ -33,6 +38,11 @@ services:
     environment:
       RUN_MODE: cli                           # entrypoint for agent workers
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}     # hosted model credential
+      AGI_INSIGHT_SECRET_BACKEND: ${AGI_INSIGHT_SECRET_BACKEND:-}
+      VAULT_ADDR: ${VAULT_ADDR:-}
+      VAULT_TOKEN: ${VAULT_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-}
+      OPENAI_API_KEY_SECRET_ID: ${OPENAI_API_KEY_SECRET_ID:-}
       AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0} # set 1 for local models
       AGI_INSIGHT_BUS_PORT: ${AGI_INSIGHT_BUS_PORT:-6006} # gRPC event bus port
       AGI_INSIGHT_LEDGER_PATH: ${AGI_INSIGHT_LEDGER_PATH:-./ledger/audit.db} # audit ledger path
@@ -46,6 +56,11 @@ services:
     environment:
       RUN_MODE: web                           # start the Streamlit dashboard
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}     # hosted model credential
+      AGI_INSIGHT_SECRET_BACKEND: ${AGI_INSIGHT_SECRET_BACKEND:-}
+      VAULT_ADDR: ${VAULT_ADDR:-}
+      VAULT_TOKEN: ${VAULT_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-}
+      OPENAI_API_KEY_SECRET_ID: ${OPENAI_API_KEY_SECRET_ID:-}
       AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0} # set 1 for local models
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-/}
     ports:

--- a/infrastructure/terraform/main_aws.tf
+++ b/infrastructure/terraform/main_aws.tf
@@ -1,6 +1,7 @@
 # Simplified AWS Fargate deployment
 variable "region" { default = "us-east-1" }
 variable "openai_api_key" { default = "" }
+variable "openai_api_key_secret_id" { default = "" }
 variable "agi_insight_offline" { default = "0" }
 variable "agi_insight_bus_port" { default = 6006 }
 variable "agi_insight_ledger_path" { default = "./ledger/audit.db" }
@@ -11,6 +12,7 @@ variable "subnets" {
 }
 
 provider "aws" { region = var.region }
+
 
 resource "aws_ecs_cluster" "af" {
   name = "alpha-factory"
@@ -28,13 +30,19 @@ resource "aws_ecs_task_definition" "af" {
       name      = "orchestrator"
       image     = var.container_image
       essential = true
-      environment = [
-        { name = "OPENAI_API_KEY", value = var.openai_api_key },
+      environment = concat([
         { name = "RUN_MODE", value = "api" },
         { name = "AGI_INSIGHT_OFFLINE", value = var.agi_insight_offline },
         { name = "AGI_INSIGHT_BUS_PORT", value = tostring(var.agi_insight_bus_port) },
         { name = "AGI_INSIGHT_LEDGER_PATH", value = var.agi_insight_ledger_path }
-      ]
+      ],
+      var.openai_api_key_secret_id == "" ? [
+        { name = "OPENAI_API_KEY", value = var.openai_api_key }
+      ] : [
+        { name = "AGI_INSIGHT_SECRET_BACKEND", value = "aws" },
+        { name = "AWS_REGION", value = var.region },
+        { name = "OPENAI_API_KEY_SECRET_ID", value = var.openai_api_key_secret_id }
+      ])
       portMappings = [
         { containerPort = 8000 },
         { containerPort = 6006 }

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,5 @@
 """Shared utilities and configuration."""
 
-from .config import CFG
+from .config import CFG, get_secret
 
-__all__ = ["CFG"]
+__all__ = ["CFG", "get_secret"]

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,11 +1,12 @@
 """Environment-driven configuration shared across components."""
+
 from __future__ import annotations
 
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional, cast
 
 _log = logging.getLogger(__name__)
 
@@ -48,11 +49,74 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Return ``name`` from the configured secret backend or environment.
+
+    The backend is selected via ``AGI_INSIGHT_SECRET_BACKEND``. Supported values
+    are ``vault``, ``aws`` and ``gcp``. When unset or empty, the environment
+    variable ``name`` is returned. Any backend error logs a warning and falls
+    back to ``os.getenv(name, default)``.
+    """
+    backend = os.getenv("AGI_INSIGHT_SECRET_BACKEND", "").lower()
+    if not backend or backend == "env":
+        return os.getenv(name, default)
+
+    if backend == "vault":
+        try:  # pragma: no cover - optional deps
+            import importlib
+
+            hvac = importlib.import_module("hvac")
+
+            addr = os.environ["VAULT_ADDR"]
+            token = os.environ["VAULT_TOKEN"]
+            secret_path = os.getenv(f"{name}_PATH", name)
+            client = hvac.Client(url=addr, token=token)
+            data = client.secrets.kv.read_secret_version(path=secret_path)
+            return cast(Optional[str], data["data"]["data"].get(name, default))
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("Vault secret '%s' failed: %s", name, exc)
+            return os.getenv(name, default)
+
+    if backend == "aws":
+        try:  # pragma: no cover - optional deps
+            import importlib
+
+            boto3 = importlib.import_module("boto3")
+
+            region = os.getenv("AWS_REGION", "us-east-1")
+            secret_id = os.getenv(f"{name}_SECRET_ID", name)
+            client = boto3.client("secretsmanager", region_name=region)
+            resp = client.get_secret_value(SecretId=secret_id)
+            return cast(Optional[str], resp.get("SecretString", default))
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("AWS secret '%s' failed: %s", name, exc)
+            return os.getenv(name, default)
+
+    if backend == "gcp":
+        try:  # pragma: no cover - optional deps
+            import importlib
+
+            secretmanager = importlib.import_module("google.cloud.secretmanager")
+
+            project = os.environ["GCP_PROJECT_ID"]
+            secret_id = os.getenv(f"{name}_SECRET_ID", name)
+            client = secretmanager.SecretManagerServiceClient()
+            secret_name = f"projects/{project}/secrets/{secret_id}/versions/latest"
+            resp = client.access_secret_version(name=secret_name)
+            return cast(str, resp.payload.data.decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("GCP secret '%s' failed: %s", name, exc)
+            return os.getenv(name, default)
+
+    _log.warning("Unknown secret backend '%s'", backend)
+    return os.getenv(name, default)
+
+
 @dataclass(slots=True)
 class Settings:
     """Environment-driven configuration."""
 
-    openai_api_key: str | None = os.getenv("OPENAI_API_KEY")
+    openai_api_key: str | None = get_secret("OPENAI_API_KEY")
     offline: bool = os.getenv("AGI_INSIGHT_OFFLINE", "0") == "1"
     bus_port: int = _env_int("AGI_INSIGHT_BUS_PORT", 6006)
     ledger_path: str = os.getenv("AGI_INSIGHT_LEDGER_PATH", "./ledger/audit.db")


### PR DESCRIPTION
## Summary
- add secret manager helper in `src/utils/config.py`
- document `AGI_INSIGHT_SECRET_BACKEND` and related env vars
- update `.env.sample` with secret backend settings
- extend Docker Compose and Terraform examples to show secret retrieval

## Testing
- `python check_env.py --auto-install`
- `ruff check src/utils/__init__.py src/utils/config.py`
- `mypy --config-file mypy.ini src/utils/__init__.py src/utils/config.py`
- `pytest -q` *(fails: 14 errors during collection)*
