### PR TITLE
[alpha_factory] run pip check after install

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -155,3 +155,6 @@ if [[ -n "${WHEELHOUSE:-}" ]]; then
 fi
 $PYTHON check_env.py --auto-install "${check_env_opts[@]}"
 
+# Verify all dependencies are satisfied and abort on issues
+$PYTHON -m pip check
+


### PR DESCRIPTION
## Summary
- run `pip check` after installing in `codex/setup.sh`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 52 failed, 441 passed, 25 skipped)*