### PR TITLE
[alpha_factory] add tracing spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,13 @@ terraform apply
 | Traces | OpenTelemetry | `trace_id` |
 | Dashboards | Grafana | `alpha-factory/trade-lifecycle.json` |
 
+By default traces and metrics print to ``stdout``. To export to a collector such
+as **Jaeger**, set ``OTEL_EXPORTER_OTLP_ENDPOINT`` and start Jaeger locally:
+
+```bash
+docker run -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
+```
+
 ---
 
 <a name="10-extending-the-mesh"></a>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -47,3 +47,5 @@ blake3==0.3.3
 grpcio==1.71.0
 grpcio-tools==1.62.1
 plotly==5.21.0
+opentelemetry-api==1.32.1
+opentelemetry-sdk==1.32.1

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
+from ..utils.tracing import span
 
 
 class SafetyGuardianAgent(BaseAgent):
@@ -21,10 +22,12 @@ class SafetyGuardianAgent(BaseAgent):
 
     async def run_cycle(self) -> None:
         """No-op periodic check."""
-        return None
+        with span("safety.run_cycle"):
+            return None
 
     async def handle(self, env: messaging.Envelope) -> None:
         """Simple pattern-based validation."""
-        code = env.payload.get("code", "")
-        status = "blocked" if "import os" in code else "ok"
-        await self.emit("memory", {"code": code, "status": status})
+        with span("safety.handle"):
+            code = env.payload.get("code", "")
+            status = "blocked" if "import os" in code else "ok"
+            await self.emit("memory", {"code": code, "status": status})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, cast
 
 from . import config
 from .config import Settings
+from .tracing import span
 
 try:  # pragma: no cover - optional dependency
     from llama_cpp import Llama
@@ -78,6 +79,7 @@ def chat(prompt: str, cfg: Settings | None = None) -> str:
         _load_model(cfg)
     assert _CALL is not None
     try:
-        return _CALL(prompt, cfg)
+        with span("local_llm.chat"):
+            return _CALL(prompt, cfg)
     except Exception:  # pragma: no cover - runtime error
         return f"[offline] {prompt}"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/tracing.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/tracing.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenTelemetry helpers used by the Insight demo."""
+from __future__ import annotations
+
+import os
+from contextlib import nullcontext
+
+try:  # optional dependency
+    from opentelemetry import metrics, trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import (
+        ConsoleMetricExporter,
+        OTLPMetricExporter,
+        PeriodicExportingMetricReader,
+    )
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        OTLPSpanExporter,
+    )
+except Exception:  # pragma: no cover - missing SDK
+    metrics = trace = None  # type: ignore
+
+__all__ = ["tracer", "meter", "span", "configure"]
+
+tracer = None
+meter = None
+
+
+def configure() -> None:
+    """Initialise tracing and metrics if the SDK is installed."""
+    global tracer, meter
+    if trace is None:
+        return
+
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if endpoint:
+        span_exporter = OTLPSpanExporter(endpoint=endpoint)
+        metric_exporter = OTLPMetricExporter(endpoint=endpoint)
+    else:
+        span_exporter = ConsoleSpanExporter()
+        metric_exporter = ConsoleMetricExporter()
+
+    resource = Resource.create({"service.name": "alpha-insight"})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(span_exporter))
+    trace.set_tracer_provider(provider)
+    tracer = trace.get_tracer("alpha_insight")
+
+    meter_provider = MeterProvider(
+        resource=resource,
+        metric_readers=[PeriodicExportingMetricReader(metric_exporter)],
+    )
+    metrics.set_meter_provider(meter_provider)
+    meter = metrics.get_meter("alpha_insight")
+
+
+def span(name: str):
+    """Return a context manager for ``name``."""
+    if tracer:
+        return tracer.start_as_current_span(name)
+    return nullcontext()
+
+
+configure()


### PR DESCRIPTION
## Summary
- add optional OpenTelemetry setup
- instrument bus, ledger and agent cycles with spans
- wrap all Insight agent LLM/tool calls with spans
- document Jaeger usage
- pin OpenTelemetry packages for Insight demo

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit` *(failed: Could not install pre-commit)*