### PR TITLE
[alpha_factory] add status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ dashboard is reachable without additional tooling.
 Once running, Docker Compose marks the services **healthy** when:
 
 - `http://localhost:8000/healthz` returns status `200` for the orchestrator container.
+- `http://localhost:8000/status` exposes agent heartbeats and restart counts.
 - `http://localhost:8080/` returns status `200` for the web container.
 
 The dashboard now plots a 3‑D scatter chart of effectiveness vs. risk vs.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py
@@ -23,10 +23,8 @@ class Sector:
     disrupted: bool = False
 
 
-def load_sectors(
-    path: str | os.PathLike[str], *, energy: float = 1.0, entropy: float = 1.0
-) -> list[Sector]:
-"""Load sector definitions from a JSON file.
+def load_sectors(path: str | os.PathLike[str], *, energy: float = 1.0, entropy: float = 1.0) -> list[Sector]:
+    """Load sector definitions from a JSON file.
 
     The file may contain a list of strings representing sector names or a list
     of objects with ``name`` and optional ``energy``, ``entropy`` and ``growth``

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,7 @@ shut down on exit. Available endpoints are:
 - `GET /results/{sim_id}` – fetch final forecast data.
 - `GET /population/{sim_id}` – retrieve only the population list.
 - `POST /insight` – aggregate existing forecasts.
+- `GET /status` – current agent heartbeats and restart counts.
 - `WS  /ws/progress` – stream progress logs while the simulation runs.
 - `GET /openapi.json` – FastAPI auto-generated schema.
 - `GET /metrics` – Prometheus metrics for monitoring.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented in this file.
 - Aggregated forecast endpoint `/insight` and OpenAPI schema exposure.
 - Baseline load test metrics: p95 latency below 180 ms with 20 VUs.
 - Prometheus metrics available at `/metrics`.
+- Lightweight `/status` endpoint listing agent names, heartbeats and restarts.
 - `GraphMemory._fallback_query` now returns stub data when both Neo4j and NetworkX are missing.
 - Property-based tests verify `SafetyGuardianAgent` blocks malicious code.
 - Added optional e2e test broadcasting Merkle roots to the Solana devnet.

--- a/tests/test_cli_runner_ext.py
+++ b/tests/test_cli_runner_ext.py
@@ -94,10 +94,17 @@ def test_show_results_export_formats(tmp_path) -> None:
 
 
 def test_agents_status_names() -> None:
-    with patch.object(cli.orchestrator, "Orchestrator") as orch_cls:
-        orch = orch_cls.return_value
-        runner_obj = type("Runner", (), {"agent": type("Agent", (), {"name": "AgentZ"})()})()
-        orch.runners = {"AgentZ": runner_obj}
+    class Dummy:
+        status_code = 200
+
+        def __init__(self, data: dict) -> None:
+            self._data = data
+
+        def json(self) -> dict:
+            return self._data
+
+    payload = {"agents": [{"name": "AgentZ", "last_beat": 0.0, "restarts": 2}]}
+    with patch.object(cli.requests, "get", return_value=Dummy(payload)):
         result = CliRunner().invoke(cli.main, ["agents-status"])
     assert "AgentZ" in result.output
     assert "restarts" in result.output


### PR DESCRIPTION
## Summary
- add `/status` endpoint in api_server
- query `/status` from CLI `agents-status`
- update docs for new endpoint
- tweak tests for HTTP status calls

## Testing
- `ruff check src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_demo_cli.py tests/test_cli.py tests/test_cli_runner_ext.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py`
- `black --check src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_demo_cli.py tests/test_cli.py tests/test_cli_runner_ext.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/sector.py`
- `pytest -q tests/test_demo_cli.py tests/test_cli.py tests/test_cli_runner_ext.py`
