### PR TITLE
[alpha_factory] add self-improve prompt config

### DIFF
--- a/src/prompts/self_improve.yaml
+++ b/src/prompts/self_improve.yaml
@@ -1,0 +1,4 @@
+system: |
+  You are the SelfImprover agent. Apply patches safely.
+user: |
+  Propose improvements for the repository.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for self-improvement prompt loading."""
+
+from pathlib import Path
+
+import yaml
+
+from src.utils import config
+
+
+def test_self_improve_template_parses(tmp_path, monkeypatch):
+    data = {"system": "sys", "user": "usr"}
+    path = tmp_path / "tpl.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    monkeypatch.setenv("SELF_IMPROVE_TEMPLATE", str(path))
+    config.init_config()
+    cfg = config.Settings()
+    assert cfg.self_improve.system == "sys"
+    assert cfg.self_improve.user == "usr"


### PR DESCRIPTION
## Summary
- add template YAML under `src/prompts`
- load template in `Settings` via `SELF_IMPROVE_TEMPLATE`
- test prompt parsing

## Testing
- `pre-commit run --files src/utils/config.py src/prompts/self_improve.yaml tests/test_prompts.py` *(fails: unable to access 'https://github.com/psf/black/')*
- `python check_env.py --auto-install`
- `pytest -q tests/test_prompts.py`