### PR TITLE
[alpha_factory] fix wheelhouse default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,9 @@ Follow these steps when installing without internet access:
   pip install -r requirements.lock
   ```
 
-- Install from the wheelhouse (the setup script automatically uses a
-  `wheels/` directory in the repository root when `WHEELHOUSE` is unset):
+- Install from the wheelhouse (the setup script automatically sets
+  `WHEELHOUSE` to the `wheels/` directory in the repository root when
+  that directory exists):
   ```bash
   WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
   WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 python check_env.py --auto-install --wheelhouse /media/wheels

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ pip install -r requirements.lock
 ./quickstart.sh               # creates venv, installs deps, launches
 # Use `--wheelhouse /path/to/wheels` to install offline packages when
 # the host has no internet access. The setup script automatically
-# falls back to `./wheels` if present. Running
+# sets `WHEELHOUSE` to `./wheels` when that directory exists. Running
 # `python check_env.py --auto-install --wheelhouse /path/to/wheels`
 # installs any missing optional packages. Example offline setup:
 #   export WHEELHOUSE=/media/wheels

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -3,6 +3,14 @@ set -euo pipefail
 
 PYTHON=${PYTHON:-python3}
 
+# Default to a wheelhouse next to the repository root when available
+if [[ -z "${WHEELHOUSE:-}" ]]; then
+  default_wheelhouse="$(dirname "$0")/../wheels"
+  if [[ -d "$default_wheelhouse" ]]; then
+    export WHEELHOUSE="$default_wheelhouse"
+  fi
+fi
+
 # Support offline installation via WHEELHOUSE
 wheel_opts=()
 if [[ -n "${WHEELHOUSE:-}" ]]; then


### PR DESCRIPTION
## Summary
- update setup script to default WHEELHOUSE to `../wheels`
- document wheelhouse fallback in README and AGENTS guide

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 2 failed, 4 passed, 9 skipped)*
- `pre-commit run --files codex/setup.sh README.md AGENTS.md` *(fails to fetch hooks)*