### PR TITLE
[alpha_factory] note offline pip-compile failure

### DIFF
--- a/alpha_factory_v1/requirements.lock
+++ b/alpha_factory_v1/requirements.lock
@@ -1,3 +1,4 @@
+# TODO: pip-compile failed offline – missing wheelhouse
 # Editable Git install with no remote (alpha-factory-v1==1.1.0)
 -e .
 annotated-types==0.7.0


### PR DESCRIPTION
## Summary
- add TODO comment to requirements.lock stating pip-compile failed offline

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly')*
- `pre-commit run --files alpha_factory_v1/requirements.lock` *(fails: could not fetch black)*
