### PR TITLE
[alpha_factory] add seed option

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -9,6 +9,7 @@ console output optionally leverages ``rich`` for nicer tables.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import csv
 import sys
 import json
@@ -179,6 +180,13 @@ def simulate(
     """
     if seed is not None:
         random.seed(seed)
+        with contextlib.suppress(ModuleNotFoundError):
+            import numpy as np  # type: ignore
+            np.random.seed(seed)
+        with contextlib.suppress(ModuleNotFoundError):
+            import torch  # type: ignore
+            torch.manual_seed(seed)
+        config.CFG.seed = seed
 
     if llama_model_path is not None:
         os.environ["LLAMA_MODEL_PATH"] = str(llama_model_path)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -48,6 +48,7 @@ class Settings(SettingsBase):
     offline: bool = Field(default=False, alias="AGI_INSIGHT_OFFLINE")
     bus_port: int = Field(default=6006, alias="AGI_INSIGHT_BUS_PORT")
     ledger_path: str = Field(default="./ledger/audit.db", alias="AGI_INSIGHT_LEDGER_PATH")
+    seed: Optional[int] = Field(default=None, alias="AGI_INSIGHT_SEED")
     memory_path: Optional[str] = Field(default=None, alias="AGI_INSIGHT_MEMORY_PATH")
     broker_url: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BROKER_URL")
     bus_token: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_TOKEN")

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -97,6 +97,7 @@ class Settings(SettingsBase):
     offline: bool = Field(default=False, alias="AGI_INSIGHT_OFFLINE")
     bus_port: int = Field(default=6006, alias="AGI_INSIGHT_BUS_PORT")
     ledger_path: str = Field(default="./ledger/audit.db", alias="AGI_INSIGHT_LEDGER_PATH")
+    seed: Optional[int] = Field(default=None, alias="SEED")
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - exercised in tests
         super().__init__(**data)


### PR DESCRIPTION
## Summary
- add optional seed to config
- seed numpy and torch in CLI when provided
- verify CLI output stable with same seed

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 30 failed, 318 passed, 19 skipped)*