### PR TITLE
[alpha_factory] extend adapter tests

### DIFF
--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3,18 +3,21 @@
 import sys
 import types
 import asyncio
+import importlib
 import pytest
 
 # Stub generated proto dependency if missing
 _stub_path = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.a2a_pb2"
 if _stub_path not in sys.modules:
     stub = types.ModuleType("a2a_pb2")
+
     class Envelope:
         def __init__(self, sender: str = "", recipient: str = "", payload: dict | None = None, ts: float = 0.0) -> None:
             self.sender = sender
             self.recipient = recipient
             self.payload = payload or {}
             self.ts = ts
+
     stub.Envelope = Envelope
     sys.modules[_stub_path] = stub
 
@@ -27,6 +30,7 @@ def test_adk_list_packages():
     adapter = ADKAdapter()
     pkgs = adapter.list_packages()
     assert isinstance(pkgs, list)
+
 
 @pytest.mark.skipif(not MCPAdapter.is_available(), reason="MCP not installed")
 def test_mcp_invoke_tool_missing():
@@ -130,3 +134,65 @@ def test_mcp_invoke_tool_flow(monkeypatch) -> None:
     assert mcp.called == [("echo", {"t": 1})]
     assert bus.published and bus.published[-1][1].payload == {"ok": True}
 
+
+@pytest.mark.skipif(not ADKAdapter.is_available(), reason="ADK not installed")
+def test_adk_generate_text_calls_library(monkeypatch) -> None:
+    """Ensure ADKAdapter.generate_text delegates to the ADK client."""
+    try:
+        mod = importlib.import_module("adk")
+    except Exception:
+        mod = importlib.import_module("google.adk")
+
+    calls: dict[str, str] = {}
+
+    def fake_generate(self, prompt: str) -> str:
+        calls["prompt"] = prompt
+        return "resp"
+
+    monkeypatch.setattr(mod.Client, "generate", fake_generate, raising=False)
+    adapter = ADKAdapter()
+    result = adapter.generate_text("hello")
+    assert result == "resp"
+    assert calls == {"prompt": "hello"}
+
+
+def test_adk_adapter_unavailable(monkeypatch) -> None:
+    """Adapter gracefully degrades when ADK is missing."""
+
+    def _raise(_name: str):
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(importlib, "import_module", _raise)
+    assert not ADKAdapter.is_available()
+    with pytest.raises(ModuleNotFoundError):
+        ADKAdapter()
+
+
+@pytest.mark.skipif(not MCPAdapter.is_available(), reason="MCP not installed")
+def test_mcp_invoke_tool_calls_library(monkeypatch) -> None:
+    """Ensure MCPAdapter.invoke_tool delegates to the MCP client."""
+    import mcp
+
+    calls: dict[str, tuple[str, dict[str, object]]] = {}
+
+    async def fake_call_tool(self, name: str, args: dict[str, object]) -> object:
+        calls["call"] = (name, args)
+        return {"done": True}
+
+    monkeypatch.setattr(mcp.ClientSessionGroup, "call_tool", fake_call_tool, raising=False)
+    adapter = MCPAdapter()
+    result = asyncio.run(adapter.invoke_tool("mytool", {"x": 1}))
+    assert result == {"done": True}
+    assert calls["call"] == ("mytool", {"x": 1})
+
+
+def test_mcp_adapter_unavailable(monkeypatch) -> None:
+    """Adapter gracefully degrades when MCP is missing."""
+
+    def _raise(_name: str):
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(importlib, "import_module", _raise)
+    assert not MCPAdapter.is_available()
+    with pytest.raises(ModuleNotFoundError):
+        MCPAdapter()


### PR DESCRIPTION
## Summary
- exercise ADK/MCP adapters when optional packages are available
- ensure adapters degrade gracefully when those packages are absent

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `pip install pre-commit` *(fails: no network access)*