### PR TITLE
[alpha_factory] expose init_config entry points

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -28,7 +28,6 @@ def _load_dotenv(path: str = ".env") -> None:
             os.environ.setdefault(k, v)
 
 
-_load_dotenv()
 
 
 def _env_int(name: str, default: int) -> int:
@@ -56,6 +55,15 @@ def _prefetch_vault() -> None:
                 os.environ["OPENAI_API_KEY"] = value
         except Exception as exc:  # noqa: BLE001
             _log.warning("Vault lookup failed: %s", exc)
+
+
+def init_config(env_file: str = ".env") -> None:
+    """Load environment variables and refresh :data:`CFG`."""
+
+    _load_dotenv(env_file)
+    _prefetch_vault()
+    global CFG
+    CFG = Settings()
 
 
 class Settings(BaseSettings):
@@ -110,6 +118,5 @@ class Settings(BaseSettings):
         return f"Settings({data})"
 
 
-_prefetch_vault()
 
 CFG = Settings()

--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -22,6 +22,7 @@ from typing import Callable
 
 from alpha_factory_v1 import run as af_run, __version__
 from alpha_factory_v1.utils.env import _env_int
+from src.utils.config import init_config
 
 log = logging.getLogger(__name__)
 
@@ -120,6 +121,7 @@ def main() -> None:
     flags.
     """
 
+    init_config()
     args = parse_args()
 
     if args.version:

--- a/edge_runner.py
+++ b/edge_runner.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Wrapper script forwarding to :mod:`alpha_factory_v1.edge_runner`."""
 from alpha_factory_v1.edge_runner import main
+from src.utils.config import init_config
 
 if __name__ == "__main__":
+    init_config()
     main()

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Any, List, TYPE_CHECKING, cast, Set
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import alerts
+from src.utils.config import init_config
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -547,6 +548,7 @@ def main(argv: List[str] | None = None) -> None:
     if FastAPI is None:
         raise SystemExit("FastAPI is required to run the API server")
 
+    init_config()
     parser = argparse.ArgumentParser(description="Run the AGI simulation API server")
     parser.add_argument("--host", default="0.0.0.0", help="Bind host")
     parser.add_argument("--port", type=int, default=8000, help="Bind port")

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -21,7 +21,6 @@ def _load_dotenv(path: str = ".env") -> None:
             os.environ.setdefault(k, v)
 
 
-_load_dotenv()
 
 
 def _env_int(name: str, default: int) -> int:
@@ -114,7 +113,15 @@ def _prefetch_vault() -> None:
             _log.warning("Vault lookup failed: %s", exc)
 
 
-_prefetch_vault()
+def init_config(env_file: str = ".env") -> None:
+    """Load environment variables and refresh :data:`CFG`."""
+
+    _load_dotenv(env_file)
+    _prefetch_vault()
+    global CFG
+    CFG = Settings()
+
+
 
 
 class Settings(BaseSettings):

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 import os
 from pathlib import Path
 
@@ -31,7 +30,7 @@ def test_get_secret_env(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_settings_secret_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("AGI_INSIGHT_SECRET_BACKEND", raising=False)
-    importlib.reload(cfg)
+    cfg.init_config()
     monkeypatch.setattr(cfg, "get_secret", lambda name, default=None: "backend")
     settings = cfg.Settings()
     assert settings.openai_api_key == "backend"

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -1,9 +1,5 @@
-import importlib
 import sys
 import types
-from pathlib import Path
-
-import pytest
 
 
 def test_settings_loads_dotenv(tmp_path, monkeypatch):
@@ -12,7 +8,7 @@ def test_settings_loads_dotenv(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     import src.utils.config as cfg
-    importlib.reload(cfg)
+    cfg.init_config()
     settings = cfg.Settings()
     assert settings.openai_api_key == "abc"
     assert settings.bus_port == 1234
@@ -32,7 +28,7 @@ def test_settings_vault_auto(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setitem(sys.modules, "hvac", types.SimpleNamespace(Client=FakeClient))
     import src.utils.config as cfg
-    importlib.reload(cfg)
+    cfg.init_config()
     settings = cfg.Settings()
     assert settings.openai_api_key == "vault"
 
@@ -53,7 +49,7 @@ def test_vault_overrides_dotenv(tmp_path, monkeypatch):
     monkeypatch.setenv("VAULT_ADDR", "http://vault")
     monkeypatch.setitem(sys.modules, "hvac", types.SimpleNamespace(Client=FakeClient))
     import src.utils.config as cfg
-    importlib.reload(cfg)
+    cfg.init_config()
     settings = cfg.Settings()
     assert settings.openai_api_key == "vault"
 
@@ -61,7 +57,7 @@ def test_vault_overrides_dotenv(tmp_path, monkeypatch):
 def test_settings_repr_masks_secret(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "shh")
     import src.utils.config as cfg
-    importlib.reload(cfg)
+    cfg.init_config()
     settings = cfg.Settings()
     rep = repr(settings)
     assert "shh" not in rep


### PR DESCRIPTION
## Summary
- define `init_config()` in src utils
- call `init_config()` in edge_runner and API server
- add `init_config()` for insight demo config
- update tests for explicit initialization

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py src/utils/config.py edge_runner.py alpha_factory_v1/edge_runner.py src/interface/api_server.py tests/test_config_utils.py tests/test_root_config.py`
- `mypy --config-file mypy.ini src/utils/config.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py edge_runner.py alpha_factory_v1/edge_runner.py src/interface/api_server.py tests/test_config_utils.py tests/test_root_config.py` *(fails: 202 errors)*
- `pytest -q`