### PR TITLE
[alpha_factory] add proto stub generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,9 +793,11 @@ Alternatively run inside Docker:
 # build the web client first so `dist/` exists
 make build_web
 # regenerate protobuf modules and Go stubs
-make proto  # outputs Go files under alpha_factory_v1/proto/go/
+./tools/gen_proto_stubs.sh  # updates src/utils/a2a_pb2.py and tools/go_a2a_client/a2a.pb.go
 make compose-up  # builds and waits for healthy services
 ```
+Run `./tools/gen_proto_stubs.sh` whenever `src/utils/a2a.proto` changes to keep the
+Python and Go stubs up to date.
 Open <http://localhost:8080> in your browser. When `RUN_MODE=web`, the container
 serves the static files from `src/interface/web_client/dist` using `python -m
 http.server`. The FastAPI demo also mounts this folder at `/` when present so the

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -1,0 +1,12 @@
+# α‑AGI Insight Docs
+
+Documentation for the α‑AGI Insight demo.
+
+Whenever `src/utils/a2a.proto` changes, regenerate the protocol stubs:
+
+```bash
+./tools/gen_proto_stubs.sh
+```
+
+This updates `src/utils/a2a_pb2.py` and `tools/go_a2a_client/a2a.pb.go`.
+

--- a/tools/gen_proto_stubs.sh
+++ b/tools/gen_proto_stubs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Generate protobuf stubs for Python and Go.
+set -euo pipefail
+
+PROTO="src/utils/a2a.proto"
+PY_OUT="src/utils"
+GO_OUT="tools/go_a2a_client"
+PY_INCLUDE=$(python -c 'import pkg_resources,os;print(os.path.dirname(pkg_resources.resource_filename("google.protobuf","struct.proto")))')
+
+protoc -I "$(dirname "$PROTO")" -I "$PY_INCLUDE" --python_out="$PY_OUT" "$PROTO"
+
+if command -v protoc-gen-go >/dev/null; then
+  mkdir -p "$GO_OUT"
+  protoc -I "$(dirname "$PROTO")" -I "$PY_INCLUDE" --go_out="$GO_OUT" --go_opt=paths=source_relative "$PROTO"
+else
+  echo "protoc-gen-go not found; skipping Go stub generation" >&2
+fi
+


### PR DESCRIPTION
## Summary
- add tools/gen_proto_stubs.sh to generate Python & Go protobuf stubs
- update root README with instructions to rerun the script when a2a.proto changes
- document stub regeneration in alpha_agi_insight_v1 docs

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 23 failed, 307 passed)*