### PR TITLE
[alpha_factory] Add protobuf build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install pytest pytest-cov pytest-benchmark mutmut
+      - name: Install proto compiler
+        run: pip install grpcio-tools
+      - name: Verify protobuf
+        run: make proto-verify
       - name: Run tests with coverage
         run: |
           pytest --cov --cov-report=xml --cov-fail-under=70

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,37 @@
-.PHONY: build_web demo-setup demo-run compose-up loadtest proto
+.PHONY: build_web demo-setup demo-run compose-up loadtest proto proto-verify
+
 build_web:
-    pnpm --dir src/interface/web_client install
-    pnpm --dir src/interface/web_client run build
+	pnpm --dir src/interface/web_client install
+	pnpm --dir src/interface/web_client run build
 
 demo-setup:
-    bash scripts/demo_setup.sh
+	bash scripts/demo_setup.sh
 
 demo-run:
-    @RUN_MODE=${RUN_MODE:-cli}; \
-    if [ "$$RUN_MODE" = "web" ]; then \
-        .venv/bin/python -m streamlit run alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py; \
-    else \
-        .venv/bin/python -m alpha_factory_v1.demos.alpha_agi_insight_v1 --episodes 5; \
-    fi
+	@RUN_MODE=${RUN_MODE:-cli}; \
+	if [ "$$RUN_MODE" = "web" ]; then \
+		.venv/bin/python -m streamlit run alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py; \
+	else \
+		.venv/bin/python -m alpha_factory_v1.demos.alpha_agi_insight_v1 --episodes 5; \
+	fi
 
 compose-up:
-    docker compose -f docker-compose.yml up --build &
-    sleep 2
-    python -m webbrowser http://localhost:8080 >/dev/null 2>&1
+	docker compose -f docker-compose.yml up --build &
+	sleep 2
+	python -m webbrowser http://localhost:8080 >/dev/null 2>&1
 
 loadtest:
-k6 run --summary-export=tools/loadtest/summary.json tools/loadtest/insight.js
-@python - <<'PY'
+	k6 run --summary-export=tools/loadtest/summary.json tools/loadtest/insight.js
+	@python - <<'PY2'
 import json
 with open('tools/loadtest/summary.json') as f:
     data=json.load(f)
 print(f"p95 latency: {data['metrics']['http_req_duration']['p(95)']} ms")
-PY
+PY2
 
 proto:
-    python -m grpc_tools.protoc -I src/utils --python_out=src/utils \
-        --python_betterproto_out=src/utils src/utils/a2a.proto
+	./scripts/gen_proto.py
 
-
+proto-verify:
+	$(MAKE) proto
+	git --no-pager diff --exit-code src/utils/a2a_pb2.py src/utils/a2a_pb2_dataclass.py

--- a/scripts/gen_proto.py
+++ b/scripts/gen_proto.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Generate protobuf modules from ``src/utils/a2a.proto``."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    proto = Path("src/utils/a2a.proto")
+    out_dir = proto.parent
+    cmd = [
+        sys.executable,
+        "-m",
+        "grpc_tools.protoc",
+        f"-I{out_dir}",
+        f"--python_out={out_dir}",
+        str(proto),
+    ]
+    if subprocess.run(cmd, check=False).returncode != 0:
+        return 1
+
+    dataclass = out_dir / "a2a_pb2_dataclass.py"
+    dataclass.write_text(
+        """# SPDX-License-Identifier: Apache-2.0\n"""
+        "\n""\"Dataclass version of ``a2a.proto`` messages.\"\n"""
+        "from __future__ import annotations\n"
+        "\n"
+        "from dataclasses import dataclass, field, asdict\n"
+        "from typing import Any, Dict\n"
+        "\n\n"
+        "@dataclass(slots=True)\n"
+        "class Envelope:\n"
+        "    \"\"\"Lightweight envelope for bus messages.\"\"\"\n"
+        "\n"
+        "    sender: str = \"\"\n"
+        "    recipient: str = \"\"\n"
+        "    payload: Dict[str, Any] = field(default_factory=dict)\n"
+        "    ts: float = 0.0\n"
+        "\n"
+        "    def to_dict(self) -> Dict[str, Any]:\n"
+        "        \"\"\"Return a dictionary representation.\"\"\"\n"
+        "        return asdict(self)\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add script to generate protobuf modules
- fix Makefile with working proto and proto-verify targets
- ensure CI runs `make proto-verify`

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
