### PR TITLE
[alpha_factory] install pip-tools in setup script

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -12,6 +12,9 @@ fi
 # Upgrade pip and core build tools
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" --upgrade pip setuptools wheel
 
+# Install pip-compile (pip-tools) early so hooks can verify lock files
+$PYTHON -m pip install --quiet "${wheel_opts[@]}" pip-tools
+
 # Install package in editable mode
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" -e .
 


### PR DESCRIPTION
## Summary
- install pip-tools from `.codex/setup.sh`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 27 failed, 306 passed, 27 skipped)*
- `pre-commit run --files codex/setup.sh` *(fails: command not found)*