### PR TITLE
[alpha_factory] Add ChaosAgent agent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -11,6 +11,7 @@ from .mcp_adapter import MCPAdapter
 from .base_agent import BaseAgent
 from .research_agent import ResearchAgent
 from .adk_summariser_agent import ADKSummariserAgent
+from .chaos_agent import ChaosAgent
 
 __all__ = [
     "ADKAdapter",
@@ -18,4 +19,5 @@ __all__ = [
     "BaseAgent",
     "ResearchAgent",
     "ADKSummariserAgent",
+    "ChaosAgent",
 ]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/chaos_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/chaos_agent.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Agent spamming malicious prompts."""
+
+from __future__ import annotations
+
+from .base_agent import BaseAgent
+from ..utils import messaging
+from ..utils.logging import Ledger
+from ..utils.tracing import span
+
+
+class ChaosAgent(BaseAgent):
+    """Emit a burst of harmful code snippets."""
+
+    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger", burst: int = 20) -> None:
+        super().__init__("chaos", bus, ledger)
+        self.burst = burst
+
+    async def run_cycle(self) -> None:
+        """Send multiple malicious messages quickly."""
+        with span("chaos.run_cycle"):
+            for _ in range(self.burst):
+                await self.emit("safety", {"code": "import os\nos.system('rm -rf /')"})
+
+    async def handle(self, env: messaging.Envelope) -> None:
+        """Forward incoming code directly to the safety agent."""
+        with span("chaos.handle"):
+            code = env.payload.get("code", "import os")
+            await self.emit("safety", {"code": code})

--- a/tests/test_chaos_agent.py
+++ b/tests/test_chaos_agent.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import chaos_agent, safety_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+class DummyBus:
+    def __init__(self, settings: config.Settings) -> None:
+        self.settings = settings
+        self.published: list[tuple[str, messaging.Envelope]] = []
+
+    def publish(self, topic: str, env: messaging.Envelope) -> None:
+        self.published.append((topic, env))
+
+    def subscribe(self, _t: str, _h):
+        pass
+
+
+class DummyLedger:
+    def __init__(self) -> None:
+        self.logged: list[messaging.Envelope] = []
+
+    def log(self, env: messaging.Envelope) -> None:  # type: ignore[override]
+        self.logged.append(env)
+
+    def start_merkle_task(self, *_a, **_kw):
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - interface
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def test_safety_blocks_chaos() -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    chaos = chaos_agent.ChaosAgent(bus, led, burst=20)
+    guardian = safety_agent.SafetyGuardianAgent(bus, led)
+
+    asyncio.run(chaos.run_cycle())
+    chaos_msgs = [env for topic, env in bus.published if topic == "safety"]
+
+    blocked = 0
+    for env in chaos_msgs:
+        asyncio.run(guardian.handle(env))
+        if bus.published[-1][1].payload["status"] == "blocked":
+            blocked += 1
+
+    assert chaos_msgs
+    assert blocked / len(chaos_msgs) >= 0.95


### PR DESCRIPTION
## Summary
- add `ChaosAgent` that spams harmful code
- export `ChaosAgent` from the agents package
- test that `SafetyGuardianAgent` blocks at least 95% of chaos messages

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 24 failed, 192 passed)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/chaos_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py tests/test_chaos_agent.py` *(fails due to network)*
- `mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/chaos_agent.py tests/test_chaos_agent.py` *(fails with many errors)*