### PR TITLE
[alpha_factory] default to lock install

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -47,12 +47,8 @@ if [[ "${COLAB_INSTALL:-0}" == "1" ]]; then
   # same offline mode as WHEELHOUSE.
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" \
     -r alpha_factory_v1/requirements-colab.lock
-elif [[ "${FULL_INSTALL:-0}" == "1" ]]; then
-  # When FULL_INSTALL=1, use the deterministic lock file for reproducible
-  # offline installs.
-  $PYTHON -m pip install --quiet "${wheel_opts[@]}" -r requirements.lock
-else
-  # Minimal runtime/test dependencies
+elif [[ "${MINIMAL_INSTALL:-0}" == "1" ]]; then
+  # Install a reduced set of runtime/test dependencies
   packages=(
     pytest
     prometheus_client
@@ -66,6 +62,9 @@ else
     uvicorn
   )
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
+else
+  # By default use the deterministic lock file for reproducible installs.
+  $PYTHON -m pip install --quiet "${wheel_opts[@]}" -r requirements.lock
 fi
 
 # Validate environment and install any remaining deps


### PR DESCRIPTION
## Summary
- default `.codex/setup.sh` to install `requirements.lock`
- allow `MINIMAL_INSTALL=1` to request reduced install

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 432 passed, 33 skipped)*
- `pre-commit run --files .codex/setup.sh` *(fails: command not found)*