### PR TITLE
[alpha_factory] Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+max_line_length = 120
+
+[*.md]
+max_line_length = 120

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,7 @@ template). The sample file now lists every variable with its default value.
 ## Coding Style
 - Use Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**) and include type hints for public APIs.
 - Indent with 4 spaces and keep lines under 120 characters.
+- `.editorconfig` enforces UTF-8 encoding, LF line endings and the 120-character limit for Python and Markdown files.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
 for modules, classes and functions.
 - Format code with `black` (line length 120) and run `ruff` or `flake8` for linting, if available.


### PR DESCRIPTION
## Summary
- add `.editorconfig` for indentation and line length
- note `.editorconfig` settings in the contributor guide

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ❌ `pre-commit run --files AGENTS.md .editorconfig` *(failed: pre-commit not installed)*