### PR TITLE
[alpha_factory] Fix problem JSON media type

### DIFF
--- a/src/interface/problem_json.py
+++ b/src/interface/problem_json.py
@@ -28,5 +28,9 @@ def problem_response(exc: HTTPException) -> JSONResponse:
     if detail:
         body["detail"] = detail
 
-    return JSONResponse(status_code=exc.status_code, content=body)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=body,
+        media_type="application/problem+json",
+    )
 

--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -162,6 +162,9 @@ def test_problem_json_subprocess() -> None:
         _wait_running(url, headers)
         r = httpx.get(f"{url}/results/missing", headers=headers)
         assert r.status_code == 404
+        assert r.headers.get("content-type", "").startswith(
+            "application/problem+json"
+        )
         data = r.json()
         assert data.get("type") == "about:blank"
         assert data.get("status") == 404


### PR DESCRIPTION
## Summary
- send RFC7807 problem responses with `application/problem+json`
- update subprocess API test for new content type

## Testing
- `pytest`
