### PR TITLE
[alpha_factory] add optional dev deps to setup

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -39,6 +39,14 @@ else
     httpx
     uvicorn
   )
+  if [[ "${DEV_INSTALL:-0}" == "1" ]]; then
+    packages+=(
+      pytest-benchmark
+      pytest-httpx
+      hypothesis
+      grpcio-tools
+    )
+  fi
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 fi
 


### PR DESCRIPTION
## Summary
- extend `packages` array in `codex/setup.sh` to optionally include extra testing tools under `DEV_INSTALL`
- keep automatic environment validation after install

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 24 failed, 194 passed, 26 skipped)*
- `pre-commit run --files codex/setup.sh` *(fails: pre-commit not installed)*