### PR TITLE
[alpha_factory] fix: ensure plotly is required

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -38,6 +38,7 @@ REQUIRED = [
     "websockets",
     "pytest_benchmark",
     "hypothesis",
+    "plotly",
 ]
 
 # Optional integrations that may not be present in restricted environments.


### PR DESCRIPTION
## Summary
- add `plotly` to REQUIRED dependencies in `check_env.py`

## Testing
- `python check_env.py --auto-install` *(fails: Network failure detected)*
- `pytest -q` *(fails to import `plotly`)*