### PR TITLE
[alpha_factory] Deduplicate setup packages

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -77,6 +77,8 @@ elif [[ "${MINIMAL_INSTALL:-0}" == "1" ]]; then
     click
     requests
   )
+  # Deduplicate packages to avoid extra install noise
+  mapfile -t packages < <(printf '%s\n' "${packages[@]}" | sort -u)
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 else
   packages=(
@@ -145,6 +147,8 @@ else
     requests
     pydantic-settings
   )
+  # Deduplicate packages to avoid extra install noise
+  mapfile -t packages < <(printf '%s\n' "${packages[@]}" | sort -u)
   $PYTHON -m pip install --quiet "${wheel_opts[@]}" "${packages[@]}"
 fi
 


### PR DESCRIPTION
## Summary
- ensure `codex/setup.sh` installs each dependency once by uniquing the package list

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 52 failed, 441 passed, 25 skipped)*
- `pre-commit run --files codex/setup.sh` *(fails to fetch hooks: no network access)*