### PR TITLE
[alpha_factory] add backtrack boost

### DIFF
--- a/src/simulation/mats_ops.py
+++ b/src/simulation/mats_ops.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import random
-from typing import List
+from typing import Any, List
 
 from src.self_edit.safety import is_code_safe
+from src.archive.selector import select_parent
 
 
 class GaussianParam:
@@ -64,3 +65,22 @@ class SelfRewriteOperator:
             else:
                 break
         return text
+
+
+def backtrack_boost(pop: List[Any], archive: List[Any], rate: float) -> Any:
+    """Return a parent possibly selected from weaker individuals.
+
+    With probability ``rate`` the parent is drawn uniformly from the
+    lower half of ``archive`` based on fitness.  Otherwise the regular
+    ``select_parent`` mechanism chooses from ``pop``.
+    """
+
+    if not pop:
+        raise ValueError("population is empty")
+    if rate <= 0.0:
+        return select_parent(pop, temp=1.0)
+    if random.random() < rate:
+        ranked = sorted(archive, key=lambda c: getattr(c, "fitness", 0.0))
+        bottom = ranked[: max(1, len(ranked) // 2)]
+        return random.choice(bottom)
+    return select_parent(pop, temp=1.0)

--- a/tests/test_backtrack_boost.py
+++ b/tests/test_backtrack_boost.py
@@ -1,0 +1,53 @@
+import asyncio
+import asyncio
+import asyncio
+import random
+
+import asyncio
+import random
+
+from src.evolve import Candidate, InMemoryArchive, evolve
+from src.simulation.mats_ops import backtrack_boost  # ensure import works
+
+
+def _diversity(values):
+    if len(values) < 2:
+        return 0.0
+    d = 0.0
+    c = 0
+    for i in range(len(values)):
+        for j in range(i + 1, len(values)):
+            d += abs(values[i] - values[j])
+            c += 1
+    return d / c
+
+
+def _mutate(g):
+    return g + random.uniform(-1, 1)
+
+
+async def _evaluate(g):
+    await asyncio.sleep(0)
+    return g, 0.01
+
+
+def _run(rate):
+    random.seed(123)
+    arch = InMemoryArchive()
+    asyncio.run(arch.accept(Candidate(0.0, fitness=0.0, novelty=1.0)))
+    asyncio.run(
+        evolve(
+            _mutate,
+            _evaluate,
+            arch,
+            max_cost=0.1,
+            backtrack_rate=rate,
+        )
+    )
+    return [c.genome for c in arch.all()]
+
+
+def test_backtrack_boost_improves_diversity():
+    base = _run(0.0)
+    boosted = _run(1.0)
+    assert _diversity(boosted) > _diversity(base)


### PR DESCRIPTION
## Summary
- introduce `backtrack_boost` for selecting weaker parents
- apply boost in asynchronous evolution loop
- expose new `--backtrack-rate` CLI option
- basic test covering diversity impact

## Testing
- `pre-commit run --files src/simulation/mats_ops.py src/evolve.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_backtrack_boost.py` *(fails: failed to fetch remote hook)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_683a01b9a6a48333a4f2ef7ce0863150