### PR TITLE
[alpha_factory] add readiness probe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,12 @@ services:
       - "8000:8000"
       - "8080:8080"
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/healthz && curl -sf http://localhost:8000/readiness"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    readiness:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/readiness"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- add `readiness` check to insight-api service

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_insight_health.py::test_readiness - assert 503 == 200)*