### PR TITLE
[alpha_factory] Add sector equity mapping

### DIFF
--- a/data/sector_equity_map.csv
+++ b/data/sector_equity_map.csv
@@ -1,0 +1,11 @@
+sector,ticker
+search,GOOG
+retail,AMZN
+biotech,AMGN
+pharma,PFE
+smartphones,AAPL
+apps,MSFT
+ai_research,NVDA
+cloud_compute,MSFT
+vaccine,MRNA
+biotech_platforms,CRSP

--- a/src/finance/adapter.py
+++ b/src/finance/adapter.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 
 from typing import Dict, Any
 
+import csv
+import json
+from pathlib import Path
+
+
+_MAP_PATH = Path(__file__).resolve().parents[2] / "data" / "sector_equity_map.csv"
+
 
 def delta_sector_to_dcf(sector_state: Dict[str, float]) -> Dict[str, Any]:
     """Convert ``sector_state`` deltas into a discounted cash flow representation.
@@ -28,4 +35,31 @@ def delta_sector_to_dcf(sector_state: Dict[str, float]) -> Dict[str, Any]:
     cash_flows = [cash_flow for _ in range(years)]
     npv = sum(cf / ((1 + discount_rate) ** (i + 1)) for i, cf in enumerate(cash_flows))
     return {"cash_flows": cash_flows, "npv": npv}
+
+
+def load_sector_equity_map(path: str | Path = _MAP_PATH) -> Dict[str, list[str]]:
+    """Return the sector-to-equity mapping from ``path``."""
+
+    mapping: Dict[str, list[str]] = {}
+    with Path(path).open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            sector = (row.get("sector") or "").strip()
+            ticker = (row.get("ticker") or "").strip()
+            if not sector or not ticker:
+                continue
+            mapping.setdefault(sector, []).append(ticker)
+    return mapping
+
+
+def propagate_shocks_to_tickers(shocks: Dict[str, float], *, map_path: str | Path = _MAP_PATH) -> str:
+    """Propagate ``shocks`` to equity tickers and return the result as JSON."""
+
+    mapping = load_sector_equity_map(map_path)
+    impacts: Dict[str, float] = {}
+    for sector, pct in shocks.items():
+        tickers = mapping.get(sector, [])
+        for ticker in tickers:
+            impacts[ticker] = impacts.get(ticker, 0.0) + float(pct)
+    return json.dumps(impacts)
 

--- a/tests/test_finance_adapter.py
+++ b/tests/test_finance_adapter.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from src.finance.adapter import delta_sector_to_dcf
+import json
+
+from src.finance.adapter import delta_sector_to_dcf, propagate_shocks_to_tickers
 
 
 def test_delta_sector_to_dcf_npv() -> None:
@@ -14,4 +16,14 @@ def test_delta_sector_to_dcf_npv() -> None:
     result = delta_sector_to_dcf(sector_state)
     expected_npv = 497370.3981968444
     assert result["npv"] == pytest.approx(expected_npv, rel=0.02)
+
+
+def test_propagate_shocks_to_tickers() -> None:
+    shocks = {"smartphones": -0.1, "retail": -0.05, "apps": 0.02}
+    result_json = propagate_shocks_to_tickers(shocks)
+    impacts = json.loads(result_json)
+    assert impacts["AAPL"] == pytest.approx(-0.1)
+    assert impacts["AMZN"] == pytest.approx(-0.05)
+    # MSFT appears in apps and cloud_compute; only apps is provided
+    assert impacts["MSFT"] == pytest.approx(0.02)
 


### PR DESCRIPTION
## Summary
- add `sector_equity_map.csv` dataset
- extend finance adapter with CSV loader and shock propagation
- test shock propagation logic

## Testing
- `pre-commit run --files src/finance/adapter.py data/sector_equity_map.csv tests/test_finance_adapter.py` *(failed: Could not fetch hook dependencies)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: 56 failed, 453 passed, 25 skipped)*