### PR TITLE
[alpha_factory] rename NEO4J_PASSWORD setting

### DIFF
--- a/alpha_factory_v1/backend/memory_graph.py
+++ b/alpha_factory_v1/backend/memory_graph.py
@@ -157,7 +157,7 @@ class GraphMemory:
     ) -> None:
         uri = uri or os.getenv("NEO4J_URI")
         user = user or os.getenv("NEO4J_USER")
-        password = password or os.getenv("NEO4J_PASS")
+        password = password or os.getenv("NEO4J_PASSWORD") or os.getenv("NEO4J_PASS")
         self._db = database or os.getenv("NEO4J_DATABASE", "neo4j")
 
         self._driver = None


### PR DESCRIPTION
## Summary
- update memory_fabric to use `NEO4J_PASSWORD` with `NEO4J_PASS` fallback
- update GraphMemory to check the new environment variable

## Testing
- `python check_env.py --auto-install`
- `pytest -q`