### PR TITLE
[alpha_factory] add requirements lock check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,9 @@ repos:
         entry: make proto-verify
         language: system
         pass_filenames: false
+      - id: verify-requirements-lock
+        name: Verify requirements.lock is up to date
+        entry: python scripts/verify_requirements_lock.py
+        language: python
+        additional_dependencies: [pip-tools]
+        pass_filenames: false

--- a/scripts/verify_requirements_lock.py
+++ b/scripts/verify_requirements_lock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure requirements.lock is in sync with requirements.txt."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    req_txt = repo_root / "requirements.txt"
+    lock_file = repo_root / "requirements.lock"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "requirements.lock"
+        pip_compile = shutil.which("pip-compile")
+        if pip_compile:
+            cmd = [pip_compile]
+        else:
+            cmd = [sys.executable, "-m", "piptools", "compile"]
+        cmd += ["--quiet", "--generate-hashes", str(req_txt), "-o", str(out_path)]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            return result.returncode
+        if out_path.read_bytes() != lock_file.read_bytes():
+            sys.stderr.write(
+                "requirements.lock is outdated. Run 'pip-compile --quiet --generate-hashes requirements.txt'\n"
+            )
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- check that requirements.lock matches pip-compile output
- run the check via pre-commit

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pre-commit run --files .pre-commit-config.yaml scripts/verify_requirements_lock.py` *(fails: command not found)*