### PR TITLE
[alpha_factory] Add backtrack analysis

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/backtrack_hist.svg
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/backtrack_hist.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="150">
+<rect x="20" y="50" width="20" height="80" fill="skyblue" />
+<rect x="60" y="30" width="20" height="100" fill="skyblue" />
+<rect x="100" y="70" width="20" height="60" fill="skyblue" />
+<rect x="140" y="90" width="20" height="40" fill="skyblue" />
+</svg>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 - Synced `openai`, `openai-agents` and `uvicorn` pins across requirements files
   and clarified why `requests` and `rich` differ between layers.
+- Added [`src/tools/analyse_backtrack.py`](../src/tools/analyse_backtrack.py) for visualising archive backtracks.
 
 ## [1.1.0] - 2025-07-15
 ### Added

--- a/src/tools/analyse_backtrack.py
+++ b/src/tools/analyse_backtrack.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Analyse archive backtracks and generate a histogram."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+import plotly.express as px
+
+from src.archive.db import ArchiveDB, ArchiveEntry
+
+DEFAULT_DB = Path(os.getenv("ARCHIVE_PATH", "archive.db"))
+DEFAULT_OUT = Path(
+    "alpha_factory_v1/demos/alpha_agi_insight_v1/docs/backtrack_hist.svg"
+)
+
+
+def _load_entries(db_path: Path) -> List[ArchiveEntry]:
+    """Return all archive entries."""
+    with sqlite3.connect(db_path) as cx:
+        rows = list(
+            cx.execute(
+                "SELECT hash, parent, score, novelty, is_live, ts FROM archive"
+            )
+        )
+    return [
+        ArchiveEntry(
+            hash=r[0],
+            parent=r[1],
+            score=float(r[2]),
+            novelty=float(r[3]),
+            is_live=bool(r[4]),
+            ts=float(r[5]),
+        )
+        for r in rows
+    ]
+
+
+def count_backtracks(db_path: str | Path = DEFAULT_DB) -> List[int]:
+    """Return backtrack counts for each chain in ``db_path``."""
+    db_path = Path(db_path)
+    entries = _load_entries(db_path)
+    entry_map = {e.hash: e for e in entries}
+    parents = {e.parent for e in entries if e.parent}
+    leaves = [e.hash for e in entries if e.hash not in parents]
+    counts: List[int] = []
+    for leaf in leaves:
+        history = [entry_map[h.hash] for h in ArchiveDB(db_path).history(leaf)]
+        count = sum(
+            1
+            for child, parent in zip(history, history[1:])
+            if child.score < parent.score
+        )
+        counts.append(count)
+    return counts
+
+
+def plot_histogram(counts: Iterable[int], out_file: str | Path = DEFAULT_OUT) -> None:
+    """Save histogram of ``counts`` to ``out_file``."""
+    df = pd.DataFrame({"backtracks": list(counts)})
+    fig = px.histogram(df, x="backtracks")
+    path = Path(out_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.write_image(str(path))
+
+
+__all__ = ["count_backtracks", "plot_histogram"]

--- a/tests/test_analyse_backtrack.py
+++ b/tests/test_analyse_backtrack.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from src.archive.db import ArchiveDB, ArchiveEntry
+from src.tools import analyse_backtrack as ab
+
+
+def test_detect_backtrack(tmp_path) -> None:
+    db_path = tmp_path / "arch.db"
+    db = ArchiveDB(db_path)
+    db.add(ArchiveEntry("a", None, 0.5, 0.0, True, 0.0))
+    db.add(ArchiveEntry("b", "a", 0.6, 0.0, True, 1.0))
+    db.add(ArchiveEntry("c", "b", 0.4, 0.0, True, 2.0))
+    counts = ab.count_backtracks(db_path)
+    assert any(c > 0 for c in counts)


### PR DESCRIPTION
## Summary
- add histogram script `analyse_backtrack.py`
- update docs changelog with new script link
- commit placeholder histogram SVG
- test backtrack counting logic

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_analyse_backtrack.py`
- `pre-commit run --files src/tools/analyse_backtrack.py tests/test_analyse_backtrack.py docs/CHANGELOG.md` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6839ffd13ad88333912d751276575328