### PR TITLE
[alpha_factory] Alert on high 429 rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,8 @@ start if `NEO4J_PASSWORD` remains `REPLACE_ME` or is missing.
 Set `API_TOKEN` to a strong secret so that the REST API can authenticate
 incoming requests. Clients must send `Authorization: Bearer <token>`. Use
 `API_RATE_LIMIT` to limit requests per minute per IP (default `60`).
+If more than 5% of requests return HTTP `429` within a minute, the server calls
+`utils.alerts.send_alert` to report excessive throttling.
 Avoid storing private keys directly in `.env`. Instead set
 `AGI_INSIGHT_SOLANA_WALLET_FILE` to a file containing your hex-encoded wallet
 key and keep that file readable only by the orchestrator.

--- a/tests/test_api_server_static.py
+++ b/tests/test_api_server_static.py
@@ -1,0 +1,40 @@
+import importlib
+import os
+import time
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+
+def test_throttle_alert(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_RATE_LIMIT", "1")
+    from src.interface import api_server as mod
+    api = importlib.reload(mod)
+
+    sent: list[str] = []
+    monkeypatch.setattr(api.alerts, "send_alert", lambda msg, url=None: sent.append(msg))
+
+    client = TestClient(cast(Any, api.app))
+    headers = {"Authorization": "Bearer test-token"}
+
+    client.get("/runs", headers=headers)
+    client.get("/runs", headers=headers)
+
+    stack = api.app.middleware_stack
+    metrics = stack.app.app
+    limiter = metrics.app
+    metrics.window_start = time.time() - 61
+    limiter.counters["testclient"] = (0, time.time())
+
+    client.get("/runs", headers=headers)
+
+    assert sent, "alert not triggered"
+
+    monkeypatch.setenv("API_RATE_LIMIT", "1000")
+    importlib.reload(api)


### PR DESCRIPTION
## Summary
- add alerts import and MetricsMiddleware tracking for request volume
- trigger webhook alert if 429 responses exceed 5% in the last minute
- document throttling alerts in the README
- add unit test covering alert behaviour

## Testing
- `mypy --config-file mypy.ini src/interface/api_server.py tests/test_api_server_static.py`
- `pytest -q`