### PR TITLE
[alpha_factory] add basic file ops

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,5 +3,6 @@
 
 from .config import CFG, get_secret
 from .visual import plot_pareto
+from .file_ops import view, str_replace
 
-__all__ = ["CFG", "get_secret", "plot_pareto"]
+__all__ = ["CFG", "get_secret", "plot_pareto", "view", "str_replace"]

--- a/src/utils/file_ops.py
+++ b/src/utils/file_ops.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Basic file manipulation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["view", "str_replace"]
+
+
+def view(path: str | Path, start: int = 0, end: int | None = None) -> str:
+    """Return a slice of lines from ``path``.
+
+    Parameters
+    ----------
+    path:
+        File to read.
+    start:
+        Zero-based start line. Negative values count from the end.
+    end:
+        Exclusive end line. ``None`` reads to EOF.
+    """
+    lines = Path(path).read_text(encoding="utf-8", errors="replace").splitlines()
+    sliced = lines[start:end] if end is not None else lines[start:]
+    return "\n".join(sliced)
+
+
+def str_replace(path: str | Path, old: str, new: str, *, count: int = 0) -> int:
+    """Replace ``old`` with ``new`` inside ``path``.
+
+    Parameters
+    ----------
+    path:
+        File to modify in-place.
+    old:
+        Substring to search for.
+    new:
+        Replacement text.
+    count:
+        Maximum number of replacements. ``0`` means replace all.
+
+    Returns
+    -------
+    int
+        Number of substitutions performed.
+    """
+    p = Path(path)
+    text = p.read_text(encoding="utf-8", errors="replace")
+    if count:
+        new_text = text.replace(old, new, count)
+        num = text.count(old, 0, len(text))
+        num = min(num, count)
+    else:
+        new_text = text.replace(old, new)
+        num = text.count(old)
+    if num:
+        p.write_text(new_text, encoding="utf-8")
+    return num
+

--- a/tests/test_file_ops.py
+++ b/tests/test_file_ops.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+from src.utils.file_ops import view, str_replace
+
+
+def test_view_basic(tmp_path: Path) -> None:
+    p = tmp_path / "f.txt"
+    p.write_text("a\nb\nc\nd\n")
+    assert view(p, 1, 3) == "b\nc"
+    assert view(p, -2) == "c\nd"
+    assert view(p) == "a\nb\nc\nd"
+
+
+def test_str_replace_basic(tmp_path: Path) -> None:
+    p = tmp_path / "f.txt"
+    p.write_text("foo bar foo")
+    n = str_replace(p, "foo", "baz")
+    assert n == 2
+    assert p.read_text() == "baz bar baz"
+
+
+def test_str_replace_count(tmp_path: Path) -> None:
+    p = tmp_path / "f.txt"
+    p.write_text("abc abc abc")
+    n = str_replace(p, "abc", "xyz", count=1)
+    assert n == 1
+    assert p.read_text() == "xyz abc abc"
+
+
+def test_str_replace_not_found(tmp_path: Path) -> None:
+    p = tmp_path / "f.txt"
+    p.write_text("hello world")
+    n = str_replace(p, "foo", "bar")
+    assert n == 0
+    assert p.read_text() == "hello world"


### PR DESCRIPTION
## Summary
- implement `view` and `str_replace` helpers
- expose helpers in utils package
- add unit tests

## Testing
- `pre-commit run --files src/utils/file_ops.py src/utils/__init__.py tests/test_file_ops.py` *(fails: couldn't fetch pre-commit dependencies)*
- `python check_env.py --auto-install`
- `pytest -q tests/test_file_ops.py`
- `pytest -q` *(fails: 4 errors during collection)*