### PR TITLE
[alpha_factory] add ADK summariser agent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -10,10 +10,12 @@ from .adk_adapter import ADKAdapter
 from .mcp_adapter import MCPAdapter
 from .base_agent import BaseAgent
 from .research_agent import ResearchAgent
+from .adk_summariser_agent import ADKSummariserAgent
 
 __all__ = [
     "ADKAdapter",
     "MCPAdapter",
     "BaseAgent",
     "ResearchAgent",
+    "ADKSummariserAgent",
 ]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/adk_summariser_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/adk_summariser_agent.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Agent summarising research data via the Google ADK."""
+from __future__ import annotations
+
+from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
+from ..utils.tracing import span
+
+
+class ADKSummariserAgent(BaseAgent):
+    """Collect research updates and produce a summary using ADK."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
+        super().__init__("summariser", bus, ledger)
+        self._records: list[str] = []
+
+    async def run_cycle(self) -> None:
+        """Generate and emit an ADK summary when data is available."""
+        with span("summariser.run_cycle"):
+            if not self._records or not self.adk:
+                return
+            try:
+                summary = self.adk.generate_text("\n".join(self._records))
+            except Exception:
+                return
+            await self.emit("strategy", {"summary": summary})
+            self._records.clear()
+
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Store research payload for later summarisation."""
+        with span("summariser.handle"):
+            val = env.payload.get("research")
+            if val is not None:
+                self._records.append(str(val))

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -43,9 +43,11 @@ class ResearchAgent(BaseAgent):
                         self.mcp.heartbeat()
                     with span("mcp.invoke"):
                         try:
-                            await self.mcp.invoke_tool("noop", {})
+                            result = await self.mcp.invoke_tool("noop", {})
                         except Exception:
-                            pass
+                            result = None
+                    if result is not None:
+                        await self.emit("memory", {"noop": result})
                 except Exception:
                     pass
             await self.emit("strategy", {"research": traj[0].capability})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -24,6 +24,7 @@ from .agents import (
     codegen_agent,
     safety_agent,
     memory_agent,
+    adk_summariser_agent,
 )
 from .utils import config, messaging, logging as insight_logging
 from .utils.tracing import agent_cycle_seconds
@@ -120,6 +121,7 @@ class Orchestrator:
         agents = [
             planning_agent.PlanningAgent(self.bus, self.ledger),
             research_agent.ResearchAgent(self.bus, self.ledger),
+            adk_summariser_agent.ADKSummariserAgent(self.bus, self.ledger),
             strategy_agent.StrategyAgent(self.bus, self.ledger),
             market_agent.MarketAgent(self.bus, self.ledger),
             codegen_agent.CodeGenAgent(self.bus, self.ledger),

--- a/tests/test_adk_agent.py
+++ b/tests/test_adk_agent.py
@@ -1,0 +1,85 @@
+import sys
+import types
+import asyncio
+
+# Stub generated proto dependency if missing
+_stub_path = "src.utils.a2a_pb2"
+if _stub_path not in sys.modules:
+    stub = types.ModuleType("a2a_pb2")
+
+    class Envelope:
+        def __init__(self, sender: str = "", recipient: str = "", payload: dict | None = None, ts: float = 0.0) -> None:
+            self.sender = sender
+            self.recipient = recipient
+            self.payload = payload or {}
+            self.ts = ts
+
+    stub.Envelope = Envelope
+    sys.modules[_stub_path] = stub
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (
+    adk_summariser_agent,
+    base_agent,
+)
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+class DummyBus:
+    def __init__(self, settings: config.Settings) -> None:
+        self.settings = settings
+        self.published: list[tuple[str, messaging.Envelope]] = []
+
+    def publish(self, topic: str, env: messaging.Envelope) -> None:
+        self.published.append((topic, env))
+
+    def subscribe(self, _t: str, _h):
+        pass
+
+
+class DummyLedger:
+    def __init__(self) -> None:
+        self.logged: list[messaging.Envelope] = []
+
+    def log(self, env: messaging.Envelope) -> None:  # type: ignore[override]
+        self.logged.append(env)
+
+    def start_merkle_task(self, *_a, **_kw):
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - interface
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def test_adk_summariser_runs(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class StubADK:
+        def __init__(self) -> None:
+            pass
+
+        @classmethod
+        def is_available(cls) -> bool:
+            return True
+
+        def generate_text(self, prompt: str) -> str:
+            calls.append(prompt)
+            return "sum"
+
+    monkeypatch.setattr(base_agent, "ADKAdapter", StubADK)
+
+    settings = config.Settings(bus_port=0)
+    bus = DummyBus(settings)
+    agent = adk_summariser_agent.ADKSummariserAgent(bus, DummyLedger())
+
+    env = messaging.Envelope("research", "summariser", {"research": "r"}, 0.0)
+    asyncio.run(agent.handle(env))
+    asyncio.run(agent.run_cycle())
+
+    assert calls == ["r"]
+    assert bus.published
+    topic, sent = bus.published[-1]
+    assert topic == "strategy"
+    assert sent.payload["summary"] == "sum"


### PR DESCRIPTION
## Summary
- implement ADKSummariserAgent leveraging ADKAdapter
- expose ADKSummariserAgent in package
- register summariser in orchestrator agent list
- call MCP noop tool inside ResearchAgent
- test summariser execution when ADK is available

## Testing
- `pytest -q tests/test_adk_agent.py`