### PR TITLE
[alpha_factory] Add softmax-based parent selector

### DIFF
--- a/src/archive/selector.py
+++ b/src/archive/selector.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parent selection helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+
+
+def select_parent(population: Sequence[Any], temp: float) -> Any:
+    """Return a candidate chosen via softmax of ``fitness * novelty``.
+
+    Args:
+        population: Sequence of candidates exposing ``fitness`` and ``novelty`` attributes.
+        temp: Softmax temperature. Higher values yield a more uniform distribution.
+
+    Returns:
+        The selected candidate from ``population``.
+    """
+    if not population:
+        raise ValueError("population is empty")
+    if temp <= 0:
+        raise ValueError("temp must be positive")
+
+    scores = np.asarray([float(getattr(ind, "fitness")) * float(getattr(ind, "novelty")) for ind in population])
+    logits = scores / temp
+    weights = np.exp(logits - np.max(logits))
+    probs = weights / weights.sum()
+
+    index = int(np.random.choice(len(population), p=probs))
+    return population[index]

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+from src.archive.selector import select_parent
+
+
+@dataclass(slots=True)
+class Candidate:
+    fitness: float
+    novelty: float
+
+
+def softmax(arr: np.ndarray) -> np.ndarray:
+    exp = np.exp(arr - np.max(arr))
+    return exp / exp.sum()
+
+
+def sample_distribution(pop, temp, runs=20000):
+    np.random.seed(42)
+    counts = {id(ind): 0 for ind in pop}
+    for _ in range(runs):
+        ind = select_parent(pop, temp)
+        counts[id(ind)] += 1
+    return np.asarray([counts[id(ind)] / runs for ind in pop])
+
+
+def test_select_parent_softmax() -> None:
+    pop = [
+        Candidate(1.0, 1.0),
+        Candidate(0.5, 2.0),
+        Candidate(2.0, 0.5),
+    ]
+    temp = 1.0
+    expected = softmax(np.asarray([p.fitness * p.novelty for p in pop]) / temp)
+    observed = sample_distribution(pop, temp)
+    assert np.allclose(observed, expected, atol=0.02)
+
+
+def test_select_parent_temperature() -> None:
+    pop = [
+        Candidate(1.0, 1.0),
+        Candidate(0.5, 2.0),
+        Candidate(2.0, 0.5),
+    ]
+    temp = 0.5
+    expected = softmax(np.asarray([p.fitness * p.novelty for p in pop]) / temp)
+    observed = sample_distribution(pop, temp)
+    assert np.allclose(observed, expected, atol=0.02)


### PR DESCRIPTION
## Summary
- implement `select_parent` for novelty-driven selection
- verify selection follows softmax distribution

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/archive/selector.py tests/test_selector.py` *(fails: Couldn't connect to server)*
- `pytest -q tests/test_selector.py`
- `pytest -q` *(fails: 4 errors during collection)*