### PR TITLE
[alpha_factory] add colab requirements lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,12 @@ repos:
         language: python
         additional_dependencies: [pip-tools]
         pass_filenames: false
+      - id: verify-alpha-colab-requirements-lock
+        name: Verify alpha_factory_v1 requirements-colab.lock is up to date
+        entry: python scripts/verify_alpha_colab_requirements_lock.py
+        language: python
+        additional_dependencies: [pip-tools]
+        pass_filenames: false
       - id: verify-backend-requirements-lock
         name: Verify backend requirements-lock.txt is up to date
         entry: python scripts/verify_backend_requirements_lock.py

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -33,7 +33,7 @@ MuZero-style model-based search to stay sample-efficient.
 | **Docker script**<br>`deploy_alpha_factory_cross_industry_demo.sh` | dev-ops / prod | 8 min | any Ubuntu with Docker 24 |
 | **Colab notebook**<br>`colab_deploy_alpha_factory_cross_industry_demo.ipynb` | analysts / no install | 4 min | free Colab CPU |
 
-The notebook installs dependencies from `../requirements-colab.txt` for a quick setup.
+The notebook installs dependencies from `../requirements-colab.lock` for a quick setup.
 
 Both flows autodetect `OPENAI_API_KEY`; when absent they inject a **Mixtral 8×7B**
 local LLM container so the demo works **fully offline**.

--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -193,7 +193,7 @@ cd ../../..
 pip install -r requirements.txt  # install dependencies
 python check_env.py              # confirm optional extras available
 # If packages are reported missing, install them:
-pip install -r requirements.txt  # or requirements-colab.txt in Colab
+pip install -r requirements.txt  # or requirements-colab.lock in Colab
 pytest -q                        # optional quick self-test
 python -m alpha_factory_v1.demos.omni_factory_demo --metrics-port 9137
 python alpha_factory_v1/demos/omni_factory_demo/omni_dashboard.py

--- a/alpha_factory_v1/requirements-colab.lock
+++ b/alpha_factory_v1/requirements-colab.lock
@@ -1,0 +1,13 @@
+fastapi>=0.111,<1.0
+uvicorn[standard]~=0.34
+pyngrok
+ctransformers==0.2.27
+k6-python
+subprocess-tee
+ray[default]==2.10.0
+openai>=1.82.0,<2.0
+openai-agents>=0.0.16
+anthropic>=0.21
+litellm>=1.31
+pytest~=8.2
+prometheus-client~=0.19

--- a/scripts/verify_alpha_colab_requirements_lock.py
+++ b/scripts/verify_alpha_colab_requirements_lock.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure alpha_factory_v1/requirements-colab.lock matches requirements-colab.txt."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    req_txt = repo_root / "alpha_factory_v1" / "requirements-colab.txt"
+    lock_file = repo_root / "alpha_factory_v1" / "requirements-colab.lock"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "requirements.lock"
+        pip_compile = shutil.which("pip-compile")
+        if pip_compile:
+            cmd = [pip_compile]
+        else:
+            cmd = [sys.executable, "-m", "piptools", "compile"]
+        cmd += ["--quiet", "--generate-hashes", str(req_txt), "-o", str(out_path)]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            return result.returncode
+        if out_path.read_bytes() != lock_file.read_bytes():
+            sys.stderr.write(
+                "alpha_factory_v1/requirements-colab.lock is outdated. "
+                "Run 'pip-compile --quiet --generate-hashes alpha_factory_v1/requirements-colab.txt'\n"
+            )
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- create `requirements-colab.lock`
- verify lock file in pre-commit
- add script `verify_alpha_colab_requirements_lock.py`
- note lock file use in Colab READMEs

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed)*