### PR TITLE
[alpha_factory] log chat exceptions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py
@@ -81,5 +81,6 @@ def chat(prompt: str, cfg: Settings | None = None) -> str:
     try:
         with span("local_llm.chat"):
             return _CALL(prompt, cfg)
-    except Exception:  # pragma: no cover - runtime error
+    except Exception as exc:  # pragma: no cover - runtime error
+        _log.exception("Local chat failed: %s", exc)
         return f"[offline] {prompt}"

--- a/tests/test_local_llm_logging.py
+++ b/tests/test_local_llm_logging.py
@@ -14,3 +14,13 @@ def test_load_model_warning(monkeypatch, caplog):
     local_llm._load_model(local_llm.config.CFG)
 
     assert any("boom" in r.message for r in caplog.records)
+
+
+def test_chat_exception_logs_error(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR)
+    monkeypatch.setattr(local_llm, "_CALL", lambda _p, _c: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    out = local_llm.chat("hello", local_llm.config.CFG)
+
+    assert out == "[offline] hello"
+    assert any("boom" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- log runtime failures in `local_llm.chat`
- test logging of exceptions in `local_llm.chat`

## Testing
- `python check_env.py --auto-install`
- `black --check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py tests/test_local_llm_logging.py`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py tests/test_local_llm_logging.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/local_llm.py tests/test_local_llm_logging.py` *(fails: numerous errors in unrelated modules)*
- `pytest -q tests/test_local_llm_logging.py`
