### PR TITLE
[alpha_factory] remove DEV_INSTALL flag

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -100,17 +100,15 @@ else
     websockets
     yfinance
   )
-  if [[ "${DEV_INSTALL:-0}" == "1" ]]; then
-    packages+=(
-      pytest-benchmark
-      pytest-httpx
-      hypothesis
-      grpcio-tools
-      grpcio
-      requests
-      pydantic-settings
-    )
-  fi
+  packages+=(
+    pytest-benchmark
+    pytest-httpx
+    hypothesis
+    grpcio-tools
+    grpcio
+    requests
+    pydantic-settings
+  )
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 fi
 


### PR DESCRIPTION
## Summary
- always append dev packages when running codex/setup.sh in minimal mode

## Testing
- `pre-commit run --files codex/setup.sh` *(fails: couldn't fetch hooks)*
- `python check_env.py --auto-install --wheelhouse wheels`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly')*