### PR TITLE
[alpha_factory] improve exception handling

### DIFF
--- a/alpha_factory_v1/backend/portfolio.py
+++ b/alpha_factory_v1/backend/portfolio.py
@@ -65,7 +65,8 @@ class Portfolio:
             for line in db_path.read_text().splitlines():
                 try:
                     rec = Fill(**json.loads(line))
-                except Exception:
+                except (json.JSONDecodeError, TypeError, KeyError) as exc:
+                    logger.warning("Skipping corrupt fill record: %s", exc)
                     continue  # skip corrupt lines
                 self._apply(rec, persist=False)
 
@@ -106,7 +107,8 @@ class Portfolio:
             for line in fh:
                 try:
                     yield Fill(**json.loads(line))
-                except Exception:
+                except (json.JSONDecodeError, TypeError, KeyError) as exc:
+                    logger.warning("Skipping corrupt fill record: %s", exc)
                     continue
 
     def clear(self) -> None:


### PR DESCRIPTION
## Summary
- catch ModuleNotFoundError when importing optional FastAPI modules
- log and skip bad simulation results
- handle WebSocketDisconnect errors when streaming progress
- log corrupt fill records in `portfolio` loader and history

## Testing
- `python check_env.py --auto-install`
- `pytest -q`