### PR TITLE
[alpha_factory] refine mesh error handling

### DIFF
--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -110,6 +110,17 @@ try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
     adk = None  # type: ignore
+try:
+    from aiohttp import ClientError as AiohttpClientError  # type: ignore
+except Exception:  # pragma: no cover - optional
+    AiohttpClientError = OSError  # type: ignore
+try:
+    from adk import ClientError as AdkClientError  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - optional
+
+    class AdkClientError(Exception):
+        pass
+
 
 # ───────────────────────────── Alpha-Factory locals ─────────────────────────
 from backend.agents.base import AgentBase  # pylint: disable=import-error
@@ -121,6 +132,7 @@ logger = logging.getLogger(__name__)
 
 
 # ─────────────────────────── helper / governance utils ──────────────────────
+
 
 def _now() -> str:  # ISO-UTC
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -400,8 +412,11 @@ class BiotechAgent(AgentBase):
             client = adk.Client()
             await client.register(node_type=self.NAME, metadata={"kg": str(self.cfg.kg_file)})
             logger.info("[BT] registered in ADK mesh id=%s", client.node_id)
-        except Exception as exc:
+        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
             logger.warning("ADK registration failed: %s", exc)
+        except Exception as exc:  # pragma: no cover - unexpected
+            logger.exception("Unexpected ADK registration error: %s", exc)
+            raise
 
 
 # ───────────────────────────── registry hook ────────────────────────────────

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -97,6 +97,17 @@ try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
     adk = None  # type: ignore
+try:
+    from aiohttp import ClientError as AiohttpClientError  # type: ignore
+except Exception:  # pragma: no cover - optional
+    AiohttpClientError = OSError  # type: ignore
+try:
+    from adk import ClientError as AdkClientError  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - optional
+
+    class AdkClientError(Exception):
+        pass
+
 
 try:
     import selfies as sf  # type: ignore
@@ -116,6 +127,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Environment & governance helpers -----------------------------------------
 # ---------------------------------------------------------------------------
+
 
 def _env_float(var: str, default: float) -> float:
     try:
@@ -483,8 +495,11 @@ class DrugDesignAgent(AgentBase):
             client = adk.Client()
             await client.register(node_type=self.NAME)
             logger.info("[DD] registered mesh id=%s", client.node_id)
-        except Exception as exc:  # noqa: BLE001
+        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
             logger.warning("ADK register failed: %s", exc)
+        except Exception as exc:  # pragma: no cover - unexpected
+            logger.exception("Unexpected ADK registration error: %s", exc)
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -96,6 +96,17 @@ try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
     adk = None  # type: ignore
+try:
+    from aiohttp import ClientError as AiohttpClientError  # type: ignore
+except Exception:  # pragma: no cover - optional
+    AiohttpClientError = OSError  # type: ignore
+try:
+    from adk import ClientError as AdkClientError  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - optional
+
+    class AdkClientError(Exception):
+        pass
+
 
 # ---------------------------------------------------------------------------
 # Alpha-Factory core imports (lightweight, always available)
@@ -361,8 +372,11 @@ class EnergyAgent(AgentBase):
             client = adk.Client()
             await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
             logger.info("[EN] registered in ADK mesh id=%s", client.node_id)
-        except Exception as exc:  # noqa: BLE001
+        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
             logger.warning("ADK registration failed: %s", exc)
+        except Exception as exc:  # pragma: no cover - unexpected
+            logger.exception("Unexpected ADK registration error: %s", exc)
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -85,6 +85,17 @@ try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
     adk = None  # type: ignore
+try:
+    from aiohttp import ClientError as AiohttpClientError  # type: ignore
+except Exception:  # pragma: no cover - optional
+    AiohttpClientError = OSError  # type: ignore
+try:
+    from adk import ClientError as AdkClientError  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - optional
+
+    class AdkClientError(Exception):
+        pass
+
 
 # ---------------------------------------------------------------------------
 # Alpha‑Factory lightweight imports ------------------------------------------
@@ -100,6 +111,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Helper utilities -----------------------------------------------------------
 # ---------------------------------------------------------------------------
+
 
 def _env_float(key: str, default: float) -> float:
     try:
@@ -436,8 +448,11 @@ class ManufacturingAgent(AgentBase):
             client = adk.Client()
             await client.register(node_type=self.NAME, metadata={"cp_sat": self._cp_available})
             logger.info("[MF] registered in ADK mesh id=%s", client.node_id)
-        except Exception as exc:  # noqa: BLE001
+        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
             logger.warning("ADK registration failed: %s", exc)
+        except Exception as exc:  # pragma: no cover - unexpected
+            logger.exception("Unexpected ADK registration error: %s", exc)
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -92,6 +92,17 @@ try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
     adk = None  # type: ignore
+try:
+    from aiohttp import ClientError as AiohttpClientError  # type: ignore
+except Exception:  # pragma: no cover - optional
+    AiohttpClientError = OSError  # type: ignore
+try:
+    from adk import ClientError as AdkClientError  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - optional
+
+    class AdkClientError(Exception):
+        pass
+
 
 try:
     import httpx  # type: ignore
@@ -367,8 +378,11 @@ class PolicyAgent(AgentBase):
             client = adk.Client()
             await client.register(node_type=self.NAME, metadata={"corpus": str(self.cfg.corpus_dir)})
             logger.info("[PL] registered in ADK mesh id=%s", client.node_id)
-        except Exception as exc:  # noqa: BLE001
+        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
             logger.warning("ADK registration failed: %s", exc)
+        except Exception as exc:  # pragma: no cover - unexpected
+            logger.exception("Unexpected ADK registration error: %s", exc)
+            raise
 
 
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- catch network/ADK errors when reading prices and registering with the mesh
- log and re-raise unexpected issues
- remove duplicate error imports

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `black alpha_factory_v1/backend/agents/manufacturing_agent.py`
- `ruff check alpha_factory_v1/backend/agents/manufacturing_agent.py`
- `mypy --config-file mypy.ini alpha_factory_v1/backend/agents/biotech_agent.py alpha_factory_v1/backend/agents/climate_risk_agent.py alpha_factory_v1/backend/agents/cyber_threat_agent.py alpha_factory_v1/backend/agents/drug_design_agent.py alpha_factory_v1/backend/agents/energy_agent.py alpha_factory_v1/backend/agents/finance_agent.py alpha_factory_v1/backend/agents/manufacturing_agent.py alpha_factory_v1/backend/agents/policy_agent.py alpha_factory_v1/backend/agents/retail_demand_agent.py alpha_factory_v1/backend/agents/smart_contract_agent.py alpha_factory_v1/backend/agents/supply_chain_agent.py alpha_factory_v1/backend/agents/talent_match_agent.py` *(fails: many strict type errors)*
- `flake8 …` *(fails: command not found)*
- `pre-commit run --files <changed files>` *(fails: command not found)*