### PR TITLE
[alpha_factory] add energy and entropy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Example (using ``--sectors-file`` to customise the simulation):
 AGI_INSIGHT_OFFLINE=1 AGI_INSIGHT_BROADCAST=0 \
 python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \
   --curve linear --k 8 --x0 0.0 --llama-model-path "$LLAMA_MODEL_PATH" \
-  --offline --sectors-file alpha_factory_v1/demos/alpha_agi_insight_v1/docs/sectors.sample.json
+  --offline --energy 2.0 --entropy 0.5 \
+  --sectors-file alpha_factory_v1/demos/alpha_agi_insight_v1/docs/sectors.sample.json
 ```
 
 Produces output similar to:
@@ -251,9 +252,10 @@ See [AGENTS.md](AGENTS.md) for the full contributor guide.
     - `AGI_INSIGHT_BROADCAST=0` disables blockchain broadcasting
     - Example:
       ```bash
-      AGI_INSIGHT_OFFLINE=1 AGI_INSIGHT_BROADCAST=0 
-        python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli 
-        simulate --offline --llama-model-path "$LLAMA_MODEL_PATH"
+      AGI_INSIGHT_OFFLINE=1 AGI_INSIGHT_BROADCAST=0
+        python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli
+        simulate --offline --energy 2.0 --entropy 0.5 \
+        --llama-model-path "$LLAMA_MODEL_PATH"
       ```
 7. [Deployment Recipes 🍳](#7-deployment-recipes)
 7.1. [Deploying securely 🚀](#71-deploying-securely)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -83,6 +83,8 @@ def main() -> None:
 @click.option("--context-window", type=int, help="Context window size")
 @click.option("--sectors-file", type=click.Path(exists=True), help="JSON file with sector definitions")
 @click.option("--sectors", default=6, show_default=True, type=int, help="Number of sectors")
+@click.option("--energy", default=1.0, show_default=True, type=float, help="Initial sector energy")
+@click.option("--entropy", default=1.0, show_default=True, type=float, help="Initial sector entropy")
 @click.option("--pop-size", default=6, show_default=True, type=int, help="MATS population size")
 @click.option("--generations", default=3, show_default=True, type=int, help="Evolution steps")
 @click.option("--export", type=click.Choice(["json", "csv"]), help="Export results format")
@@ -95,6 +97,8 @@ def simulate(
     offline: bool,
     sectors_file: str | None,
     sectors: int,
+    energy: float,
+    entropy: float,
     pop_size: int,
     generations: int,
     export: str | None,
@@ -117,6 +121,8 @@ def simulate(
         offline: Force offline mode.
         sectors_file: JSON file with sector definitions.
         sectors: Number of sectors to simulate.
+        energy: Initial sector energy.
+        entropy: Initial sector entropy.
         pop_size: MATS population size.
         generations: Number of evolution steps.
         export: Format to export results.
@@ -154,9 +160,9 @@ def simulate(
 
     orch = orchestrator.Orchestrator(settings)
     if sectors_file:
-        secs = sector.load_sectors(sectors_file)
+        secs = sector.load_sectors(sectors_file, energy=energy, entropy=entropy)
     else:
-        secs = [sector.Sector(f"s{i:02d}") for i in range(sectors)]
+        secs = [sector.Sector(f"s{i:02d}", energy, entropy) for i in range(sectors)]
     trajectory = forecast.forecast_disruptions(
         secs,
         horizon,

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
@@ -23,12 +23,15 @@ class Sector:
     disrupted: bool = False
 
 
-def load_sectors(path: str | os.PathLike[str]) -> list[Sector]:
-    """Load sector definitions from a JSON file.
+def load_sectors(
+    path: str | os.PathLike[str], *, energy: float = 1.0, entropy: float = 1.0
+) -> list[Sector]:
+"""Load sector definitions from a JSON file.
 
     The file may contain a list of strings representing sector names or a list
     of objects with ``name`` and optional ``energy``, ``entropy`` and ``growth``
-    fields.
+    fields. The ``energy`` and ``entropy`` arguments provide defaults when these
+    values are omitted.
     """
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
@@ -36,13 +39,13 @@ def load_sectors(path: str | os.PathLike[str]) -> list[Sector]:
     sectors: list[Sector] = []
     for entry in data:
         if isinstance(entry, str):
-            sectors.append(Sector(entry))
+            sectors.append(Sector(entry, energy, entropy))
         elif isinstance(entry, dict):
             sectors.append(
                 Sector(
                     entry.get("name", ""),
-                    float(entry.get("energy", 1.0)),
-                    float(entry.get("entropy", 1.0)),
+                    float(entry.get("energy", energy)),
+                    float(entry.get("entropy", entropy)),
                     float(entry.get("growth", 0.05)),
                     bool(entry.get("disrupted", False)),
                 )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project are documented in this file.
 - Property-based tests verify `SafetyGuardianAgent` blocks malicious code.
 - Added optional e2e test broadcasting Merkle roots to the Solana devnet.
 - Example Helm values file for the Insight chart.
+- `simulate` command now accepts `--energy` and `--entropy` to set initial
+  sector values. The React dashboard exposes matching input fields.
 
 ## [v1.0] - 2025-07-01
 - CLI commands `simulate`, `show-results`, `agents-status` and `replay` for running and inspecting forecasts.

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -27,6 +27,8 @@ function Dashboard() {
   const [popSize, setPopSize] = useState(6);
   const [generations, setGenerations] = useState(3);
   const [curve, setCurve] = useState('logistic');
+  const [energy, setEnergy] = useState(1);
+  const [entropy, setEntropy] = useState(1);
   const [progress, setProgress] = useState(0);
   const [runId, setRunId] = useState<string | null>(null);
   const [timeline, setTimeline] = useState<ForecastPoint[]>([]);
@@ -104,6 +106,11 @@ function Dashboard() {
         pop_size: Number(popSize),
         generations: Number(generations),
         curve,
+        sectors: Array.from({ length: 6 }, (_, i) => ({
+          name: `s${String(i).padStart(2, '0')}`,
+          energy: Number(energy),
+          entropy: Number(entropy),
+        })),
       }),
     });
     if (!res.ok) return;
@@ -154,6 +161,24 @@ function Dashboard() {
             type="number"
             value={generations}
             onChange={(e) => setGenerations(Number(e.target.value))}
+          />
+        </label>
+        <label>
+          Energy
+          <input
+            type="number"
+            step="any"
+            value={energy}
+            onChange={(e) => setEnergy(Number(e.target.value))}
+          />
+        </label>
+        <label>
+          Entropy
+          <input
+            type="number"
+            step="any"
+            value={entropy}
+            onChange={(e) => setEntropy(Number(e.target.value))}
           />
         </label>
         <label>


### PR DESCRIPTION
## Summary
- allow passing energy and entropy to `simulate`
- forward values when loading sectors
- add matching fields to the React dashboard
- document new options

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 28 errors during collection)*