### PR TITLE
[alpha_factory] document edge runner env vars

### DIFF
--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -125,6 +125,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main() -> None:
+    """Parse CLI options and launch :mod:`alpha_factory_v1.run`.
+
+    Environment variables such as ``PORT``, ``CYCLE``, ``METRICS_PORT`` and
+    ``A2A_PORT`` provide default values for the corresponding command line
+    flags.
+    """
+
     args = parse_args()
 
     if args.version:


### PR DESCRIPTION
## Summary
- document CLI parsing and env vars in `edge_runner.main`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`