### PR TITLE
[alpha_factory] support unsubscribing agent handlers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -63,6 +63,12 @@ class AgentRunner:
             self.task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self.task
+        try:
+            close = getattr(self.agent, "close")
+        except AttributeError:
+            pass
+        else:
+            close()
         self.agent = self.cls(bus, ledger)
         self.start(bus, ledger)
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -47,3 +47,53 @@ def test_agent_runner_loop_publishes_heartbeat() -> None:
     assert agent.calls == 1
     assert ("pub", "dummy") in events
     assert ("log", "dummy") in events
+
+
+class _Ledger:
+    def log(self, _env: messaging.Envelope) -> None:  # pragma: no cover - test helper
+        pass
+
+    def start_merkle_task(self, *_a: object, **_kw: object) -> None:  # pragma: no cover - test helper
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - test helper
+        pass
+
+    def close(self) -> None:  # pragma: no cover - test helper
+        pass
+
+
+class DummyBaseAgent(orchestrator.BaseAgent):  # type: ignore[misc]
+    def __init__(self, bus: messaging.A2ABus, ledger: _Ledger) -> None:
+        super().__init__("dummy", bus, ledger)
+        self.count = 0
+
+    async def run_cycle(self) -> None:
+        pass
+
+    async def handle(self, _env: messaging.Envelope) -> None:
+        self.count += 1
+
+
+def test_restart_unsubscribes_handler() -> None:
+    bus = messaging.A2ABus(orchestrator.config.Settings(bus_port=0))
+    ledger = _Ledger()
+    agent = DummyBaseAgent(bus, ledger)
+    runner = orchestrator.AgentRunner(agent)
+
+    async def _run() -> tuple[int, int]:
+        bus.publish("dummy", messaging.Envelope("a", "dummy", {}, 0.0))
+        await asyncio.sleep(0)
+        before = agent.count
+        await runner.restart(bus, ledger)
+        new_agent = runner.agent  # type: ignore[assignment]
+        bus.publish("dummy", messaging.Envelope("a", "dummy", {}, 0.0))
+        await asyncio.sleep(0)
+        return before, getattr(new_agent, "count")
+
+    before, after = asyncio.run(_run())
+
+    assert before == 1
+    assert agent.count == 1
+    assert after == 1
+    assert len(bus._subs.get("dummy", [])) == 1


### PR DESCRIPTION
## Summary
- allow removing bus handlers
- ensure BaseAgent unsubscribes on close
- restart AgentRunner cleanly
- verify old handlers are removed after restart

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/base_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py tests/test_agent_runner.py` *(fails: `pre-commit: command not found`)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_api_server.py::test_api_endpoints - assert 429 == 200)*