### PR TITLE
[alpha_factory] use relative path in lock file

### DIFF
--- a/alpha_factory_v1/requirements.lock
+++ b/alpha_factory_v1/requirements.lock
@@ -1,5 +1,5 @@
 # Editable Git install with no remote (alpha-factory-v1==1.1.0)
--e /workspace/AGI-Alpha-Agent-v0
+-e .
 annotated-types==0.7.0
 anthropic==0.52.1
 anyio==4.9.0


### PR DESCRIPTION
## Summary
- make `alpha_factory_v1/requirements.lock` use a relative editable install path

## Testing
- `pre-commit run --files alpha_factory_v1/requirements.lock` *(fails: `pre-commit: command not found`)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*