### PR TITLE
[alpha_factory] add mini benchmark suites

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,7 @@ jobs:
         run: python scripts/run_replay_bench.py
       - name: Run micro benchmarks
         run: |
-          python benchmarks/run_benchmarks.py > bench_results.json
+          make benchmark
       - name: Upload micro benchmark results
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build_web demo-setup demo-run compose-up loadtest proto proto-verify
+.PHONY: build_web demo-setup demo-run compose-up loadtest proto proto-verify benchmark
 
 build_web:
 	pnpm --dir src/interface/web_client install
@@ -35,3 +35,6 @@ proto:
 proto-verify:
         $(MAKE) proto
         git --no-pager diff --exit-code src/utils/a2a_pb2.py alpha_factory_v1/proto/go/a2a.pb.go
+
+benchmark:
+	python benchmarks/docker_runner.py > bench_results.json

--- a/benchmarks/docker_runner.py
+++ b/benchmarks/docker_runner.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Run benchmarks inside Docker and enforce runtime limit."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from time import perf_counter_ns
+
+ROOT = Path(__file__).resolve().parent
+IMAGE = "python:3.11-slim"
+
+
+def _run_container() -> str:
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{ROOT.parent}:/work",
+        "-w",
+        "/work",
+        IMAGE,
+        "python",
+        "benchmarks/run_benchmarks.py",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return result.stdout
+
+
+def main() -> None:
+    t0 = perf_counter_ns()
+    out = _run_container()
+    elapsed_ms = int((perf_counter_ns() - t0) / 1_000_000)
+    data = json.loads(out)
+    json.dump(data, sys.stdout)
+    sys.stdout.write("\n")
+    avg_ms = sum(d["time_ms"] for d in data) / len(data)
+    if avg_ms > 300_000:  # 5 minutes
+        raise SystemExit(
+            f"Average runtime {avg_ms/1000:.1f}s exceeds 5 minute limit (total {elapsed_ms/1000:.1f}s)"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/benchmarks/poly_mini/__init__.py
+++ b/benchmarks/poly_mini/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/poly_mini/task_001.py
+++ b/benchmarks/poly_mini/task_001.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 001."""
+
+def run() -> None:
+    parts = ["poly", "task", "1"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(1)

--- a/benchmarks/poly_mini/task_002.py
+++ b/benchmarks/poly_mini/task_002.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 002."""
+
+def run() -> None:
+    parts = ["poly", "task", "2"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(2)

--- a/benchmarks/poly_mini/task_003.py
+++ b/benchmarks/poly_mini/task_003.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 003."""
+
+def run() -> None:
+    parts = ["poly", "task", "3"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(3)

--- a/benchmarks/poly_mini/task_004.py
+++ b/benchmarks/poly_mini/task_004.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 004."""
+
+def run() -> None:
+    parts = ["poly", "task", "4"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(4)

--- a/benchmarks/poly_mini/task_005.py
+++ b/benchmarks/poly_mini/task_005.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 005."""
+
+def run() -> None:
+    parts = ["poly", "task", "5"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(5)

--- a/benchmarks/poly_mini/task_006.py
+++ b/benchmarks/poly_mini/task_006.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 006."""
+
+def run() -> None:
+    parts = ["poly", "task", "6"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(6)

--- a/benchmarks/poly_mini/task_007.py
+++ b/benchmarks/poly_mini/task_007.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 007."""
+
+def run() -> None:
+    parts = ["poly", "task", "7"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(7)

--- a/benchmarks/poly_mini/task_008.py
+++ b/benchmarks/poly_mini/task_008.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 008."""
+
+def run() -> None:
+    parts = ["poly", "task", "8"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(8)

--- a/benchmarks/poly_mini/task_009.py
+++ b/benchmarks/poly_mini/task_009.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 009."""
+
+def run() -> None:
+    parts = ["poly", "task", "9"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(9)

--- a/benchmarks/poly_mini/task_010.py
+++ b/benchmarks/poly_mini/task_010.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 010."""
+
+def run() -> None:
+    parts = ["poly", "task", "10"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(10)

--- a/benchmarks/poly_mini/task_011.py
+++ b/benchmarks/poly_mini/task_011.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 011."""
+
+def run() -> None:
+    parts = ["poly", "task", "11"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(11)

--- a/benchmarks/poly_mini/task_012.py
+++ b/benchmarks/poly_mini/task_012.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 012."""
+
+def run() -> None:
+    parts = ["poly", "task", "12"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(12)

--- a/benchmarks/poly_mini/task_013.py
+++ b/benchmarks/poly_mini/task_013.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 013."""
+
+def run() -> None:
+    parts = ["poly", "task", "13"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(13)

--- a/benchmarks/poly_mini/task_014.py
+++ b/benchmarks/poly_mini/task_014.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 014."""
+
+def run() -> None:
+    parts = ["poly", "task", "14"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(14)

--- a/benchmarks/poly_mini/task_015.py
+++ b/benchmarks/poly_mini/task_015.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 015."""
+
+def run() -> None:
+    parts = ["poly", "task", "15"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(15)

--- a/benchmarks/poly_mini/task_016.py
+++ b/benchmarks/poly_mini/task_016.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 016."""
+
+def run() -> None:
+    parts = ["poly", "task", "16"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(16)

--- a/benchmarks/poly_mini/task_017.py
+++ b/benchmarks/poly_mini/task_017.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 017."""
+
+def run() -> None:
+    parts = ["poly", "task", "17"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(17)

--- a/benchmarks/poly_mini/task_018.py
+++ b/benchmarks/poly_mini/task_018.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 018."""
+
+def run() -> None:
+    parts = ["poly", "task", "18"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(18)

--- a/benchmarks/poly_mini/task_019.py
+++ b/benchmarks/poly_mini/task_019.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 019."""
+
+def run() -> None:
+    parts = ["poly", "task", "19"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(19)

--- a/benchmarks/poly_mini/task_020.py
+++ b/benchmarks/poly_mini/task_020.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Poly mini task 020."""
+
+def run() -> None:
+    parts = ["poly", "task", "20"]
+    joined = "-".join(parts)
+    assert joined.split("-")[2] == str(20)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -38,7 +38,12 @@ def run_task(task_id: str, module_name: str) -> dict[str, object]:
 def main() -> None:
     # Ensure the repository root is on sys.path so benchmark modules import
     sys.path.insert(0, str(ROOT.parent))
-    datasets = ["swebench_verified_mini", "polyglot_lite"]
+    datasets = [
+        "swebench_verified_mini",
+        "polyglot_lite",
+        "swe_mini",
+        "poly_mini",
+    ]
     results = []
     for ds in datasets:
         for task_id, module in _discover_tasks(ds):

--- a/benchmarks/swe_mini/__init__.py
+++ b/benchmarks/swe_mini/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/swe_mini/task_001.py
+++ b/benchmarks/swe_mini/task_001.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 001."""
+
+def run() -> None:
+    n = 1
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_002.py
+++ b/benchmarks/swe_mini/task_002.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 002."""
+
+def run() -> None:
+    n = 2
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_003.py
+++ b/benchmarks/swe_mini/task_003.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 003."""
+
+def run() -> None:
+    n = 3
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_004.py
+++ b/benchmarks/swe_mini/task_004.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 004."""
+
+def run() -> None:
+    n = 4
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_005.py
+++ b/benchmarks/swe_mini/task_005.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 005."""
+
+def run() -> None:
+    n = 5
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_006.py
+++ b/benchmarks/swe_mini/task_006.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 006."""
+
+def run() -> None:
+    n = 6
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_007.py
+++ b/benchmarks/swe_mini/task_007.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 007."""
+
+def run() -> None:
+    n = 7
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_008.py
+++ b/benchmarks/swe_mini/task_008.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 008."""
+
+def run() -> None:
+    n = 8
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_009.py
+++ b/benchmarks/swe_mini/task_009.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 009."""
+
+def run() -> None:
+    n = 9
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_010.py
+++ b/benchmarks/swe_mini/task_010.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 010."""
+
+def run() -> None:
+    n = 10
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_011.py
+++ b/benchmarks/swe_mini/task_011.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 011."""
+
+def run() -> None:
+    n = 11
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_012.py
+++ b/benchmarks/swe_mini/task_012.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 012."""
+
+def run() -> None:
+    n = 12
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_013.py
+++ b/benchmarks/swe_mini/task_013.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 013."""
+
+def run() -> None:
+    n = 13
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_014.py
+++ b/benchmarks/swe_mini/task_014.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 014."""
+
+def run() -> None:
+    n = 14
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_015.py
+++ b/benchmarks/swe_mini/task_015.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 015."""
+
+def run() -> None:
+    n = 15
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_016.py
+++ b/benchmarks/swe_mini/task_016.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 016."""
+
+def run() -> None:
+    n = 16
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_017.py
+++ b/benchmarks/swe_mini/task_017.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 017."""
+
+def run() -> None:
+    n = 17
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_018.py
+++ b/benchmarks/swe_mini/task_018.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 018."""
+
+def run() -> None:
+    n = 18
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_019.py
+++ b/benchmarks/swe_mini/task_019.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 019."""
+
+def run() -> None:
+    n = 19
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_020.py
+++ b/benchmarks/swe_mini/task_020.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 020."""
+
+def run() -> None:
+    n = 20
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_021.py
+++ b/benchmarks/swe_mini/task_021.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 021."""
+
+def run() -> None:
+    n = 21
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_022.py
+++ b/benchmarks/swe_mini/task_022.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 022."""
+
+def run() -> None:
+    n = 22
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_023.py
+++ b/benchmarks/swe_mini/task_023.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 023."""
+
+def run() -> None:
+    n = 23
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_024.py
+++ b/benchmarks/swe_mini/task_024.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 024."""
+
+def run() -> None:
+    n = 24
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/benchmarks/swe_mini/task_025.py
+++ b/benchmarks/swe_mini/task_025.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SWE mini task 025."""
+
+def run() -> None:
+    n = 25
+    total = sum(range(n))
+    expected = n*(n-1)//2
+    assert total == expected

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -19,6 +19,8 @@ def test_run_benchmarks(tmp_path: Path) -> None:
     data = json.loads(result.stdout)
     assert any(d['task_id'].startswith('swebench_verified_mini') for d in data)
     assert any(d['task_id'].startswith('polyglot_lite') for d in data)
+    assert any(d['task_id'].startswith('swe_mini') for d in data)
+    assert any(d['task_id'].startswith('poly_mini') for d in data)
     for entry in data:
         assert 'time_ms' in entry and isinstance(entry['time_ms'], int)
         assert 'pass' in entry


### PR DESCRIPTION
## Summary
- add swe_mini and poly_mini benchmark directories
- update benchmark runner to include the new datasets
- add a dockerised benchmark runner with runtime limit
- make `benchmark` target and update bench workflow
- test coverage for new benchmark datasets

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 4 errors during collection)*
- `pre-commit run --files benchmarks/docker_runner.py benchmarks/run_benchmarks.py tests/test_benchmarks.py Makefile .github/workflows/bench.yml` *(fails: network access during hooks)*