### PR TITLE
[alpha_factory] add SelfRewriteOperator

### DIFF
--- a/src/simulation/__init__.py
+++ b/src/simulation/__init__.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Lightweight simulation helpers."""
 
-from .mats_ops import GaussianParam, PromptRewrite, CodePatch
+from .mats_ops import GaussianParam, PromptRewrite, CodePatch, SelfRewriteOperator
 from .replay import Scenario, available_scenarios, load_scenario, run_scenario
 
 __all__ = [
     "GaussianParam",
     "PromptRewrite",
     "CodePatch",
+    "SelfRewriteOperator",
     "Scenario",
     "available_scenarios",
     "load_scenario",

--- a/src/simulation/mats_ops.py
+++ b/src/simulation/mats_ops.py
@@ -44,3 +44,17 @@ class CodePatch:
         if not code.endswith("\n"):
             code += "\n"
         return code + suffix + "\n"
+
+
+class SelfRewriteOperator:
+    """Apply ``PromptRewrite`` multiple times."""
+
+    def __init__(self, steps: int = 2, rng: random.Random | None = None) -> None:
+        self.steps = steps
+        self.rng = rng or random.Random()
+        self._op = PromptRewrite(rng=self.rng)
+
+    def __call__(self, text: str) -> str:
+        for _ in range(self.steps):
+            text = self._op(text)
+        return text

--- a/tests/test_self_rewrite.py
+++ b/tests/test_self_rewrite.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+import random
+
+from src.simulation import SelfRewriteOperator
+
+
+class TestSelfRewriteOperator(unittest.TestCase):
+    def test_self_rewrite_happy_path(self) -> None:
+        rng = random.Random(42)
+        op = SelfRewriteOperator(steps=2, rng=rng)
+        text = "improve quick test"
+        result = op(text)
+        self.assertEqual(result, "enhance quick trial")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a SelfRewriteOperator utility that applies PromptRewrite multiple times
- expose SelfRewriteOperator from simulation
- test basic behaviour

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/simulation/mats_ops.py src/simulation/__init__.py tests/test_self_rewrite.py` *(fails: couldn't connect to github.com)*
- `pytest -q tests/test_self_rewrite.py`
- `make unit` *(fails: `missing separator`)*