### PR TITLE
[alpha_factory] Add fuzz and devnet tests

### DIFF
--- a/tests/test_ledger_devnet_e2e.py
+++ b/tests/test_ledger_devnet_e2e.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end test broadcasting a Merkle root to Solana devnet."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
+
+pytestmark = [pytest.mark.e2e]
+
+
+async def _devnet_available() -> bool:
+    try:
+        from solana.rpc.async_api import AsyncClient
+    except Exception:
+        return False
+    try:
+        client = AsyncClient("https://api.devnet.solana.com")
+        await client.get_version()
+        await client.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_broadcast_merkle_root_devnet_e2e() -> None:
+    if os.getenv("PYTEST_NET_OFF") == "1" or not await _devnet_available():
+        pytest.skip("network disabled or devnet unreachable")
+    tmp = tempfile.TemporaryDirectory()
+    ledger = Ledger(os.path.join(tmp.name, "l.db"), rpc_url="https://api.devnet.solana.com", broadcast=True)
+    env = messaging.Envelope("a", "b", {"v": 1}, 0.0)
+    ledger.log(env)
+    try:
+        await ledger.broadcast_merkle_root()
+    finally:
+        await ledger.stop_merkle_task()
+        ledger.close()
+        tmp.cleanup()

--- a/tests/test_safety_guardian_fuzz.py
+++ b/tests/test_safety_guardian_fuzz.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fuzz tests for SafetyGuardianAgent."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, settings, strategies as st
+from hypothesis.strategies import composite
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+_STUB = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.a2a_pb2"
+if _STUB not in sys.modules:
+    stub = types.ModuleType("a2a_pb2")
+
+    @dataclass
+    class Envelope:
+        sender: str = ""
+        recipient: str = ""
+        payload: dict[str, object] | None = None
+        ts: float = 0.0
+
+    stub.Envelope = Envelope
+    sys.modules[_STUB] = stub
+
+
+class DummyBus:
+    def __init__(self, settings: config.Settings) -> None:
+        self.settings = settings
+        self.published: list[tuple[str, messaging.Envelope]] = []
+
+    def publish(self, topic: str, env: messaging.Envelope) -> None:
+        self.published.append((topic, env))
+
+    def subscribe(self, topic: str, handler) -> None:  # pragma: no cover - dummy
+        pass
+
+
+class DummyLedger:
+    def __init__(self) -> None:
+        self.logged: list[messaging.Envelope] = []
+
+    def log(self, env: messaging.Envelope) -> None:  # type: ignore[override]
+        self.logged.append(env)
+
+    def start_merkle_task(self, *a, **kw) -> None:  # pragma: no cover - dummy
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - interface
+        pass
+
+    def close(self) -> None:  # pragma: no cover - dummy
+        pass
+
+
+json_scalars = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(max_size=20),
+)
+
+json_values = st.recursive(
+    json_scalars,
+    lambda children: st.one_of(
+        st.lists(children, max_size=3),
+        st.dictionaries(st.text(min_size=1, max_size=5), children, max_size=3),
+    ),
+    max_leaves=5,
+)
+
+
+@composite
+def malformed_envelopes(draw: st.DrawFn) -> messaging.Envelope:
+    sender = draw(st.one_of(st.text(max_size=5), st.integers(), st.none()))
+    recipient = draw(st.one_of(st.text(max_size=5), st.integers(), st.none()))
+    ts = draw(st.one_of(st.floats(allow_nan=False, allow_infinity=False), st.text(), st.none()))
+    payload = draw(st.dictionaries(st.text(min_size=1, max_size=5), json_values, max_size=3))
+    code = draw(st.text(min_size=0, max_size=100).map(lambda s: "import os" + s))
+    payload["code"] = code
+    return messaging.Envelope(sender, recipient, payload, ts)
+
+
+@settings(max_examples=25)
+@given(env=malformed_envelopes())
+def test_fuzz_blocks_malformed(env: messaging.Envelope) -> None:
+    bus = DummyBus(config.Settings(bus_port=0))
+    led = DummyLedger()
+    agent = safety_agent.SafetyGuardianAgent(bus, led)
+    asyncio.run(agent.handle(env))
+    assert bus.published[-1][1].payload["status"] == "blocked"


### PR DESCRIPTION
## Summary
- add Hypothesis-based fuzzing tests for `SafetyGuardianAgent`
- add e2e test broadcasting a Merkle root on Solana devnet

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
