### PR TITLE
[alpha_factory] add lineage tree TS component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Project Documentation
+
+## Building the React Dashboard
+
+The React dashboard sources live under `src/interface/web_client`. Build the static assets before serving the API:
+
+```bash
+pnpm --dir src/interface/web_client install
+pnpm --dir src/interface/web_client run build
+```
+
+The compiled files appear in `src/interface/web_client/dist` and are automatically served when running `uvicorn src.interface.api_server:app` with `RUN_MODE=web`.

--- a/src/interface/web_client/cypress/e2e/dashboard.cy.ts
+++ b/src/interface/web_client/cypress/e2e/dashboard.cy.ts
@@ -8,4 +8,10 @@ describe('dashboard', () => {
     cy.get('#lineage-tree g.slice').should('have.length.gte', 3);
     cy.get('@consoleError').should('not.be.called');
   });
+
+  it('shows annotation on hover', () => {
+    cy.visit('/');
+    cy.get('#lineage-tree g.slice').first().trigger('mouseover');
+    cy.get('#lineage-tree .hovertext').should('be.visible');
+  });
 });

--- a/src/interface/web_client/src/LineageTree.tsx
+++ b/src/interface/web_client/src/LineageTree.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect } from 'react';
+import Plotly from 'plotly.js-dist';
+
+export interface LineageNode {
+  id: number;
+  parent?: number | null;
+  patch?: string | null;
+  pass_rate: number;
+}
+
+interface Props {
+  data: LineageNode[];
+}
+
+export default function LineageTree({ data }: Props) {
+  useEffect(() => {
+    if (!data.length) return;
+    const idMap: Record<number, LineageNode> = {};
+    for (const n of data) idMap[n.id] = n;
+
+    const ids = data.map((n) => String(n.id));
+    const parents = data.map((n) => (n.parent ? String(n.parent) : ''));
+    const passRates = data.map((n) => n.pass_rate);
+    const custom = data.map((n) => {
+      const parent = n.parent ? idMap[n.parent] : undefined;
+      const delta = parent ? n.pass_rate - parent.pass_rate : n.pass_rate;
+      return [n.patch ?? '', delta];
+    });
+
+    Plotly.react(
+      'lineage-tree',
+      [
+        {
+          type: 'treemap',
+          ids,
+          parents,
+          values: ids.map(() => 1),
+          customdata: custom,
+          text: ids,
+          hovertemplate: 'patch=%{customdata[0]}<br>\u0394pass-rate=%{customdata[1]:.2f}<extra></extra>',
+          marker: { colors: passRates, colorscale: 'Blues' },
+        },
+      ],
+      { margin: { t: 0 } },
+    );
+  }, [data]);
+
+  return <div id="lineage-tree" style={{ width: '100%', height: 400 }} />;
+}

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, FormEvent } from 'react';
 import ReactDOM from 'react-dom/client';
 import Plotly from 'plotly.js-dist';
-import LineageTree, { LineageNode } from '../components/LineageTree';
+import LineageTree, { LineageNode } from './LineageTree';
 
 interface SectorData {
   name: string;
@@ -92,6 +92,12 @@ function Dashboard() {
     if (!res.ok) return;
     const body = await res.json();
     setTimeline(body.forecast ?? []);
+  }
+
+  async function fetchPopulation(id: string) {
+    const res = await fetch(`${API_BASE}/population/${id}`, { headers: HEADERS });
+    if (!res.ok) return;
+    const body = await res.json();
     setPopulation(body.population ?? []);
   }
 
@@ -142,6 +148,7 @@ function Dashboard() {
     };
     ws.onclose = () => {
       fetchResults(id).catch(() => null);
+      fetchPopulation(id).catch(() => null);
     };
   }
 


### PR DESCRIPTION
## Summary
- render archive lineage with tooltips showing patch name and Δpass-rate
- display lineage tree in main dashboard and retrieve population separately
- test tooltip visibility via Cypress
- document building the dashboard

## Testing
- `pre-commit run --files docs/README.md src/interface/web_client/src/LineageTree.tsx src/interface/web_client/src/main.tsx src/interface/web_client/cypress/e2e/dashboard.cy.ts` *(fails: Failed to connect to proxy port 8080)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 50 failed, 456 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6839fca663bc83339978b552699afc5b