### PR TITLE
[alpha_factory] describe _load_dotenv

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -17,6 +17,15 @@ _log = logging.getLogger(__name__)
 
 
 def _load_dotenv(path: str = ".env") -> None:
+    """Load default variables from ``path`` when available.
+
+    Key/value pairs from the file are added to :mod:`os.environ` only if the
+    variable is not already defined.
+
+    Args:
+        path: Location of the ``.env`` file.
+    """
+
     if Path(path).is_file():
         for k, v in _load_env_file(path).items():
             os.environ.setdefault(k, v)


### PR DESCRIPTION
## Summary
- document `_load_dotenv` helper in `src/utils/config.py`

## Testing
- `pre-commit run --files src/utils/config.py` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 20 failed, 189 passed, 26 skipped)*