### PR TITLE
[alpha_factory] update lock instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,9 @@ Follow these steps when installing without internet access:
   pip wheel -r requirements-dev.txt -w /media/wheels
   ```
 
-- Generate a deterministic lock file after installing dependencies:
+- Generate a deterministic lock file with hashes:
   ```bash
-  pip install -r requirements.txt
-  pip freeze > requirements.lock
+  pip-compile --generate-hashes --output-file requirements.lock requirements.txt
   ```
 
 - Install from the lock file to reproduce identical environments:

--- a/README.md
+++ b/README.md
@@ -219,12 +219,10 @@ python -m webbrowser http://localhost:8000/docs
 ```
 The adapters initialise automatically when these optional packages are present.
 
-To regenerate `requirements.lock` with the exact versions from
-`requirements.txt`, run:
+To regenerate `requirements.lock` from `requirements.txt` with hashes, run:
 
 ```bash
-pip install -r requirements.txt
-pip freeze > requirements.lock
+pip-compile --generate-hashes --output-file requirements.lock requirements.txt
 ```
 
 Once the API server is running you can launch a simulation:


### PR DESCRIPTION
## Summary
- update README instructions for regenerating requirements.lock
- clarify lock generation in AGENTS guide

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*