### PR TITLE
[alpha_factory] Add historical scenario replay

### DIFF
--- a/data/historic_scenarios/1994_web.yaml
+++ b/data/historic_scenarios/1994_web.yaml
@@ -1,0 +1,8 @@
+{
+  "name": "1994 Web",
+  "horizon": 3,
+  "sectors": [
+    {"name": "search", "growth": 0.1},
+    {"name": "retail", "growth": 0.05}
+  ]
+}

--- a/data/historic_scenarios/2001_genome.yaml
+++ b/data/historic_scenarios/2001_genome.yaml
@@ -1,0 +1,8 @@
+{
+  "name": "2001 Genome",
+  "horizon": 3,
+  "sectors": [
+    {"name": "biotech", "growth": 0.08},
+    {"name": "pharma", "growth": 0.05}
+  ]
+}

--- a/data/historic_scenarios/2008_mobile.yaml
+++ b/data/historic_scenarios/2008_mobile.yaml
@@ -1,0 +1,8 @@
+{
+  "name": "2008 Mobile",
+  "horizon": 3,
+  "sectors": [
+    {"name": "smartphones", "growth": 0.12},
+    {"name": "apps", "growth": 0.1}
+  ]
+}

--- a/data/historic_scenarios/2012_dl.yaml
+++ b/data/historic_scenarios/2012_dl.yaml
@@ -1,0 +1,8 @@
+{
+  "name": "2012 DL",
+  "horizon": 3,
+  "sectors": [
+    {"name": "ai_research", "growth": 0.15},
+    {"name": "cloud_compute", "growth": 0.07}
+  ]
+}

--- a/data/historic_scenarios/2020_mrna.yaml
+++ b/data/historic_scenarios/2020_mrna.yaml
@@ -1,0 +1,8 @@
+{
+  "name": "2020 mRNA",
+  "horizon": 3,
+  "sectors": [
+    {"name": "vaccine", "growth": 0.2},
+    {"name": "biotech_platforms", "growth": 0.1}
+  ]
+}

--- a/src/simulation/__init__.py
+++ b/src/simulation/__init__.py
@@ -2,5 +2,14 @@
 """Lightweight simulation helpers."""
 
 from .mats_ops import GaussianParam, PromptRewrite, CodePatch
+from .replay import Scenario, available_scenarios, load_scenario, run_scenario
 
-__all__ = ["GaussianParam", "PromptRewrite", "CodePatch"]
+__all__ = [
+    "GaussianParam",
+    "PromptRewrite",
+    "CodePatch",
+    "Scenario",
+    "available_scenarios",
+    "load_scenario",
+    "run_scenario",
+]

--- a/src/simulation/replay.py
+++ b/src/simulation/replay.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities for replaying historic scenarios."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Any, cast
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import forecast, sector
+
+
+BASE_DIR = Path(__file__).resolve().parents[2] / "data" / "historic_scenarios"
+
+
+@dataclass(slots=True)
+class Scenario:
+    """A minimal scenario description."""
+
+    name: str
+    horizon: int
+    sectors: List[sector.Sector]
+    curve: str = "logistic"
+    k: float | None = None
+    x0: float | None = None
+    pop_size: int = 6
+    generations: int = 1
+
+
+__all__ = ["Scenario", "available_scenarios", "load_scenario", "run_scenario"]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+
+        data: Any = yaml.safe_load(text)
+    except Exception:
+        data = json.loads(text)
+    return cast(dict[str, Any], data or {})
+
+
+def available_scenarios(directory: str | Path | None = None) -> list[str]:
+    """Return the list of available scenario names."""
+
+    dir_path = Path(directory or BASE_DIR)
+    names = {p.stem for p in dir_path.glob("*.yaml")}
+    names.update(p.stem for p in dir_path.glob("*.yml"))
+    return sorted(names)
+
+
+def load_scenario(name: str, directory: str | Path | None = None) -> Scenario:
+    """Load a scenario definition by name."""
+
+    dir_path = Path(directory or BASE_DIR)
+    path = dir_path / f"{name}.yaml"
+    if not path.exists():
+        path = dir_path / f"{name}.yml"
+    data = _load_yaml(path)
+
+    secs: list[sector.Sector] = []
+    for entry in data.get("sectors", []):
+        if isinstance(entry, str):
+            secs.append(sector.Sector(entry))
+        elif isinstance(entry, dict):
+            secs.append(
+                sector.Sector(
+                    entry.get("name", ""),
+                    float(entry.get("energy", 1.0)),
+                    float(entry.get("entropy", 1.0)),
+                    float(entry.get("growth", 0.05)),
+                    bool(entry.get("disrupted", False)),
+                )
+            )
+        else:
+            raise ValueError(f"Invalid sector entry: {entry!r}")
+
+    return Scenario(
+        name=data.get("name", name),
+        horizon=int(data.get("horizon", 1)),
+        sectors=secs,
+        curve=data.get("curve", "logistic"),
+        k=data.get("k"),
+        x0=data.get("x0"),
+        pop_size=int(data.get("pop_size", 6)),
+        generations=int(data.get("generations", 1)),
+    )
+
+
+def run_scenario(scn: Scenario) -> list[forecast.TrajectoryPoint]:
+    """Execute ``scn`` and return its trajectory."""
+
+    secs = [sector.Sector(s.name, s.energy, s.entropy, s.growth, s.disrupted) for s in scn.sectors]
+    return forecast.forecast_disruptions(
+        secs,
+        scn.horizon,
+        scn.curve,
+        k=scn.k,
+        x0=scn.x0,
+        pop_size=scn.pop_size,
+        generations=scn.generations,
+    )

--- a/tests/test_replay_scenarios.py
+++ b/tests/test_replay_scenarios.py
@@ -1,0 +1,28 @@
+import time
+
+import pytest
+
+from src.simulation import replay
+
+
+EXPECTED = {
+    "1994_web",
+    "2001_genome",
+    "2008_mobile",
+    "2012_dl",
+    "2020_mrna",
+}
+
+
+def test_available_scenarios() -> None:
+    names = set(replay.available_scenarios())
+    assert EXPECTED.issubset(names)
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED))
+def test_scenario_runs_fast(name: str) -> None:
+    start = time.perf_counter()
+    scn = replay.load_scenario(name)
+    result = replay.run_scenario(scn)
+    assert len(result) == scn.horizon
+    assert time.perf_counter() - start < 120


### PR DESCRIPTION
## Summary
- add scenario replay loader with run helper
- ship historic scenario fixtures
- export replay helpers from simulation package
- verify scenarios in test suite

## Testing
- `pre-commit` *(fails: Couldn't connect to server)*
- `python check_env.py --auto-install`
- `pytest -q tests/test_replay_scenarios.py`