### PR TITLE
[alpha_factory] add optional firejail sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ The values above mirror `.env.sample`. When running the stack with Docker
 Compose, adjust the environment section of
 `infrastructure/docker-compose.yml` to override any variable—such as the gRPC
 bus port or ledger path. Sandbox limits are described in [docs/sandbox.md](docs/sandbox.md).
+When the `firejail` binary is present, CodeGen snippets run inside `firejail --net=none --private` for stronger isolation.
 
 ### Finance Demo Quick‑Start
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - Documented `AGI_INSIGHT_MEMORY_PATH` for persistent storage configuration.
 - Optional CPU and memory caps for the CodeGen sandbox via
   `SANDBOX_CPU_SEC` and `SANDBOX_MEM_MB`.
+- Optional `firejail` sandboxing when the binary is available.
 - Configurable secret backend for HashiCorp Vault and cloud managers via `AGI_INSIGHT_SECRET_BACKEND`.
 - Optional JSON console logging and DuckDB ledger support.
 - Aggregated forecast endpoint `/insight` and OpenAPI schema exposure.

--- a/tests/test_codegen_agent.py
+++ b/tests/test_codegen_agent.py
@@ -2,6 +2,7 @@ from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import codegen_agent
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
 import sys
+import shutil
 
 
 def _make_agent() -> codegen_agent.CodeGenAgent:
@@ -11,14 +12,16 @@ def _make_agent() -> codegen_agent.CodeGenAgent:
     return codegen_agent.CodeGenAgent(bus, ledger)
 
 
-def test_execute_in_sandbox_stdout() -> None:
+def test_execute_in_sandbox_stdout(monkeypatch) -> None:
+    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: None)
     agent = _make_agent()
     out, err = agent.execute_in_sandbox("print('x')")
     assert out == "x\n"
     assert err == ""
 
 
-def test_execute_in_sandbox_exception() -> None:
+def test_execute_in_sandbox_exception(monkeypatch) -> None:
+    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: None)
     agent = _make_agent()
     out, err = agent.execute_in_sandbox("1/0")
     assert out == ""
@@ -44,6 +47,7 @@ def test_sandbox_env_limits(monkeypatch) -> None:
     monkeypatch.setenv("SANDBOX_CPU_SEC", "1")
     monkeypatch.setenv("SANDBOX_MEM_MB", "64")
     monkeypatch.setattr(codegen_agent.subprocess, "run", fake_run)
+    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: None)
     fake_resource = type(
         "R",
         (),
@@ -55,3 +59,27 @@ def test_sandbox_env_limits(monkeypatch) -> None:
     agent.execute_in_sandbox("print('hi')")
     assert (0, (1, 1)) in recorded
     assert (1, (64 * 1024 * 1024, 64 * 1024 * 1024)) in recorded
+
+
+def test_firejail_used_when_available(monkeypatch) -> None:
+    calls: dict[str, list] = {}
+
+    def fake_run(cmd, **kwargs):
+        calls["cmd"] = cmd
+        calls["preexec_fn"] = kwargs.get("preexec_fn")
+
+        class P:
+            stdout = "{}"
+            stderr = ""
+
+        return P()
+
+    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: "/usr/bin/firejail")
+    monkeypatch.setattr(codegen_agent.subprocess, "run", fake_run)
+
+    agent = _make_agent()
+    agent.execute_in_sandbox("print('hi')")
+
+    assert calls["cmd"][0] == "/usr/bin/firejail"
+    assert "--net=none" in calls["cmd"]
+    assert calls["preexec_fn"] is None


### PR DESCRIPTION
## Summary
- use firejail when present in CodeGen sandbox
- cover firejail execution path in unit tests
- document optional dependency in README and CHANGELOG

## Testing
- `pre-commit` *(failed: command not found)*
- `pytest -q` *(failed: 1 failed, 411 passed, 17 skipped)*