### PR TITLE
[alpha_factory] add cryptography to setup

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -33,6 +33,7 @@ else
     google-adk
     anthropic
     fastapi
+    cryptography
     opentelemetry-api
     httpx
     uvicorn


### PR DESCRIPTION
## Summary
- include `cryptography` in the minimal packages installed by `codex/setup.sh`

## Testing
- `./codex/setup.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*