### PR TITLE
[alpha_factory] add missing SPDX header

### DIFF
--- a/alpha_factory_v1/backend/__init__.py
+++ b/alpha_factory_v1/backend/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 alpha_factory_v1/backend/__init__.py
 ────────────────────────────────────


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX header to `alpha_factory_v1/backend/__init__.py`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pip install pre-commit` *(fails: no network access)*