### PR TITLE
[alpha_factory] update offline setup packages

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -40,6 +40,8 @@ else
     anthropic
     fastapi
     opentelemetry-api
+    httpx
+    uvicorn
   )
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 fi


### PR DESCRIPTION
## Summary
- add httpx and uvicorn to `.codex/setup.sh`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*