### PR TITLE
[alpha_factory] Add pip check after setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -74,3 +74,6 @@ if [[ -n "${WHEELHOUSE:-}" ]]; then
 fi
 $PYTHON check_env.py --auto-install "${check_env_opts[@]}"
 
+# Verify all dependencies are satisfied
+$PYTHON -m pip check
+


### PR DESCRIPTION
## Summary
- ensure `.codex/setup.sh` validates installed packages with `pip check`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pre-commit run --files .codex/setup.sh` *(fails: command not found)*