### PR TITLE
[alpha_factory] Add compose for Insight API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.9'
+
+volumes:
+  ledger:
+    driver: local
+
+services:
+  insight-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      AGI_INSIGHT_LEDGER_PATH: /app/ledger/audit.db
+      AGI_INSIGHT_DB: duckdb
+    volumes:
+      - ledger:/app/ledger
+    ports:
+      - "8000:8000"
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/healthz && curl -sf http://localhost:8000/readiness"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  duckdb:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: insight
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-insight}
+      POSTGRES_DB: insight
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - ledger:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.56
+    profiles: ["tracing"]
+    ports:
+      - "16686:16686"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:16686"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+


### PR DESCRIPTION
## Summary
- add Docker Compose to run insight-api, Postgres and Jaeger

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pip install pre-commit` *(fails: no network)*