### PR TITLE
[alpha_factory] expose energy entropy sliders

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py
@@ -21,10 +21,17 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd
 
 
-def _simulate(horizon: int, curve: str, pop_size: int, generations: int) -> list[Any]:
+def _simulate(
+    horizon: int,
+    curve: str,
+    pop_size: int,
+    generations: int,
+    energy: float = 1.0,
+    entropy: float = 1.0,
+) -> list[Any]:
     """Run the disruption forecast and return the trajectory."""
 
-    secs = [sector.Sector(f"s{i:02d}") for i in range(pop_size)]
+    secs = [sector.Sector(f"s{i:02d}", energy, entropy) for i in range(pop_size)]
     return forecast.forecast_disruptions(
         secs,
         horizon,
@@ -81,9 +88,11 @@ def main() -> None:  # pragma: no cover - entry point
     curve = st.sidebar.selectbox("Growth curve", ["logistic", "linear", "exponential"], index=0)
     pop_size = st.sidebar.slider("Population size", 2, 20, 6)
     generations = st.sidebar.slider("Generations", 1, 20, 3)
+    energy = st.sidebar.number_input("Initial energy", min_value=0.0, value=1.0)
+    entropy = st.sidebar.number_input("Initial entropy", min_value=0.0, value=1.0)
 
     if st.sidebar.button("Run forecast"):
-        traj = _simulate(horizon, curve, pop_size, generations)
+        traj = _simulate(horizon, curve, pop_size, generations, energy, entropy)
         df = _timeline_df(traj)
         import plotly.express as px
 

--- a/alpha_factory_v1/docs/README.md
+++ b/alpha_factory_v1/docs/README.md
@@ -9,6 +9,9 @@ This directory hosts reference files and configuration snippets for **Alpha‑Fa
 - `grafana/` – Grafana dashboards and datasource provisioning.
 - `prometheus.yml` – sample Prometheus scraper configuration.
 
+When running the Insight demo the `/simulate` endpoint and CLI accept `energy`
+and `entropy` parameters to control the initial state of generated sectors.
+
 All container images are [Cosign](https://github.com/sigstore/cosign) signed. Verify signatures before running:
 ```bash
 cosign verify ghcr.io/montrealai/alpha-factory:latest

--- a/docs/API.md
+++ b/docs/API.md
@@ -122,6 +122,9 @@ Start a new simulation. Send a JSON payload with the following fields:
 - `entropy` – initial entropy level for generated sectors
 - `sectors` – optional list of sector objects with `name`, `energy`, `entropy` and `growth`
 
+`energy` and `entropy` apply when no custom `sectors` list is provided and map
+to the `--energy` and `--entropy` CLI options.
+
 ```json
 {
   "horizon": 5,

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -161,7 +161,7 @@ function Dashboard() {
           />
         </label>
         <label>
-          Energy
+          Initial energy
           <input
             type="number"
             step="any"
@@ -170,7 +170,7 @@ function Dashboard() {
           />
         </label>
         <label>
-          Entropy
+          Initial entropy
           <input
             type="number"
             step="any"


### PR DESCRIPTION
## Summary
- add energy/entropy parameters to the Insight demo `web_app.py`
- show fields in the React web client
- document energy/entropy usage

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: TypeError No posix...)