### PR TITLE
[alpha_factory] orchestrator error threshold

### DIFF
--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -13,11 +13,13 @@ os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 
 from typing import Any, cast
+import importlib
 
 
 def make_client() -> TestClient:
     from src.interface import api_server
 
+    api_server = importlib.reload(api_server)
     return TestClient(cast(Any, api_server.app))
 
 
@@ -87,8 +89,9 @@ def test_background_run_direct(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert (tmp_path / f"{sim_id}.json").exists()
     assert messages and messages[0]["id"] == sim_id
 
+
 def test_root_serves_spa() -> None:
     client = make_client()
     r = client.get("/")
     assert r.status_code == 200
-    assert "<div id=\"root\">" in r.text
+    assert '<div id="root">' in r.text

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -12,8 +12,10 @@ def test_run_forever_shutdown() -> None:
         orch = orchestrator.Orchestrator(settings)
 
     async def run() -> None:
-        with mock.patch.object(orch.bus, "stop", mock.AsyncMock()) as bus_stop, \
-             mock.patch.object(orch.ledger, "stop_merkle_task", mock.AsyncMock()) as merkle_stop:
+        with (
+            mock.patch.object(orch.bus, "stop", mock.AsyncMock()) as bus_stop,
+            mock.patch.object(orch.ledger, "stop_merkle_task", mock.AsyncMock()) as merkle_stop,
+        ):
             task = asyncio.create_task(orch.run_forever())
             await asyncio.sleep(0.05)
             task.cancel()
@@ -23,3 +25,68 @@ def test_run_forever_shutdown() -> None:
             merkle_stop.assert_awaited_once()
 
     asyncio.run(run())
+
+
+class FailingAgent(orchestrator.BaseAgent):
+    NAME = "fail"
+    CYCLE_SECONDS = 0.1
+
+    def __init__(self, bus: orchestrator.messaging.A2ABus, ledger: orchestrator.Ledger) -> None:
+        super().__init__("fail", bus, ledger)
+
+    async def run_cycle(self) -> None:
+        raise RuntimeError("boom")
+
+    async def handle(self, _env: orchestrator.messaging.Envelope) -> None:  # pragma: no cover - test helper
+        pass
+
+
+def test_error_threshold_restart(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_ERR_THRESHOLD", "2")
+
+    events: list[str] = []
+
+    class DummyLedger:
+        def __init__(self, *_a, **_kw) -> None:
+            pass
+
+        def log(self, env) -> None:  # type: ignore[override]
+            if env.payload.get("event"):
+                events.append(env.payload["event"])
+
+        def start_merkle_task(self, *_a, **_kw) -> None:
+            pass
+
+        async def stop_merkle_task(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    settings = config.Settings(bus_port=0)
+    monkeypatch.setattr(orchestrator, "Ledger", DummyLedger)
+    monkeypatch.setattr(
+        orchestrator.Orchestrator,
+        "_init_agents",
+        lambda self: [FailingAgent(self.bus, self.ledger)],
+    )
+    orch = orchestrator.Orchestrator(settings)
+    runner = orch.runners["fail"]
+
+    async def run() -> None:
+        await orch.bus.start()
+        runner.start(orch.bus, orch.ledger)
+        monitor = asyncio.create_task(orch._monitor())
+        await asyncio.sleep(3)
+        monitor.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await monitor
+        if runner.task:
+            runner.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await runner.task
+        await orch.bus.stop()
+
+    asyncio.run(run())
+
+    assert "restart" in events


### PR DESCRIPTION
## Summary
- keep agents alive by counting consecutive errors
- restart failing agents when they exceed AGENT_ERR_THRESHOLD
- add a regression test for automatic restart on repeated errors
- reload API server in tests to reset rate limits

## Testing
- `python check_env.py --auto-install`
- `pytest -q`