### PR TITLE
[alpha_factory] Add finance adapter DCF

### DIFF
--- a/src/finance/adapter.py
+++ b/src/finance/adapter.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Finance adapter utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+def delta_sector_to_dcf(sector_state: Dict[str, float]) -> Dict[str, Any]:
+    """Convert ``sector_state`` deltas into a discounted cash flow representation.
+
+    The input dictionary should contain the following keys:
+
+    - ``delta_revenue``: annual revenue delta (absolute value).
+    - ``margin``: operating margin as a decimal.
+    - ``discount_rate``: discount rate as a decimal.
+    - ``years``: number of forecast years.
+
+    Returns a dictionary with calculated ``cash_flows`` and ``npv``.
+    """
+
+    delta_revenue = float(sector_state.get("delta_revenue", 0.0))
+    margin = float(sector_state.get("margin", 0.0))
+    discount_rate = float(sector_state.get("discount_rate", 0.1))
+    years = int(sector_state.get("years", 1))
+
+    cash_flow = delta_revenue * margin
+    cash_flows = [cash_flow for _ in range(years)]
+    npv = sum(cf / ((1 + discount_rate) ** (i + 1)) for i, cf in enumerate(cash_flows))
+    return {"cash_flows": cash_flows, "npv": npv}
+

--- a/tests/test_finance_adapter.py
+++ b/tests/test_finance_adapter.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from src.finance.adapter import delta_sector_to_dcf
+
+
+def test_delta_sector_to_dcf_npv() -> None:
+    sector_state = {
+        "delta_revenue": 1_000_000.0,
+        "margin": 0.2,
+        "discount_rate": 0.1,
+        "years": 3,
+    }
+    result = delta_sector_to_dcf(sector_state)
+    expected_npv = 497370.3981968444
+    assert result["npv"] == pytest.approx(expected_npv, rel=0.02)
+


### PR DESCRIPTION
## Summary
- introduce `delta_sector_to_dcf` helper
- test discounted cash flow conversion

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/finance/adapter.py tests/test_finance_adapter.py` *(fails: Failed to connect to proxy port 8080)*
- `pytest -q tests/test_finance_adapter.py`