### PR TITLE
[alpha_factory] docs: note energy and entropy API options

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,15 @@ python -m webbrowser http://localhost:8000/docs
 ```
 The adapters initialise automatically when these optional packages are present.
 
+Once the API server is running you can launch a simulation:
+
+```bash
+curl -X POST http://localhost:8000/simulate \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"horizon": 5, "pop_size": 6, "generations": 3, "curve": "linear", "energy": 1.0, "entropy": 1.0}'
+```
+
 ## Disclaimer
 This repository is a conceptual research prototype. References to "AGI" and
 "superintelligence" describe aspirational goals and do not indicate the presence

--- a/docs/API.md
+++ b/docs/API.md
@@ -59,7 +59,7 @@ Once the server is running you can trigger a forecast using `curl`:
 curl -X POST http://localhost:8000/simulate \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"horizon": 5, "pop_size": 6, "generations": 3, "curve": "linear"}'
+  -d '{"horizon": 5, "pop_size": 6, "generations": 3, "curve": "linear", "energy": 1.0, "entropy": 1.0}'
 ```
 
 Retrieve the results when the run finishes:
@@ -118,6 +118,9 @@ Start a new simulation. Send a JSON payload with the following fields:
 - `curve` – capability growth curve (`logistic`, `linear`, `exponential`)
 - `k` – optional growth curve steepness
 - `x0` – optional growth curve midpoint
+- `energy` – initial energy level for generated sectors
+- `entropy` – initial entropy level for generated sectors
+- `sectors` – optional list of sector objects with `name`, `energy`, `entropy` and `growth`
 
 ```json
 {
@@ -126,7 +129,10 @@ Start a new simulation. Send a JSON payload with the following fields:
   "generations": 3,
   "curve": "logistic",
   "k": 10.0,
-  "x0": 0.0
+  "x0": 0.0,
+  "energy": 1.0,
+  "entropy": 1.0,
+  "sectors": [{"name": "s00", "energy": 1.0, "entropy": 1.0, "growth": 0.05}]
 }
 ```
 

--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -55,6 +55,8 @@ def test_simulate_curve_subprocess() -> None:
                 "pop_size": 2,
                 "generations": 1,
                 "curve": "linear",
+                "energy": 1.0,
+                "entropy": 1.0,
             },
             headers=headers,
         )
@@ -206,6 +208,8 @@ def test_insight_endpoint_subprocess() -> None:
                 "pop_size": 2,
                 "generations": 1,
                 "curve": "linear",
+                "energy": 1.0,
+                "entropy": 1.0,
             },
             headers=headers,
         )

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,8 +1,8 @@
 import pytest
 
 pd = pytest.importorskip("pandas")
-from src.interface import web_app
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast, sector, mats  # type: ignore[import]
+from src.interface import web_app  # noqa: E402
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast, sector, mats  # noqa: E402
 
 
 def test_timeline_df() -> None:
@@ -33,9 +33,9 @@ def test_population_df() -> None:
 
 
 def test_run_simulation_smoke(capsys: pytest.CaptureFixture[str]) -> None:
-    """Ensure _run_simulation accepts the new num_sectors argument."""
+    """Ensure _run_simulation accepts energy and entropy options."""
 
-    web_app._run_simulation(1, "logistic", 2, 3, 1)
+    web_app._run_simulation(1, "logistic", 2, 3, 1, 1.0, 1.0)
     out, _ = capsys.readouterr()
     assert "Streamlit not installed" in out
 


### PR DESCRIPTION
## Summary
- document optional energy & entropy in API examples
- show how to call the API from README
- update tests for new parameters

## Testing
- `python check_env.py --auto-install`
- `ruff check tests/test_web_app.py tests/test_api_server_subprocess.py`
- `mypy --config-file mypy.ini tests/test_web_app.py tests/test_api_server_subprocess.py`
- `pytest tests/test_api_server_subprocess.py::test_simulate_curve_subprocess tests/test_api_server_subprocess.py::test_insight_endpoint_subprocess -q`
