### PR TITLE
[alpha_factory] add plotly to minimal install

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -88,6 +88,7 @@ elif [[ "${MINIMAL_INSTALL:-0}" == "1" ]]; then
     numpy
     pandas
     playwright
+    plotly
     websockets
     click
     requests


### PR DESCRIPTION
## Summary
- include `plotly` when running the MINIMAL_INSTALL setup

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files .codex/setup.sh` *(fails: unable to access https://github.com/psf/black/)*
- `pytest -q` *(fails: 52 failed, 441 passed, 25 skipped)*