### PR TITLE
[alpha_factory] add webhook alert handling

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Simple webhook alerts for restarts and failures."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+try:
+    import af_requests as requests
+except Exception:  # pragma: no cover - optional real requests
+    import requests  # type: ignore
+
+__all__ = ["send_alert"]
+
+_log = logging.getLogger(__name__)
+
+
+def send_alert(message: str, url: str | None = None) -> None:
+    """Post *message* to ``url`` or ``ALERT_WEBHOOK_URL`` if set."""
+
+    hook = url or os.getenv("ALERT_WEBHOOK_URL")
+    if not hook:
+        return
+
+    payload = {"content": message}
+    if "slack.com" in hook:
+        payload = {"text": message}
+
+    try:
+        requests.post(hook, json=payload, timeout=5)
+    except Exception as exc:  # pragma: no cover - network errors
+        _log.warning("alert failed: %s", exc)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -90,6 +90,7 @@ class Settings(BaseSettings):
     bus_token: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_TOKEN")
     bus_cert: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_CERT")
     bus_key: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_KEY")
+    alert_webhook_url: Optional[str] = Field(default=None, alias="ALERT_WEBHOOK_URL")
     allow_insecure: bool = Field(default=False, alias="AGI_INSIGHT_ALLOW_INSECURE")
     broadcast: bool = Field(default=True, alias="AGI_INSIGHT_BROADCAST")
     solana_rpc_url: str = Field(default="https://api.testnet.solana.com", alias="AGI_INSIGHT_SOLANA_URL")
@@ -127,6 +128,7 @@ class Settings(BaseSettings):
             if any(s in k.lower() for s in ("token", "key", "password")) and data[k]:
                 data[k] = "***"
         return f"Settings({data})"
+
 
 _prefetch_vault()
 

--- a/tests/test_alert_webhook.py
+++ b/tests/test_alert_webhook.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for webhook alert integration."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import alerts, messaging, config
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent import BaseAgent
+
+
+class DummyLedger:
+    def __init__(self, *_a, **_kw) -> None:
+        self.events = []
+
+    def log(self, env) -> None:  # type: ignore[override]
+        self.events.append(env.payload.get("event"))
+
+    def start_merkle_task(self, *_a, **_kw) -> None:  # pragma: no cover - test stub
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - test stub
+        pass
+
+    def close(self) -> None:  # pragma: no cover - test stub
+        pass
+
+
+class DummyAgent(BaseAgent):
+    NAME = "dummy"
+
+    def __init__(self, bus: messaging.A2ABus, ledger: DummyLedger) -> None:
+        super().__init__("dummy", bus, ledger)
+
+    async def run_cycle(self) -> None:
+        raise RuntimeError("boom")
+
+    async def handle(self, _env) -> None:
+        pass
+
+
+def test_restart_alert(monkeypatch) -> None:
+    sent: dict[str, object] = {}
+
+    def fake_post(url: str, *, json=None, timeout=None):
+        sent["url"] = url
+        sent["payload"] = json
+        return type("R", (), {"status_code": 200})()
+
+    monkeypatch.setattr(alerts, "requests", type("M", (), {"post": fake_post}))
+    monkeypatch.setattr(orchestrator, "Ledger", DummyLedger)
+    monkeypatch.setattr(orchestrator.Orchestrator, "_init_agents", lambda self: [])
+
+    settings = config.Settings(bus_port=0, alert_webhook_url="http://hook")
+    orch = orchestrator.Orchestrator(settings)
+    runner = orchestrator.AgentRunner(DummyAgent(orch.bus, orch.ledger))
+
+    orch._record_restart(runner)
+
+    assert sent["url"] == "http://hook"
+    assert (
+        sent["payload"].get("text") == "dummy restarted"
+        if "text" in sent["payload"]
+        else sent["payload"].get("content") == "dummy restarted"
+    )
+
+
+def test_agent_failure_alert(monkeypatch) -> None:
+    sent: dict[str, object] = {}
+
+    def fake_post(url: str, *, json=None, timeout=None):
+        sent["url"] = url
+        sent["payload"] = json
+        return type("R", (), {"status_code": 200})()
+
+    monkeypatch.setattr(alerts, "requests", type("M", (), {"post": fake_post}))
+    monkeypatch.setenv("ALERT_WEBHOOK_URL", "http://hook")
+
+    bus = messaging.A2ABus(config.Settings(bus_port=0))
+    ledger = DummyLedger()
+    runner = orchestrator.AgentRunner(DummyAgent(bus, ledger))
+
+    async def run() -> None:
+        task = asyncio.create_task(runner.loop(bus, ledger))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+
+    assert sent["url"] == "http://hook"
+    assert "failed" in (sent["payload"].get("text") or sent["payload"].get("content", ""))


### PR DESCRIPTION
## Summary
- implement a simple webhook helper to post to Slack or Discord
- expose `ALERT_WEBHOOK_URL` in Insight config
- emit alerts when an agent fails or restarts
- test webhook alerts via monkeypatched HTTP client

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py tests/test_alert_webhook.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py tests/test_alert_webhook.py` *(fails: "SimplePath has no attribute exists" and other type issues)*
- `pytest -q` *(fails: test_insight_health::test_readiness - assert 503 == 200)*