### PR TITLE
[alpha_factory] Improve CSV output quoting

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -9,6 +9,8 @@ console output optionally leverages ``rich`` for nicer tables.
 from __future__ import annotations
 
 import asyncio
+import csv
+import sys
 import json
 import os
 import random
@@ -177,10 +179,10 @@ def simulate(
         ]
         click.echo(json.dumps(data))
     elif export == "csv":
-        lines = ["year,capability,affected"]
+        writer = csv.writer(sys.stdout)
+        writer.writerow(["year", "capability", "affected"])
         for r in results:
-            lines.append(f"{r.year},{r.capability},{'|'.join(s.name for s in r.affected)}")
-        click.echo("\n".join(lines))
+            writer.writerow([r.year, r.capability, "|".join(s.name for s in r.affected)])
     else:
         _format_results(results)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 import os
+import csv
+from io import StringIO
 from unittest.mock import patch
 from click.testing import CliRunner
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
@@ -126,7 +128,10 @@ def test_simulate_export_csv() -> None:
                 ],
             )
     assert res.exit_code == 0
-    assert "year,capability,affected" in res.output
+    reader = csv.reader(StringIO(res.output))
+    rows = list(reader)
+    assert rows[0] == ["year", "capability", "affected"]
+    assert len(rows) > 1
 
 
 def test_show_results_export_csv(tmp_path) -> None:

--- a/tests/test_cli_runner_ext.py
+++ b/tests/test_cli_runner_ext.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Additional CLI tests using click CliRunner."""
 
+import csv
+from io import StringIO
 from unittest.mock import patch
 from click.testing import CliRunner
 
@@ -72,7 +74,10 @@ def test_simulate_export_formats() -> None:
                 ],
             )
     assert res_json.output.startswith("[")
-    assert "year,capability,affected" in res_csv.output
+    reader = csv.reader(StringIO(res_csv.output))
+    rows = list(reader)
+    assert rows[0] == ["year", "capability", "affected"]
+    assert len(rows) > 1
 
 
 def test_show_results_export_formats(tmp_path) -> None:

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -1,5 +1,7 @@
 import os
+import csv
 import json
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 import pytest
@@ -175,9 +177,10 @@ def test_simulate_export_formats(export_fmt: str) -> None:
     if export_fmt == "json":
         assert res.output.startswith("[")
     else:
-        lines = res.output.splitlines()
-        assert lines[0] == "year,capability,affected"
-        assert "," in lines[1]
+        reader = csv.reader(StringIO(res.output))
+        rows = list(reader)
+        assert rows[0] == ["year", "capability", "affected"]
+        assert len(rows) > 1
 
 
 def test_simulate_invalid_option() -> None:


### PR DESCRIPTION
## Summary
- use csv.writer to output results
- check CSV parsing in CLI tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_api_server.py::test_api_endpoints)*