### PR TITLE
[alpha_factory] align requirements versions

### DIFF
--- a/alpha_factory_v1/backend/requirements.txt
+++ b/alpha_factory_v1/backend/requirements.txt
@@ -19,7 +19,7 @@ better-profanity~=0.7
 httpx~=0.28
 aiohttp~=3.9
 backoff~=2.2
-requests~=2.32
+requests~=2.32       # real HTTP client (root uses lightweight af_requests)
 
 # ─────────── Observability & task-orchestration ────────────────────────
 prometheus-client~=0.19
@@ -30,7 +30,7 @@ pytest~=8.2
 gitpython~=3.1          # local PR simulation for self-healing demo
 
 # ─────────── LLM / Agents stack ────────────────────────────────────────
-openai>=1.77.0,<2.0       # GPT-4o & embeddings
+openai>=1.77.0,<2.0       # GPT-4o & embeddings (synced with root)
 openai-agents>=0.0.14   # **critical** – official Agents SDK
 anthropic>=0.21         # Claude & MCP bridge
 litellm>=1.31           # local gateway / fallback router

--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -19,7 +19,7 @@ better-profanity~=0.7
 httpx~=0.28
 aiohttp~=3.9
 backoff~=2.2
-rich>=13
+rich>=13           # CLI output only (backend omits to stay lean)
 
 # ─────────── Observability & task-orchestration ────────────────────────
 prometheus-client~=0.19
@@ -30,7 +30,7 @@ pytest~=8.2
 gitpython~=3.1          # local PR simulation for self-healing demo
 
 # ─────────── LLM / Agents stack ────────────────────────────────────────
-openai>=1.76.0,<2.0       # GPT-4o & embeddings
+openai>=1.77.0,<2.0       # GPT-4o & embeddings (sync with backend)
 openai-agents>=0.0.14   # **critical** – official Agents SDK
 anthropic>=0.21         # Claude & MCP bridge
 litellm>=1.31           # local gateway / fallback router

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+- Synced `openai` pin across requirements files and clarified why
+  `requests` and `rich` differ between layers.
 
 ## [1.1.0] - 2025-07-15
 ### Added


### PR DESCRIPTION
## Summary
- sync openai versions across the two requirement files
- document why requests is only used by backend and rich by the root
- note changes in the changelog

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pre-commit` *(failed: command not found)*