### PR TITLE
[alpha_factory] Add lineage tree web component

### DIFF
--- a/src/interface/web_client/components/LineageTree.tsx
+++ b/src/interface/web_client/components/LineageTree.tsx
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect } from 'react';
+import Plotly from 'plotly.js-dist';
+
+export interface LineageNode {
+  id: number;
+  parent?: number | null;
+  diff?: string | null;
+  pass_rate: number;
+}
+
+interface Props {
+  data: LineageNode[];
+}
+
+export default function LineageTree({ data }: Props) {
+  useEffect(() => {
+    if (!data.length) return;
+    const ids = data.map((n) => String(n.id));
+    const parents = data.map((n) => (n.parent ? String(n.parent) : ''));
+    const diffs = data.map((n) => n.diff ?? '');
+    const passRates = data.map((n) => n.pass_rate);
+    Plotly.react(
+      'lineage-tree',
+      [
+        {
+          type: 'treemap',
+          ids,
+          parents,
+          values: ids.map(() => 1),
+          customdata: diffs,
+          text: ids.map((id, i) => (diffs[i] ? `<a href='${diffs[i]}'>${id}</a>` : id)),
+          hovertemplate: 'hash=%{id}<br>diff=%{customdata}<extra></extra>',
+          marker: { colors: passRates, colorscale: 'Blues' },
+        },
+      ],
+      { margin: { t: 0 } },
+    );
+  }, [data]);
+
+  return <div id="lineage-tree" style={{ width: '100%', height: 400 }} />;
+}

--- a/src/interface/web_client/cypress.config.ts
+++ b/src/interface/web_client/cypress.config.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:5173',
+    supportFile: false,
+  },
+});

--- a/src/interface/web_client/cypress/e2e/dashboard.cy.ts
+++ b/src/interface/web_client/cypress/e2e/dashboard.cy.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+describe('dashboard', () => {
+  it('loads lineage tree', () => {
+    cy.on('window:before:load', (win) => {
+      cy.spy(win.console, 'error').as('consoleError');
+    });
+    cy.visit('/');
+    cy.get('#lineage-tree g.slice').should('have.length.gte', 3);
+    cy.get('@consoleError').should('not.be.called');
+  });
+});

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, FormEvent } from 'react';
 import ReactDOM from 'react-dom/client';
 import Plotly from 'plotly.js-dist';
+import LineageTree, { LineageNode } from '../components/LineageTree';
 
 interface SectorData {
   name: string;
@@ -33,10 +34,15 @@ function Dashboard() {
   const [runId, setRunId] = useState<string | null>(null);
   const [timeline, setTimeline] = useState<ForecastPoint[]>([]);
   const [population, setPopulation] = useState<PopulationMember[]>([]);
+  const [lineage, setLineage] = useState<LineageNode[]>([]);
 
   const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
   const TOKEN = import.meta.env.VITE_API_TOKEN ?? '';
   const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
+
+  useEffect(() => {
+    fetchLineage().catch(() => null);
+  }, []);
 
   useEffect(() => {
     if (!timeline.length) return;
@@ -87,6 +93,13 @@ function Dashboard() {
     const body = await res.json();
     setTimeline(body.forecast ?? []);
     setPopulation(body.population ?? []);
+  }
+
+  async function fetchLineage() {
+    const res = await fetch(`${API_BASE}/lineage`, { headers: HEADERS });
+    if (!res.ok) return;
+    const body = await res.json();
+    setLineage(body);
   }
 
   async function onSubmit(e: FormEvent) {
@@ -193,6 +206,7 @@ function Dashboard() {
       <div id="sectors" style={{ width: '100%', height: 300 }} />
       <div id="capability" style={{ width: '100%', height: 300 }} />
       <div id="pareto" style={{ width: '100%', height: 400 }} />
+      <LineageTree data={lineage} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `LineageTree.tsx` Plotly component
- expose `/lineage` API returning archive entries
- fetch lineage data in React dashboard
- display lineage tree
- add Cypress scaffolding for dashboard test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 4 errors during collection)*
- `pre-commit run --files src/interface/api_server.py src/interface/web_client/components/LineageTree.tsx src/interface/web_client/src/main.tsx src/interface/web_client/cypress.config.ts src/interface/web_client/cypress/e2e/dashboard.cy.ts` *(fails: could not fetch hooks)*