### PR TITLE
[alpha_factory] Add Prometheus metrics router

### DIFF
--- a/tests/test_metrics_router.py
+++ b/tests/test_metrics_router.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+from src.interface import api_server as api
+
+
+def make_client() -> TestClient:
+    return TestClient(cast(Any, api.app))
+
+
+def test_metrics_endpoint() -> None:
+    client = make_client()
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert "api_requests_total" in resp.text


### PR DESCRIPTION
## Summary
- expose `/metrics` in api_server with Prometheus
- collect request counts and durations
- test metrics endpoint

## Testing
- `python check_env.py --auto-install`
- `PYTHONPATH=$(pwd) pytest -q tests/test_metrics_router.py`
- `PYTHONPATH=$(pwd) pytest -q` *(fails: tests/test_insight_health.py::test_readiness)*