### PR TITLE
[alpha_factory] add insight and retry tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
@@ -6,9 +6,9 @@ default) and can periodically broadcast the Merkle root to Solana.
 ``setup`` configures console logging, optionally emitting JSON lines.
 """
 
-__all__ = ["Ledger", "setup", "logging"]
-
 from __future__ import annotations
+
+__all__ = ["Ledger", "setup", "logging"]
 
 import asyncio
 import json

--- a/tests/test_docker_health.py
+++ b/tests/test_docker_health.py
@@ -1,0 +1,32 @@
+import os
+import shutil
+import subprocess
+import time
+
+import pytest
+
+if not shutil.which("docker"):
+    pytest.skip("docker not available", allow_module_level=True)
+
+
+@pytest.mark.e2e
+def test_container_healthcheck() -> None:
+    tag = "af-health-test"
+    dockerfile = os.path.join("alpha_factory_v1", "Dockerfile")
+    subprocess.run(["docker", "build", "-t", tag, "-f", dockerfile, "."], check=True)
+    cid = subprocess.check_output(["docker", "run", "-d", tag]).decode().strip()
+    try:
+        status = "starting"
+        for _ in range(60):
+            inspect = subprocess.check_output(
+                ["docker", "inspect", "-f", "{{.State.Health.Status}}", cid],
+                text=True,
+            ).strip()
+            status = inspect
+            if status == "healthy":
+                break
+            time.sleep(2)
+        assert status == "healthy"
+    finally:
+        subprocess.run(["docker", "rm", "-f", cid], check=False)
+        subprocess.run(["docker", "rmi", tag], check=False)

--- a/tests/test_insight_endpoint.py
+++ b/tests/test_insight_endpoint.py
@@ -1,0 +1,46 @@
+import os
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+from src.interface import api_server as api
+
+
+def _make_client() -> TestClient:
+    return TestClient(cast(Any, api.app))
+
+
+def _setup_simulations() -> None:
+    api._simulations.clear()
+    api._simulations["a"] = api.ResultsResponse(
+        id="a",
+        forecast=[api.ForecastPoint(year=1, capability=0.1)],
+        population=None,
+    )
+    api._simulations["b"] = api.ResultsResponse(
+        id="b",
+        forecast=[api.ForecastPoint(year=1, capability=0.9)],
+        population=None,
+    )
+
+
+def test_insight_aggregates_results() -> None:
+    _setup_simulations()
+    client = _make_client()
+    headers = {"Authorization": "Bearer test-token"}
+    resp = client.post("/insight", json={"ids": ["a", "b"]}, headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"forecast": [{"year": 1, "capability": 0.5}]}
+
+
+def test_insight_invalid_token() -> None:
+    _setup_simulations()
+    client = _make_client()
+    resp = client.post("/insight", json={}, headers={"Authorization": "Bearer bad"})
+    assert resp.status_code == 403

--- a/tests/test_retry_wrapper.py
+++ b/tests/test_retry_wrapper.py
@@ -1,0 +1,50 @@
+import asyncio
+
+import pytest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import retry
+
+
+def test_with_retry_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(retry, "backoff", None)
+    calls = {"n": 0}
+
+    def func() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ValueError("boom")
+        return "ok"
+
+    wrapped = retry.with_retry(func, max_tries=3)
+    assert wrapped() == "ok"
+    assert calls["n"] == 3
+
+
+def test_with_retry_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(retry, "backoff", None)
+    calls = {"n": 0}
+
+    async def func() -> str:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise ValueError("fail")
+        return "ok"
+
+    wrapped = retry.with_retry(func, max_tries=2)
+    result = asyncio.run(wrapped())
+    assert result == "ok"
+    assert calls["n"] == 2
+
+
+def test_with_retry_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(retry, "backoff", None)
+    calls = {"n": 0}
+
+    def func() -> str:
+        calls["n"] += 1
+        raise ValueError("fail")
+
+    wrapped = retry.with_retry(func, max_tries=2)
+    with pytest.raises(ValueError):
+        wrapped()
+    assert calls["n"] == 2


### PR DESCRIPTION
## Summary
- validate `/insight` endpoint and token handling
- test backoff retry wrapper logic
- exercise Docker healthcheck in integration test
- fix future import order in Insight logging module

## Testing
- `python check_env.py --auto-install`
- `ruff check tests/test_insight_endpoint.py tests/test_retry_wrapper.py tests/test_docker_health.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py`
- `mypy --config-file mypy.ini tests/test_insight_endpoint.py tests/test_retry_wrapper.py tests/test_docker_health.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py` *(fails: Argument "population" to "PopulationResponse" has incompatible type)*
- `pytest -q`