### PR TITLE
[alpha_factory] expose num sectors option

### DIFF
--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -221,6 +221,7 @@ class SimRequest(BaseModel):
     """Payload for the ``/simulate`` endpoint."""
 
     horizon: int = 5
+    num_sectors: int = 6
     pop_size: int = 6
     generations: int = 3
     curve: str = "logistic"
@@ -305,7 +306,7 @@ async def _background_run(sim_id: str, cfg: SimRequest) -> None:
     if cfg.sectors:
         secs = [sector.Sector(s.name, s.energy, s.entropy, s.growth) for s in cfg.sectors]
     else:
-        secs = [sector.Sector(f"s{i:02d}") for i in range(cfg.pop_size)]
+        secs = [sector.Sector(f"s{i:02d}") for i in range(cfg.num_sectors)]
     traj: list[ForecastTrajectoryPoint] = []
     for year in range(1, cfg.horizon + 1):
         t = year / cfg.horizon

--- a/src/interface/web_app.py
+++ b/src/interface/web_app.py
@@ -73,14 +73,20 @@ def population_df(pop: list[Any]) -> pd.DataFrame:
     )
 
 
-def _run_simulation(horizon: int, curve: str, pop_size: int, generations: int) -> None:
+def _run_simulation(
+    horizon: int,
+    curve: str,
+    num_sectors: int,
+    pop_size: int,
+    generations: int,
+) -> None:
     """Execute the simulation and update charts live."""
     if st is None:  # pragma: no cover - fallback
         print("Streamlit not installed")
         return
 
     st.session_state.logs = []
-    secs = [sector.Sector(f"s{i:02d}") for i in range(pop_size)]
+    secs = [sector.Sector(f"s{i:02d}") for i in range(num_sectors)]
     timeline_placeholder = st.empty()
     pareto_placeholder = st.empty()
     scatter_placeholder = st.empty()
@@ -178,10 +184,15 @@ def main() -> None:  # pragma: no cover - entry point
     st.title("AGI Simulation Dashboard")
     horizon = st.sidebar.number_input("Forecast horizon", min_value=1, max_value=20, value=5)
     curve = st.sidebar.selectbox("Growth curve", ["logistic", "linear", "exponential"], index=0)
-    pop_size = st.sidebar.number_input("Population size", min_value=2, max_value=20, value=6)
+    num_sectors = st.sidebar.number_input(
+        "Number of sectors", min_value=1, max_value=20, value=6
+    )
+    pop_size = st.sidebar.number_input(
+        "Population size", min_value=2, max_value=20, value=6
+    )
     generations = st.sidebar.number_input("Generations", min_value=1, max_value=20, value=3)
     if st.sidebar.button("Run simulation"):
-        _run_simulation(horizon, curve, pop_size, generations)
+        _run_simulation(horizon, curve, num_sectors, pop_size, generations)
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry

--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -47,7 +47,13 @@ def test_simulate_curve_subprocess() -> None:
             raise AssertionError("server did not start")
         r = httpx.post(
             f"{url}/simulate",
-            json={"horizon": 1, "pop_size": 2, "generations": 1, "curve": "linear"},
+            json={
+                "horizon": 1,
+                "num_sectors": 2,
+                "pop_size": 2,
+                "generations": 1,
+                "curve": "linear",
+            },
             headers=headers,
         )
         assert r.status_code == 200

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -30,3 +30,11 @@ def test_population_df() -> None:
     df = web_app.population_df(pop)
     assert set(df.columns) == {"effectiveness", "risk", "complexity", "rank"}
     assert len(df) == 2
+
+
+def test_run_simulation_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    """Ensure _run_simulation accepts the new num_sectors argument."""
+
+    web_app._run_simulation(1, "logistic", 2, 3, 1)
+    out, _ = capsys.readouterr()
+    assert "Streamlit not installed" in out


### PR DESCRIPTION
## Summary
- separate sector count from GA population
- expose new slider in Streamlit dashboard
- adjust API SimRequest schema for `num_sectors`
- extend tests for web app and API server subprocess

## Testing
- `pre-commit run --files src/interface/web_app.py src/interface/api_server.py tests/test_web_app.py tests/test_api_server_subprocess.py` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pytest -q`