### PR TITLE
[alpha_factory] add missing license header

### DIFF
--- a/alpha_factory_v1/backend/a2a_client.py
+++ b/alpha_factory_v1/backend/a2a_client.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 a2a_client.py
 -------------


### PR DESCRIPTION
## Summary
- add SPDX license identifier to `a2a_client.py`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`