### PR TITLE
[alpha_factory] add unit tests and mutation testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
-          pip install pytest pytest-cov pytest-benchmark
+          pip install pytest pytest-cov pytest-benchmark mutmut
       - name: Run tests with coverage
         run: |
-          pytest --cov --cov-report=xml --cov-fail-under=60
+          pytest --cov --cov-report=xml --cov-fail-under=70
+      - name: Mutation tests
+        run: |
+          mutmut run --paths-to-mutate alpha_factory_v1/demos/alpha_agi_insight_v1/src --runner "pytest -q"
       - name: Run benchmark
         run: |
           pytest tests/test_benchmark.py -q

--- a/tests/.mutmut-config
+++ b/tests/.mutmut-config
@@ -1,0 +1,3 @@
+[mutmut]
+paths_to_mutate=alpha_factory_v1/demos/alpha_agi_insight_v1/src
+runner=pytest -q

--- a/tests/test_agent_handle_methods.py
+++ b/tests/test_agent_handle_methods.py
@@ -1,0 +1,116 @@
+import asyncio
+import random
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (
+    memory_agent,
+    strategy_agent,
+    planning_agent,
+    market_agent,
+    research_agent,
+    safety_agent,
+    codegen_agent,
+)
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+class DummyBus:
+    def __init__(self, settings: config.Settings) -> None:
+        self.settings = settings
+        self.published: list[tuple[str, messaging.Envelope]] = []
+
+    def publish(self, topic: str, env: messaging.Envelope) -> None:
+        self.published.append((topic, env))
+
+    def subscribe(self, topic: str, handler):
+        pass
+
+
+class DummyLedger:
+    def __init__(self) -> None:
+        self.logged: list[messaging.Envelope] = []
+
+    def log(self, env: messaging.Envelope) -> None:  # type: ignore[override]
+        self.logged.append(env)
+
+    def start_merkle_task(self, *a, **kw):
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - interface
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def test_memory_agent_handle_appends() -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = memory_agent.MemoryAgent(bus, led)
+    env = messaging.Envelope("a", "memory", {"v": 1}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert agent.records == [{"v": 1}]
+
+
+def test_planning_agent_handle_logs() -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = planning_agent.PlanningAgent(bus, led)
+    env = messaging.Envelope("a", "planning", {"plan": "x"}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert led.logged and led.logged[0] is env
+
+
+def test_strategy_agent_emits_market() -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = strategy_agent.StrategyAgent(bus, led)
+    env = messaging.Envelope("research", "strategy", {"research": "foo"}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert bus.published
+    topic, sent = bus.published[-1]
+    assert topic == "market"
+    assert "strategy" in sent.payload
+
+
+def test_market_agent_emits_codegen() -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = market_agent.MarketAgent(bus, led)
+    env = messaging.Envelope("strategy", "market", {"strategy": "foo"}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert bus.published[-1][0] == "codegen"
+
+
+def test_research_agent_emits_strategy(monkeypatch) -> None:
+    cfg = config.Settings(bus_port=0, openai_api_key="k")
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = research_agent.ResearchAgent(bus, led)
+    monkeypatch.setattr(random, "random", lambda: 0.5)
+    env = messaging.Envelope("planning", "research", {"plan": "y"}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert bus.published[-1][0] == "strategy"
+
+
+def test_safety_agent_emits_status() -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = safety_agent.SafetyGuardianAgent(bus, led)
+    env = messaging.Envelope("codegen", "safety", {"code": "import os"}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert bus.published[-1][1].payload["status"] == "blocked"
+
+
+def test_codegen_agent_emits_to_safety(monkeypatch) -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = codegen_agent.CodeGenAgent(bus, led)
+    monkeypatch.setattr(agent, "execute_in_sandbox", lambda code: ("", ""))
+    env = messaging.Envelope("market", "codegen", {"analysis": "x"}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert bus.published[-1][0] == "safety"

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -1,0 +1,9 @@
+import importlib
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config
+
+
+def test_settings_offline_enabled_when_missing_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    importlib.reload(config)
+    s = config.Settings()
+    assert s.offline

--- a/tests/test_ledger_basic.py
+++ b/tests/test_ledger_basic.py
@@ -1,0 +1,13 @@
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
+
+
+def test_log_and_tail(tmp_path):
+    ledger = Ledger(str(tmp_path / "ledger.db"), broadcast=False)
+    e1 = messaging.Envelope("a", "b", {"v": 1}, 0.0)
+    e2 = messaging.Envelope("b", "c", {"v": 2}, 1.0)
+    ledger.log(e1)
+    ledger.log(e2)
+    tail = ledger.tail(2)
+    assert tail[0]["payload"]["v"] == 1
+    assert tail[1]["payload"]["v"] == 2


### PR DESCRIPTION
## Summary
- add coverage threshold to CI and run mutation tests
- create mutmut config
- add basic Ledger, Settings, and agent handle tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_insight_health.py::test_readiness - assert 503 == 200)*