### PR TITLE
[alpha_factory] add __all__ to interface modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ complexity from the final population.
 
 If Streamlit isn't installed or you're running on a headless server, use:
 ```bash
-python src/interface/minimal_ui.py --text
+python -m src.interface.minimal_ui --text
 ```
 to display the forecast results directly in the console.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -1,6 +1,6 @@
 # API Overview
 
-This demo exposes a minimal REST and WebSocket interface implemented in `src/interface/api_server.py`. All requests must include `Authorization: Bearer $API_TOKEN`.
+This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.
 
 | Endpoint | Query/Path Params | Payload | Example Response |
 |---------|------------------|---------|-----------------|

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@ This page documents the REST endpoints provided by the demo API server and the a
 
 ## REST endpoints
 
-The API is implemented with FastAPI in `src/interface/api_server.py`. The
+The API is implemented with FastAPI in `src.interface.api_server`. The
 orchestrator boots in the background when the server starts and is gracefully
 shut down on exit. Available endpoints are:
 

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -18,6 +18,20 @@ from typing import Any, List, TYPE_CHECKING, cast, Set
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import alerts
 from src.utils.config import init_config
 
+__all__ = [
+    "app",
+    "InsightPoint",
+    "InsightRequest",
+    "InsightResponse",
+    "PopulationResponse",
+    "ResultsResponse",
+    "RunsResponse",
+    "SimRequest",
+    "SimStartResponse",
+    "StatusResponse",
+    "main",
+]
+
 _log = logging.getLogger(__name__)
 
 

--- a/src/interface/minimal_ui.py
+++ b/src/interface/minimal_ui.py
@@ -14,6 +14,8 @@ except Exception:  # pragma: no cover - optional
     _st = None
 st: Any | None = cast(Any, _st)
 
+__all__ = ["main"]
+
 forecast = importlib.import_module("alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.forecast")
 sector = importlib.import_module("alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation.sector")
 

--- a/src/interface/web_app.py
+++ b/src/interface/web_app.py
@@ -22,6 +22,8 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional
     st = None
 
+__all__ = ["pareto_df", "population_df", "timeline_df", "main"]
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     ForecastModule = Any
     SectorModule = Any


### PR DESCRIPTION
## Summary
- define explicit `__all__` lists for interface modules
- tweak documentation references to these modules

## Testing
- `pre-commit` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pytest tests/test_api_status.py::test_status_endpoint -q` *(fails: assert 503 == 200)*