### PR TITLE
[alpha_factory] add ledger corruption test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
@@ -250,7 +250,11 @@ class Ledger:
         return result
 
     async def broadcast_merkle_root(self) -> None:
-        root = self.compute_merkle_root()
+        try:
+            root = self.compute_merkle_root()
+        except Exception as exc:  # pragma: no cover - corruption
+            _log.warning("Failed to compute Merkle root: %s", exc)
+            return
         if AsyncClient is None or not self.broadcast:
             _log.info("Merkle root %s", root)
             return

--- a/tests/test_ledger_corruption.py
+++ b/tests/test_ledger_corruption.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from unittest import mock
+import asyncio
+
+import pytest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging as insight_logging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
+
+
+def test_compute_merkle_root_with_malformed_row(tmp_path: Path) -> None:
+    ledger = Ledger(str(tmp_path / "ledger.db"), broadcast=False)
+    e1 = messaging.Envelope(sender="a", recipient="b", payload={"v": 1}, ts=0.0)
+    e2 = messaging.Envelope(sender="b", recipient="c", payload={"v": 2}, ts=1.0)
+    ledger.log(e1)
+    ledger.log(e2)
+    # insert invalid hash value
+    ledger.conn.execute(
+        "INSERT INTO messages (ts, sender, recipient, payload, hash) VALUES (?, ?, ?, ?, ?)",
+        (2.0, "x", "y", "{}", "zz"),
+    )
+    ledger.conn.commit()
+    with pytest.raises(ValueError):
+        ledger.compute_merkle_root()
+
+
+def test_broadcast_merkle_root_handles_corrupt_db(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "ledger.db"
+    ledger = Ledger(str(ledger_path), rpc_url="http://rpc.test", broadcast=True)
+    ledger.log(messaging.Envelope(sender="a", recipient="b", payload={"v": 1}, ts=0.0))
+    ledger.compute_merkle_root()
+    # truncate database file to simulate missing pages
+    data = ledger_path.read_bytes()
+    ledger_path.write_bytes(data[: len(data) // 2])
+    with mock.patch.object(insight_logging, "_log") as log:
+        asyncio.run(ledger.broadcast_merkle_root())
+        log.warning.assert_called()


### PR DESCRIPTION
## Summary
- test ledger handling for malformed rows and truncated files
- log a warning if compute_merkle_root fails in broadcast

## Testing
- `pytest -q tests/test_ledger_corruption.py`
- `PYTEST_NET_OFF=1 pytest -q` *(fails: 36 failed, 420 passed)*