### PR TITLE
[alpha_factory] add compose health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,8 +778,7 @@ Alternatively run inside Docker:
 ```bash
 # build the web client first so `dist/` exists
 make build_web
-docker compose build
-docker compose up
+make compose-up  # builds and waits for healthy services
 ```
 Open <http://localhost:8080> in your browser. When `RUN_MODE=web`, the container
 serves the static files from `src/interface/web_client/dist` using `python -m
@@ -788,8 +787,7 @@ dashboard is reachable without additional tooling.
 
 Once running, Docker Compose marks the services **healthy** when:
 
-- `http://localhost:8000/runs` responds with `{"ids": []}` (or listed run IDs) for the
-  orchestrator container.
+- `http://localhost:8000/healthz` returns status `200` for the orchestrator container.
 - `http://localhost:8080/` returns status `200` for the web container.
 
 The dashboard now plots a 3‑D scatter chart of effectiveness vs. risk vs.

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped              # restart policy
     healthcheck:
       <<: *default_healthcheck
-      test: ["CMD", "curl", "-sf", "http://localhost:8000/runs"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8000/healthz"]
 
   agents:
     image: alpha-demo:latest             # reuse the demo image
@@ -69,4 +69,4 @@ services:
       - orchestrator                     # wait for orchestrator
     healthcheck:
       <<: *default_healthcheck
-      test: ["CMD", "curl", "-sf", "http://localhost:8501/"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8000/healthz"]

--- a/infrastructure/helm-chart/templates/deployment.yaml
+++ b/infrastructure/helm-chart/templates/deployment.yaml
@@ -32,13 +32,13 @@ spec:
             - containerPort: 6006
           livenessProbe:
             httpGet:
-              path: /runs
+              path: /healthz
               port: 8000
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /runs
+              path: /readiness
               port: 8000
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/tests/test_compose_health.py
+++ b/tests/test_compose_health.py
@@ -1,0 +1,37 @@
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+if not shutil.which("docker"):
+    pytest.skip("docker not available", allow_module_level=True)
+
+COMPOSE_FILE = Path(__file__).resolve().parents[1] / "infrastructure" / "docker-compose.yml"
+
+
+def _wait(url: str, timeout: int = 60) -> bool:
+    for _ in range(timeout):
+        try:
+            if requests.get(url, timeout=2).status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
+@pytest.fixture(scope="module")
+def compose_stack() -> None:
+    subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d"], check=True)
+    try:
+        yield
+    finally:
+        subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "down", "-v"], check=False)
+
+
+def test_compose_health(compose_stack: None) -> None:
+    assert _wait("http://localhost:8000/healthz"), "/healthz endpoint not healthy"
+    assert _wait("http://localhost:8000/readiness"), "/readiness endpoint not healthy"


### PR DESCRIPTION
## Summary
- add healthchecks for orchestrator and web in Compose
- probe `/healthz` and `/readiness` in Helm chart
- mention waiting for healthy services in README
- test compose health endpoints

## Checks
- ❌ `pre-commit` *(failed: command not found)*
- ✅ `python check_env.py --auto-install`
- ✅ `pytest -q`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
