### PR TITLE
[alpha_factory] add license headers to src interface utils

### DIFF
--- a/src/interface/__init__.py
+++ b/src/interface/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Web and API front ends for running the demo."""

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """FastAPI server exposing simulation endpoints."""
 
 from __future__ import annotations

--- a/src/interface/minimal_ui.py
+++ b/src/interface/minimal_ui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Simple Streamlit interface for forecasting disruptions."""
 
 from __future__ import annotations

--- a/src/interface/web_app.py
+++ b/src/interface/web_app.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Interactive Streamlit dashboard for running AGI simulations.
 
 The app mirrors the ``cli.py`` options with widgets for the forecast horizon,

--- a/src/interface/web_client/__init__.py
+++ b/src/interface/web_client/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """React front-end for the demo.
 
 The production build lives in the ``dist`` directory and can be served by any

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Shared utilities and configuration."""
 
 from .config import CFG, get_secret

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Environment-driven configuration shared across components."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX header to Python files under `src/interface` and `src/utils`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- ❌ `pre-commit run --files ...` *(failed: `pre-commit` not installed)*