### PR TITLE
[alpha_factory] Add Docker quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,10 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py --loglevel info
 ```
 
+## Quick Start with Docker
+docker compose up --build
+# browse http://localhost:8080
+
 ### .env Setup & Security
 Before running the orchestrator, copy `alpha_factory_v1/.env.sample` to `.env` and
 replace all placeholder values with strong secrets. The sample sets


### PR DESCRIPTION
## Summary
- document quick Docker start command in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit run --files README.md` *(fails: command not found)*