### PR TITLE
[alpha_factory] add self-edit tools

### DIFF
--- a/src/self_edit/__init__.py
+++ b/src/self_edit/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Self-editing utilities."""
+
+from .tools import view, edit, replace
+
+__all__ = ["view", "edit", "replace"]

--- a/src/self_edit/tools.py
+++ b/src/self_edit/tools.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""File manipulation helpers for self-editing agents."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+# Optional OpenAI Agents SDK ---------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from agents import function_tool, RunContextWrapper  # type: ignore
+
+    _HAVE_AGENTS = True
+except ModuleNotFoundError:  # pragma: no cover - stub fallbacks
+
+    def function_tool(*_dargs, **_dkwargs):
+        def _wrap(func):
+            return func
+
+        return _wrap
+
+    RunContextWrapper = dict  # type: ignore
+    _HAVE_AGENTS = False
+
+# Optional Google ADK ----------------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    import google_adk as adk  # type: ignore
+
+    _HAVE_ADK = True
+except ModuleNotFoundError:  # pragma: no cover - stub fallbacks
+
+    class _StubAgent:  # type: ignore
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _StubDecor:  # type: ignore
+        def __call__(self, func):
+            return func
+
+    class adk:  # type: ignore
+        Agent = _StubAgent
+
+        @staticmethod
+        def task(**_kw):
+            return _StubDecor()
+
+        JsonSchema = dict
+
+    _HAVE_ADK = False
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+__all__ = [
+    "view",
+    "edit",
+    "replace",
+    "view_tool",
+    "edit_tool",
+    "replace_tool",
+    "FileToolsADK",
+]
+
+
+def _safe_path(path: str | Path) -> Path:
+    p = Path(path).expanduser().resolve()
+    if REPO_ROOT not in p.parents and p != REPO_ROOT:
+        raise PermissionError(f"path '{p}' outside repository root")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+def view(path: str | Path, start: int = 0, end: Optional[int] = None) -> str:
+    """Return lines ``start:end`` from ``path``."""
+    p = _safe_path(path)
+    lines = p.read_text(encoding="utf-8", errors="replace").splitlines()
+    sliced = lines[start:end] if end is not None else lines[start:]
+    return "\n".join(sliced)
+
+
+def edit(path: str | Path, start: int, end: Optional[int], new_code: str) -> None:
+    """Replace lines ``start:end`` in ``path`` with ``new_code``."""
+    p = _safe_path(path)
+    lines = p.read_text(encoding="utf-8", errors="replace").splitlines()
+    new_lines = new_code.splitlines()
+    if end is None:
+        end = start
+    lines[start:end] = new_lines
+    p.write_text("\n".join(lines), encoding="utf-8")
+
+
+def replace(path: str | Path, pattern: str, repl: str) -> int:
+    """Regex replace ``pattern`` with ``repl`` inside ``path``."""
+    p = _safe_path(path)
+    text = p.read_text(encoding="utf-8", errors="replace")
+    new_text, n = re.subn(pattern, repl, text, flags=re.MULTILINE)
+    if n:
+        p.write_text(new_text, encoding="utf-8")
+    return n
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Agents wrappers
+# ---------------------------------------------------------------------------
+
+
+def _view_tool(ctx: RunContextWrapper | dict, path: str, start: int = 0, end: Optional[int] = None) -> str:
+    return view(path, start, end)
+
+
+def _edit_tool(ctx: RunContextWrapper | dict, path: str, start: int, end: Optional[int], new_code: str) -> str:
+    edit(path, start, end, new_code)
+    return "ok"
+
+
+def _replace_tool(ctx: RunContextWrapper | dict, path: str, pattern: str, repl: str) -> int:
+    return replace(path, pattern, repl)
+
+
+if _HAVE_AGENTS:  # pragma: no cover - thin wrapper
+    view_tool = function_tool(
+        name_override="view_file",
+        description_override="Return selected lines from a repository file",
+        strict_mode=False,
+    )(_view_tool)
+
+    edit_tool = function_tool(
+        name_override="edit_file",
+        description_override="Replace a line range inside a repository file",
+        strict_mode=False,
+    )(_edit_tool)
+
+    replace_tool = function_tool(
+        name_override="replace_text",
+        description_override="Regex search/replace inside a repository file",
+        strict_mode=False,
+    )(_replace_tool)
+else:  # pragma: no cover - simple alias
+    view_tool = _view_tool
+    edit_tool = _edit_tool
+    replace_tool = _replace_tool
+
+
+# ---------------------------------------------------------------------------
+# Google ADK adapter
+# ---------------------------------------------------------------------------
+class FileToolsADK(adk.Agent):
+    """Expose file utilities via Google ADK."""
+
+    def __init__(self) -> None:
+        super().__init__(name="file_tools")
+
+    @adk.task(
+        name="view",
+        description="Return selected lines from a repository file",
+        input_schema=adk.JsonSchema(
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "start": {"type": "integer", "default": 0},
+                    "end": {"type": ["integer", "null"], "default": None},
+                },
+                "required": ["path"],
+            }
+        ),
+        output_schema=adk.JsonSchema(
+            {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]}
+        ),
+    )
+    def view_task(self, *, path: str, start: int = 0, end: Optional[int] = None) -> dict[str, str]:
+        return {"text": view(path, start, end)}
+
+    @adk.task(
+        name="edit",
+        description="Replace a line range inside a repository file",
+        input_schema=adk.JsonSchema(
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "start": {"type": "integer"},
+                    "end": {"type": ["integer", "null"]},
+                    "new_code": {"type": "string"},
+                },
+                "required": ["path", "start", "new_code"],
+            }
+        ),
+        output_schema=adk.JsonSchema({"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}),
+    )
+    def edit_task(self, *, path: str, start: int, end: Optional[int] = None, new_code: str) -> dict[str, bool]:
+        edit(path, start, end, new_code)
+        return {"ok": True}
+
+    @adk.task(
+        name="replace",
+        description="Regex search/replace inside a repository file",
+        input_schema=adk.JsonSchema(
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "pattern": {"type": "string"},
+                    "repl": {"type": "string"},
+                },
+                "required": ["path", "pattern", "repl"],
+            }
+        ),
+        output_schema=adk.JsonSchema(
+            {"type": "object", "properties": {"count": {"type": "integer"}}, "required": ["count"]}
+        ),
+    )
+    def replace_task(self, *, path: str, pattern: str, repl: str) -> dict[str, int]:
+        return {"count": replace(path, pattern, repl)}

--- a/tests/test_self_edit_tools.py
+++ b/tests/test_self_edit_tools.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import re
+
+import pytest
+
+from src.self_edit.tools import view, edit, replace, REPO_ROOT
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, strategies as st
+
+
+@pytest.fixture()
+def temp_file():
+    path = REPO_ROOT / "tmp_self_edit.txt"
+    try:
+        yield path
+    finally:
+        if path.exists():
+            path.unlink()
+
+
+def test_edit_and_view(temp_file: Path) -> None:
+    temp_file.write_text("a\nb\nc\n")
+    edit(temp_file, 1, 2, "X")
+    assert temp_file.read_text() == "a\nX\nc"
+    assert view(temp_file, 0, 2) == "a\nX"
+
+
+def test_replace_regex(temp_file: Path) -> None:
+    temp_file.write_text("foo bar foo\n")
+    n = replace(temp_file, r"foo", "baz")
+    assert n == 2
+    assert temp_file.read_text() == "baz bar baz\n"
+
+
+@given(data=st.text())
+def test_replace_property(data: str) -> None:
+    path = REPO_ROOT / "tmp_self_edit_prop.txt"
+    try:
+        path.write_bytes(data.encode())
+        count = replace(path, "a", "b")
+        expected, exp_count = re.subn("a", "b", data, flags=re.MULTILINE)
+        assert count == exp_count
+        assert path.read_bytes().decode() == expected
+    finally:
+        if path.exists():
+            path.unlink()
+
+
+def test_outside_repo_forbidden(tmp_path: Path) -> None:
+    p = tmp_path / "x.txt"
+    p.write_text("hi")
+    with pytest.raises(PermissionError):
+        edit(p, 0, 1, "bye")
+    with pytest.raises(PermissionError):
+        replace(p, "hi", "ho")


### PR DESCRIPTION
## Summary
- implement guarded file editing helpers
- expose edit/view/replace tools for OpenAI Agents and Google ADK
- test file editing logic with pytest and hypothesis

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/self_edit/tools.py src/self_edit/__init__.py tests/test_self_edit_tools.py` *(fails: Failed to connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rocketry')*
- `pytest tests/test_self_edit_tools.py -q`