### PR TITLE
[alpha_factory] Add MATS operators and tests

### DIFF
--- a/src/simulation/__init__.py
+++ b/src/simulation/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight simulation helpers."""
+
+from .mats_ops import GaussianParam, PromptRewrite, CodePatch
+
+__all__ = ["GaussianParam", "PromptRewrite", "CodePatch"]

--- a/src/simulation/mats_ops.py
+++ b/src/simulation/mats_ops.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal mutation operators for MATS demos."""
+from __future__ import annotations
+
+import random
+from typing import List
+
+
+class GaussianParam:
+    """Add Gaussian noise to numeric genomes within bounds."""
+
+    def __init__(self, std: float = 0.1, bounds: tuple[float, float] = (-1.0, 1.0), rng: random.Random | None = None) -> None:
+        self.std = std
+        self.bounds = bounds
+        self.rng = rng or random.Random()
+
+    def __call__(self, genome: List[float]) -> List[float]:
+        low, high = self.bounds
+        return [min(high, max(low, g + self.rng.gauss(0.0, self.std))) for g in genome]
+
+
+class PromptRewrite:
+    """Basic text rewrite inserting a simple synonym."""
+
+    def __init__(self, rng: random.Random | None = None) -> None:
+        self.rng = rng or random.Random()
+        self.synonyms = {"improve": "enhance", "quick": "fast", "test": "trial"}
+
+    def __call__(self, text: str) -> str:
+        words = text.split()
+        if not words:
+            return text
+        idx = self.rng.randrange(len(words))
+        w = words[idx].lower()
+        words[idx] = self.synonyms.get(w, words[idx])
+        return " ".join(words)
+
+
+class CodePatch:
+    """Return code with a small comment appended."""
+
+    def __call__(self, code: str) -> str:
+        suffix = "# patched"
+        if not code.endswith("\n"):
+            code += "\n"
+        return code + suffix + "\n"

--- a/tests/test_mats_ops.py
+++ b/tests/test_mats_ops.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+import random
+
+from src.simulation import GaussianParam
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import mats
+
+
+def _diversity(pop: list[mats.Individual]) -> float:
+    if len(pop) < 2:
+        return 0.0
+    dists = []
+    for i in range(len(pop)):
+        for j in range(i + 1, len(pop)):
+            a = pop[i].genome
+            b = pop[j].genome
+            d = sum((x - y) ** 2 for x, y in zip(a, b)) ** 0.5
+            dists.append(d)
+    return sum(dists) / len(dists)
+
+
+class TestMatsOps(unittest.TestCase):
+    def test_gaussian_param_bounds_and_diversity(self) -> None:
+        rng = random.Random(123)
+        pop = [mats.Individual([rng.uniform(-0.05, 0.05) for _ in range(2)]) for _ in range(10)]
+        base_div = _diversity(pop)
+        op = GaussianParam(std=0.3, rng=rng)
+        mutated = [mats.Individual(op(ind.genome)) for ind in pop]
+        after_div = _diversity(mutated)
+        for ind in mutated:
+            for gene in ind.genome:
+                self.assertGreaterEqual(gene, -1.0)
+                self.assertLessEqual(gene, 1.0)
+        self.assertGreater(after_div, base_div * 1.3)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement gaussian, prompt, and patch operators
- expose operators from `src/simulation`
- test that gaussian operator keeps genomes within bounds and increases diversity

## Testing
- `pre-commit run --files src/simulation/mats_ops.py src/simulation/__init__.py tests/test_mats_ops.py` *(fails: unable to fetch black)*
- `python check_env.py --auto-install`
- `pytest tests/test_mats_ops.py -q`