### PR TITLE
[alpha_factory] sync backend dependency pins

### DIFF
--- a/alpha_factory_v1/backend/requirements-lock.txt
+++ b/alpha_factory_v1/backend/requirements-lock.txt
@@ -9,7 +9,7 @@
 
 # ────────── Web runtimes ───────────────────────────────────────────────
 fastapi==0.111.0
-uvicorn[standard]==0.29.0
+uvicorn[standard]==0.34.2
 flask==3.0.3
 gunicorn==21.2.0
 orjson==3.9.15
@@ -29,8 +29,8 @@ pytest==8.2.2
 gitpython==3.1.43
 
 # ────────── LLM / Agents stack ─────────────────────────────────────────
-openai==1.77.0
-openai-agents==0.0.14
+openai==1.82.0
+openai-agents==0.0.16
 anthropic==0.21.1
 litellm==1.31.6
 tiktoken==0.5.2

--- a/alpha_factory_v1/backend/requirements.txt
+++ b/alpha_factory_v1/backend/requirements.txt
@@ -7,7 +7,7 @@
 
 # ─────────── Core web runtimes ─────────────────────────────────────────
 fastapi>=0.111,<1.0
-uvicorn[standard]~=0.29
+uvicorn[standard]~=0.34
 flask~=3.0
 gunicorn~=21.2
 orjson~=3.9
@@ -30,8 +30,8 @@ pytest~=8.2
 gitpython~=3.1          # local PR simulation for self-healing demo
 
 # ─────────── LLM / Agents stack ────────────────────────────────────────
-openai>=1.77.0,<2.0       # GPT-4o & embeddings (synced with root)
-openai-agents>=0.0.14   # **critical** – official Agents SDK
+openai>=1.82.0,<2.0       # GPT-4o & embeddings (sync with root)
+openai-agents>=0.0.16   # **critical** – official Agents SDK
 anthropic>=0.21         # Claude & MCP bridge
 litellm>=1.31           # local gateway / fallback router
 tiktoken>=0.5


### PR DESCRIPTION
## Summary
- update openai, openai-agents and uvicorn versions in backend requirements
- align backend requirements-lock.txt with the root lock file

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/backend/requirements.txt alpha_factory_v1/backend/requirements-lock.txt` *(fails: command not found)*
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pip install --no-index -r alpha_factory_v1/backend/requirements-lock.txt` *(fails: no matching distribution found)*
- `pip install --no-index -r alpha_factory_v1/requirements.lock` *(fails: could not install build dependencies)*