### PR TITLE
[alpha_factory] isolate CLI settings

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -139,17 +139,18 @@ def simulate(
     if llama_model_path is not None:
         os.environ["LLAMA_MODEL_PATH"] = str(llama_model_path)
 
-    settings = config.CFG
+    cfg = config.CFG.model_dump()
     if offline:
-        settings.offline = True
+        cfg["offline"] = True
+    if model_name is not None:
+        cfg["model_name"] = model_name
+    if temperature is not None:
+        cfg["temperature"] = temperature
+    if context_window is not None:
+        cfg["context_window"] = context_window
+    settings = config.Settings(**cfg)
     if no_broadcast:
         settings.broadcast = False
-    if model_name is not None:
-        settings.model_name = model_name
-    if temperature is not None:
-        settings.temperature = temperature
-    if context_window is not None:
-        settings.context_window = context_window
 
     orch = orchestrator.Orchestrator(settings)
     if sectors_file:
@@ -325,7 +326,9 @@ def agents_status(watch: bool) -> None:
 @click.option("--model", "model_name", help="Model name for AgentContext/local models")
 @click.option("--temperature", type=float, help="Model temperature")
 @click.option("--context-window", type=int, help="Context window size")
-def run_orchestrator(verbose: bool, model_name: str | None, temperature: float | None, context_window: int | None) -> None:
+def run_orchestrator(
+    verbose: bool, model_name: str | None, temperature: float | None, context_window: int | None
+) -> None:
     """Run the orchestrator until interrupted."""
     settings = config.CFG
     if model_name is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,3 +191,35 @@ def test_replay_existing(tmp_path) -> None:
             led.tail.return_value = [{"ts": 0.0, "sender": "a", "recipient": "b", "payload": {"x": 1}}]
             out = CliRunner().invoke(cli.main, ["replay"])
             assert "a -> b" in out.output
+
+
+def test_simulate_does_not_modify_global_cfg() -> None:
+    """CLI options should not persist on the global config."""
+    runner = CliRunner()
+    original = cli.config.CFG.model_dump()
+
+    with patch.object(cli, "asyncio"), patch.object(cli.orchestrator, "Orchestrator"):
+        res = runner.invoke(
+            cli.main,
+            [
+                "simulate",
+                "--horizon",
+                "1",
+                "--offline",
+                "--sectors",
+                "1",
+                "--pop-size",
+                "1",
+                "--generations",
+                "1",
+                "--model",
+                "other",
+                "--temperature",
+                "0.9",
+                "--context-window",
+                "1024",
+            ],
+        )
+
+    assert res.exit_code == 0
+    assert cli.config.CFG.model_dump() == original


### PR DESCRIPTION
## Summary
- ensure `simulate` uses a fresh `Settings` instance
- keep global `config.CFG` unchanged when running the CLI
- add regression test

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_cli.py`
- `ruff format --check alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_cli.py`
- `pytest tests/test_cli.py::test_simulate_does_not_modify_global_cfg -q`
- `pytest -q`