### PR TITLE
[alpha_factory] add retry property tests and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install pytest pytest-cov
-      - name: Run tests
+      - name: Run tests with coverage
         run: |
-          pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/tests
+          pytest --cov --cov-report=xml --cov-fail-under=60
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
 
   docker:
     name: "🐳 Docker build"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ mypy
 fastapi
 opentelemetry-api
 cryptography
+hypothesis

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -1,0 +1,24 @@
+import json
+import logging
+from datetime import datetime
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import _JsonFormatter
+
+
+def test_json_formatter_output() -> None:
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    out = _JsonFormatter().format(record)
+    data = json.loads(out)
+    assert data["msg"] == "hello"
+    assert data["lvl"] == "INFO"
+    assert data["name"] == "test"
+    # timestamp is ISO formatted
+    datetime.fromisoformat(data["ts"])

--- a/tests/test_retry_property.py
+++ b/tests/test_retry_property.py
@@ -1,0 +1,59 @@
+import asyncio
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, strategies as st, settings, assume
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import retry
+
+
+@settings(max_examples=25)
+@given(failures=st.integers(min_value=0, max_value=4), max_tries=st.integers(min_value=1, max_value=5))
+def test_with_retry_sync_property(monkeypatch: pytest.MonkeyPatch, failures: int, max_tries: int) -> None:
+    assume(max_tries > 0)
+    monkeypatch.setattr(retry, "backoff", None)
+    monkeypatch.setattr(retry.time, "sleep", lambda *_: None)
+    calls = {"n": 0}
+
+    def func() -> str:
+        calls["n"] += 1
+        if calls["n"] <= failures:
+            raise ValueError("boom")
+        return "ok"
+
+    wrapped = retry.with_retry(func, max_tries=max_tries)
+    if failures >= max_tries:
+        with pytest.raises(ValueError):
+            wrapped()
+        assert calls["n"] == max_tries
+    else:
+        assert wrapped() == "ok"
+        assert calls["n"] == failures + 1
+
+
+@settings(max_examples=25)
+@given(failures=st.integers(min_value=0, max_value=4), max_tries=st.integers(min_value=1, max_value=5))
+def test_with_retry_async_property(monkeypatch: pytest.MonkeyPatch, failures: int, max_tries: int) -> None:
+    assume(max_tries > 0)
+    monkeypatch.setattr(retry, "backoff", None)
+
+    async def no_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(retry.asyncio, "sleep", no_sleep)
+    calls = {"n": 0}
+
+    async def func() -> str:
+        calls["n"] += 1
+        if calls["n"] <= failures:
+            raise ValueError("boom")
+        return "ok"
+
+    wrapped = retry.with_retry(func, max_tries=max_tries)
+    if failures >= max_tries:
+        with pytest.raises(ValueError):
+            asyncio.run(wrapped())
+        assert calls["n"] == max_tries
+    else:
+        assert asyncio.run(wrapped()) == "ok"
+        assert calls["n"] == failures + 1


### PR DESCRIPTION
## Summary
- add property-based tests for `with_retry`
- add basic test for `_JsonFormatter`
- install `hypothesis` during dev installs
- gather coverage in CI and upload artifact

## Testing
- `python check_env.py --auto-install`
- `pytest -q`