### PR TITLE
[alpha_factory] add proto verify pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,10 @@ repos:
     hooks:
       - id: mypy
         args: ["--config-file", "mypy.ini"]
+  - repo: local
+    hooks:
+      - id: proto-verify
+        name: Verify protobuf files are up to date
+        entry: make proto-verify
+        language: system
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ pre-commit run --files <paths>   # before each commit
   - Re-run `pre-commit run --all-files` whenever `requirements.txt`, `requirements-dev.txt`,
     `.pre-commit-config.yaml`, `pyproject.toml`, `mypy.ini`, or other lint configs change.
     **CI enforces these checks.**
+  - After editing `src/utils/a2a.proto`, run `pre-commit run --files src/utils/a2a.proto`
+    to regenerate and verify protobuf sources.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using
     `mypy.ini`.
   - Hooks are configured in `.pre-commit-config.yaml` at the repository root.


### PR DESCRIPTION
## Summary
- check protobuf generation in pre-commit
- mention running pre-commit when editing a2a.proto

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 35 failed, 429 passed, 32 skipped)*
- `pre-commit run --files .pre-commit-config.yaml AGENTS.md` *(fails: command not found)*