### PR TITLE
[alpha_factory] include opentelemetry-sdk in setup

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -35,6 +35,7 @@ else
     fastapi
     cryptography
     opentelemetry-api
+    opentelemetry-sdk
     httpx
     uvicorn
   )


### PR DESCRIPTION
## Summary
- install `opentelemetry-sdk` during minimal setup

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 24 failed, 194 passed, 26 skipped)*