### PR TITLE
[alpha_factory] replace private metric lookup

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -75,13 +75,11 @@ try:  # Prometheus metrics
         Gauge as _Gauge,
         Histogram as _Histogram,
         CollectorRegistry,
-        REGISTRY as _REG,
     )  # type: ignore
+    from alpha_factory_v1.backend.metrics_registry import get_metric as _reg_metric
 
     def _get_metric(cls, name: str, desc: str, labels=None):
-        if name in getattr(_REG, "_names_to_collectors", {}):
-            return _REG._names_to_collectors[name]
-        return cls(name, desc, labels) if labels else cls(name, desc)
+        return _reg_metric(cls, name, desc, labels)
 
     def Counter(name: str, desc: str, labels=None):  # type: ignore[misc]
         return _get_metric(_Counter, name, desc, labels)

--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -68,12 +68,11 @@ _Prom: SimpleNamespace = SimpleNamespace(Counter=None, Gauge=None, Histogram=Non
 _OTEL: SimpleNamespace = SimpleNamespace(tracer=None)
 
 try:
-    from prometheus_client import Counter, Gauge, Histogram, REGISTRY  # type: ignore
+    from prometheus_client import Counter, Gauge, Histogram  # type: ignore
+    from alpha_factory_v1.backend.metrics_registry import get_metric as _reg_metric
 
     def _get_metric(cls, name: str, desc: str):
-        if name in getattr(REGISTRY, "_names_to_collectors", {}):
-            return REGISTRY._names_to_collectors[name]
-        return cls(name, desc)
+        return _reg_metric(cls, name, desc)
 
     _Prom.Counter = Counter  # type: ignore[assignment]
     _Prom.Gauge = Gauge

--- a/alpha_factory_v1/backend/memory_fabric.py
+++ b/alpha_factory_v1/backend/memory_fabric.py
@@ -149,12 +149,10 @@ CFG = _Settings()  # single instance
 
 # ───────────────────── telemetry helpers ░────────────────────
 if "Counter" in globals():
-    from prometheus_client import REGISTRY as _REG
+    from alpha_factory_v1.backend.metrics_registry import get_metric as _reg_metric
 
     def _get_metric(cls, name: str, desc: str):
-        if name in getattr(_REG, "_names_to_collectors", {}):
-            return _REG._names_to_collectors[name]
-        return cls(name, desc)
+        return _reg_metric(cls, name, desc)
 
     _MET_V_ADD = _get_metric(Counter, "af_mem_vector_add_total", "Vectors stored")
     _MET_V_SRCH = _get_metric(

--- a/alpha_factory_v1/backend/metrics_registry.py
+++ b/alpha_factory_v1/backend/metrics_registry.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared Prometheus metric registry."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, MutableMapping
+
+METRICS: MutableMapping[str, Any] = {}
+
+
+def get_metric(factory: Callable[..., Any], name: str, desc: str, labels: list[str] | None = None) -> Any:
+    """Return an existing metric or create a new one.
+
+    This avoids depending on ``REGISTRY._names_to_collectors`` which may
+    change between ``prometheus_client`` versions.
+    """
+    metric = METRICS.get(name)
+    if metric is not None:
+        return metric
+    metric = factory(name, desc, labels) if labels is not None else factory(name, desc)
+    METRICS[name] = metric
+    return metric

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -166,12 +166,10 @@ def _noop(*_a, **_kw):  # type: ignore
 
 
 if "Histogram" in globals():
-    from prometheus_client import REGISTRY as _REG
+    from alpha_factory_v1.backend.metrics_registry import get_metric as _reg_metric
 
     def _get_metric(cls, name: str, desc: str, labels=None):
-        if name in getattr(_REG, "_names_to_collectors", {}):
-            return _REG._names_to_collectors[name]
-        return cls(name, desc, labels) if labels else cls(name, desc)
+        return _reg_metric(cls, name, desc, labels)
 
     MET_LAT = _get_metric(Histogram, "af_agent_cycle_latency_ms", "Per-cycle latency", ["agent"])
     MET_ERR = _get_metric(Counter, "af_agent_cycle_errors_total", "Exceptions per agent", ["agent"])

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/tracing.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/tracing.py
@@ -62,12 +62,10 @@ def _noop(*_a: Any, **_kw: Any) -> Any:
     return _N()
 
 if prometheus_client is not None:
-    from prometheus_client import REGISTRY as _REG
+    from alpha_factory_v1.backend.metrics_registry import get_metric as _reg_metric
 
     def _get_metric(cls: Any, name: str, desc: str, labels: list[str]) -> Any:
-        if name in getattr(_REG, "_names_to_collectors", {}):
-            return _REG._names_to_collectors[name]
-        return cls(name, desc, labels)
+        return _reg_metric(cls, name, desc, labels)
 
     bus_messages_total = _get_metric(
         Counter,

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -58,7 +58,6 @@ try:
     import prometheus_client
     from prometheus_client import (
         Counter,
-        Histogram,
         generate_latest,
     )
     from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.tracing import (
@@ -91,12 +90,10 @@ if app is not None:
         return _N()
 
     if prometheus_client is not None:
-        from prometheus_client import REGISTRY as _REG
+        from alpha_factory_v1.backend.metrics_registry import get_metric
 
         def _get_metric(cls: Any, name: str, desc: str, labels: list[str]) -> Any:
-            if name in getattr(_REG, "_names_to_collectors", {}):
-                return _REG._names_to_collectors[name]
-            return cls(name, desc, labels)
+            return get_metric(cls, name, desc, labels)
 
         REQ_COUNT = _get_metric(Counter, "api_requests_total", "HTTP requests", ["method", "endpoint", "status"])
         REQ_LAT = api_request_seconds


### PR DESCRIPTION
## Summary
- avoid prometheus private attribute access
- share metrics via new backend.metrics_registry

## Testing
- `pre-commit` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pytest -q`
- `mypy --config-file mypy.ini alpha_factory_v1/backend/metrics_registry.py` *(fails: many errors)*