### PR TITLE
[alpha_factory] bump version to 1.1.0

### DIFF
--- a/alpha_factory_v1/__init__.py
+++ b/alpha_factory_v1/__init__.py
@@ -16,7 +16,7 @@ try:  # attempt to read the installed package version
 
     __version__ = _version(__name__)
 except Exception:  # pragma: no cover - fallback when not installed
-    __version__ = "1.0.1"
+    __version__ = "1.1.0"
 
 __all__ = ["backend", "demos", "ui", "run", "get_version"]
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/__init__.py
@@ -7,5 +7,5 @@ from typing import Final
 
 __all__ = ["__version__"]
 
-__version__: Final[str] = "1.0.0"
+__version__: Final[str] = "1.1.0"
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
@@ -45,7 +45,7 @@ __all__: Final[List[str]] = [
     "__version__",
 ]
 
-__version__: Final[str] = "1.0.0"
+__version__: Final[str] = "1.1.0"
 
 # ──────────────────────────────────────────────────────────────────────────────
 #  Agent showcase (edu-doc string for auditors & newcomers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alpha-factory-v1"
-version = "1.0.1"
+version = "1.1.0"
 description = "Alpha-Factory v1"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"


### PR DESCRIPTION
## Summary
- bump package version to 1.1.0
- sync demo `__version__` constants with latest release

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 23 failed, 304 passed)*
- `pre-commit run --files pyproject.toml alpha_factory_v1/__init__.py alpha_factory_v1/demos/alpha_agi_insight_v1/__init__.py alpha_factory_v1/demos/alpha_asi_world_model/__init__.py` *(fails: command not found)*