### PR TITLE
[alpha_factory] drop hashes from verify scripts

### DIFF
--- a/scripts/verify_alpha_requirements_lock.py
+++ b/scripts/verify_alpha_requirements_lock.py
@@ -27,7 +27,7 @@ def main() -> int:
         cmd += ["--quiet"]
         if wheelhouse:
             cmd += ["--no-index", "--find-links", wheelhouse]
-        cmd += ["--generate-hashes", str(req_txt), "-o", str(out_path)]
+        cmd += [str(req_txt), "-o", str(out_path)]
         result = subprocess.run(cmd, capture_output=True, text=True)
         sys.stdout.write(result.stdout)
         sys.stderr.write(result.stderr)
@@ -39,7 +39,7 @@ def main() -> int:
                 extra = f"--no-index --find-links {wheelhouse} "
             msg = (
                 "alpha_factory_v1/requirements.lock is outdated. Run 'pip-compile "
-                f"{extra}--quiet --generate-hashes alpha_factory_v1/requirements.txt'\n"
+                f"{extra}--quiet alpha_factory_v1/requirements.txt -o alpha_factory_v1/requirements.lock'\n"
             )
             sys.stderr.write(msg)
             return 1

--- a/scripts/verify_requirements_lock.py
+++ b/scripts/verify_requirements_lock.py
@@ -27,7 +27,7 @@ def main() -> int:
         cmd += ["--quiet"]
         if wheelhouse:
             cmd += ["--no-index", "--find-links", wheelhouse]
-        cmd += ["--generate-hashes", str(req_txt), "-o", str(out_path)]
+        cmd += [str(req_txt), "-o", str(out_path)]
         result = subprocess.run(cmd, capture_output=True, text=True)
         sys.stdout.write(result.stdout)
         sys.stderr.write(result.stderr)
@@ -38,7 +38,7 @@ def main() -> int:
             if wheelhouse:
                 extra = f"--no-index --find-links {wheelhouse} "
             sys.stderr.write(
-                f"requirements.lock is outdated. Run 'pip-compile {extra}--quiet --generate-hashes requirements.txt'\n"
+                f"requirements.lock is outdated. Run 'pip-compile {extra}--quiet requirements.txt -o requirements.lock'\n"
             )
             return 1
     return 0


### PR DESCRIPTION
## Summary
- remove `--generate-hashes` from verification scripts
- attempted to recompile requirements but pip-compile failed offline

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly')*
- `pre-commit run --files scripts/verify_alpha_requirements_lock.py scripts/verify_requirements_lock.py alpha_factory_v1/requirements.lock` *(fails: could not fetch hooks)*
