### PR TITLE
[alpha_factory] clarify requirements header

### DIFF
--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -1,8 +1,8 @@
 # ======================================================================
-#  AGI-Alpha-Agent-v0  ·  Backend dependency lockfile  (May 2025)
-#  -- Supports online (OpenAI/Anthropic keys) *and* fully-offline runs
+#  AGI-Alpha-Agent-v0  ·  Baseline runtime requirements  (May 2025)
+#  -- This file lists the minimum versions tested by CI; it is not a lock file
+#  -- Supports online (OpenAI/Anthropic keys) and fully offline runs
 #  -- All packages ship manylinux / pure-python wheels on PyPI
-#  -- Version pins chosen to avoid known CVEs & resolve dependency DAG
 # ======================================================================
 
 # ─────────── Core web runtimes ─────────────────────────────────────────


### PR DESCRIPTION
# Summary
- update notes in `alpha_factory_v1/requirements.txt` to explain it's a baseline requirements file

# Checks
- [ ] I ran `pre-commit run --files alpha_factory_v1/requirements.txt` *(failed: command not found)*
- [x] I ran `python check_env.py --auto-install`
- [x] I ran `pytest -q` and documented any failures below

# Testing
- `pre-commit run --files alpha_factory_v1/requirements.txt` failed: `pre-commit: command not found`
- `python check_env.py --auto-install` succeeded
- `pytest -q` had 40 failures