### PR TITLE
[alpha_factory] add helm example values and infra tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,8 @@ helm upgrade --install alpha-demo ./infrastructure/helm-chart \
 # → browse to <http://localhost:8080>
 ```
 
+`values.example.yaml` demonstrates typical overrides such as API tokens, service ports and replica counts.
+
 Terraform scripts in `infrastructure/terraform` provide GCP and AWS
 examples. Update the placeholder image and networking variables,
 then initialise and apply:

--- a/infrastructure/helm-chart/values.example.yaml
+++ b/infrastructure/helm-chart/values.example.yaml
@@ -1,0 +1,14 @@
+# Example overrides for Alpha Factory demo
+image: ghcr.io/example/alpha-demo:latest
+replicaCount: 2
+env:
+  OPENAI_API_KEY: "sk-REPLACE-ME"
+  RUN_MODE: web
+  AGI_INSIGHT_BUS_PORT: "7000"
+  AGI_INSIGHT_OFFLINE: "0"
+  AGI_INSIGHT_LEDGER_PATH: "/data/ledger/audit.db"
+service:
+  type: NodePort
+  port: 8080
+  uiPort: 8585
+  busPort: 7000

--- a/tests/test_helm_template.py
+++ b/tests/test_helm_template.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CHART_DIR = Path(__file__).resolve().parents[1] / "infrastructure" / "helm-chart"
+VALUES_FILE = CHART_DIR / "values.example.yaml"
+
+if not shutil.which("helm"):
+    pytest.skip("helm not available", allow_module_level=True)
+
+
+def test_helm_template_renders() -> None:
+    subprocess.run(
+        ["helm", "template", "alpha-demo", str(CHART_DIR), "-f", str(VALUES_FILE)],
+        check=True,
+        cwd=CHART_DIR,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+TERRAFORM_DIR = Path(__file__).resolve().parents[1] / "infrastructure" / "terraform"
+
+if not shutil.which("terraform"):
+    pytest.skip("terraform not available", allow_module_level=True)
+
+
+def test_terraform_validate() -> None:
+    env = os.environ.copy()
+    subprocess.run(
+        ["terraform", "init", "-backend=false", "-input=false"],
+        cwd=TERRAFORM_DIR,
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        ["terraform", "validate", "-no-color"],
+        cwd=TERRAFORM_DIR,
+        check=True,
+        env=env,
+    )


### PR DESCRIPTION
## Summary
- add `values.example.yaml` with common overrides for Helm chart
- run `terraform init` and `validate` in new CI test
- render Helm chart using example values in new CI test
- document example values file in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_terraform.py tests/test_helm_template.py`