### PR TITLE
[alpha_factory] expand tool coverage

### DIFF
--- a/tests/test_patch_guard.py
+++ b/tests/test_patch_guard.py
@@ -31,3 +31,19 @@ def test_accepts_normal_patch() -> None:
 +b
 """
     assert is_patch_valid(diff)
+
+
+def test_mixed_test_and_src_patch() -> None:
+    diff = (
+        "--- a/src/foo.py\n"
+        "+++ b/src/foo.py\n"
+        "@@\n"
+        "-a\n"
+        "+b\n"
+        "--- a/tests/bar.py\n"
+        "+++ b/tests/bar.py\n"
+        "@@\n"
+        "-x\n"
+        "+y\n"
+    )
+    assert is_patch_valid(diff)

--- a/tests/test_self_edit_tools.py
+++ b/tests/test_self_edit_tools.py
@@ -4,10 +4,10 @@ import re
 
 import pytest
 
-from src.self_edit.tools import view, edit, replace, REPO_ROOT
-
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, strategies as st
+from hypothesis import given, strategies as st  # noqa: E402
+
+from src.self_edit.tools import view, edit, replace, REPO_ROOT  # noqa: E402
 
 
 @pytest.fixture()
@@ -55,3 +55,20 @@ def test_outside_repo_forbidden(tmp_path: Path) -> None:
         edit(p, 0, 1, "bye")
     with pytest.raises(PermissionError):
         replace(p, "hi", "ho")
+
+
+def test_filetools_adk_tasks(temp_file: Path) -> None:
+    from src.self_edit.tools import FileToolsADK
+
+    temp_file.write_text("a\nb\nc\n")
+    adk = FileToolsADK()
+
+    res = adk.view_task(path=str(temp_file), start=1, end=3)
+    assert res == {"text": "b\nc"}
+
+    adk.edit_task(path=str(temp_file), start=1, end=2, new_code="X")
+    assert temp_file.read_text() == "a\nX\nc"
+
+    out = adk.replace_task(path=str(temp_file), pattern="X", repl="Y")
+    assert out == {"count": 1}
+    assert temp_file.read_text() == "a\nY\nc"

--- a/tests/test_self_improver.py
+++ b/tests/test_self_improver.py
@@ -33,3 +33,32 @@ def test_improve_repo(tmp_path: Path) -> None:
     assert (clone / "metric.txt").read_text().strip() == "2"
     data = json.loads(log_file.read_text())
     assert data and data[0]["delta"] == 1
+
+
+def test_improve_repo_invalid_patch(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _init_repo(repo_dir)
+
+    patch_file = tmp_path / "patch.diff"
+    patch_file.write_text("")
+    log_file = tmp_path / "log.json"
+
+    with pytest.raises(ValueError):
+        self_improver.improve_repo(
+            str(repo_dir), str(patch_file), "metric.txt", str(log_file)
+        )
+
+
+def test_improve_repo_requires_git(monkeypatch, tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    patch_file = tmp_path / "p.diff"
+    patch_file.write_text("dummy")
+    log_file = tmp_path / "log.json"
+
+    monkeypatch.setattr(self_improver, "git", None)
+    with pytest.raises(RuntimeError):
+        self_improver.improve_repo(
+            str(repo_dir), str(patch_file), "metric.txt", str(log_file)
+        )

--- a/tests/test_transfer_test.py
+++ b/tests/test_transfer_test.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from pathlib import Path
 from click.testing import CliRunner
 
 from src.archive import Archive
@@ -19,7 +18,7 @@ rocketry_stub.conds = conds_mod
 sys.modules.setdefault("rocketry", rocketry_stub)
 sys.modules.setdefault("rocketry.conds", conds_mod)
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli  # noqa: E402
 
 
 def test_run_transfer_test_writes_csv(tmp_path, monkeypatch) -> None:
@@ -52,3 +51,20 @@ def test_cli_transfer_test_invokes(monkeypatch) -> None:
     res = CliRunner().invoke(cli.main, ["transfer-test", "--models", "x,y", "--top-n", "2"])
     assert res.exit_code == 0
     assert called == {"models": ["x", "y"], "top_n": 2}
+
+
+def test_run_transfer_test_appends(tmp_path, monkeypatch) -> None:
+    db = tmp_path / "arch.db"
+    arch = Archive(db)
+    arch.add({"name": "a"}, 0.5)
+    out = tmp_path / "results" / "transfer.csv"
+    out.parent.mkdir(parents=True)
+    out.write_text("id,model,score\n1,z,0.500\n")
+
+    def fake_eval(agent, model):
+        return agent.score + 0.1
+
+    monkeypatch.setattr(tt, "evaluate_agent", fake_eval)
+    tt.run_transfer_test(["m"], 1, archive_path=db, out_file=out)
+    lines = out.read_text().splitlines()
+    assert lines == ["id,model,score", "1,z,0.500", "1,m,0.600"]


### PR DESCRIPTION
## Summary
- add invalid patch and missing Git checks for improve_repo
- test patch_guard on mixed changes
- cover FileToolsADK tasks
- ensure transfer test appends to existing results

## Testing
- `pre-commit run --files tests/test_patch_guard.py tests/test_self_edit_tools.py tests/test_self_improver.py tests/test_transfer_test.py` *(fails: unable to fetch hooks)*
- `python check_env.py --auto-install`
- `pytest tests/test_self_improver.py tests/test_patch_guard.py tests/test_self_edit_tools.py tests/test_transfer_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6839f61feab48333a17893fe5a1334f3