### PR TITLE
[alpha_factory] Add insight Helm example

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -435,6 +435,7 @@ The directory is created with permissions `0700` when missing.
 | **Cloud Run** | `terraform apply -chdir=infrastructure/terraform` | GCP example |
 
 All containers are x86-64/arm64 multi-arch and GPU-aware (CUDA 12).
+`infrastructure/helm-chart/values.example.yaml` shows typical overrides such as API tokens, service ports and replica counts.
 
 ---
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the α‑AGI Insight demo are documented in this file.
 
 ## [Unreleased]
 ### Added
-- _Nothing yet_
+- Example Helm values file `infrastructure/helm-chart/values.example.yaml`.
 
 <!-- Template for future entries
 ## [VERSION] - YYYY-MM-DD

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
@@ -7,3 +7,4 @@ helm upgrade --install insight ./alpha_factory_v1/demos/alpha_agi_insight_v1/inf
   --set env.RUN_MODE=api
 ```
 Values such as `service.port` or `image` can be customised via `--set` or a custom values file.
+`values.example.yaml` demonstrates typical overrides such as API tokens, service ports and replica counts.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/values.example.yaml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/values.example.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Example values for deploying \xCE\xB1-AGI Insight with Helm.
+# These settings enable offline mode and map service ports.
+image: ghcr.io/example/alpha-insight:latest
+replicaCount: 2
+env:
+  OPENAI_API_KEY: "sk-REPLACE-ME"
+  RUN_MODE: api
+  AGI_INSIGHT_OFFLINE: "1"
+  AGI_INSIGHT_BUS_PORT: "7000"
+  AGI_INSIGHT_LEDGER_PATH: "/data/ledger/audit.db"
+service:
+  type: NodePort
+  port: 8080
+  uiPort: 8585
+  busPort: 7000

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project are documented in this file.
 - `GraphMemory._fallback_query` now returns stub data when both Neo4j and NetworkX are missing.
 - Property-based tests verify `SafetyGuardianAgent` blocks malicious code.
 - Added optional e2e test broadcasting Merkle roots to the Solana devnet.
+- Example Helm values file for the Insight chart.
 
 ## [v1.0] - 2025-07-01
 - CLI commands `simulate`, `show-results`, `agents-status` and `replay` for running and inspecting forecasts.

--- a/tests/test_insight_helm_template.py
+++ b/tests/test_insight_helm_template.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CHART_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "alpha_factory_v1"
+    / "demos"
+    / "alpha_agi_insight_v1"
+    / "infrastructure"
+    / "helm-chart"
+)
+VALUES_FILE = CHART_DIR / "values.example.yaml"
+
+if not shutil.which("helm"):
+    pytest.skip("helm not available", allow_module_level=True)
+
+
+def test_insight_helm_template_renders_env_vars() -> None:
+    result = subprocess.run(
+        ["helm", "template", "insight", str(CHART_DIR), "-f", str(VALUES_FILE)],
+        check=True,
+        cwd=CHART_DIR,
+        capture_output=True,
+        text=True,
+    )
+    rendered = result.stdout
+    assert "OPENAI_API_KEY" in rendered
+    assert "AGI_INSIGHT_OFFLINE" in rendered
+    assert "AGI_INSIGHT_BUS_PORT" in rendered
+    assert "AGI_INSIGHT_LEDGER_PATH" in rendered


### PR DESCRIPTION
## Summary
- add values.example.yaml for the α‑AGI Insight Helm chart
- document example values in Insight README and chart README
- note new file in CHANGELOGs
- test Helm template rendering with the new values file

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_insight_helm_template.py tests/test_helm_template.py`