### PR TITLE
[alpha_factory] warn on failed alert

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py
@@ -28,6 +28,8 @@ def send_alert(message: str, url: str | None = None) -> None:
         payload = {"text": message}
 
     try:
-        requests.post(hook, json=payload, timeout=5)
+        resp = requests.post(hook, json=payload, timeout=5)
+        if not 200 <= resp.status_code <= 299:
+            _log.warning("alert failed with status %s", resp.status_code)
     except Exception as exc:  # pragma: no cover - network errors
         _log.warning("alert failed: %s", exc)


### PR DESCRIPTION
## Summary
- log a warning if the alert webhook returns a non-2xx code
- add a regression test for the warning

## Testing
- `python check_env.py --auto-install`
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py tests/test_alert_webhook.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/alerts.py tests/test_alert_webhook.py` *(fails: SimplePath has no attribute exists)*
- `pytest -q`