### PR TITLE
[alpha_factory] fix codex setup path

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -23,9 +23,11 @@ packages=(
   pytest
   prometheus_client
   openai
-  openai_agents
-  google_adk
+  openai-agents
+  google-adk
   anthropic
+  fastapi
+  opentelemetry-api
 )
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,7 @@ Follow these steps when installing without internet access:
 
 - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
 - After setup, validate with `python check_env.py --auto-install`. When `WHEELHOUSE` is set, run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly offline.
-- The unit tests rely on `fastapi` and `opentelemetry-api`. `./codex/setup.sh`
-  installs these packages automatically. When skipping the setup script, run
+- The unit tests rely on `fastapi`, `opentelemetry-api`, `openai-agents` and `google-adk`. `./codex/setup.sh` installs these packages automatically. When skipping the setup script, run
   `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no
   missing packages before running `pytest`.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes.

--- a/check_env.py
+++ b/check_env.py
@@ -34,6 +34,8 @@ OPTIONAL = [
     "google_adk",
 ]
 
+PIP_NAMES = {"openai_agents": "openai-agents", "google_adk": "google-adk"}
+
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Validate runtime dependencies")
@@ -71,7 +73,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             cmd = [sys.executable, "-m", "pip", "install", "--quiet"]
             if wheelhouse:
                 cmd += ["--no-index", "--find-links", wheelhouse]
-            cmd += missing
+            packages = [PIP_NAMES.get(pkg, pkg) for pkg in missing]
+            cmd += packages
             print("Attempting automatic install:", " ".join(cmd))
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, check=True)

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -29,8 +29,8 @@ else
     pytest
     prometheus_client
     openai
-    openai_agents
-    google_adk
+    openai-agents
+    google-adk
     anthropic
     fastapi
     opentelemetry-api


### PR DESCRIPTION
## Summary
- install fastapi and otel api when running `.codex/setup.sh`
- mention new distribution names in AGENTS.md

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 35 failed, 382 passed, 29 skipped)*