### PR TITLE
[alpha_factory] improve rate limiter cleanup

### DIFF
--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -124,6 +124,11 @@ if app is not None:
             ip = request.client.host if request.client else "unknown"
             now = time.time()
             async with self.lock:
+                # purge expired entries to prevent unbounded growth
+                expired = [k for k, (_, ts) in self.counters.items() if now - ts > self.window]
+                for k in expired:
+                    del self.counters[k]
+
                 count, start = self.counters.get(ip, (0, now))
                 if now - start > self.window:
                     count = 0

--- a/tests/test_rate_limiter_eviction.py
+++ b/tests/test_rate_limiter_eviction.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SimpleRateLimiter eviction logic."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import time
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+pytest.importorskip("fastapi")
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+
+def _make_request(ip: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "client": (ip, 0),
+    }
+    return Request(scope)  # type: ignore[arg-type]
+
+
+async def _call_next(_: Request) -> Response:
+    return Response("ok")
+
+
+def test_rate_limiter_evicts_old_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_RATE_LIMIT", "5")
+    from src.interface import api_server as api
+
+    api = importlib.reload(api)
+
+    limiter = api.SimpleRateLimiter(api.app, limit=5, window=0.1)
+
+    asyncio.run(limiter.dispatch(_make_request("1.1.1.1"), _call_next))
+    assert "1.1.1.1" in limiter.counters
+    time.sleep(0.2)
+    asyncio.run(limiter.dispatch(_make_request("2.2.2.2"), _call_next))
+    assert "1.1.1.1" not in limiter.counters
+    assert list(limiter.counters.keys()) == ["2.2.2.2"]


### PR DESCRIPTION
## Summary
- purge expired entries in `SimpleRateLimiter.dispatch`
- add regression test for eviction logic

## Testing
- `python check_env.py --auto-install`
- `pytest -q`