### PR TITLE
[alpha_factory] support offline pip compile for verifies

### DIFF
--- a/scripts/verify_alpha_requirements_lock.py
+++ b/scripts/verify_alpha_requirements_lock.py
@@ -3,6 +3,7 @@
 """Ensure alpha_factory_v1/requirements.lock matches requirements.txt."""
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -22,16 +23,25 @@ def main() -> int:
             cmd = [pip_compile]
         else:
             cmd = [sys.executable, "-m", "piptools", "compile"]
-        cmd += ["--quiet", "--generate-hashes", str(req_txt), "-o", str(out_path)]
+        wheelhouse = os.getenv("WHEELHOUSE")
+        cmd += ["--quiet"]
+        if wheelhouse:
+            cmd += ["--no-index", "--find-links", wheelhouse]
+        cmd += ["--generate-hashes", str(req_txt), "-o", str(out_path)]
         result = subprocess.run(cmd, capture_output=True, text=True)
         sys.stdout.write(result.stdout)
         sys.stderr.write(result.stderr)
         if result.returncode != 0:
             return result.returncode
         if out_path.read_bytes() != lock_file.read_bytes():
-            sys.stderr.write(
-                "alpha_factory_v1/requirements.lock is outdated. Run 'pip-compile --quiet --generate-hashes alpha_factory_v1/requirements.txt'\n"
+            extra = ""
+            if wheelhouse:
+                extra = f"--no-index --find-links {wheelhouse} "
+            msg = (
+                "alpha_factory_v1/requirements.lock is outdated. Run 'pip-compile "
+                f"{extra}--quiet --generate-hashes alpha_factory_v1/requirements.txt'\n"
             )
+            sys.stderr.write(msg)
             return 1
     return 0
 

--- a/scripts/verify_backend_requirements_lock.py
+++ b/scripts/verify_backend_requirements_lock.py
@@ -3,6 +3,7 @@
 """Ensure backend requirements-lock.txt matches requirements.txt."""
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -22,16 +23,25 @@ def main() -> int:
             cmd = [pip_compile]
         else:
             cmd = [sys.executable, "-m", "piptools", "compile"]
-        cmd += ["--quiet", "--generate-hashes", str(req_txt), "-o", str(out_path)]
+        wheelhouse = os.getenv("WHEELHOUSE")
+        cmd += ["--quiet"]
+        if wheelhouse:
+            cmd += ["--no-index", "--find-links", wheelhouse]
+        cmd += ["--generate-hashes", str(req_txt), "-o", str(out_path)]
         result = subprocess.run(cmd, capture_output=True, text=True)
         sys.stdout.write(result.stdout)
         sys.stderr.write(result.stderr)
         if result.returncode != 0:
             return result.returncode
         if out_path.read_bytes() != lock_file.read_bytes():
-            sys.stderr.write(
-                "alpha_factory_v1/backend/requirements-lock.txt is outdated. Run 'pip-compile --quiet --generate-hashes alpha_factory_v1/backend/requirements.txt'\n"
+            extra = ""
+            if wheelhouse:
+                extra = f"--no-index --find-links {wheelhouse} "
+            msg = (
+                "alpha_factory_v1/backend/requirements-lock.txt is outdated. Run 'pip-compile "
+                f"{extra}--quiet --generate-hashes alpha_factory_v1/backend/requirements.txt'\n"
             )
+            sys.stderr.write(msg)
             return 1
     return 0
 


### PR DESCRIPTION
## Summary
- allow verify scripts to read `WHEELHOUSE`
- add `--no-index --find-links` flags when `WHEELHOUSE` is set
- mention wheelhouse path in outdated messages

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
