### PR TITLE
[alpha_factory] centralize env loader

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -11,35 +11,15 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
+
+from alpha_factory_v1.utils.env import _load_env_file
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 _log = logging.getLogger(__name__)
-
-
-def _load_env_file(path: str | os.PathLike[str]) -> Dict[str, str]:
-    """Return key/value pairs from ``path``.
-
-    Falls back to a minimal parser when :mod:`python_dotenv` is unavailable.
-    """
-    try:  # pragma: no cover - optional dependency
-        from dotenv import dotenv_values
-
-        return {k: v for k, v in dotenv_values(path).items() if v is not None}
-    except Exception:  # noqa: BLE001 - any import/parsing error falls back
-        pass
-
-    data: Dict[str, str] = {}
-    for line in Path(path).read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        data[k.strip()] = v.strip().strip('"')
-    return data
 
 
 def _load_dotenv(path: str = ".env") -> None:

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -3,34 +3,11 @@
 import os
 import argparse
 from pathlib import Path
-from typing import Mapping
+
+from .utils.env import _load_env_file
 
 from .scripts.preflight import main as preflight_main
 from . import __version__
-
-
-def _load_env_file(path: str | os.PathLike[str]) -> Mapping[str, str]:
-    """Return key/value pairs from ``path``.
-
-    The parser first attempts to use :mod:`python_dotenv` if available for
-    robust parsing of quoted values and comments.  It falls back to a minimal
-    line‑based implementation otherwise.
-    """
-    try:  # pragma: no cover - optional dependency
-        from dotenv import dotenv_values
-
-        return {k: v for k, v in dotenv_values(path).items() if v is not None}
-    except Exception:  # noqa: BLE001 - any import/parsing error falls back
-        pass
-
-    data: dict[str, str] = {}
-    for line in Path(path).read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        data[k.strip()] = v.strip().strip('"')
-    return data
 
 
 def parse_args() -> argparse.Namespace:

--- a/alpha_factory_v1/utils/__init__.py
+++ b/alpha_factory_v1/utils/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utility helpers for Alpha-Factory."""
+
+__all__ = ["env"]

--- a/alpha_factory_v1/utils/env.py
+++ b/alpha_factory_v1/utils/env.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Environment file helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+
+def _load_env_file(path: str | os.PathLike[str]) -> Dict[str, str]:
+    """Return key/value pairs from ``path``.
+
+    Falls back to a minimal parser when :mod:`python_dotenv` is unavailable.
+    """
+    try:  # pragma: no cover - optional dependency
+        from dotenv import dotenv_values
+
+        return {k: v for k, v in dotenv_values(path).items() if v is not None}
+    except Exception:  # noqa: BLE001 - any import/parsing error falls back
+        pass
+
+    data: Dict[str, str] = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k.strip()] = v.strip().strip('"')
+    return data

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -5,34 +5,14 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, cast
+from typing import Any, Optional, cast
+
+from alpha_factory_v1.utils.env import _load_env_file
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _log = logging.getLogger(__name__)
-
-
-def _load_env_file(path: str | os.PathLike[str]) -> Dict[str, str]:
-    """Return key/value pairs from ``path``.
-
-    Falls back to a minimal parser when :mod:`python_dotenv` is unavailable.
-    """
-    try:  # pragma: no cover - optional dependency
-        from dotenv import dotenv_values
-
-        return {k: v for k, v in dotenv_values(path).items() if v is not None}
-    except Exception:  # noqa: BLE001 - any import/parsing error falls back
-        pass
-
-    data: Dict[str, str] = {}
-    for line in Path(path).read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        data[k.strip()] = v.strip().strip('"')
-    return data
 
 
 def _load_dotenv(path: str = ".env") -> None:


### PR DESCRIPTION
## Summary
- add `alpha_factory_v1.utils.env` with `_load_env_file`
- use the new helper in `src/utils/config.py`, CLI `run.py`, and demo config

## Testing
- `python check_env.py --auto-install`
- `pytest -q`