### PR TITLE
[alpha_factory] web client progress charts

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
@@ -1,14 +1,60 @@
 // SPDX-License-Identifier: Apache-2.0
 (function () {
-  const { useEffect } = React;
+  const { useState, useEffect } = React;
   function App() {
+    const [timeline, setTimeline] = useState([]);
+    const [sectors, setSectors] = useState([]);
+    const API_BASE = '';
+    const TOKEN = '';
+    const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
     useEffect(() => {
-      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-      const ws = new WebSocket(`${proto}://${location.host}/ws/progress`);
-      ws.onmessage = (e) => console.log(e.data);
-      return () => ws.close();
-    }, []);
-    return React.createElement('div', null, 'α‑AGI Insight Demo');
+      if (!timeline.length) return;
+      Plotly.react('capability', [{
+        x: timeline.map(p => p.year),
+        y: timeline.map(p => p.capability),
+        mode: 'lines', type: 'scatter'
+      }], { margin: { t: 20 } });
+    }, [timeline]);
+    async function fetchResults(id) {
+      try {
+        const r = await fetch(`${API_BASE}/results/${id}`, { headers: HEADERS });
+        if (!r.ok) return;
+        const b = await r.json();
+        const names = new Set();
+        for (const p of b.forecast || []) {
+          for (const s of p.affected || []) names.add(s);
+        }
+        setSectors(Array.from(names));
+      } catch {}
+    }
+    async function startRun() {
+      setTimeline([]);
+      setSectors([]);
+      const r = await fetch(`${API_BASE}/simulate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...HEADERS },
+        body: JSON.stringify({ horizon: 5, pop_size: 6, generations: 3 })
+      });
+      if (!r.ok) return;
+      const data = await r.json();
+      const id = data.id;
+      const ws = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/progress?token=${TOKEN}`);
+      ws.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.id === id) setTimeline(t => t.concat([msg]));
+        } catch {}
+      };
+      ws.onclose = () => { fetchResults(id).catch(() => null); };
+    }
+    return React.createElement('div', null,
+      React.createElement('h1', null, 'α‑AGI Insight Demo'),
+      React.createElement('button', { onClick: startRun }, 'Run simulation'),
+      React.createElement('div', { id: 'capability', style: { width: '100%', height: 300 } }),
+      sectors.length ? React.createElement('div', null,
+        React.createElement('h2', null, 'Disrupted sectors'),
+        React.createElement('ul', null, sectors.map(s => React.createElement('li', { key: s }, s)))) : null
+    );
   }
   ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
 })();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
@@ -3,8 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <title>α‑AGI Insight</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; }
+      h1 { margin-bottom: 1rem; }
+    </style>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-2.24.2.min.js"></script>
     <script src="app.js" defer></script>
   </head>
   <body>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <title>α‑AGI Insight</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; }
+      h1 { margin-bottom: 1rem; }
+    </style>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-2.24.2.min.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
@@ -1,19 +1,118 @@
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
+import Plotly from 'plotly.js-dist';
+
+interface ProgressMsg {
+  id: string;
+  year: number;
+  capability: number;
+}
+
+interface ForecastPoint {
+  year: number;
+  capability: number;
+  affected?: string[];
+}
+
+interface ResultsResponse {
+  forecast: ForecastPoint[];
+}
 
 function App() {
+  const [runId, setRunId] = useState<string | null>(null);
+  const [timeline, setTimeline] = useState<ProgressMsg[]>([]);
+  const [sectors, setSectors] = useState<string[]>([]);
+  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+  const TOKEN = import.meta.env.VITE_API_TOKEN ?? '';
+  const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
+
   useEffect(() => {
-    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${proto}://${location.host}/ws/progress`);
-    ws.onmessage = (ev) => console.log(ev.data);
-    return () => ws.close();
-  }, []);
-  return <div>α‑AGI Insight Demo</div>;
+    if (!timeline.length) return;
+    Plotly.react(
+      'capability',
+      [
+        {
+          x: timeline.map((p) => p.year),
+          y: timeline.map((p) => p.capability),
+          mode: 'lines',
+          type: 'scatter',
+        },
+      ],
+      { margin: { t: 20 } },
+    );
+  }, [timeline]);
+
+  async function fetchResults(id: string) {
+    try {
+      const res = await fetch(`${API_BASE}/results/${id}`, { headers: HEADERS });
+      if (!res.ok) return;
+      const body: ResultsResponse = await res.json();
+      const names = new Set<string>();
+      for (const p of body.forecast) {
+        for (const s of p.affected ?? []) {
+          names.add(s);
+        }
+      }
+      setSectors([...names]);
+    } catch {
+      // ignore
+    }
+  }
+
+  async function startRun() {
+    setTimeline([]);
+    setSectors([]);
+    const res = await fetch(`${API_BASE}/simulate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...HEADERS,
+      },
+      body: JSON.stringify({ horizon: 5, pop_size: 6, generations: 3 }),
+    });
+    if (!res.ok) return;
+    const body = await res.json();
+    const id = body.id as string;
+    setRunId(id);
+    const wsBase = API_BASE.replace(/^http/, 'ws');
+    const ws = new WebSocket(`${wsBase}/ws/progress?token=${TOKEN}`);
+    ws.onmessage = (ev) => {
+      try {
+        const msg: ProgressMsg = JSON.parse(ev.data);
+        if (msg.id === id) {
+          setTimeline((t) => [...t, msg]);
+        }
+      } catch {
+        // ignore non-JSON messages
+      }
+    };
+    ws.onclose = () => {
+      fetchResults(id).catch(() => null);
+    };
+  }
+
+  return (
+    <div>
+      <h1>α‑AGI Insight Demo</h1>
+      <button type="button" onClick={startRun}>Run simulation</button>
+      <div id="capability" style={{ width: '100%', height: 300 }} />
+      {sectors.length > 0 && (
+        <div>
+          <h2>Disrupted sectors</h2>
+          <ul>
+            {sectors.map((s) => (
+              <li key={s}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
 }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -38,3 +38,19 @@ def test_run_simulation_smoke(capsys: pytest.CaptureFixture[str]) -> None:
     web_app._run_simulation(1, "logistic", 2, 3, 1)
     out, _ = capsys.readouterr()
     assert "Streamlit not installed" in out
+
+
+def test_progress_dom_updates() -> None:
+    """Smoke test that the React dashboard receives progress events."""
+
+    pw = pytest.importorskip("playwright.sync_api")
+    from fastapi.testclient import TestClient
+    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
+
+    client = TestClient(api_server.app)
+    browser = pw.sync_playwright().start().chromium.launch()
+    page = browser.new_page()
+    page.goto(str(client.base_url) + "/web/")
+    page.click("text=Run simulation")
+    page.wait_for_selector("#capability")
+    browser.close()


### PR DESCRIPTION
## Summary
- update insight demo web client to display capability timeline and disrupted sectors
- style index pages and include Plotly
- add Playwright-based smoke test for DOM updates

## Testing
- `python check_env.py --auto-install`
- `pytest -q`