### PR TITLE
[alpha_factory] use unified env helper

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -24,13 +24,6 @@ def _load_dotenv(path: str = ".env") -> None:
 
 
 
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, default))
-    except (TypeError, ValueError):
-        return default
-
-
 def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
     """Return ``name`` from the configured secret backend or environment.
 


### PR DESCRIPTION
## Summary
- remove local `_env_int` implementation from demo config
- rely on `alpha_factory_v1.utils.env._env_int`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`