### PR TITLE
[alpha_factory] centralize env int helper

### DIFF
--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -115,17 +115,12 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agents.base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # pylint: disable=import-error
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 
 # ─────────────────────────── helper / governance utils ──────────────────────
-def _env_int(key: str, default: int) -> int:  # robust ENV→int
-    try:
-        return int(os.getenv(key, default))
-    except ValueError:
-        return default
-
 
 def _now() -> str:  # ISO-UTC
     return datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -103,20 +103,13 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agent_base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # re‑use event bus
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Config dataclass
 # ────────────────────────────────────────────────────────────────────────────────
-
-
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, default))
-    except ValueError:
-        return default
-
 
 def _env_float(name: str, default: float) -> float:
     try:

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -101,20 +101,13 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agent_base import AgentBase  # pylint: disable=import‑error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # reuse orchestrator event bus
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration structure
 # ---------------------------------------------------------------------------
-
-
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, default))
-    except ValueError:
-        return default
-
 
 def _env_float(name: str, default: float) -> float:
     try:

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -109,20 +109,13 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agent_base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent  # pylint: disable=import-error
 from backend.orchestrator import _publish  # pylint: disable=import-error
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Environment & governance helpers -----------------------------------------
 # ---------------------------------------------------------------------------
-
-
-def _env_int(var: str, default: int) -> int:
-    try:
-        return int(os.getenv(var, default))
-    except ValueError:
-        return default
-
 
 def _env_float(var: str, default: float) -> float:
     try:

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -103,17 +103,13 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agents.base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # reuse event-bus helper
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
 # Configuration ----------------------------------------------------------------
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, default))
-    except ValueError:
-        return default
 
 
 @dataclass

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -93,20 +93,13 @@ from backend.trace_ws import hub  # pylint: disable=import-error
 from backend.agent_base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent  # pylint: disable=import-error
 from backend.orchestrator import _publish  # pylint: disable=import-error
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helper utilities -----------------------------------------------------------
 # ---------------------------------------------------------------------------
-
-
-def _env_int(key: str, default: int) -> int:
-    try:
-        return int(os.getenv(key, default))
-    except ValueError:
-        return default
-
 
 def _env_float(key: str, default: float) -> float:
     try:

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -91,20 +91,13 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agent_base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # structured‑event helper
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration dataclass  ---------------------------------------------------
 # ---------------------------------------------------------------------------
-
-
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, default))
-    except ValueError:
-        return default
-
 
 def _env_bool(name: str) -> bool:
     return os.getenv(name, "").lower() in {"1", "true", "yes"}

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -102,20 +102,13 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agent_base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration helpers
 # ---------------------------------------------------------------------------
-
-
-def _env_int(key: str, default: int) -> int:
-    try:
-        return int(os.getenv(key, default))
-    except ValueError:
-        return default
-
 
 def _env_float(key: str, default: float) -> float:
     try:

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -101,6 +101,7 @@ except ModuleNotFoundError:  # pragma: no cover
 from backend.agent_base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish
+from alpha_factory_v1.utils.env import _env_int
 
 logger = logging.getLogger(__name__)
 
@@ -111,14 +112,6 @@ logger = logging.getLogger(__name__)
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
-
-
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, default))
-    except ValueError:
-        return default
-
 
 def _digest(payload: Any) -> str:
     return hashlib.sha256(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()).hexdigest()

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -93,6 +93,7 @@ with contextlib.suppress(ModuleNotFoundError):
 
 # ───────────────────── mandatory local imports ────────────────────────
 from backend.agents import list_agents, get_agent  # auto-disc helpers
+from alpha_factory_v1.utils.env import _env_int
 
 # Memory fabric is optional → graceful stub when absent
 try:
@@ -121,15 +122,6 @@ except ModuleNotFoundError:  # pragma: no cover
 
 # ────────────────────────── configuration ─────────────────────────────
 ENV = os.getenv
-
-
-def _env_int(name: str, default: int) -> int:
-    """Return ``int`` environment value or ``default`` if conversion fails."""
-
-    try:
-        return int(ENV(name, default))
-    except (TypeError, ValueError):
-        return default
 
 
 DEV_MODE = ENV("DEV_MODE", "false").lower() == "true" or "--dev" in sys.argv

--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -21,21 +21,9 @@ import os
 from typing import Callable
 
 from alpha_factory_v1 import run as af_run, __version__
+from alpha_factory_v1.utils.env import _env_int
 
 log = logging.getLogger(__name__)
-
-
-def _env_int(name: str, default: int) -> int:
-    """Return ``int`` environment value or ``default`` if conversion fails."""
-
-    val = os.getenv(name)
-    if val is None:
-        return default
-    try:
-        return int(val)
-    except (TypeError, ValueError):
-        log.warning("Invalid %s=%r, using default %s", name, val, default)
-        return default
 
 
 def _positive_int(name: str) -> Callable[[str], int]:

--- a/alpha_factory_v1/utils/env.py
+++ b/alpha_factory_v1/utils/env.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Dict
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 def _load_env_file(path: str | os.PathLike[str]) -> Dict[str, str]:
@@ -28,3 +32,16 @@ def _load_env_file(path: str | os.PathLike[str]) -> Dict[str, str]:
         k, v = line.split("=", 1)
         data[k.strip()] = v.strip().strip('"')
     return data
+
+
+def _env_int(name: str, default: int) -> int:
+    """Return ``int`` environment value or ``default`` if conversion fails."""
+
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        log.warning("Invalid %s=%r, using default %s", name, val, default)
+        return default

--- a/tests/test_edge_runner.py
+++ b/tests/test_edge_runner.py
@@ -4,12 +4,13 @@ import unittest
 from unittest.mock import patch
 
 from alpha_factory_v1 import edge_runner
+from alpha_factory_v1.utils.env import _env_int
 
 
 class TestEnvIntWarning(unittest.TestCase):
     def test_invalid_env_logs_warning(self) -> None:
         logging.disable(logging.NOTSET)
         with patch.dict(os.environ, {"FOO": "bar"}, clear=True):
-            with self.assertLogs("alpha_factory_v1.edge_runner", level="WARNING") as cm:
-                self.assertEqual(edge_runner._env_int("FOO", 5), 5)
+            with self.assertLogs("alpha_factory_v1.utils.env", level="WARNING") as cm:
+                self.assertEqual(_env_int("FOO", 5), 5)
         self.assertTrue(any("Invalid FOO" in msg for msg in cm.output))


### PR DESCRIPTION
## Summary
- share `_env_int` in `alpha_factory_v1.utils.env`
- use helper across orchestrator, edge runner and agents
- update tests for new logger location

## Testing
- `python check_env.py --auto-install`
- `pytest -q`