### PR TITLE
[alpha_factory] share config helpers

### DIFF
--- a/alpha_factory_v1/utils/config_common.py
+++ b/alpha_factory_v1/utils/config_common.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared configuration helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from alpha_factory_v1.utils.env import _load_env_file
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import ClassVar
+
+_log = logging.getLogger(__name__)
+
+
+def _load_dotenv(path: str = ".env") -> None:
+    """Load default variables from ``path`` when available."""
+    if Path(path).is_file():
+        for k, v in _load_env_file(path).items():
+            os.environ.setdefault(k, v)
+
+
+def _prefetch_vault() -> None:
+    """Populate environment secrets from HashiCorp Vault if configured."""
+    if "VAULT_ADDR" in os.environ:
+        try:  # pragma: no cover - optional dependency
+            import importlib
+
+            hvac = importlib.import_module("hvac")
+
+            addr = os.environ["VAULT_ADDR"]
+            token = os.getenv("VAULT_TOKEN")
+            secret_path = os.getenv("OPENAI_API_KEY_PATH", "OPENAI_API_KEY")
+            client = hvac.Client(url=addr, token=token)
+            data = client.secrets.kv.read_secret_version(path=secret_path)
+            value = data["data"]["data"].get("OPENAI_API_KEY")
+            if value:
+                os.environ["OPENAI_API_KEY"] = value
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("Vault lookup failed: %s", exc)
+
+
+class SettingsBase(BaseSettings):
+    """Base settings with shared behavior."""
+
+    model_config: ClassVar[SettingsConfigDict] = {
+        "env_file": ".env",
+        "extra": "ignore",
+        "populate_by_name": True,
+        "env_prefix": "",
+    }
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        data = self.model_dump()
+        for k in tuple(data):
+            if any(s in k.lower() for s in ("token", "key", "password")) and data[k]:
+                data[k] = "***"
+        return f"{self.__class__.__name__}({data})"


### PR DESCRIPTION
## Summary
- centralize `_load_dotenv`, `_prefetch_vault` and a base `SettingsBase`
- refactor config modules to use the new helpers

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 39 failed, 431 passed, 33 skipped)*