### PR TITLE
[alpha_factory] decouple background threads

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -552,7 +552,7 @@ def _health_loop():
         )
 
 
-threading.Thread(target=_health_loop, daemon=True, name="agent-health").start()
+
 
 
 ##############################################################################
@@ -567,7 +567,25 @@ def _rescan_loop():  # pragma: no cover
         time.sleep(_RESCAN_SEC)
 
 
-threading.Thread(target=_rescan_loop, daemon=True, name="agent-rescan").start()
+_bg_started = False
+_health_thread: threading.Thread | None = None
+_rescan_thread: threading.Thread | None = None
+
+
+def start_background_tasks() -> None:
+    """Launch health monitor and rescan loops exactly once."""
+    global _bg_started, _health_thread, _rescan_thread
+    if _bg_started:
+        return
+    _bg_started = True
+    _health_thread = threading.Thread(
+        target=_health_loop, daemon=True, name="agent-health"
+    )
+    _rescan_thread = threading.Thread(
+        target=_rescan_loop, daemon=True, name="agent-rescan"
+    )
+    _health_thread.start()
+    _rescan_thread.start()
 
 
 ##############################################################################
@@ -647,4 +665,5 @@ __all__ = [
     "list_agents",
     "capability_agents",
     "get_agent",
+    "start_background_tasks",
 ]

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -92,7 +92,11 @@ with contextlib.suppress(ModuleNotFoundError):
 
 
 # ───────────────────── mandatory local imports ────────────────────────
-from backend.agents import list_agents, get_agent  # auto-disc helpers
+from backend.agents import (
+    list_agents,
+    get_agent,
+    start_background_tasks,
+)  # auto-disc helpers
 from alpha_factory_v1.utils.env import _env_int
 
 # Memory fabric is optional → graceful stub when absent
@@ -472,6 +476,8 @@ async def _main() -> None:
             "Edit .env or your Docker secrets to configure a strong password."
         )
         sys.exit(1)
+
+    start_background_tasks()
 
     # ─── Discover/instantiate agents ─────────────────────────────────
     avail = list_agents()

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -195,7 +195,12 @@ class TestHealthQuarantine(unittest.TestCase):
         AGENT_REGISTRY.update(self._registry_backup)
 
     def test_stub_after_errors(self):
-        from alpha_factory_v1.backend.agents import _HEALTH_Q, StubAgent, _ERR_THRESHOLD
+        from alpha_factory_v1.backend.agents import (
+            _HEALTH_Q,
+            StubAgent,
+            _ERR_THRESHOLD,
+            start_background_tasks,
+        )
 
         class FailingAgent(AgentBase):
             NAME = "fail"
@@ -205,6 +210,7 @@ class TestHealthQuarantine(unittest.TestCase):
 
         meta = AgentMetadata(name="fail", cls=FailingAgent, version="0", capabilities=[])  # type: ignore[list-item]
         register_agent(meta)
+        start_background_tasks()
         # Pre-set error count to threshold -1
         object.__setattr__(AGENT_REGISTRY["fail"], "err_count", _ERR_THRESHOLD - 1)
         _HEALTH_Q.put(("fail", 0.0, False))


### PR DESCRIPTION
## Summary
- start agent health monitor and rescan loops lazily
- expose `start_background_tasks` from agents
- call initializer during orchestrator startup
- update health quarantine test

## Testing
- `python check_env.py --auto-install`
- `pytest -q`