### PR TITLE
[alpha_factory] enable PVC and health probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,8 @@ setup:
 helm upgrade --install alpha-demo ./infrastructure/helm-chart \
   --values ./infrastructure/helm-chart/values.yaml \
   --set env.RUN_MODE=web
+# Enable persistent storage for the audit ledger
+#   --set persistence.enabled=true --set persistence.size=5Gi
 # → browse to <http://localhost:8080>
 ```
 

--- a/infrastructure/helm-chart/README.md
+++ b/infrastructure/helm-chart/README.md
@@ -5,6 +5,8 @@ helm upgrade --install alpha-demo ./infrastructure/helm-chart \
   --set env.OPENAI_API_KEY=<key> \
   --set env.RUN_MODE=api \
   --set env.AGI_INSIGHT_BUS_PORT=6006
+# enable persistent storage
+#   --set persistence.enabled=true --set persistence.size=5Gi
 ```
 
 Values such as `service.port` or `image` can be overridden with `--set` or a custom `values.yaml` file.

--- a/infrastructure/helm-chart/templates/deployment.yaml
+++ b/infrastructure/helm-chart/templates/deployment.yaml
@@ -30,3 +30,26 @@ spec:
             - containerPort: 8000
             - containerPort: 8501
             - containerPort: 6006
+          livenessProbe:
+            httpGet:
+              path: /runs
+              port: 8000
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /runs
+              port: 8000
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          volumeMounts:
+            - name: ledger
+              mountPath: /app/ledger
+      volumes:
+        - name: ledger
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: alpha-demo-ledger
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/infrastructure/helm-chart/templates/pvc.yaml
+++ b/infrastructure/helm-chart/templates/pvc.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: alpha-demo-ledger
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/infrastructure/helm-chart/values.yaml
+++ b/infrastructure/helm-chart/values.yaml
@@ -6,6 +6,15 @@ env:
   AGI_INSIGHT_OFFLINE: "0"
   AGI_INSIGHT_BUS_PORT: "6006"
   AGI_INSIGHT_LEDGER_PATH: "./ledger/audit.db"
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 5
+persistence:
+  enabled: false
+  size: 1Gi
 service:
   type: ClusterIP
   port: 8000


### PR DESCRIPTION
## Summary
- add health probes to orchestrator Deployment
- mount persistent storage for the ledger
- expose probe and storage settings in `values.yaml`
- document persistence flags for Helm installs

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_insight_health.py::test_readiness)*
- `pre-commit` *(fails: command not found)*