### PR TITLE
[alpha_factory] enforce results dir permissions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -140,7 +140,7 @@ if app is not None:
         )
     )
     _max_results = int(os.getenv("MAX_RESULTS", "100"))
-    _results_dir.mkdir(parents=True, exist_ok=True)
+    _results_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
     def _load_results() -> None:
         entries: list[tuple[float, ResultsResponse]] = []

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from pathlib import Path
+import importlib
+import pytest
+
+pytest.importorskip("fastapi")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+os.environ.setdefault("API_TOKEN", "test-token")
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+
+def test_results_dir_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "results"
+    monkeypatch.setenv("SIM_RESULTS_DIR", str(path))
+
+    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
+
+    api_server = importlib.reload(api_server)
+
+    assert path.exists()
+    assert (path.stat().st_mode & 0o777) == 0o700


### PR DESCRIPTION
## Summary
- ensure result directories are created with secure mode
- add unit test verifying permissions for Insight API

## Testing
- `python check_env.py --auto-install`
- `pytest alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py -q`
- `pytest -q` *(fails: 35 failed, 429 passed, 31 skipped)*