### PR TITLE
[alpha_factory] Add web energy controls

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -84,8 +84,20 @@ def main() -> None:
 @click.option("--context-window", type=int, help="Context window size")
 @click.option("--sectors-file", type=click.Path(exists=True), help="JSON file with sector definitions")
 @click.option("--sectors", default=6, show_default=True, type=int, help="Number of sectors")
-@click.option("--energy", default=1.0, show_default=True, type=float, help="Initial sector energy")
-@click.option("--entropy", default=1.0, show_default=True, type=float, help="Initial sector entropy")
+@click.option(
+    "--energy",
+    default=1.0,
+    show_default=True,
+    type=float,
+    help="Initial sector energy (also configurable via the web UI)",
+)
+@click.option(
+    "--entropy",
+    default=1.0,
+    show_default=True,
+    type=float,
+    help="Initial sector entropy (also configurable via the web UI)",
+)
 @click.option("--pop-size", default=6, show_default=True, type=int, help="MATS population size")
 @click.option("--generations", default=3, show_default=True, type=int, help="Evolution steps")
 @click.option("--export", type=click.Choice(["json", "csv"]), help="Export results format")

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -285,6 +285,8 @@ class SimRequest(BaseModel):
 
     horizon: int = 5
     num_sectors: int = 6
+    energy: float = 1.0
+    entropy: float = 1.0
     pop_size: int = 6
     generations: int = 3
     curve: str = "logistic"
@@ -383,7 +385,7 @@ async def _background_run(sim_id: str, cfg: SimRequest) -> None:
     if cfg.sectors:
         secs = [sector.Sector(s.name, s.energy, s.entropy, s.growth) for s in cfg.sectors]
     else:
-        secs = [sector.Sector(f"s{i:02d}") for i in range(cfg.num_sectors)]
+        secs = [sector.Sector(f"s{i:02d}", cfg.energy, cfg.entropy) for i in range(cfg.num_sectors)]
     traj: list[ForecastTrajectoryPoint] = []
     for year in range(1, cfg.horizon + 1):
         t = year / cfg.horizon

--- a/src/interface/web_app.py
+++ b/src/interface/web_app.py
@@ -80,14 +80,29 @@ def _run_simulation(
     num_sectors: int,
     pop_size: int,
     generations: int,
+    energy: float,
+    entropy: float,
 ) -> None:
-    """Execute the simulation and update charts live."""
+    """Execute the simulation and update charts live.
+
+    Args:
+        horizon: Forecast horizon in years.
+        curve: Capability growth curve.
+        num_sectors: Number of simulated sectors.
+        pop_size: Evolutionary population size.
+        generations: Number of evolution steps.
+        energy: Initial sector energy.
+        entropy: Initial sector entropy.
+
+    Returns:
+        None
+    """
     if st is None:  # pragma: no cover - fallback
         print("Streamlit not installed")
         return
 
     st.session_state.logs = []
-    secs = [sector.Sector(f"s{i:02d}") for i in range(num_sectors)]
+    secs = [sector.Sector(f"s{i:02d}", energy, entropy) for i in range(num_sectors)]
     timeline_placeholder = st.empty()
     pareto_placeholder = st.empty()
     scatter_placeholder = st.empty()
@@ -185,15 +200,13 @@ def main() -> None:  # pragma: no cover - entry point
     st.title("AGI Simulation Dashboard")
     horizon = st.sidebar.number_input("Forecast horizon", min_value=1, max_value=20, value=5)
     curve = st.sidebar.selectbox("Growth curve", ["logistic", "linear", "exponential"], index=0)
-    num_sectors = st.sidebar.number_input(
-        "Number of sectors", min_value=1, max_value=20, value=6
-    )
-    pop_size = st.sidebar.number_input(
-        "Population size", min_value=2, max_value=20, value=6
-    )
+    num_sectors = st.sidebar.number_input("Number of sectors", min_value=1, max_value=20, value=6)
+    pop_size = st.sidebar.number_input("Population size", min_value=2, max_value=20, value=6)
     generations = st.sidebar.number_input("Generations", min_value=1, max_value=20, value=3)
+    energy = st.sidebar.slider("Initial energy", min_value=0.0, max_value=10.0, value=1.0)
+    entropy = st.sidebar.slider("Initial entropy", min_value=0.0, max_value=10.0, value=1.0)
     if st.sidebar.button("Run simulation"):
-        _run_simulation(horizon, curve, num_sectors, pop_size, generations)
+        _run_simulation(horizon, curve, num_sectors, pop_size, generations, energy, entropy)
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -106,11 +106,8 @@ function Dashboard() {
         pop_size: Number(popSize),
         generations: Number(generations),
         curve,
-        sectors: Array.from({ length: 6 }, (_, i) => ({
-          name: `s${String(i).padStart(2, '0')}`,
-          energy: Number(energy),
-          entropy: Number(entropy),
-        })),
+        energy: Number(energy),
+        entropy: Number(entropy),
       }),
     });
     if (!res.ok) return;


### PR DESCRIPTION
## Summary
- add sliders for initial energy and entropy in Streamlit dashboard
- send energy and entropy with web form payload
- support energy and entropy in API server request model
- mention web UI in CLI help text

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 36 failed, 423 passed)*
- `black` *(success)*
- `ruff check` *(success)*
- `mypy --config-file mypy.ini` *(fails: 183 errors)*
