### PR TITLE
[alpha_factory] add backend requirements lock check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,9 @@ repos:
         language: python
         additional_dependencies: [pip-tools]
         pass_filenames: false
+      - id: verify-backend-requirements-lock
+        name: Verify backend requirements-lock.txt is up to date
+        entry: python scripts/verify_backend_requirements_lock.py
+        language: python
+        additional_dependencies: [pip-tools]
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,9 @@ pre-commit run --files <paths>   # before each commit
     to regenerate and verify protobuf sources.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using
     `mypy.ini`.
+  - Hooks `verify-requirements-lock`, `verify-alpha-requirements-lock` and
+    `verify-backend-requirements-lock` ensure each `requirements-lock` file
+    matches its `requirements.txt`. They rely on `pip-tools`.
   - Hooks are configured in `.pre-commit-config.yaml` at the repository root.
 
 ## Pull Requests

--- a/scripts/verify_backend_requirements_lock.py
+++ b/scripts/verify_backend_requirements_lock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure backend requirements-lock.txt matches requirements.txt."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    req_txt = repo_root / "alpha_factory_v1" / "backend" / "requirements.txt"
+    lock_file = repo_root / "alpha_factory_v1" / "backend" / "requirements-lock.txt"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "requirements.lock"
+        pip_compile = shutil.which("pip-compile")
+        if pip_compile:
+            cmd = [pip_compile]
+        else:
+            cmd = [sys.executable, "-m", "piptools", "compile"]
+        cmd += ["--quiet", "--generate-hashes", str(req_txt), "-o", str(out_path)]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            return result.returncode
+        if out_path.read_bytes() != lock_file.read_bytes():
+            sys.stderr.write(
+                "alpha_factory_v1/backend/requirements-lock.txt is outdated. Run 'pip-compile --quiet --generate-hashes alpha_factory_v1/backend/requirements.txt'\n"
+            )
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `verify_backend_requirements_lock.py` to enforce backend lockfile
- run new script through a pre-commit hook
- document the backend lockfile check

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: UpdateModelTest + others)*
- `pre-commit` *(failed to run: command not found)*