### PR TITLE
[alpha_factory] install pip-tools in dot-codex setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -12,6 +12,9 @@ fi
 # Upgrade pip and core build tools
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" --upgrade pip setuptools wheel
 
+# Install pip-compile (pip-tools) early so hooks can verify lock files
+$PYTHON -m pip install --quiet "${wheel_opts[@]}" pip-tools
+
 # Install package in editable mode
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" -e .
 

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -12,6 +12,9 @@ fi
 # Upgrade pip and core build tools
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" --upgrade pip setuptools wheel
 
+# Install pip-compile (pip-tools) early so hooks can verify lock files
+$PYTHON -m pip install --quiet "${wheel_opts[@]}" pip-tools
+
 # Install package in editable mode
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" -e .
 


### PR DESCRIPTION
## Summary
- ensure `.codex/setup.sh` installs `pip-tools` before any hooks run

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 35 failed, 382 passed, 29 skipped)*
- `pre-commit run --files .codex/setup.sh` *(fails: command not found)*
