### PR TITLE
[alpha_factory] handle malformed ledger rows

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/logging.py
@@ -217,10 +217,21 @@ class Ledger:
         if self.db_type == "postgres":
             with self.conn.cursor() as cur:
                 cur.execute("SELECT hash FROM messages ORDER BY id")
-                hashes = [row[0] for row in cur.fetchall()]
+                raw_hashes = [row[0] for row in cur.fetchall()]
         else:
             cur = self.conn.execute("SELECT hash FROM messages ORDER BY id")
-            hashes = [row[0] for row in cur.fetchall()]
+            raw_hashes = [row[0] for row in cur.fetchall()]
+
+        hashes: List[str] = []
+        for h in raw_hashes:
+            if not isinstance(h, str) or not h:
+                continue
+            try:
+                bytes.fromhex(h)
+            except Exception:
+                continue
+            hashes.append(h)
+
         return _merkle_root(hashes)
 
     def tail(self, count: int = 10) -> List[dict[str, object]]:

--- a/tests/test_ledger_corruption.py
+++ b/tests/test_ledger_corruption.py
@@ -2,8 +2,6 @@ from pathlib import Path
 from unittest import mock
 import asyncio
 
-import pytest
-
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging as insight_logging
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
@@ -15,14 +13,14 @@ def test_compute_merkle_root_with_malformed_row(tmp_path: Path) -> None:
     e2 = messaging.Envelope(sender="b", recipient="c", payload={"v": 2}, ts=1.0)
     ledger.log(e1)
     ledger.log(e2)
+    baseline = ledger.compute_merkle_root()
     # insert invalid hash value
     ledger.conn.execute(
         "INSERT INTO messages (ts, sender, recipient, payload, hash) VALUES (?, ?, ?, ?, ?)",
         (2.0, "x", "y", "{}", "zz"),
     )
     ledger.conn.commit()
-    with pytest.raises(ValueError):
-        ledger.compute_merkle_root()
+    assert ledger.compute_merkle_root() == baseline
 
 
 def test_broadcast_merkle_root_handles_corrupt_db(tmp_path: Path) -> None:

--- a/tests/test_ledger_malformed_rows.py
+++ b/tests/test_ledger_malformed_rows.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
+
+
+def test_merkle_root_ignores_corrupt_rows(tmp_path: Path) -> None:
+    ledger = Ledger(str(tmp_path / "ledger.db"), broadcast=False)
+    env1 = messaging.Envelope(sender="a", recipient="b", payload={"v": 1}, ts=0.0)
+    env2 = messaging.Envelope(sender="b", recipient="c", payload={"v": 2}, ts=1.0)
+    ledger.log(env1)
+    ledger.log(env2)
+
+    baseline = ledger.compute_merkle_root()
+
+    # insert rows with missing hash and invalid hash
+    ledger.conn.execute(
+        "INSERT INTO messages (ts, sender, recipient, payload) VALUES (?, ?, ?, ?)",
+        (2.0, "x", "y", "{oops"),
+    )
+    ledger.conn.execute(
+        "INSERT INTO messages (ts, sender, recipient, payload, hash) VALUES (?, ?, ?, ?, ?)",
+        (3.0, "y", "z", "{}", "zz"),
+    )
+    ledger.conn.commit()
+
+    root = ledger.compute_merkle_root()
+    assert root == baseline
+
+    # further logging should still succeed
+    ledger.log(messaging.Envelope(sender="c", recipient="d", payload={"v": 3}, ts=2.0))
+    ledger.compute_merkle_root()
+


### PR DESCRIPTION
## Summary
- ignore bad rows in Ledger.compute_merkle_root
- adjust corrupt ledger test for new behaviour
- add test ensuring malformed rows do not break the ledger

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_ledger_corruption.py::test_compute_merkle_root_with_malformed_row tests/test_ledger_malformed_rows.py::test_merkle_root_ignores_corrupt_rows -q`
- `pytest -q` *(fails: 35 failed, 426 passed, 30 skipped)*