### PR TITLE
[alpha_factory] secure orchestrator REST API

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py
@@ -1,0 +1,51 @@
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from alpha_factory_v1.backend import orchestrator
+
+
+class DummyRunner:
+    def __init__(self) -> None:
+        self.inst = object()
+        self.next_ts = 0
+        self.period = 1
+        self.last_beat = time.time()
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch, token: str = "secret") -> TestClient:
+    monkeypatch.setenv("API_TOKEN", token)
+    app = orchestrator._build_rest({"dummy": DummyRunner()})
+    assert app is not None
+    return TestClient(app)
+
+
+def test_valid_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _make_client(monkeypatch)
+    resp = client.get("/agents", headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 200
+
+
+def test_invalid_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _make_client(monkeypatch)
+    resp = client.get("/agents", headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 403
+
+
+def test_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _make_client(monkeypatch)
+    resp = client.get("/agents")
+    assert resp.status_code == 403
+
+
+def test_env_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("API_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        orchestrator._build_rest({"dummy": DummyRunner()})


### PR DESCRIPTION
## Summary
- require API_TOKEN for orchestrator REST server
- validate requests using FastAPI HTTPBearer
- adjust orchestrator REST unit tests
- add tests for token validation

## Testing
- `ruff check alpha_factory_v1/backend/orchestrator.py tests/test_orchestrator_rest.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py`
- `black alpha_factory_v1/backend/orchestrator.py tests/test_orchestrator_rest.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py`
- `pytest -q` *(fails: 39 failed, 431 passed)*
