### PR TITLE
[alpha_factory] Expand transfer test matrix

### DIFF
--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -1,0 +1,28 @@
+name: "📊 Transfer Matrix"
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  transfer-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.lock
+      - name: Run transfer test
+        run: |
+          python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli transfer-test --models "o3-mini,llama-3" --top-n 5
+      - name: Upload matrix
+        uses: actions/upload-artifact@v4
+        with:
+          name: transfer-matrix
+          path: results/transfer_matrix.csv

--- a/src/tools/transfer_test.py
+++ b/src/tools/transfer_test.py
@@ -12,7 +12,7 @@ from src.archive import Archive, Agent
 
 
 DEFAULT_ARCHIVE = Path(os.getenv("ARCHIVE_PATH", "archive.db"))
-DEFAULT_RESULTS = Path("results/transfer.csv")
+DEFAULT_RESULTS = Path("results/transfer_matrix.csv")
 
 
 def evaluate_agent(agent: Agent, model: str) -> float:
@@ -32,25 +32,23 @@ def run_transfer_test(
     archive_path: str | Path = DEFAULT_ARCHIVE,
     out_file: str | Path = DEFAULT_RESULTS,
 ) -> None:
-    """Evaluate the top ``top_n`` agents on each model.
-
-    Appends the results to ``out_file``.
-    """
+    """Evaluate the top ``top_n`` agents on each model and store a score matrix."""
 
     arch = Archive(archive_path)
     agents = sorted(arch.all(), key=lambda a: a.score, reverse=True)[:top_n]
 
     path = Path(out_file)
     path.parent.mkdir(parents=True, exist_ok=True)
-    exists = path.exists()
-    with path.open("a", newline="", encoding="utf-8") as fh:
+    with path.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.writer(fh)
-        if not exists:
-            writer.writerow(["id", "model", "score"])
+        model_list = list(models)
+        writer.writerow(["id", *model_list])
         for agent in agents:
-            for model in models:
+            row = [agent.id]
+            for model in model_list:
                 score = evaluate_agent(agent, model)
-                writer.writerow([agent.id, model, f"{score:.3f}"])
+                row.append(f"{score:.3f}")
+            writer.writerow(row)
 
 
 __all__ = ["run_transfer_test", "evaluate_agent"]


### PR DESCRIPTION
## Summary
- output transfer matrix across models
- adjust transfer tests for matrix output
- run nightly transfer matrix workflow

## Testing
- `pre-commit run --files src/tools/transfer_test.py tests/test_transfer_test.py .github/workflows/nightly-transfer.yml` *(failed: Could not fetch black)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: 61 failed, 487 passed)*

------
https://chatgpt.com/codex/tasks/task_e_683a02ecf79c833382c689e8fb6d31f5