### PR TITLE
[alpha_factory] ensure ledger tests use context managers

### DIFF
--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -14,141 +14,138 @@ from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
 
 
 def test_compute_merkle_root_matches_manual() -> None:
-    tmp = tempfile.TemporaryDirectory()
-    ledger = Ledger(os.path.join(tmp.name, "l.db"), broadcast=False)
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger = Ledger(os.path.join(tmp, "l.db"), broadcast=False)
 
-    envs = [
-        messaging.Envelope("a", "b", {"v": 1}, 0.0),
-        messaging.Envelope("b", "c", {"v": 2}, 1.0),
-        messaging.Envelope("c", "d", {"v": 3}, 2.0),
-    ]
-    for env in envs:
-        ledger.log(env)
+        envs = [
+            messaging.Envelope("a", "b", {"v": 1}, 0.0),
+            messaging.Envelope("b", "c", {"v": 2}, 1.0),
+            messaging.Envelope("c", "d", {"v": 3}, 2.0),
+        ]
+        for env in envs:
+            ledger.log(env)
 
-    computed = ledger.compute_merkle_root()
+        computed = ledger.compute_merkle_root()
 
-    hashes = []
-    for env in envs:
-        data = json.dumps(asdict(env), sort_keys=True).encode()
-        hashes.append(insight_logging.blake3(data).hexdigest())  # type: ignore[attr-defined]
+        hashes = []
+        for env in envs:
+            data = json.dumps(asdict(env), sort_keys=True).encode()
+            hashes.append(insight_logging.blake3(data).hexdigest())  # type: ignore[attr-defined]
 
-    manual = insight_logging._merkle_root(hashes)
-    assert computed == manual
-    tmp.cleanup()
+        manual = insight_logging._merkle_root(hashes)
+        assert computed == manual
 
 
 def test_broadcast_merkle_root_uses_async_client() -> None:
-    tmp = tempfile.TemporaryDirectory()
-    ledger = Ledger(os.path.join(tmp.name, "l.db"), rpc_url="http://rpc.test", broadcast=True)
-    env = messaging.Envelope("a", "b", {"v": 1}, 0.0)
-    ledger.log(env)
-    root = ledger.compute_merkle_root()
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger = Ledger(os.path.join(tmp, "l.db"), rpc_url="http://rpc.test", broadcast=True)
+        env = messaging.Envelope("a", "b", {"v": 1}, 0.0)
+        ledger.log(env)
+        root = ledger.compute_merkle_root()
 
-    calls: list[Any] = []
+        calls: list[Any] = []
 
-    class DummyClient:
-        def __init__(self, url: str) -> None:
-            calls.append(("url", url))
+        class DummyClient:
+            def __init__(self, url: str) -> None:
+                calls.append(("url", url))
 
-        async def send_transaction(self, tx: Any, *args: Any) -> None:
-            calls.append(("sent", tx.instructions[0].data.decode()))
+            async def send_transaction(self, tx: Any, *args: Any) -> None:
+                calls.append(("sent", tx.instructions[0].data.decode()))
 
-        async def close(self) -> None:
-            pass
+            async def close(self) -> None:
+                pass
 
-    class DummyTx:
-        def __init__(self) -> None:
-            self.instructions: list[Any] = []
+        class DummyTx:
+            def __init__(self) -> None:
+                self.instructions: list[Any] = []
 
-        def add(self, instr: Any) -> "DummyTx":
-            self.instructions.append(instr)
-            return self
+            def add(self, instr: Any) -> "DummyTx":
+                self.instructions.append(instr)
+                return self
 
-    class DummyInstr:
-        def __init__(self, program_id: Any, data: bytes, keys: list[Any]):
-            self.data = data
+        class DummyInstr:
+            def __init__(self, program_id: Any, data: bytes, keys: list[Any]):
+                self.data = data
 
-    class DummyPk:
-        def __init__(self, val: str) -> None:
-            pass
+        class DummyPk:
+            def __init__(self, val: str) -> None:
+                pass
 
-    # ensure mock module hierarchy exists for patching
-    with (
-        mock.patch.dict(
-            sys.modules,
-            {
-                "solana": ModuleType("solana"),
-                "solana.rpc": ModuleType("solana.rpc"),
-                "solana.rpc.async_api": ModuleType("solana.rpc.async_api"),
-            },
-        ),
-        mock.patch("solana.rpc.async_api.AsyncClient", DummyClient, create=True),
-        mock.patch.object(insight_logging, "AsyncClient", DummyClient, create=True),
-        mock.patch.object(insight_logging, "Transaction", DummyTx, create=True),
-        mock.patch.object(insight_logging, "TransactionInstruction", DummyInstr, create=True),
-        mock.patch.object(insight_logging, "PublicKey", DummyPk, create=True),
-    ):
-        asyncio.run(ledger.broadcast_merkle_root())
+        # ensure mock module hierarchy exists for patching
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "solana": ModuleType("solana"),
+                    "solana.rpc": ModuleType("solana.rpc"),
+                    "solana.rpc.async_api": ModuleType("solana.rpc.async_api"),
+                },
+            ),
+            mock.patch("solana.rpc.async_api.AsyncClient", DummyClient, create=True),
+            mock.patch.object(insight_logging, "AsyncClient", DummyClient, create=True),
+            mock.patch.object(insight_logging, "Transaction", DummyTx, create=True),
+            mock.patch.object(insight_logging, "TransactionInstruction", DummyInstr, create=True),
+            mock.patch.object(insight_logging, "PublicKey", DummyPk, create=True),
+        ):
+            asyncio.run(ledger.broadcast_merkle_root())
 
-    assert ("url", "http://rpc.test") in calls
-    assert ("sent", root) in calls
-    tmp.cleanup()
+        assert ("url", "http://rpc.test") in calls
+        assert ("sent", root) in calls
 
 
 def test_broadcast_merkle_root_handles_network_errors() -> None:
-    tmp = tempfile.TemporaryDirectory()
-    ledger = Ledger(os.path.join(tmp.name, "l.db"), rpc_url="http://rpc.test", broadcast=True)
-    env = messaging.Envelope("a", "b", {"v": 1}, 0.0)
-    ledger.log(env)
-    root = ledger.compute_merkle_root()
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger = Ledger(os.path.join(tmp, "l.db"), rpc_url="http://rpc.test", broadcast=True)
+        env = messaging.Envelope("a", "b", {"v": 1}, 0.0)
+        ledger.log(env)
+        root = ledger.compute_merkle_root()
 
-    captured: dict[str, Any] = {}
+        captured: dict[str, Any] = {}
 
-    class DummyClient:
-        def __init__(self, url: str) -> None:
-            captured["url"] = url
+        class DummyClient:
+            def __init__(self, url: str) -> None:
+                captured["url"] = url
 
-        async def send_transaction(self, tx: Any, *args: Any) -> None:
-            captured["root"] = tx.instructions[0].data.decode()
-            raise RuntimeError("fail")
+            async def send_transaction(self, tx: Any, *args: Any) -> None:
+                captured["root"] = tx.instructions[0].data.decode()
+                raise RuntimeError("fail")
 
-        async def close(self) -> None:
-            pass
+            async def close(self) -> None:
+                pass
 
-    class DummyTx:
-        def __init__(self) -> None:
-            self.instructions: list[Any] = []
+        class DummyTx:
+            def __init__(self) -> None:
+                self.instructions: list[Any] = []
 
-        def add(self, instr: Any) -> "DummyTx":
-            self.instructions.append(instr)
-            return self
+            def add(self, instr: Any) -> "DummyTx":
+                self.instructions.append(instr)
+                return self
 
-    class DummyInstr:
-        def __init__(self, program_id: Any, data: bytes, keys: list[Any]):
-            self.data = data
+        class DummyInstr:
+            def __init__(self, program_id: Any, data: bytes, keys: list[Any]):
+                self.data = data
 
-    class DummyPk:
-        def __init__(self, val: str) -> None:
-            pass
+        class DummyPk:
+            def __init__(self, val: str) -> None:
+                pass
 
-    with (
-        mock.patch.dict(
-            sys.modules,
-            {
-                "solana": ModuleType("solana"),
-                "solana.rpc": ModuleType("solana.rpc"),
-                "solana.rpc.async_api": ModuleType("solana.rpc.async_api"),
-            },
-        ),
-        mock.patch("solana.rpc.async_api.AsyncClient", DummyClient, create=True),
-        mock.patch.object(insight_logging, "AsyncClient", DummyClient, create=True),
-        mock.patch.object(insight_logging, "Transaction", DummyTx, create=True),
-        mock.patch.object(insight_logging, "TransactionInstruction", DummyInstr, create=True),
-        mock.patch.object(insight_logging, "PublicKey", DummyPk, create=True),
-        mock.patch.object(insight_logging, "_log") as log,
-    ):
-        asyncio.run(ledger.broadcast_merkle_root())
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "solana": ModuleType("solana"),
+                    "solana.rpc": ModuleType("solana.rpc"),
+                    "solana.rpc.async_api": ModuleType("solana.rpc.async_api"),
+                },
+            ),
+            mock.patch("solana.rpc.async_api.AsyncClient", DummyClient, create=True),
+            mock.patch.object(insight_logging, "AsyncClient", DummyClient, create=True),
+            mock.patch.object(insight_logging, "Transaction", DummyTx, create=True),
+            mock.patch.object(insight_logging, "TransactionInstruction", DummyInstr, create=True),
+            mock.patch.object(insight_logging, "PublicKey", DummyPk, create=True),
+            mock.patch.object(insight_logging, "_log") as log,
+        ):
+            asyncio.run(ledger.broadcast_merkle_root())
 
-    assert captured["root"] == root
-    log.warning.assert_called()
-    tmp.cleanup()
+        assert captured["root"] == root
+        log.warning.assert_called()


### PR DESCRIPTION
## Summary
- refactor `tests/test_ledger.py` to use `TemporaryDirectory` as a context manager
- keep all mocked broadcast interactions within the temp directory scope

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_ledger.py -q`
- `pytest -q` *(fails: tests/test_insight_health.py::test_readiness)*