### PR TITLE
[alpha_factory] add deployment security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ See [AGENTS.md](AGENTS.md) for the full contributor guide.
 6.2. [Marketplace Demo Example 🛒](#62-marketplace-demo-example)
 6.3. [Offline Mode](#63-offline-mode)
 7. [Deployment Recipes 🍳](#7-deployment-recipes)
+7.1. [Deploying securely 🚀](#71-deploying-securely)
 8. [Governance & Compliance ⚖️](#8-governance--compliance)  
 9. [Observability 🔭](#9-observability)  
 10. [Extending the Mesh 🔌](#10-extending-the-mesh)  
@@ -824,6 +825,10 @@ terraform apply
 | **Helm (K8s)** | `helm install af helm/alpha-factory` | `--set env.RUN_MODE=web` |
 | **AWS Fargate** | `./infra/deploy_fargate.sh` | set `container_image` & `subnets` |
 | **IoT Edge** | `python edge_runner.py --agents manufacturing,energy` | Jetson Nano |
+<a name="71-deploying-securely"></a>
+### 🚀 Deploying securely
+See [docs/deployment_security.md](docs/deployment_security.md) for TLS setup, API tokens and Vault usage. Mount secrets via Docker or Kubernetes and never commit them.
+
 
 ---
 

--- a/docs/deployment_security.md
+++ b/docs/deployment_security.md
@@ -1,0 +1,97 @@
+# Secure Deployment
+
+This guide explains how to protect Alpha-Factory in production.
+
+## TLS configuration
+
+Use TLS to encrypt both the REST API and the gRPC bus. Run `infrastructure/gen_bus_certs.sh` to generate a self-signed certificate or supply your own:
+
+```bash
+./infrastructure/gen_bus_certs.sh
+# prints AGI_INSIGHT_BUS_CERT, AGI_INSIGHT_BUS_KEY
+```
+
+Set these environment variables when starting the orchestrator. For the REST API you may terminate HTTPS with a reverse proxy like Nginx or pass `--ssl-keyfile` and `--ssl-certfile` to `uvicorn`.
+
+## API tokens
+
+Set `API_TOKEN` to a strong secret so clients must send
+`Authorization: Bearer <token>` when calling the REST endpoints.
+Combine this with `API_RATE_LIMIT` to limit requests per minute.
+
+## Loading secrets from Vault
+
+Alpha‑Factory can pull credentials from HashiCorp Vault by setting
+`AGI_INSIGHT_SECRET_BACKEND=vault` and providing `VAULT_ADDR` and
+`VAULT_TOKEN`. Secrets like `OPENAI_API_KEY` are read from
+`secret/data/alpha-factory` by default.
+
+## Mounting secrets into containers
+
+Do not commit private keys or tokens. Instead, mount them at runtime:
+
+### Docker Compose
+
+```yaml
+services:
+  orchestrator:
+    volumes:
+      - ./certs:/certs:ro
+    environment:
+      - AGI_INSIGHT_BUS_CERT=/certs/bus.crt
+      - AGI_INSIGHT_BUS_KEY=/certs/bus.key
+      - API_TOKEN_FILE=/run/secrets/api_token
+    secrets:
+      - api_token
+secrets:
+  api_token:
+    file: ./secrets/api_token
+```
+
+### Kubernetes
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alpha-factory
+type: Opaque
+stringData:
+  api_token: "strongtoken"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alpha-factory
+spec:
+  template:
+    spec:
+      containers:
+        - name: orchestrator
+          image: alpha-demo
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+          env:
+            - name: AGI_INSIGHT_BUS_CERT
+              value: /certs/bus.crt
+            - name: AGI_INSIGHT_BUS_KEY
+              value: /certs/bus.key
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: alpha-factory
+                  key: api_token
+      volumes:
+        - name: certs
+          secret:
+            secretName: alpha-factory
+            items:
+              - key: bus.crt
+                path: bus.crt
+              - key: bus.key
+                path: bus.key
+```
+
+Store keys in a secure secret manager and never check them into git.


### PR DESCRIPTION
## Summary
- add `docs/deployment_security.md` describing TLS, API tokens and Vault
- link it from README in a new "Deploying securely" section

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
