### PR TITLE
[alpha_factory] add prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,8 @@ See [docs/deployment_security.md](docs/deployment_security.md) for TLS setup, AP
 | Traces | OpenTelemetry | `trace_id` |
 | Dashboards | Grafana | `alpha-factory/trade-lifecycle.json` |
 
+Prometheus scrapes metrics from the API server at `/metrics`.
+
 By default traces and metrics print to ``stdout``. To export to a collector such
 as **Jaeger**, set ``OTEL_EXPORTER_OTLP_ENDPOINT`` and start Jaeger locally:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -17,7 +17,7 @@ import contextlib
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from .config import Settings
-from .tracing import span
+from .tracing import span, bus_messages_total
 
 try:
     import grpc
@@ -65,6 +65,7 @@ class A2ABus:
 
     def publish(self, topic: str, env: Envelope) -> None:
         with span("bus.publish"):
+            bus_messages_total.labels(topic).inc()
             if self._producer:
                 data = json.dumps(env.__dict__).encode()
                 asyncio.create_task(self._producer.send_and_wait(topic, data))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - Optional JSON console logging and DuckDB ledger support.
 - Aggregated forecast endpoint `/insight` and OpenAPI schema exposure.
 - Baseline load test metrics: p95 latency below 180 ms with 20 VUs.
+- Prometheus metrics available at `/metrics`.
 
 ## [v1.0] - 2025-07-01
 - CLI commands `simulate`, `show-results`, `agents-status` and `replay` for running and inspecting forecasts.

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -58,6 +58,9 @@ try:
         Histogram,
         generate_latest,
     )
+    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.tracing import (
+        api_request_seconds,
+    )
 except ModuleNotFoundError:  # pragma: no cover - optional
     prometheus_client = None  # type: ignore
 
@@ -93,10 +96,10 @@ if app is not None:
             return cls(name, desc, labels)
 
         REQ_COUNT = _get_metric(Counter, "api_requests_total", "HTTP requests", ["method", "endpoint", "status"])
-        REQ_LAT = _get_metric(Histogram, "api_request_duration_seconds", "Request latency", ["method", "endpoint"])
+        REQ_LAT = api_request_seconds
     else:  # pragma: no cover - prometheus not installed
         REQ_COUNT = _noop()
-        REQ_LAT = _noop()
+        REQ_LAT = api_request_seconds
 
     metrics_router = APIRouter()
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -60,7 +60,7 @@ def test_metrics_endpoint_subprocess() -> None:
         assert resp.status_code == 200
         text = resp.text
         assert "api_requests_total" in text
-        assert "api_request_duration_seconds" in text
+        assert "api_request_seconds" in text
         assert text.startswith("# HELP")
     finally:
         proc.terminate()

--- a/tests/test_metrics_router.py
+++ b/tests/test_metrics_router.py
@@ -23,4 +23,4 @@ def test_metrics_endpoint() -> None:
     resp = client.get("/metrics")
     assert resp.status_code == 200
     assert "api_requests_total" in resp.text
-    assert "api_request_duration_seconds" in resp.text
+    assert "api_request_seconds" in resp.text


### PR DESCRIPTION
## Summary
- instrument message bus, agent loop and API requests with Prometheus metrics
- expose `/metrics` with new histogram name
- document metrics endpoint

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
