### PR TITLE
[alpha_factory] handle gRPC handshake failure

### DIFF
--- a/alpha_factory_v1/backend/a2a_client.py
+++ b/alpha_factory_v1/backend/a2a_client.py
@@ -197,10 +197,14 @@ class _GrpcTransport:
             else:
                 channel = grpc.aio.secure_channel(target, creds)
         # Wait for the TLS handshake to complete
-        if timeout:
-            await asyncio.wait_for(channel.channel_ready(), timeout)
-        else:
-            await channel.channel_ready()
+        try:
+            if timeout:
+                await asyncio.wait_for(channel.channel_ready(), timeout)
+            else:
+                await channel.channel_ready()
+        except Exception:
+            await channel.close()
+            raise
         # Lazy import of auto‑generated stub
         from proto.alpha_factory.v1 import alpha_pb2_grpc as stubs  # type: ignore
 

--- a/tests/test_grpc_transport_timeout.py
+++ b/tests/test_grpc_transport_timeout.py
@@ -1,0 +1,28 @@
+import asyncio
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+from alpha_factory_v1.backend.a2a_client import _GrpcTransport
+
+
+class TestGrpcTransport(unittest.TestCase):
+    def test_closes_on_channel_ready_timeout(self) -> None:
+        channel = mock.Mock()
+        channel.channel_ready = mock.AsyncMock(side_effect=asyncio.TimeoutError)
+        channel.close = mock.AsyncMock()
+
+        async def run() -> None:
+            fake_workloadapi = types.SimpleNamespace(X509Source=object, WorkloadApiClient=object)
+            with (
+                mock.patch("grpc.aio.insecure_channel", return_value=channel),
+                mock.patch.dict(sys.modules, {"workloadapi": fake_workloadapi}),
+            ):
+                with self.assertRaises(asyncio.TimeoutError):
+                    await _GrpcTransport.new("svc:1", spiffe_id=None, timeout=1.0)
+
+        with mock.patch.dict(os.environ, {"A2A_INSECURE": "1"}, clear=False):
+            asyncio.run(run())
+        channel.close.assert_awaited_once()


### PR DESCRIPTION
## Summary
- handle exceptions during `channel_ready()` by closing the channel
- add regression test for timeout during gRPC handshake

## Testing
- `pytest tests/test_grpc_transport_timeout.py::TestGrpcTransport::test_closes_on_channel_ready_timeout -q`
- `pytest -q` *(fails: pre-commit not installed)*
