### PR TITLE
[alpha_factory] add SPDX headers to web client files

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 (function () {
   const { useEffect } = React;
   function App() {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/vite.config.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/vite.config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 

--- a/alpha_factory_v1/ui/static/main.js
+++ b/alpha_factory_v1/ui/static/main.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 
 async function refresh(){
   const tbody=document.querySelector('#tbl tbody');

--- a/src/interface/web_client/dist/app.js
+++ b/src/interface/web_client/dist/app.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 (function(){
   const {useState, useEffect} = React;
   function App(){

--- a/src/interface/web_client/src/App.tsx
+++ b/src/interface/web_client/src/App.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState, FormEvent } from 'react';
 import Plotly from 'plotly.js-dist';
 

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/src/interface/web_client/vite.config.ts
+++ b/src/interface/web_client/vite.config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 

--- a/tools/loadtest/insight.js
+++ b/tools/loadtest/insight.js
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+// SPDX-License-Identifier: Apache-2.0
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to JS/TS files

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_insight_health.py::test_readiness - assert 503 == 200)*
- `pre-commit` *(failed: command not found)*