### PR TITLE
[alpha_factory] rename memory dir parameter

### DIFF
--- a/alpha_factory_v1/backend/memory.py
+++ b/alpha_factory_v1/backend/memory.py
@@ -27,11 +27,16 @@ _log.setLevel(os.getenv("LOGLEVEL", "INFO"))
 class Memory:
     """Append‑only JSONL store; just good enough for unit‑tests & demos."""
 
-    def __init__(self, dir: str | os.PathLike[str] | None = None) -> None:
+    def __init__(self, directory: str | os.PathLike[str] | None = None) -> None:
+        """Create a new memory store.
+
+        When *directory* is ``None``, the path defaults to the ``AF_MEMORY_DIR``
+        environment variable or ``/tmp/alphafactory``.
+        """
         # Pick a safe, always‑writeable directory.
-        if dir is None:
-            dir = os.getenv("AF_MEMORY_DIR", Path(tempfile.gettempdir()) / "alphafactory")
-        self.dir = Path(dir)
+        if directory is None:
+            directory = os.getenv("AF_MEMORY_DIR", Path(tempfile.gettempdir()) / "alphafactory")
+        self.dir = Path(directory)
         self.dir.mkdir(parents=True, exist_ok=True)
 
         self.file = self.dir / "events.jsonl"

--- a/alpha_factory_v1/tests/test_memory.py
+++ b/alpha_factory_v1/tests/test_memory.py
@@ -1,12 +1,11 @@
 import unittest
 import tempfile
-import os
 from alpha_factory_v1.backend.memory import Memory
 
 class MemoryTest(unittest.TestCase):
     def test_write_and_read(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            mem = Memory(tmpdir)
+            mem = Memory(directory=tmpdir)
             mem.write('agent1', 'greeting', {'msg': 'hello'})
             mem.write('agent2', 'greeting', {'msg': 'world'})
             records = mem.read()
@@ -18,7 +17,7 @@ class MemoryTest(unittest.TestCase):
 
     def test_limit_and_query_alias(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            mem = Memory(tmpdir)
+            mem = Memory(directory=tmpdir)
             for i in range(10):
                 mem.write('agent', 'num', {'i': i})
             recs = mem.read(limit=5)
@@ -29,7 +28,7 @@ class MemoryTest(unittest.TestCase):
 
     def test_flush(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            mem = Memory(tmpdir)
+            mem = Memory(directory=tmpdir)
             mem.write('agent', 'x', {'n': 1})
             self.assertEqual(len(mem.read()), 1)
             mem.flush()

--- a/alpha_factory_v1/tests/test_planner_agent.py
+++ b/alpha_factory_v1/tests/test_planner_agent.py
@@ -31,7 +31,7 @@ class DummyGov:
 class PlannerAgentTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
-        self.memory = Memory(self.tmpdir.name)
+        self.memory = Memory(directory=self.tmpdir.name)
         self.gov = DummyGov()
         # Disable Prometheus metrics to avoid duplicate registry errors
         import backend.agents.base as base


### PR DESCRIPTION
## Summary
- adjust Memory's constructor to take `directory` instead of `dir`
- document AF_MEMORY_DIR usage
- update tests for new parameter

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/backend/memory.py alpha_factory_v1/tests/test_memory.py alpha_factory_v1/tests/test_planner_agent.py`
- `pytest -q`