### PR TITLE
[alpha_factory] add scenario replay fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.simulation import replay
+
+
+@pytest.fixture(scope="module")
+def scenario_1994_web() -> replay.Scenario:
+    return replay.load_scenario("1994_web")
+
+
+@pytest.fixture(scope="module")
+def scenario_2001_genome() -> replay.Scenario:
+    return replay.load_scenario("2001_genome")
+
+
+@pytest.fixture(scope="module")
+def scenario_2008_mobile() -> replay.Scenario:
+    return replay.load_scenario("2008_mobile")
+
+
+@pytest.fixture(scope="module")
+def scenario_2012_dl() -> replay.Scenario:
+    return replay.load_scenario("2012_dl")
+
+
+@pytest.fixture(scope="module")
+def scenario_2020_mrna() -> replay.Scenario:
+    return replay.load_scenario("2020_mrna")
+
+
+@pytest.fixture
+def scenario(request) -> replay.Scenario:
+    return request.getfixturevalue(request.param)

--- a/tests/test_replay_metrics.py
+++ b/tests/test_replay_metrics.py
@@ -12,12 +12,24 @@ EXPECTED = {
 }
 
 
-def test_f1_scores_above_threshold(tmp_path) -> None:
+def test_f1_scores_above_threshold(
+    tmp_path,
+    scenario_1994_web,
+    scenario_2001_genome,
+    scenario_2008_mobile,
+    scenario_2012_dl,
+    scenario_2020_mrna,
+) -> None:
     csv_path = tmp_path / "metrics.csv"
-    for name in sorted(EXPECTED):
-        scn = replay.load_scenario(name)
+    for scn in [
+        scenario_1994_web,
+        scenario_2001_genome,
+        scenario_2008_mobile,
+        scenario_2012_dl,
+        scenario_2020_mrna,
+    ]:
         traj = replay.run_scenario(scn)
-        metrics = replay.score_trajectory(name, traj, csv_path=csv_path)
+        metrics = replay.score_trajectory(scn.name, traj, csv_path=csv_path)
         assert metrics["f1"] > 0.6
     with open(csv_path, newline="") as fh:
         rows = list(csv.reader(fh))

--- a/tests/test_replay_scenarios.py
+++ b/tests/test_replay_scenarios.py
@@ -19,10 +19,19 @@ def test_available_scenarios() -> None:
     assert EXPECTED.issubset(names)
 
 
-@pytest.mark.parametrize("name", sorted(EXPECTED))
-def test_scenario_runs_fast(name: str) -> None:
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "scenario_1994_web",
+        "scenario_2001_genome",
+        "scenario_2008_mobile",
+        "scenario_2012_dl",
+        "scenario_2020_mrna",
+    ],
+    indirect=True,
+)
+def test_scenario_runs_fast(scenario) -> None:
     start = time.perf_counter()
-    scn = replay.load_scenario(name)
-    result = replay.run_scenario(scn)
-    assert len(result) == scn.horizon
+    result = replay.run_scenario(scenario)
+    assert len(result) == scenario.horizon
     assert time.perf_counter() - start < 120


### PR DESCRIPTION
## Summary
- add scenario fixtures to conftest
- parameterize replay tests with fixtures

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_replay_scenarios.py tests/test_replay_metrics.py`