### PR TITLE
[alpha_factory] Add missing test SPDX headers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_adapters.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_adapters.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 import types

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_agents.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import sys
 from pathlib import Path

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import socket
 import subprocess

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 import time
 from pathlib import Path

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_capability_growth.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_capability_growth.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_forecast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_forecast.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_mats.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_mats.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 import pytest

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_orchestrator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import sys
 from pathlib import Path

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_retry.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_retry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 from pathlib import Path
 import asyncio

--- a/tests/.mutmut-config
+++ b/tests/.mutmut-config
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 [mutmut]
 paths_to_mutate=alpha_factory_v1/demos/alpha_agi_insight_v1/src
 runner=pytest -q

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # 🧪 Root Test Suite
 
 These integration tests expect the `alpha_factory_v1` package to be importable. When running from the repository root without installation, set `PYTHONPATH` so Python can locate the source tree:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Helper to import the project when not installed."""
 
 from importlib.util import find_spec

--- a/tests/benchmarks/.gitignore
+++ b/tests/benchmarks/.gitignore
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 *

--- a/tests/test_adk_agent.py
+++ b/tests/test_adk_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 import types
 import asyncio

--- a/tests/test_agent_aiga_entrypoint.py
+++ b/tests/test_agent_aiga_entrypoint.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import py_compile
 import unittest
 from pathlib import Path

--- a/tests/test_agent_base.py
+++ b/tests/test_agent_base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import unittest
 

--- a/tests/test_agent_handle_methods.py
+++ b/tests/test_agent_handle_methods.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import random
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import contextlib
 from unittest.mock import patch

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 from queue import Queue
 from unittest.mock import patch

--- a/tests/test_agents_alias.py
+++ b/tests/test_agents_alias.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import importlib
 

--- a/tests/test_agents_integrity.py
+++ b/tests/test_agents_integrity.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 
 from alpha_factory_v1.backend.agents import list_agents, get_agent, AGENT_REGISTRY, list_capabilities

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import asyncio
 import io

--- a/tests/test_aiga_evolver_agent.py
+++ b/tests/test_aiga_evolver_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import py_compile
 import unittest
 from pathlib import Path

--- a/tests/test_aiga_evolver_agent_logic.py
+++ b/tests/test_aiga_evolver_agent_logic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 from unittest import TestCase, mock
 

--- a/tests/test_aiga_meta_cli.py
+++ b/tests/test_aiga_meta_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_aiga_meta_module.py
+++ b/tests/test_aiga_meta_module.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_alpha_agi_insight_bridge.py
+++ b/tests/test_alpha_agi_insight_bridge.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_alpha_agi_insight_demo.py
+++ b/tests/test_alpha_agi_insight_demo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_alpha_agi_insight_env.py
+++ b/tests/test_alpha_agi_insight_env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 import sys

--- a/tests/test_alpha_agi_insight_main.py
+++ b/tests/test_alpha_agi_insight_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_alpha_agi_insight_v1_main.py
+++ b/tests/test_alpha_agi_insight_v1_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_alpha_business_v1_script.py
+++ b/tests/test_alpha_business_v1_script.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import py_compile
 import unittest
 from pathlib import Path

--- a/tests/test_alpha_conversion_stub.py
+++ b/tests/test_alpha_conversion_stub.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import subprocess
 import sys

--- a/tests/test_alpha_detection.py
+++ b/tests/test_alpha_detection.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 
 from alpha_factory_v1.demos.era_of_experience import alpha_detection

--- a/tests/test_alpha_discovery_stub.py
+++ b/tests/test_alpha_discovery_stub.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import subprocess
 import sys

--- a/tests/test_alpha_opportunity_env.py
+++ b/tests/test_alpha_opportunity_env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import os
 import unittest

--- a/tests/test_alpha_opportunity_stub.py
+++ b/tests/test_alpha_opportunity_stub.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import py_compile
 import unittest
 from pathlib import Path

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import time
 import asyncio

--- a/tests/test_api_server_cors.py
+++ b/tests/test_api_server_cors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
 from typing import Any, cast

--- a/tests/test_api_server_static.py
+++ b/tests/test_api_server_static.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import os
 import time

--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import socket
 import subprocess

--- a/tests/test_api_server_uvicorn.py
+++ b/tests/test_api_server_uvicorn.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import socket
 import threading

--- a/tests/test_base_helpers.py
+++ b/tests/test_base_helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import unittest
 

--- a/tests/test_build_core_agent.py
+++ b/tests/test_build_core_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import os
 import sys

--- a/tests/test_bus_logging.py
+++ b/tests/test_bus_logging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import logging
 from unittest import mock

--- a/tests/test_business_notebook.py
+++ b/tests/test_business_notebook.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import csv
 from io import StringIO

--- a/tests/test_codegen_agent.py
+++ b/tests/test_codegen_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import codegen_agent
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger

--- a/tests/test_compose_health.py
+++ b/tests/test_compose_health.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import shutil
 import subprocess
 import time

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config
 

--- a/tests/test_cross_alpha_discovery.py
+++ b/tests/test_cross_alpha_discovery.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import subprocess
 import sys

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import sys
 import csv

--- a/tests/test_demo_quality.py
+++ b/tests/test_demo_quality.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import os
 import glob

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from pathlib import Path
 from alpha_factory_v1.demos import validate_demos

--- a/tests/test_docker_health.py
+++ b/tests/test_docker_health.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import shutil
 import subprocess

--- a/tests/test_edge_runner.py
+++ b/tests/test_edge_runner.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import os
 import unittest

--- a/tests/test_edge_runner_cli.py
+++ b/tests/test_edge_runner_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 import sys

--- a/tests/test_edge_runner_parse.py
+++ b/tests/test_edge_runner_parse.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 import subprocess

--- a/tests/test_embedder_fallback.py
+++ b/tests/test_embedder_fallback.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import sys
 import unittest

--- a/tests/test_energy_agent.py
+++ b/tests/test_energy_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
 import types

--- a/tests/test_energy_agent_behavior.py
+++ b/tests/test_energy_agent_behavior.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import unittest

--- a/tests/test_energy_utils.py
+++ b/tests/test_energy_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_era_experience.py
+++ b/tests/test_era_experience.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import asyncio
 

--- a/tests/test_finance_utils.py
+++ b/tests/test_finance_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest.mock import patch
 import statistics

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import math
 import pytest
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast, sector

--- a/tests/test_forecast_functions.py
+++ b/tests/test_forecast_functions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast

--- a/tests/test_governance_sim.py
+++ b/tests/test_governance_sim.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from alpha_factory_v1.demos.solving_agi_governance import run_sim, summarise_with_agent
 

--- a/tests/test_gradio_dashboard.py
+++ b/tests/test_gradio_dashboard.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import py_compile
 import unittest
 from pathlib import Path

--- a/tests/test_grpc_transport_timeout.py
+++ b/tests/test_grpc_transport_timeout.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
 import sys

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import unittest
 

--- a/tests/test_insight_api_server_no_fastapi.py
+++ b/tests/test_insight_api_server_no_fastapi.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 import unittest

--- a/tests/test_insight_cli_e2e.py
+++ b/tests/test_insight_cli_e2e.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 import sys

--- a/tests/test_insight_endpoint.py
+++ b/tests/test_insight_endpoint.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 from typing import Any, cast
 

--- a/tests/test_insight_orchestrator_features.py
+++ b/tests/test_insight_orchestrator_features.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import os

--- a/tests/test_insight_orchestrator_restart.py
+++ b/tests/test_insight_orchestrator_restart.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
 import tempfile

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import logging
 from datetime import datetime

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import os

--- a/tests/test_ledger_basic.py
+++ b/tests/test_ledger_basic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging
 

--- a/tests/test_ledger_broadcast.py
+++ b/tests/test_ledger_broadcast.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
 import tempfile

--- a/tests/test_ledger_client_close.py
+++ b/tests/test_ledger_client_close.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
 import sys

--- a/tests/test_ledger_corrupt.py
+++ b/tests/test_ledger_corrupt.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_ledger_corruption.py
+++ b/tests/test_ledger_corruption.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 from unittest import mock
 import asyncio

--- a/tests/test_ledger_malformed_rows.py
+++ b/tests/test_ledger_malformed_rows.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import unittest
 

--- a/tests/test_local_llm_logging.py
+++ b/tests/test_local_llm_logging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 from unittest import mock
 

--- a/tests/test_log_dir_lazy.py
+++ b/tests/test_log_dir_lazy.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 import tempfile

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import logging

--- a/tests/test_macro_sentinel.py
+++ b/tests/test_macro_sentinel.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import unittest
 

--- a/tests/test_manufacturing_agent.py
+++ b/tests/test_manufacturing_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import asyncio
 import json

--- a/tests/test_marketplace_notebook.py
+++ b/tests/test_marketplace_notebook.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_mats.py
+++ b/tests/test_mats.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import mats
 
 

--- a/tests/test_memory_agent_persistence.py
+++ b/tests/test_memory_agent_persistence.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import memory_agent
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging, logging

--- a/tests/test_memory_fabric_fallback.py
+++ b/tests/test_memory_fabric_fallback.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import math
 import os

--- a/tests/test_memory_fabric_sqlite.py
+++ b/tests/test_memory_fabric_sqlite.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import sqlite3
 import unittest

--- a/tests/test_memory_graph_fallback.py
+++ b/tests/test_memory_graph_fallback.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_memory_graph_rel.py
+++ b/tests/test_memory_graph_rel.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 
 from alpha_factory_v1.backend.memory_graph import GraphMemory

--- a/tests/test_memory_vector.py
+++ b/tests/test_memory_vector.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest import mock
 

--- a/tests/test_merkle_broadcast.py
+++ b/tests/test_merkle_broadcast.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
 import tempfile

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import types
 from unittest import TestCase, mock

--- a/tests/test_meta_agentic_cli_v2.py
+++ b/tests/test_meta_agentic_cli_v2.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_meta_agentic_notebook.py
+++ b/tests/test_meta_agentic_notebook.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_meta_agentic_tree_search_import.py
+++ b/tests/test_meta_agentic_tree_search_import.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import unittest
 

--- a/tests/test_muzero_cli.py
+++ b/tests/test_muzero_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess, sys
 
 

--- a/tests/test_muzero_planning.py
+++ b/tests/test_muzero_planning.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from alpha_factory_v1.demos.muzero_planning.minimuzero import MiniMu, play_episode
 

--- a/tests/test_oai_runtime.py
+++ b/tests/test_oai_runtime.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest import mock
 

--- a/tests/test_official_final_demo.py
+++ b/tests/test_official_final_demo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_official_insight_demo.py
+++ b/tests/test_official_insight_demo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
 import unittest

--- a/tests/test_omni_factory_plugins.py
+++ b/tests/test_omni_factory_plugins.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from alpha_factory_v1.demos.omni_factory_demo import omni_factory_demo as demo
 

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import py_compile
 import unittest
 from pathlib import Path

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import contextlib
 from unittest import mock

--- a/tests/test_orchestrator_backoff.py
+++ b/tests/test_orchestrator_backoff.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import contextlib
 

--- a/tests/test_orchestrator_bus_tls_env.py
+++ b/tests/test_orchestrator_bus_tls_env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import os

--- a/tests/test_orchestrator_env.py
+++ b/tests/test_orchestrator_env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import os
 import unittest

--- a/tests/test_orchestrator_grpc.py
+++ b/tests/test_orchestrator_grpc.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import importlib
 import os

--- a/tests/test_orchestrator_no_fastapi.py
+++ b/tests/test_orchestrator_no_fastapi.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 import unittest

--- a/tests/test_orchestrator_rest.py
+++ b/tests/test_orchestrator_rest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import io
 import stat
 import zipfile

--- a/tests/test_ping_agent.py
+++ b/tests/test_ping_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import unittest
 

--- a/tests/test_portfolio_no_lock.py
+++ b/tests/test_portfolio_no_lock.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import os
 import sys

--- a/tests/test_postgres_ledger.py
+++ b/tests/test_postgres_ledger.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import shutil
 import subprocess

--- a/tests/test_preflight_openai_agents_version.py
+++ b/tests/test_preflight_openai_agents_version.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import types
 import unittest

--- a/tests/test_retry_property.py
+++ b/tests/test_retry_property.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import pytest
 

--- a/tests/test_retry_wrapper.py
+++ b/tests/test_retry_wrapper.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 
 import pytest

--- a/tests/test_risk_management.py
+++ b/tests/test_risk_management.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 import types
 

--- a/tests/test_run_cli_options.py
+++ b/tests/test_run_cli_options.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import sys
 from unittest import TestCase, mock

--- a/tests/test_safe_exec_security.py
+++ b/tests/test_safe_exec_security.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 
 from alpha_factory_v1.demos.meta_agentic_agi.agents import agent_base

--- a/tests/test_sector_loader.py
+++ b/tests/test_sector_loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 from pathlib import Path
 

--- a/tests/test_self_healing_patcher.py
+++ b/tests/test_self_healing_patcher.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import os
 import tempfile

--- a/tests/test_supply_chain_agent.py
+++ b/tests/test_supply_chain_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import json
 import asyncio

--- a/tests/test_trace_token_expiry.py
+++ b/tests/test_trace_token_expiry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest import mock
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 pd = pytest.importorskip("pandas")

--- a/tests/test_wheel_signature.py
+++ b/tests/test_wheel_signature.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import base64
 import unittest
 from pathlib import Path

--- a/tests/test_world_model_kafka.py
+++ b/tests/test_world_model_kafka.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from unittest import mock
 


### PR DESCRIPTION
## Summary
- add `SPDX-License-Identifier: Apache-2.0` headers to test modules

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 39 failed, 431 passed)*
- `pre-commit run --files` *(fails: command not found)*