### PR TITLE
[alpha_factory] implement insight endpoint

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -8,6 +8,7 @@ This demo exposes a minimal REST and WebSocket interface implemented in `src/int
 | **GET `/results/{sim_id}`** | `sim_id` (path) | – | `{ "id": "d4e5f6a7", "forecast": [{"year": 1, "capability": 0.1}], "population": [] }` |
 | **GET `/population/{sim_id}`** | `sim_id` (path) | – | `{ "id": "d4e5f6a7", "population": [] }` |
 | **GET `/runs`** | – | – | `{ "ids": ["d4e5f6a7"] }` |
+| **POST `/insight`** | – | `{ "ids": ["d4e5f6a7"] }` | `{ "forecast": [{"year": 1, "capability": 0.1}] }` |
 | **WS `/ws/progress`** | – | N/A | `{"id": "d4e5f6a7", "year": 1, "capability": 0.1}` |
 
 ### `GET /population/{sim_id}`
@@ -27,6 +28,26 @@ Example response:
   "population": [
     {"effectiveness": 0.5, "risk": 0.2, "complexity": 0.3, "rank": 0}
   ]
+}
+```
+
+### `POST /insight`
+
+Compute aggregated forecast data across stored runs. Optionally pass a JSON
+payload with a list of run identifiers under `ids`. When omitted, all available
+runs are included.
+
+```json
+{
+  "ids": ["abc123", "def789"]
+}
+```
+
+The response contains the average capability value per year:
+
+```json
+{
+  "forecast": [{"year": 1, "capability": 0.5}]
 }
 ```
 


### PR DESCRIPTION
## Summary
- add aggregated insight endpoint to demo server
- document the new `/insight` route
- test aggregated insights in API subprocess

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py tests/test_api_server_subprocess.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py tests/test_api_server_subprocess.py`
- `pytest -q` *(fails: IndentationError in alpha_agi_insight_v1 sector module)*