### PR TITLE
[alpha_factory] Add secure sandbox runner

### DIFF
--- a/src/utils/secure_run.py
+++ b/src/utils/secure_run.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run commands inside a restricted sandbox."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Sequence
+
+__all__ = ["SandboxTimeout", "secure_run"]
+
+
+class SandboxTimeout(Exception):
+    """Raised when the sandboxed command exceeds the time limit."""
+
+
+def secure_run(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Execute ``cmd`` under ``firejail`` or ``docker`` constraints.
+
+    The sandbox runs with seccomp, ``2`` CPU cores, ``2`` GB of RAM and a
+    ``120`` second timeout. When the command exceeds the timeout a
+    :class:`SandboxTimeout` is raised.
+    """
+
+    timeout = 120
+    firejail = shutil.which("firejail")
+    if firejail:
+        full_cmd = [
+            firejail,
+            "--quiet",
+            "--net=none",
+            "--private",
+            "--seccomp",
+            "--rlimit-as=2147483648",
+            "--rlimit-cpu=120",
+            *cmd,
+        ]
+    else:
+        docker = shutil.which("docker")
+        if docker:
+            full_cmd = [
+                docker,
+                "run",
+                "--rm",
+                "--network=none",
+                "--cpus=2",
+                "--memory=2g",
+                "--security-opt",
+                "seccomp=unconfined",
+                "python:3.11-slim",
+                *cmd,
+            ]
+        else:
+            full_cmd = list(cmd)
+    try:
+        return subprocess.run(
+            full_cmd,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover - runtime failure
+        raise SandboxTimeout(str(exc)) from exc

--- a/tests/test_secure_run.py
+++ b/tests/test_secure_run.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+import subprocess
+import shutil
+import pytest
+
+from src.utils.secure_run import secure_run, SandboxTimeout
+
+
+def test_secure_run_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(shutil, "which", lambda n: None)
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=120)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(SandboxTimeout):
+        secure_run(["sleep", "130"])


### PR DESCRIPTION
## Summary
- add `secure_run` helper that enforces firejail/docker limits
- raise `SandboxTimeout` on timeout
- test sandbox timeout behaviour

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rocketry')*