### PR TITLE
[alpha_factory] Add pre-commit install to setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -35,7 +35,8 @@ fi
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" --upgrade pip setuptools wheel
 
 # Install pip-compile (pip-tools) early so hooks can verify lock files
-$PYTHON -m pip install --quiet "${wheel_opts[@]}" pip-tools
+# Install pre-commit at the same time to enable hooks
+$PYTHON -m pip install --quiet "${wheel_opts[@]}" pip-tools pre-commit
 
 # Install package in editable mode
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" -e .


### PR DESCRIPTION
## Summary
- ensure setup installs pre-commit

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pip install pre-commit` *(fails: No route to host)*