### PR TITLE
[alpha_factory] update Makefile demo paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ demo-setup:
 demo-run:
     @RUN_MODE=${RUN_MODE:-cli}; \
     if [ "$$RUN_MODE" = "web" ]; then \
-        .venv/bin/python -m streamlit run alpha_factory_v1/demos/alpha_agi_insight_v0/insight_dashboard.py; \
+        .venv/bin/python -m streamlit run alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py; \
     else \
-        .venv/bin/python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --episodes 5; \
+        .venv/bin/python -m alpha_factory_v1.demos.alpha_agi_insight_v1 --episodes 5; \
     fi
 
 compose-up:


### PR DESCRIPTION
## Summary
- update demo-run paths for AGI Insight v1

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `make demo-run RUN_MODE=web` *(fails: `Makefile:3: *** missing separator. Stop.`)*
