### PR TITLE
[alpha_factory] implement SQLAlchemy archive db

### DIFF
--- a/src/archive/__init__.py
+++ b/src/archive/__init__.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List
 
+from .db import ArchiveDB, ArchiveEntry
+
 
 @dataclass(slots=True)
 class Agent:
@@ -53,3 +55,6 @@ class Archive:
         weights = [1.0 / (1.0 + math.exp(-lam * (a.score - alpha0))) for a in agents]
         chosen = random.choices(agents, weights=weights, k=min(k, len(agents)))
         return chosen
+
+
+__all__ = ["Agent", "Archive", "ArchiveDB", "ArchiveEntry"]

--- a/src/archive/db.py
+++ b/src/archive/db.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SQLAlchemy-backed archive database."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+import dataclasses
+from pathlib import Path
+from typing import Iterator, Optional
+
+from sqlalchemy import Boolean, Column, Float, String, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+
+Base = declarative_base()
+
+
+@dataclass(slots=True)
+class ArchiveEntry:
+    """Archive row representation."""
+
+    hash: str
+    parent: Optional[str]
+    score: float
+    novelty: float
+    is_live: bool
+    ts: float
+
+
+class _ArchiveRow(Base):
+    __tablename__ = "archive"
+
+    hash = Column(String, primary_key=True)
+    parent = Column(String, nullable=True)
+    score = Column(Float, default=0.0)
+    novelty = Column(Float, default=0.0)
+    is_live = Column(Boolean, default=True)
+    ts = Column(Float)
+
+
+class ArchiveDB:
+    """Simple wrapper around ``sqlalchemy`` for archive access."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.engine = create_engine(f"sqlite:///{self.path}")
+        Base.metadata.create_all(self.engine)
+        with Session(self.engine) as session:
+            exists = session.query(_ArchiveRow).first() is not None
+        if not exists:
+            self._migrate_legacy()
+
+    def _migrate_legacy(self) -> None:
+        json_path = self.path.with_name("archive.json")
+        if not json_path.exists():
+            return
+        try:
+            records = json.loads(json_path.read_text())
+        except Exception:
+            return
+        with Session(self.engine) as session:
+            for rec in records:
+                row = _ArchiveRow(
+                    hash=rec["hash"],
+                    parent=rec.get("parent"),
+                    score=rec.get("score", 0.0),
+                    novelty=rec.get("novelty", 0.0),
+                    is_live=rec.get("is_live", True),
+                    ts=rec.get("ts", time.time()),
+                )
+                session.merge(row)
+            session.commit()
+
+    def add(self, entry: ArchiveEntry) -> None:
+        with Session(self.engine) as session:
+            session.merge(_ArchiveRow(**dataclasses.asdict(entry)))
+            session.commit()
+
+    def get(self, h: str) -> ArchiveEntry | None:
+        with Session(self.engine) as session:
+            row = session.get(_ArchiveRow, h)
+            if row is None:
+                return None
+            return ArchiveEntry(
+                hash=row.hash,
+                parent=row.parent,
+                score=row.score,
+                novelty=row.novelty,
+                is_live=row.is_live,
+                ts=row.ts,
+            )
+
+    def history(self, start_hash: str) -> Iterator[ArchiveEntry]:
+        current = self.get(start_hash)
+        while current is not None:
+            yield current
+            if not current.parent:
+                break
+            current = self.get(current.parent)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,29 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import random
+import json
 
-from src.archive import Archive
+import pytest
 
-
-def test_archive_insert_and_load(tmp_path) -> None:
-    db = tmp_path / "a.db"
-    arch = Archive(db)
-    arch.add({"name": "a"}, 0.1)
-    arch.add({"name": "b"}, 0.2)
-    rows = arch.all()
-    assert len(rows) == 2
-    assert rows[0].meta["name"] == "a"
+from src.archive.db import ArchiveDB, ArchiveEntry
 
 
-def test_sample_bias(tmp_path) -> None:
-    db = tmp_path / "a.db"
-    arch = Archive(db)
-    arch.add({"name": "low"}, 0.0)
-    arch.add({"name": "high"}, 1.0)
-    random.seed(0)
-    counts = {"low": 0, "high": 0}
-    for _ in range(50):
-        chosen = arch.sample(1)[0]
-        counts[chosen.meta["name"]] += 1
-    assert counts["high"] > counts["low"]
+@pytest.fixture
+def TestArchiveMigration(tmp_path):
+    def _factory(entries):
+        (tmp_path / "archive.json").write_text(json.dumps(entries))
+        return ArchiveDB(tmp_path / "archive.db")
+
+    return _factory
+
+
+def test_archive_crud(tmp_path) -> None:
+    db = ArchiveDB(tmp_path / "arch.db")
+    root = ArchiveEntry("h1", None, 0.1, 0.0, True, 1.0)
+    child = ArchiveEntry("h2", "h1", 0.2, 0.0, False, 2.0)
+    db.add(root)
+    db.add(child)
+
+    assert db.get("h2") == child
+    history = list(db.history("h2"))
+    assert [e.hash for e in history] == ["h2", "h1"]
+
+
+def test_archive_migration(TestArchiveMigration) -> None:
+    entries = [
+        {"hash": "a", "parent": None, "score": 0.3, "novelty": 0.1, "is_live": True, "ts": 1.0},
+        {"hash": "b", "parent": "a", "score": 0.4, "novelty": 0.2, "is_live": False, "ts": 2.0},
+    ]
+    db = TestArchiveMigration(entries)
+    assert db.get("a") is not None
+    assert db.get("b").parent == "a"


### PR DESCRIPTION
## Summary
- convert `src.archive` to a package
- add `ArchiveDB` and `ArchiveEntry` using SQLAlchemy
- migrate legacy `archive.json` on first run
- rewrite archive unit tests with migration fixture

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_archive.py -q`
- `pytest -q` *(fails: 4 errors during collection)*