### PR TITLE
[alpha_factory] add stake governance registry

### DIFF
--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/src/governance/stake_registry.py
+++ b/src/governance/stake_registry.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Simple stake registry supporting stake-weighted voting."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, MutableMapping
+
+
+@dataclass
+class StakeRegistry:
+    """In-memory stake and vote tracking."""
+
+    stakes: MutableMapping[str, float] = field(default_factory=dict)
+    votes: Dict[str, Dict[str, bool]] = field(default_factory=dict)
+
+    def set_stake(self, agent_id: str, amount: float) -> None:
+        """Register ``agent_id`` with ``amount`` tokens."""
+        self.stakes[agent_id] = float(amount)
+
+    def burn(self, agent_id: str, fraction: float) -> None:
+        """Burn ``fraction`` of ``agent_id``'s stake if present."""
+        if agent_id in self.stakes:
+            self.stakes[agent_id] = max(0.0, self.stakes[agent_id] * (1.0 - fraction))
+
+    def total(self) -> float:
+        """Return total stake across all agents."""
+        return float(sum(self.stakes.values()))
+
+    def vote(self, proposal_id: str, agent_id: str, support: bool) -> None:
+        """Record ``agent_id``'s vote for ``proposal_id``."""
+        if agent_id not in self.stakes:
+            raise ValueError(f"unknown agent {agent_id}")
+        self.votes.setdefault(proposal_id, {})[agent_id] = bool(support)
+
+    def accepted(self, proposal_id: str) -> bool:
+        """Return ``True`` iff yes votes reach two-thirds of total stake."""
+        total = self.total()
+        if total == 0:
+            return False
+        votes = self.votes.get(proposal_id, {})
+        yes = sum(self.stakes[a] for a, v in votes.items() if v)
+        return yes / total >= 2 / 3

--- a/tests/test_slash_e2e.py
+++ b/tests/test_slash_e2e.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import messaging, config
+
+pytestmark = [pytest.mark.e2e]
+
+
+def test_slash_on_forged_ledger(tmp_path, monkeypatch) -> None:
+    settings = config.Settings(bus_port=0, ledger_path=str(tmp_path / "ledger.db"))
+    monkeypatch.setattr(orchestrator.Orchestrator, "_init_agents", lambda self: [])
+    orch = orchestrator.Orchestrator(settings)
+    orch.registry.set_stake("A", 100)
+    original_root = orch.ledger.compute_merkle_root()
+    env = messaging.Envelope("A", "b", {"v": 1}, 0.0)
+    orch.ledger.log(env)
+    orch.verify_merkle_root(original_root, "A")
+    assert orch.registry.stakes["A"] == 90

--- a/tests/test_stake_registry.py
+++ b/tests/test_stake_registry.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+from src.governance.stake_registry import StakeRegistry
+
+
+def test_stake_weighted_acceptance() -> None:
+    reg = StakeRegistry()
+    reg.set_stake("A", 50)
+    reg.set_stake("B", 30)
+    reg.set_stake("C", 20)
+    reg.vote("p1", "A", True)
+    reg.vote("p1", "B", True)
+    reg.vote("p1", "C", False)
+    assert reg.accepted("p1")
+    reg.vote("p2", "A", True)
+    reg.vote("p2", "B", False)
+    reg.vote("p2", "C", False)
+    assert not reg.accepted("p2")


### PR DESCRIPTION
## Summary
- add stake registry module for token-weighted voting
- integrate registry into the Insight orchestrator and expose slash() and verify_merkle_root()
- test stake-weighted proposal acceptance and ledger slashing behaviour

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 24 failed, 191 passed, 18 skipped)*