### PR TITLE
[alpha_factory] Lineage dashboard

### DIFF
--- a/src/interface/lineage_dashboard.py
+++ b/src/interface/lineage_dashboard.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streamlit dashboard visualising archive lineage."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+import pandas as pd
+import plotly.express as px
+
+from src.archive import Archive
+
+try:  # pragma: no cover - optional dependency
+    import streamlit as _st
+    from streamlit_autorefresh import st_autorefresh as _autorefresh
+except Exception:  # pragma: no cover - optional
+    _st = None
+    _autorefresh = None
+
+st: Any | None = _st
+st_autorefresh: Any | None = _autorefresh
+
+__all__ = ["load_df", "build_tree", "main"]
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from plotly.graph_objs import Figure
+else:  # pragma: no cover - typing runtime
+    Figure = Any
+
+
+def load_df(db_path: str | Path) -> pd.DataFrame:
+    """Return archive contents as a DataFrame."""
+    arch = Archive(db_path)
+    rows = []
+    for a in arch.all():
+        rows.append(
+            {
+                "id": a.id,
+                "parent": a.meta.get("parent"),
+                "patch": a.meta.get("diff") or a.meta.get("patch"),
+                "score": a.score,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def build_tree(df: pd.DataFrame) -> Figure:
+    """Return Plotly treemap figure for lineage."""
+    if df.empty:
+        return px.treemap()
+
+    ids = df["id"].astype(str)
+    parents = df["parent"].fillna("").astype(str)
+    fig = px.treemap(
+        df,
+        ids=ids,
+        parents=parents,
+        values=[1] * len(df),
+        color="score",
+        custom_data=[df["patch"].fillna("")],
+        color_continuous_scale="Blues",
+    )
+    labels = [f"<a href='{p}'>{i}</a>" if p else str(i) for i, p in zip(ids, df["patch"].fillna(""))]
+    fig.data[0].text = labels
+    fig.data[0].hovertemplate = (
+        "score=%{color}<br>patch=%{customdata[0]}<extra></extra>"
+    )
+    return fig
+
+
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - entry point
+    """Launch the lineage dashboard."""
+    if st is None:
+        print("Streamlit not installed")
+        return
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        default=os.getenv("ARCHIVE_PATH", "archive.db"),
+        help="Path to archive database",
+    )
+    parser.add_argument(
+        "--refresh",
+        type=int,
+        default=int(os.getenv("DASH_REFRESH", "10")),
+        help="Auto-refresh interval in seconds",
+    )
+    args = parser.parse_args(argv)
+
+    st.set_page_config(page_title="Lineage Dashboard", layout="wide")
+    if st_autorefresh is not None:
+        st_autorefresh(interval=args.refresh * 1000, key="refresh")
+
+    df = load_df(Path(args.db))
+    if df.empty:
+        st.info("Archive empty")
+        return
+
+    fig = build_tree(df)
+    st.plotly_chart(fig, use_container_width=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    main()
+

--- a/tests/test_lineage_dashboard.py
+++ b/tests/test_lineage_dashboard.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import plotly.graph_objects as go
+
+from src.archive import Archive
+from src.interface import lineage_dashboard as ld
+
+
+def test_load_df(tmp_path: Path) -> None:
+    db = tmp_path / "a.db"
+    arch = Archive(db)
+    arch.add({"diff": "root.patch"}, 0.5)
+    arch.add({"parent": 1, "diff": "child.patch"}, 0.8)
+    df = ld.load_df(db)
+    assert list(df.columns) == ["id", "parent", "patch", "score"]
+    assert len(df) == 2
+    assert df.iloc[1]["parent"] == 1
+
+
+def test_build_tree(tmp_path: Path) -> None:
+    db = tmp_path / "a.db"
+    arch = Archive(db)
+    arch.add({"diff": "root.patch"}, 1.0)
+    arch.add({"parent": 1, "diff": "child.patch"}, 0.6)
+    df = ld.load_df(db)
+    fig = ld.build_tree(df)
+    assert isinstance(fig, go.Figure)
+    data = fig.data[0]
+    assert len(data.ids) == 2
+    assert "child.patch" in data.hovertemplate
+
+
+def test_main_no_streamlit(monkeypatch) -> None:
+    mod_name = "src.interface.lineage_dashboard"
+    monkeypatch.setitem(sys.modules, "streamlit", None)
+    monkeypatch.setitem(sys.modules, "streamlit_autorefresh", None)
+    mod = importlib.reload(importlib.import_module(mod_name))
+    mod.main([])


### PR DESCRIPTION
## Summary
- add Streamlit lineage dashboard
- visualize archive records as a Plotly treemap
- auto-refresh on interval
- unit tests for dataframe conversion, figure build and no-streamlit fallback

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py, tests/test_cli.py, tests/test_cli_runner_ext.py, tests/test_demo_cli.py)*