### PR TITLE
[alpha_factory] add missing license headers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Minimal React dashboard for α‑AGI Insight."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/retry.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/retry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 # mypy: ignore-errors


### PR DESCRIPTION
## Summary
- add Apache-2.0 header to retry utils
- add header to the web client package stub

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/retry.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/__init__.py` *(fails: `pre-commit: command not found`)*