### PR TITLE
[alpha_factory] ledger async context manager

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
@@ -305,3 +305,13 @@ class Ledger:
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
         """Ensure the database connection is closed."""
         self.close()
+
+    async def __aenter__(self) -> "Ledger":
+        """Start the Merkle broadcast task and return ``self``."""
+        self.start_merkle_task()
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        """Stop the Merkle task and close the database."""
+        await self.stop_merkle_task()
+        self.close()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_memory_agent_file_persistence.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_memory_agent_file_persistence.py
@@ -20,7 +20,7 @@ def test_memory_agent_file_persistence(tmp_path: Path) -> None:
     envs = [messaging.Envelope("a", "memory", {"idx": i}, 0.0) for i in range(3)]
 
     async def _run() -> None:
-        async with bus:
+        async with bus, ledger:
             for env in envs:
                 await agent.handle(env)
 
@@ -31,5 +31,3 @@ def test_memory_agent_file_persistence(tmp_path: Path) -> None:
 
     agent2 = memory_agent.MemoryAgent(bus, ledger, str(mem_file))
     assert [r["idx"] for r in agent2.records] == list(range(3))
-
-    ledger.close()

--- a/tests/test_insight_orchestrator_restart.py
+++ b/tests/test_insight_orchestrator_restart.py
@@ -41,8 +41,7 @@ class TestInsightOrchestratorRestart(unittest.TestCase):
         runner = orch.runners["freeze"]
 
         async def run() -> bool:
-            orch.ledger.start_merkle_task(3600)
-            async with orch.bus:
+            async with orch.bus, orch.ledger:
                 runner.start(orch.bus, orch.ledger)
                 monitor = asyncio.create_task(orch._monitor())
                 await asyncio.sleep(3)
@@ -54,8 +53,6 @@ class TestInsightOrchestratorRestart(unittest.TestCase):
                     runner.task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await runner.task
-            await orch.ledger.stop_merkle_task()
-            orch.ledger.close()
             return active
 
         with mock.patch.object(orchestrator.log, "warning") as warn:

--- a/tests/test_memory_agent_persistence.py
+++ b/tests/test_memory_agent_persistence.py
@@ -11,9 +11,8 @@ def test_memory_agent_persists_records(tmp_path):
     agent = memory_agent.MemoryAgent(bus, led, str(mem_file))
     env = messaging.Envelope("a", "memory", {"v": 1}, 0.0)
     async def run() -> None:
-        async with bus:
+        async with bus, led:
             await agent.handle(env)
     asyncio.run(run())
     agent2 = memory_agent.MemoryAgent(bus, led, str(mem_file))
     assert agent2.records and agent2.records[0]["v"] == 1
-    led.close()


### PR DESCRIPTION
## Summary
- add async context manager methods to `Ledger`
- use `async with Ledger()` in several async tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
