### PR TITLE
[alpha_factory] clarify API token requirement

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -416,6 +416,9 @@ local development or customization. See the
 
 `BUSINESS_HOST` sets the orchestrator URL used by helper commands to reach the REST API.
 
+`API_TOKEN` must be set to a non-empty value before launching the API server. The
+container exits during startup when this variable is empty.
+
 To secure the gRPC bus provide `AGI_INSIGHT_BUS_CERT`,
 `AGI_INSIGHT_BUS_KEY` and `AGI_INSIGHT_BUS_TOKEN`. When these are omitted set
 `AGI_INSIGHT_ALLOW_INSECURE=1` to run without TLS. See


### PR DESCRIPTION
## Summary
- note that `API_TOKEN` must be non-empty before starting the API server

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 52 failed, 441 passed, 25 skipped)*