### PR TITLE
[alpha_factory] expose evolutionary rates

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -100,6 +100,21 @@ def main() -> None:
 )
 @click.option("--pop-size", default=6, show_default=True, type=int, help="MATS population size")
 @click.option("--generations", default=3, show_default=True, type=int, help="Evolution steps")
+@click.option(
+    "--mut-rate",
+    default=0.1,
+    show_default=True,
+    type=float,
+    help="Mutation rate during crossover",
+)
+@click.option(
+    "--xover-rate",
+    default=0.5,
+    show_default=True,
+    type=float,
+    help="Crossover rate",
+)
+@click.option("--dry-run", is_flag=True, help="Run offline without broadcasting")
 @click.option("--export", type=click.Choice(["json", "csv"]), help="Export results format")
 @click.option("--verbose", is_flag=True, help="Verbose output")
 @click.option("--start-orchestrator", is_flag=True, help="Run orchestrator after simulation")
@@ -114,6 +129,9 @@ def simulate(
     entropy: float,
     pop_size: int,
     generations: int,
+    mut_rate: float,
+    xover_rate: float,
+    dry_run: bool,
     export: str | None,
     verbose: bool,
     start_orchestrator: bool,
@@ -138,6 +156,9 @@ def simulate(
         entropy: Initial sector entropy.
         pop_size: MATS population size.
         generations: Number of evolution steps.
+        mut_rate: Probability of mutating a gene.
+        xover_rate: Probability of performing crossover.
+        dry_run: Run offline without broadcasting.
         export: Format to export results.
         verbose: Enable verbose output.
         start_orchestrator: Launch orchestrator after the run.
@@ -159,6 +180,9 @@ def simulate(
         os.environ["LLAMA_MODEL_PATH"] = str(llama_model_path)
 
     cfg = config.CFG.model_dump()
+    if dry_run:
+        offline = True
+        no_broadcast = True
     if offline:
         cfg["offline"] = True
     if model_name is not None:
@@ -185,6 +209,8 @@ def simulate(
         pop_size=pop_size,
         generations=generations,
         seed=seed,
+        mut_rate=mut_rate,
+        xover_rate=xover_rate,
     )
     results = [forecast.ForecastPoint(t.year, t.capability, [s for s in t.sectors if s.disrupted]) for t in trajectory]
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
@@ -104,6 +104,7 @@ def _evolve_step(
     *,
     rng: random.Random,
     mutation_rate: float,
+    crossover_rate: float,
 ) -> Population:
     """Return the next generation from ``pop`` using NSGA‑II."""
 
@@ -113,8 +114,11 @@ def _evolve_step(
     offspring: Population = []
     while len(offspring) < mu:
         a, b = rng.sample(pop, 2)
-        cut = rng.randint(1, genome_length - 1)
-        child_genome = a.genome[:cut] + b.genome[cut:]
+        if genome_length > 1 and rng.random() < crossover_rate:
+            cut = rng.randint(1, genome_length - 1)
+            child_genome = a.genome[:cut] + b.genome[cut:]
+        else:
+            child_genome = list(a.genome)
         if rng.random() < mutation_rate:
             idx = rng.randrange(genome_length)
             child_genome[idx] += rng.uniform(-1, 1)
@@ -138,6 +142,7 @@ def run_evolution(
     *,
     population_size: int = 20,
     mutation_rate: float = 0.1,
+    crossover_rate: float = 0.5,
     generations: int = 10,
     seed: int | None = None,
 ) -> Population:
@@ -148,6 +153,7 @@ def run_evolution(
         genome_length: Number of float genes per individual.
         population_size: Number of individuals preserved each generation.
         mutation_rate: Probability of mutating a gene during crossover.
+        crossover_rate: Probability of performing crossover between parents.
         generations: Number of NSGA-II steps to perform.
         seed: Optional random seed for deterministic behaviour.
 
@@ -159,6 +165,12 @@ def run_evolution(
     pop = [Individual([rng.uniform(-1, 1) for _ in range(genome_length)]) for _ in range(population_size)]
 
     for _ in range(generations):
-        pop = _evolve_step(pop, fn, rng=rng, mutation_rate=mutation_rate)
+        pop = _evolve_step(
+            pop,
+            fn,
+            rng=rng,
+            mutation_rate=mutation_rate,
+            crossover_rate=crossover_rate,
+        )
 
     return pop

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -242,3 +242,15 @@ def test_simulate_invalid_option() -> None:
     )
     assert res.exit_code != 0
     assert "Invalid value for '--export'" in res.output
+
+
+def test_simulate_dry_run_mut_rate() -> None:
+    """Running simulate with --dry-run and custom mutation rate should succeed."""
+    runner = CliRunner()
+    with patch.object(cli, "asyncio"):
+        with patch.object(cli.orchestrator, "Orchestrator"):
+            res = runner.invoke(
+                cli.main,
+                ["simulate", "--dry-run", "--mut-rate", "0.2"],
+            )
+    assert res.exit_code == 0


### PR DESCRIPTION
## Summary
- extend simulate CLI with `--mut-rate` and `--xover-rate`
- wire rates through forecast and MATS
- support `--dry-run` option
- test simulate dry run with custom mutation rate

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 48 failed, 425 passed, 25 skipped)*