### PR TITLE
[alpha_factory] secure results dir

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -396,7 +396,7 @@ local development or customization. See the
 | `AGI_INSIGHT_SOLANA_URL` | Solana RPC endpoint | `https://api.testnet.solana.com` |
 | `AGI_INSIGHT_SOLANA_WALLET` | Wallet private key (hex) | _unset_ |
 | `AGI_INSIGHT_SOLANA_WALLET_FILE` | Path to wallet key file | _unset_ |
-| `SIM_RESULTS_DIR` | Folder for simulation JSON results | `$ALPHA_DATA_DIR/simulations` |
+| `SIM_RESULTS_DIR` | Folder for simulation JSON results (created with mode `0700`) | `$ALPHA_DATA_DIR/simulations` |
 | `MAX_RESULTS` | Number of results to keep on disk | `100` |
 | `API_TOKEN` | Bearer token required by the REST API | `REPLACE_ME_TOKEN` |
 
@@ -421,6 +421,7 @@ use `AGI_INSIGHT_SOLANA_WALLET_FILE` to reference the file containing the
 hex-encoded private key.
 When `AGI_INSIGHT_MEMORY_PATH` is not set the MemoryAgent keeps records only in memory.
 The API server stores simulation results as JSON files under `SIM_RESULTS_DIR`.
+The directory is created with permissions `0700` when missing.
 
 ---
 

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -222,7 +222,7 @@ _results_dir = Path(
     )
 )
 _max_results = int(os.getenv("MAX_RESULTS", "100"))
-_results_dir.mkdir(parents=True, exist_ok=True)
+_results_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
 
 def _load_results() -> None:

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -90,6 +90,22 @@ def test_background_run_direct(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert messages and messages[0]["id"] == sim_id
 
 
+def test_results_dir_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Directory is created with 0700 permissions."""
+
+    path = tmp_path / "results"
+    monkeypatch.setenv("SIM_RESULTS_DIR", str(path))
+
+    import importlib
+
+    from src.interface import api_server as api
+
+    api = importlib.reload(api)
+
+    assert path.exists()
+    assert (path.stat().st_mode & 0o777) == 0o700
+
+
 def test_root_serves_spa() -> None:
     client = make_client()
     r = client.get("/")


### PR DESCRIPTION
## Summary
- secure simulation results directory permissions
- document SIM_RESULTS_DIR permissions
- test directory permissions

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_api_server.py`
- `pytest -q`