### PR TITLE
[alpha_factory] Add lockfile and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,17 @@ Follow these steps when installing without internet access:
   pip wheel -r requirements-dev.txt -w /media/wheels
   ```
 
+- Generate a deterministic lock file after installing dependencies:
+  ```bash
+  pip install -r requirements.txt
+  pip freeze > requirements.lock
+  ```
+
+- Install from the lock file to reproduce identical environments:
+  ```bash
+  pip install -r requirements.lock
+  ```
+
 - Install from the wheelhouse:
   ```bash
   WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ cd AGI-Alpha-Agent-v0
 python3 -m venv .venv
 source .venv/bin/activate
 # Install runtime dependencies
-pip install -r requirements.lock
+# Install runtime dependencies
+pip install -r requirements.lock  # pinned versions for deterministic setup
 # Optional ADK/MCP integration
 pip install google-adk mcp
 # Requires Python 3.11–3.12 (<3.13)
@@ -217,6 +218,14 @@ pip install google-adk mcp
 python -m webbrowser http://localhost:8000/docs
 ```
 The adapters initialise automatically when these optional packages are present.
+
+To regenerate `requirements.lock` with the exact versions from
+`requirements.txt`, run:
+
+```bash
+pip install -r requirements.txt
+pip freeze > requirements.lock
+```
 
 Once the API server is running you can launch a simulation:
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,2 @@
+# Root dependency lock file
+-r alpha_factory_v1/requirements.lock


### PR DESCRIPTION
## Summary
- add top-level requirements.lock
- document using the lock file in README and AGENTS contributor guide

## Testing
- `python check_env.py --auto-install` *(fails: Network failure detected)*
- `pytest -q` *(fails: 24 failed, 165 passed, 26 skipped)*