### PR TITLE
[alpha_factory] include fastapi in setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,12 +83,10 @@ Follow these steps when installing without internet access:
 
 - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
 - After setup, validate with `python check_env.py --auto-install`. When `WHEELHOUSE` is set, run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly offline.
-- The unit tests rely on `fastapi` and `opentelemetry-api`. Install them via
-  `requirements-dev.txt` or ensure `check_env.py` reports no missing packages
-  before running `pytest`.
-- If the project is installed without `./codex/setup.sh`, run
-  `pip install -r requirements-dev.txt` to obtain `fastapi` and
-  `opentelemetry-api`.
+- The unit tests rely on `fastapi` and `opentelemetry-api`. `./codex/setup.sh`
+  installs these packages automatically. When skipping the setup script, run
+  `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no
+  missing packages before running `pytest`.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes.
   If failures remain, document them in the PR description.
 - When running tests directly from the repository without installation, set `PYTHONPATH`

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -29,6 +29,8 @@ else
     openai_agents
     google_adk
     anthropic
+    fastapi
+    opentelemetry-api
   )
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 fi


### PR DESCRIPTION
## Summary
- install `fastapi` and `opentelemetry-api` in minimal setup
- document automatic install in `AGENTS.md`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed)*