### PR TITLE
[alpha_factory] rename env var for local code execution

### DIFF
--- a/alpha_factory_v1/backend/agent_factory.py
+++ b/alpha_factory_v1/backend/agent_factory.py
@@ -42,6 +42,10 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, List, Optional, Sequence
 
+# Environment variables
+ALLOW_LOCAL_CODE_ENV = "ALPHA_FACTORY_ALLOW_LOCAL_CODE"
+LEGACY_ALLOW_LOCAL_CODE_ENV = "ALPHAFAC_ALLOW_LOCAL_CODE"
+
 LOGGER = logging.getLogger(__name__)
 
 # ╭──────────────────────────────────────────────────────────────────────╮
@@ -182,6 +186,14 @@ def _auto_select_model() -> str:
     return "local-sbert"
 
 
+def _allow_local_code() -> bool:
+    """Check both new and legacy opts for enabling local PythonTool."""
+    return (
+        os.getenv(ALLOW_LOCAL_CODE_ENV)
+        or os.getenv(LEGACY_ALLOW_LOCAL_CODE_ENV)
+    ) == "1"
+
+
 # ╭──────────────────────────────────────────────────────────────────────╮
 # │ 4 ▸ Default, *safe* tool-chain                                      │
 # ╰──────────────────────────────────────────────────────────────────────╯
@@ -202,7 +214,7 @@ def get_default_tools() -> List[Any]:
         base.append(ComputerTool())
 
     # PythonTool executes *locally* – only enable if user opts in explicitly.
-    if SDK_AVAILABLE and os.getenv("ALPHAFAC_ALLOW_LOCAL_CODE") == "1":
+    if SDK_AVAILABLE and _allow_local_code():
         base.append(PythonTool())
 
     return base
@@ -244,7 +256,8 @@ def build_core_agent(
     Notes
     -----
     The default tool selection honours ``OPENAI_API_KEY`` and
-    ``ALPHAFAC_ALLOW_LOCAL_CODE`` environment variables at call time.
+    ``ALPHA_FACTORY_ALLOW_LOCAL_CODE`` (or legacy ``ALPHAFAC_ALLOW_LOCAL_CODE``)
+    environment variables at call time.
     Set them before invoking this function if the agent requires
     networked or local code execution tools.
     """

--- a/alpha_factory_v1/demos/self_healing_repo.py
+++ b/alpha_factory_v1/demos/self_healing_repo.py
@@ -37,7 +37,8 @@ Extra CLI flags:
 Environment variables:
 
 * ``OPENAI_API_KEY`` – enables full LLM reasoning (optional).
-* ``ALPHAFAC_ALLOW_LOCAL_CODE=1`` – same as ``--allow-local-code`` flag
+* ``ALPHA_FACTORY_ALLOW_LOCAL_CODE=1`` – same as ``--allow-local-code`` flag
+  (legacy ``ALPHAFAC_ALLOW_LOCAL_CODE`` is still honoured)
   (takes precedence).
 
 This script is **self‑contained** and production‑ready.  A non‑technical
@@ -124,7 +125,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     args = _parse_args(argv)
 
     if args.allow_local_code:
-        os.environ["ALPHAFAC_ALLOW_LOCAL_CODE"] = "1"
+        os.environ["ALPHA_FACTORY_ALLOW_LOCAL_CODE"] = "1"
 
     agent = build_core_agent(
         name="Repo‑Doctor",


### PR DESCRIPTION
## Summary
- rename `ALPHAFAC_ALLOW_LOCAL_CODE` to `ALPHA_FACTORY_ALLOW_LOCAL_CODE`
- keep backward compatibility by accepting the old name
- update repo doctor demo docs accordingly

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pre-commit` *(fails: `pre-commit: command not found`)*