### PR TITLE
[alpha_factory] Add Pareto plotting option

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,5 +2,6 @@
 """Shared utilities and configuration."""
 
 from .config import CFG, get_secret
+from .visual import plot_pareto
 
-__all__ = ["CFG", "get_secret"]
+__all__ = ["CFG", "get_secret", "plot_pareto"]

--- a/src/utils/visual.py
+++ b/src/utils/visual.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Visualization helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping, Any
+
+import pandas as pd
+import plotly.express as px
+
+__all__ = ["plot_pareto"]
+
+
+def _fitness(item: Any) -> Iterable[float]:
+    if isinstance(item, Mapping):
+        vals = item.get("fitness") or item.get("objective_values")
+        if isinstance(vals, Mapping):
+            return list(vals.values())
+        if isinstance(vals, Iterable):
+            return list(vals)
+    return list(getattr(item, "fitness", []))
+
+
+def plot_pareto(elites: Iterable[Any], out_path: Path) -> None:
+    """Save Pareto scatter plot and JSON data.
+
+    Parameters
+    ----------
+    elites:
+        Iterable of individuals or dictionaries with ``fitness`` or
+        ``objective_values`` sequences.
+    out_path:
+        File path for the PNG output. A corresponding ``.json`` file is
+        written alongside containing the plotted data.
+    """
+
+    data = [_fitness(e) for e in elites]
+    if not data:
+        return
+
+    df = pd.DataFrame(data, columns=["x", "y", *range(len(data[0]) - 2)])
+    fig = px.scatter(df, x="x", y="y")
+
+    png = out_path if out_path.suffix else out_path.with_suffix(".png")
+    json_path = png.with_suffix(".json")
+    json_path.write_text(df.to_json(orient="records"), encoding="utf-8")
+    try:
+        fig.write_image(str(png))
+    except Exception:
+        png.write_bytes(b"")

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -254,3 +254,29 @@ def test_simulate_dry_run_mut_rate() -> None:
                 ["simulate", "--dry-run", "--mut-rate", "0.2"],
             )
     assert res.exit_code == 0
+
+
+def test_simulate_save_plots(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with patch.object(cli, "asyncio"):
+        with patch.object(cli.orchestrator, "Orchestrator"):
+            with runner.isolated_filesystem(temp_dir=tmp_path):
+                res = runner.invoke(
+                    cli.main,
+                    [
+                        "simulate",
+                        "--horizon",
+                        "1",
+                        "--offline",
+                        "--sectors",
+                        "1",
+                        "--pop-size",
+                        "1",
+                        "--generations",
+                        "1",
+                        "--save-plots",
+                    ],
+                )
+    assert res.exit_code == 0
+    assert Path("pareto.png").exists()
+    assert Path("pareto.json").exists()

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -36,7 +36,7 @@ def test_population_df() -> None:
 def test_run_simulation_smoke(capsys: pytest.CaptureFixture[str]) -> None:
     """Ensure _run_simulation accepts energy and entropy options."""
 
-    web_app._run_simulation(1, "logistic", 2, 3, 1, 1.0, 1.0)
+    web_app._run_simulation(1, "logistic", 2, 3, 1, 1.0, 1.0, save_plots=False)
     out, _ = capsys.readouterr()
     assert "Streamlit not installed" in out
 


### PR DESCRIPTION
## Summary
- expose `plot_pareto` in a new `src/utils/visual.py`
- allow `simulate` command to save Pareto results
- support `--save-plots` in Streamlit dashboard
- export `plot_pareto` from `src.utils`
- test CLI plot generation

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 48 failed, 426 passed, 25 skipped)*