### PR TITLE
[alpha_factory] Add smoke test workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,29 @@
+name: "🔥 Smoke Test"
+
+on:
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION_MATRIX: "3.11,3.12"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        python-version: [${{ env.PYTHON_VERSION_MATRIX }}]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.lock
+      - name: Run 2-year simulation
+        run: |
+          python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \
+            --horizon 2 --sectors 1 --pop-size 1 --generations 1 --offline --no-broadcast


### PR DESCRIPTION
## Summary
- add smoke workflow running a short 2-year CLI simulation

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 40 failed, 389 passed, 21 skipped)*
- `pre-commit run --files .github/workflows/smoke.yml` *(fails to fetch hooks)*