### PR TITLE
[alpha_factory] prune unused lock deps

### DIFF
--- a/alpha_factory_v1/requirements.lock
+++ b/alpha_factory_v1/requirements.lock
@@ -3,9 +3,6 @@
 annotated-types==0.7.0
 anthropic==0.52.1
 anyio==4.9.0
-Authlib==1.6.0
-black==25.1.0
-cachetools==5.5.2
 certifi==2025.4.26
 cffi==1.17.1
 charset-normalizer==3.4.2


### PR DESCRIPTION
## Summary
- remove Authlib, black, cachetools from `requirements.lock`

## Testing
- `pre-commit run --files alpha_factory_v1/requirements.lock` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pip-compile --generate-hashes --output-file alpha_factory_v1/requirements.lock alpha_factory_v1/requirements.txt` *(fails: command not found)*
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*