### PR TITLE
[alpha_factory] Add httpx and uvicorn to setup

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -34,6 +34,8 @@ else
     anthropic
     fastapi
     opentelemetry-api
+    httpx
+    uvicorn
   )
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 fi


### PR DESCRIPTION
## Summary
- ensure API server tests run during Codex sessions by installing httpx and uvicorn via `codex/setup.sh`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pre-commit run --all-files` *(fails: could not install pre-commit, no network)*