### PR TITLE
[alpha_factory] fix imports in web_app tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_web_app.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_web_app.py
@@ -5,16 +5,16 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-
-pd = pytest.importorskip("pandas")
-
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_app import (
     _simulate,
     _timeline_df,
     _disruption_df,
 )
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+pd = pytest.importorskip("pandas")
 
 
 def test_simulate_returns_trajectory() -> None:


### PR DESCRIPTION
## Summary
- reorder imports in `test_web_app.py` so all `alpha_factory` imports come first
- call `importorskip` for pandas after the imports

## Testing
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_web_app.py`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_web_app.py`
