### PR TITLE
[alpha_factory] Add license header and docstring

### DIFF
--- a/alpha_factory_v1/ui/__init__.py
+++ b/alpha_factory_v1/ui/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""UI helpers for Alpha‑Factory demos."""


### PR DESCRIPTION
## Summary
- add Apache-2.0 license header and module docstring in `alpha_factory_v1/ui/__init__.py`

## Testing
- `pre-commit run --files alpha_factory_v1/ui/__init__.py` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 6 errors during collection)*