### PR TITLE
[alpha_factory] Add DGM operations runbook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,8 @@ repos:
         language: python
         additional_dependencies: [pip-tools]
         pass_filenames: false
+      - id: verify-env-docs
+        name: Verify environment docs and runbook checklist
+        entry: python tools/check_env_table.py
+        language: python
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ of a real general intelligence. Use at your own risk.
 ## Further Reading
 - [docs/DESIGN.md](docs/DESIGN.md) — architecture overview and agent roles.
 - [docs/API.md](docs/API.md) — REST API and CLI endpoints.
+- [docs/dgm_ops.md](docs/dgm_ops.md) — scheduler flags and lineage audit notes.
 - Release notes are maintained in [docs/CHANGELOG.md](docs/CHANGELOG.md).
 - The [v1.0 entry](docs/CHANGELOG.md#v10---2025-07-01) lists the CLI, web UI and security features.
 - A demo specific overview can be found in
@@ -923,6 +924,8 @@ docker run -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
 
 The [policy runbook](docs/POLICY_RUNBOOK.md) outlines sandbox resource limits,
 timeout behaviour, required human review and rollback steps.
+Operational tips for the governance module reside in
+[docs/dgm_ops.md](docs/dgm_ops.md).
 
 ---
 

--- a/docs/dgm_ops.md
+++ b/docs/dgm_ops.md
@@ -1,0 +1,42 @@
+# DGM Operations Runbook
+
+This guide outlines day-to-day operational tasks for the **Distributed Governance Module (DGM)**.
+
+## Scheduler Flags
+
+The orchestrator exposes flags controlling job order and concurrency:
+
+| Flag | Purpose |
+|------|---------|
+| `--priority` | Adjust agent queue weighting. |
+| `--max-jobs` | Limit concurrent job count. |
+| `--pause` | Temporarily halt scheduling without stopping workers. |
+
+Use these options to throttle or pause workloads during maintenance windows.
+
+## Rollback Steps
+
+1. Tag the current stable commit with `git tag stable`.
+2. If a deployment fails, check out the previous tag:
+   ```bash
+   git checkout stable
+   docker compose up -d --build
+   ```
+3. Verify services recover before promoting new changes.
+
+## Cost Caps
+
+Set `MAX_COST_USD` in the environment to bound cumulative API spend per cycle.
+Exceeding this value stops new jobs until the cap resets.
+
+## Sandbox Tuning
+
+The policy runbook describes CPU and memory limits. Update `.env` with
+`sandbox_cpu_sec` and `sandbox_mem_mb` to tune runtime safety. Use
+`firejail` where available for additional isolation.
+
+## Lineage Audit
+
+Run `alpha-agi-insight-v1 lineage-dashboard` to review archived agent activity.
+The dashboard visualises provenance data so you can verify each job's origin
+and decision path.


### PR DESCRIPTION
## Summary
- document scheduler flags, rollback steps, cost caps and lineage audit in `docs/dgm_ops.md`
- link to the new runbook in the README
- check runbook checklist in `tools/check_env_table.py`
- verify docs via new pre-commit hook

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files README.md docs/dgm_ops.md tools/check_env_table.py .pre-commit-config.yaml` *(fails: unable to access https://github.com/psf/black/)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rocketry')*

------
https://chatgpt.com/codex/tasks/task_e_6839f490ac64833385e379fabc15a3fa