### PR TITLE
[alpha_factory] Add async context manager for A2ABus

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py
@@ -50,6 +50,15 @@ class A2ABus:
         self._server: "grpc.aio.Server | None" = None
         self._producer: Optional[AIOKafkaProducer] = None
 
+    async def __aenter__(self) -> "A2ABus":
+        """Start the bus when entering an async context."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Stop the bus when exiting an async context."""
+        await self.stop()
+
     def subscribe(self, topic: str, handler: Callable[[Envelope], Awaitable[None] | None]) -> None:
         self._subs.setdefault(topic, []).append(handler)
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_memory_agent_file_persistence.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_memory_agent_file_persistence.py
@@ -20,8 +20,9 @@ def test_memory_agent_file_persistence(tmp_path: Path) -> None:
     envs = [messaging.Envelope("a", "memory", {"idx": i}, 0.0) for i in range(3)]
 
     async def _run() -> None:
-        for env in envs:
-            await agent.handle(env)
+        async with bus:
+            for env in envs:
+                await agent.handle(env)
 
     asyncio.run(_run())
 
@@ -31,5 +32,4 @@ def test_memory_agent_file_persistence(tmp_path: Path) -> None:
     agent2 = memory_agent.MemoryAgent(bus, ledger, str(mem_file))
     assert [r["idx"] for r in agent2.records] == list(range(3))
 
-    asyncio.run(bus.stop())
     ledger.close()

--- a/tests/test_bus_logging.py
+++ b/tests/test_bus_logging.py
@@ -10,11 +10,13 @@ from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messag
 def test_bus_logs_start_stop(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
     cfg = config.Settings(bus_port=1234, broker_url="kafka:9092")
-    bus = messaging.A2ABus(cfg)
     with mock.patch.object(messaging, "AIOKafkaProducer", None), \
          mock.patch.object(messaging, "grpc", None):
-        asyncio.run(bus.start())
-        asyncio.run(bus.stop())
+        async def run() -> None:
+            async with messaging.A2ABus(cfg):
+                pass
+
+        asyncio.run(run())
     messages = [r.message for r in caplog.records]
     assert any("A2ABus.start()" in m and "1234" in m and "kafka:9092" in m for m in messages)
     assert any("A2ABus.stop()" in m for m in messages)

--- a/tests/test_memory_agent_persistence.py
+++ b/tests/test_memory_agent_persistence.py
@@ -10,8 +10,10 @@ def test_memory_agent_persists_records(tmp_path):
     led = logging.Ledger(str(tmp_path / "ledger.db"))
     agent = memory_agent.MemoryAgent(bus, led, str(mem_file))
     env = messaging.Envelope("a", "memory", {"v": 1}, 0.0)
-    asyncio.run(agent.handle(env))
+    async def run() -> None:
+        async with bus:
+            await agent.handle(env)
+    asyncio.run(run())
     agent2 = memory_agent.MemoryAgent(bus, led, str(mem_file))
     assert agent2.records and agent2.records[0]["v"] == 1
-    asyncio.run(bus.stop())
     led.close()

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -32,11 +32,11 @@ def test_publish_to_async_subscriber() -> None:
 
 def test_start_stop_logging(caplog: Any) -> None:
     """Bus start and stop should emit informative log messages."""
-    bus = messaging.A2ABus(config.Settings(bus_port=0, broker_url="kafka:9092"))
-
     async def run() -> None:
-        await bus.start()
-        await bus.stop()
+        async with messaging.A2ABus(
+            config.Settings(bus_port=0, broker_url="kafka:9092")
+        ):
+            pass
 
     with caplog.at_level(logging.INFO):
         asyncio.run(run())

--- a/tests/test_orchestrator_bus_tls_env.py
+++ b/tests/test_orchestrator_bus_tls_env.py
@@ -79,24 +79,25 @@ def test_orchestrator_bus_tls_env(tmp_path: Path) -> None:
         orch = orchestrator.Orchestrator(config.Settings())
 
         async def run() -> None:
-            await orch.bus.start()
-            assert orch.bus._server is not None
-            try:
-                creds = grpc.ssl_channel_credentials(root_certificates=ca)
-                async with grpc.aio.secure_channel(f"localhost:{port}", creds) as ch:
-                    stub = ch.unary_unary("/bus.Bus/Send")
-                    payload = {
-                        "sender": "a",
-                        "recipient": "b",
-                        "payload": {},
-                        "ts": 0.0,
-                        "token": "bad",
-                    }
-                    with pytest.raises(grpc.aio.AioRpcError):
-                        await stub(json.dumps(payload).encode())
-            finally:
-                await orch.bus.stop()
-                await orch.ledger.stop_merkle_task()
-                orch.ledger.close()
+            async with orch.bus:
+                assert orch.bus._server is not None
+                try:
+                    creds = grpc.ssl_channel_credentials(root_certificates=ca)
+                    async with grpc.aio.secure_channel(
+                        f"localhost:{port}", creds
+                    ) as ch:
+                        stub = ch.unary_unary("/bus.Bus/Send")
+                        payload = {
+                            "sender": "a",
+                            "recipient": "b",
+                            "payload": {},
+                            "ts": 0.0,
+                            "token": "bad",
+                        }
+                        with pytest.raises(grpc.aio.AioRpcError):
+                            await stub(json.dumps(payload).encode())
+                finally:
+                    await orch.ledger.stop_merkle_task()
+                    orch.ledger.close()
 
         asyncio.run(run())


### PR DESCRIPTION
## Summary
- implement `A2ABus.__aenter__`/`__aexit__`
- update demos and tests to use `async with A2ABus(...)`

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_bus_secure.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_memory_agent_file_persistence.py tests/test_bus_logging.py tests/test_bus_ssl_gen.py tests/test_bus_tls.py tests/test_message_bus.py tests/test_messaging.py tests/test_orchestrator.py tests/test_insight_orchestrator_restart.py tests/test_orchestrator_bus_tls_env.py tests/test_agents.py tests/test_memory_agent_persistence.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/messaging.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_bus_secure.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_memory_agent_file_persistence.py tests/test_bus_logging.py tests/test_bus_ssl_gen.py tests/test_bus_tls.py tests/test_message_bus.py tests/test_messaging.py tests/test_orchestrator.py tests/test_insight_orchestrator_restart.py tests/test_orchestrator_bus_tls_env.py tests/test_agents.py tests/test_memory_agent_persistence.py` *(fails: many type errors)*
- `pytest -q`