### PR TITLE
[alpha_factory] expand minimal dependencies

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -51,15 +51,28 @@ elif [[ "${MINIMAL_INSTALL:-0}" == "1" ]]; then
   # Install a reduced set of runtime/test dependencies
   packages=(
     pytest
+    pytest-benchmark
     prometheus_client
+    mypy
     openai
     openai-agents
     google-adk
     anthropic
     fastapi
     opentelemetry-api
+    grpcio
+    grpcio-tools
     httpx
     uvicorn
+    cryptography
+    hypothesis
+    pytest-httpx
+    numpy
+    pandas
+    playwright
+    websockets
+    click
+    requests
   )
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 else


### PR DESCRIPTION
## Summary
- expand minimal package list in `.codex/setup.sh`

## Testing
- `pre-commit run --files .codex/setup.sh` *(fails: couldn't fetch repository)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly')*