### PR TITLE
[alpha_factory] add sandbox env limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,11 +650,13 @@ for instructions and example volume mounts.
 | `AGI_INSIGHT_ALLOW_INSECURE` | `0` | Set to `1` to run the bus without TLS when no certificate is provided. |
 | `API_TOKEN` | `REPLACE_ME_TOKEN` | Bearer token required by the REST API. |
 | `API_CORS_ORIGINS` | `*` | Comma-separated list of allowed CORS origins. |
+| `SANDBOX_CPU_SEC` | `2` | CPU time limit for sandboxed code. |
+| `SANDBOX_MEM_MB` | `256` | Memory cap for sandboxed code in MB. |
 
 The values above mirror `.env.sample`. When running the stack with Docker
 Compose, adjust the environment section of
 `infrastructure/docker-compose.yml` to override any variable—such as the gRPC
-bus port or ledger path.
+bus port or ledger path. Sandbox limits are described in [docs/sandbox.md](docs/sandbox.md).
 
 ### Finance Demo Quick‑Start
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -182,5 +182,6 @@ wscat -c "ws://localhost:8000/ws/progress" \
 ```
 
 The server honours environment variables defined in `.env` such as `PORT` (HTTP port) and `OPENAI_API_KEY`. When a prebuilt React dashboard exists under `src/interface/web_client/dist`, it is automatically served at the root path (`/`). CORS headers are configured via `API_CORS_ORIGINS` (default `"*"`).
+Sandbox CPU and memory limits can be set via `SANDBOX_CPU_SEC` and `SANDBOX_MEM_MB`.
 The OpenAPI specification can be fetched from `/openapi.json` when the server is
 running.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented in this file.
 - Expanded API documentation with `curl` and WebSocket examples.
 - Additional CLI notes and help command reference.
 - Documented `AGI_INSIGHT_MEMORY_PATH` for persistent storage configuration.
+- Optional CPU and memory caps for the CodeGen sandbox via
+  `SANDBOX_CPU_SEC` and `SANDBOX_MEM_MB`.
 - Configurable secret backend for HashiCorp Vault and cloud managers via `AGI_INSIGHT_SECRET_BACKEND`.
 - Optional JSON console logging and DuckDB ledger support.
 - Aggregated forecast endpoint `/insight` and OpenAPI schema exposure.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,10 @@
+# Sandbox Resource Limits
+
+Generated code snippets run in a restricted subprocess. The following environment variables control the CPU time and memory available to the sandbox:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SANDBOX_CPU_SEC` | `2` | CPU time limit in seconds. |
+| `SANDBOX_MEM_MB` | `256` | Maximum memory in megabytes. |
+
+When unset, the defaults above are applied.


### PR DESCRIPTION
## Summary
- allow `SANDBOX_CPU_SEC` and `SANDBOX_MEM_MB` to tune CodeGen sandbox limits
- document the variables in the docs and README
- mention sandbox configuration in API docs
- test environment variable handling

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_insight_health.py::test_readiness)*