### PR TITLE
[alpha_factory] add safety property tests and devnet broadcast

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project are documented in this file.
 - Baseline load test metrics: p95 latency below 180 ms with 20 VUs.
 - Prometheus metrics available at `/metrics`.
 - `GraphMemory._fallback_query` now returns stub data when both Neo4j and NetworkX are missing.
+- Property-based tests verify `SafetyGuardianAgent` blocks malicious code.
+- Added optional e2e test broadcasting Merkle roots to the Solana devnet.
 
 ## [v1.0] - 2025-07-01
 - CLI commands `simulate`, `show-results`, `agents-status` and `replay` for running and inspecting forecasts.

--- a/tests/test_devnet_broadcast.py
+++ b/tests/test_devnet_broadcast.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional integration test broadcasting a Merkle root to Solana devnet."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
+
+pytestmark = [pytest.mark.e2e]
+
+
+async def _devnet_available() -> bool:
+    try:
+        from solana.rpc.async_api import AsyncClient
+    except Exception:
+        return False
+    try:
+        client = AsyncClient("https://api.devnet.solana.com")
+        await client.get_version()
+        await client.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_broadcast_merkle_root_devnet() -> None:
+    if os.getenv("PYTEST_NET_OFF") == "1" or not await _devnet_available():
+        pytest.skip("network disabled or devnet unreachable")
+    tmp = tempfile.TemporaryDirectory()
+    ledger = Ledger(os.path.join(tmp.name, "l.db"), rpc_url="https://api.devnet.solana.com", broadcast=True)
+    env = messaging.Envelope("a", "b", {"v": 1}, 0.0)
+    ledger.log(env)
+    try:
+        await ledger.broadcast_merkle_root()
+    finally:
+        await ledger.stop_merkle_task()
+        ledger.close()
+        tmp.cleanup()

--- a/tests/test_safety_guardian_property.py
+++ b/tests/test_safety_guardian_property.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property-based tests for SafetyGuardianAgent."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import assume, given, settings, strategies as st
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+_STUB = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.a2a_pb2"
+if _STUB not in sys.modules:
+    stub = types.ModuleType("a2a_pb2")
+
+    from dataclasses import dataclass
+
+    @dataclass
+    class Envelope:
+        sender: str = ""
+        recipient: str = ""
+        payload: dict[str, object] | None = None
+        ts: float = 0.0
+
+    stub.Envelope = Envelope
+    sys.modules[_STUB] = stub
+
+
+class DummyBus:
+    def __init__(self, settings: config.Settings) -> None:
+        self.settings = settings
+        self.published: list[tuple[str, messaging.Envelope]] = []
+
+    def publish(self, topic: str, env: messaging.Envelope) -> None:
+        self.published.append((topic, env))
+
+    def subscribe(self, topic: str, handler) -> None:  # pragma: no cover - dummy
+        pass
+
+
+class DummyLedger:
+    def __init__(self) -> None:
+        self.logged: list[messaging.Envelope] = []
+
+    def log(self, env: messaging.Envelope) -> None:  # type: ignore[override]
+        self.logged.append(env)
+
+    def start_merkle_task(self, *a, **kw) -> None:  # pragma: no cover - dummy
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - interface
+        pass
+
+    def close(self) -> None:  # pragma: no cover - dummy
+        pass
+
+
+@settings(max_examples=30)
+@given(code=st.text(min_size=0, max_size=100))
+def test_blocks_import_os(code: str) -> None:
+    assume("import os" in code)
+    bus = DummyBus(config.Settings(bus_port=0))
+    led = DummyLedger()
+    agent = safety_agent.SafetyGuardianAgent(bus, led)
+    env = messaging.Envelope("codegen", "safety", {"code": code}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert bus.published[-1][1].payload["status"] == "blocked"
+
+
+@settings(max_examples=30)
+@given(code=st.text(min_size=0, max_size=100))
+def test_allows_safe_code(code: str) -> None:
+    assume("import os" not in code)
+    bus = DummyBus(config.Settings(bus_port=0))
+    led = DummyLedger()
+    agent = safety_agent.SafetyGuardianAgent(bus, led)
+    env = messaging.Envelope("codegen", "safety", {"code": code}, 0.0)
+    asyncio.run(agent.handle(env))
+    assert bus.published[-1][1].payload["status"] == "ok"


### PR DESCRIPTION
## Summary
- add property-based tests validating SafetyGuardianAgent
- create optional devnet broadcast e2e test
- document new tests in CHANGELOG

## Testing
- `PYTEST_NET_OFF=1 pytest -q tests/test_retry_property.py tests/test_safety_guardian.py tests/test_safety_guardian_property.py tests/test_ledger.py tests/test_logging.py tests/test_agent_handle_methods.py tests/test_merkle_broadcast.py -m "not e2e"`
- ⚠️ `pre-commit` and `mypy` failed: command not found or produced many errors