### PR TITLE
[alpha_factory] Add replay benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,33 @@
+name: "📈 Replay Bench"
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+jobs:
+  replay-bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.lock
+      - name: Run replay harness
+        run: python scripts/run_replay_bench.py
+      - name: Commit results
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add docs/bench_history.csv
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update bench history"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 # **META-AGENTIC** α‑AGI 👁️✨ 
+[![Replay Bench](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/actions/workflows/bench.yml/badge.svg)](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/actions/workflows/bench.yml)
 
 **Out‑learn · Out‑think · Out‑design · Out‑strategise · Out‑execute**
 

--- a/docs/bench_history.csv
+++ b/docs/bench_history.csv
@@ -1,0 +1,1 @@
+scenario,f1,auroc,lead_time

--- a/scripts/run_replay_bench.py
+++ b/scripts/run_replay_bench.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Run the replay harness and append metrics."""
+from __future__ import annotations
+from pathlib import Path
+from src.simulation import replay
+
+
+def main() -> None:
+    out = Path("docs/bench_history.csv")
+    for name in replay.available_scenarios():
+        scn = replay.load_scenario(name)
+        traj = replay.run_scenario(scn)
+        replay.score_trajectory(name, traj, csv_path=out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create weekly benchmark action
- add replay harness script
- track benchmark metrics in docs
- display workflow badge in README

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files README.md .github/workflows/bench.yml docs/bench_history.csv scripts/run_replay_bench.py` *(fails: Could not fetch hooks)*
- `pytest -q` *(fails: 57 failed, 454 passed, 25 skipped)*