### PR TITLE
[alpha_factory] Add patch validation checks to SelfRewriteOperator

### DIFF
--- a/src/utils/patch_guard.py
+++ b/src/utils/patch_guard.py
@@ -32,7 +32,7 @@ def _changed_files(diff: str) -> list[str]:
 
 
 def is_patch_valid(diff: str) -> bool:
-    """Return ``True`` if ``diff`` does not appear dangerous."""
+    """Return ``True`` if ``diff`` does not appear dangerous or malformed."""
 
     if not diff.strip():
         return False
@@ -43,7 +43,18 @@ def is_patch_valid(diff: str) -> bool:
             return False
 
     files = _changed_files(diff)
-    if files and all(f.startswith("tests/") or "/tests/" in f or f.split("/")[-1].startswith("test_") for f in files):
+
+    # Reject diffs that do not reference any files
+    if not files:
+        return False
+
+    # Reject diffs touching only test files
+    if all(
+        f.startswith("tests/")
+        or "/tests/" in f
+        or f.split("/")[-1].startswith("test_")
+        for f in files
+    ):
         return False
 
     return True

--- a/tests/fixtures/malformed_patch.diff
+++ b/tests/fixtures/malformed_patch.diff
@@ -1,0 +1,3 @@
+@@
+-print('hi')
++print('bye')

--- a/tests/test_patch_validation.py
+++ b/tests/test_patch_validation.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for patch validation utilities."""
+
+from pathlib import Path
+
+from src.utils.patch_guard import is_patch_valid
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _read(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+def test_rejects_malformed_patch() -> None:
+    diff = _read("malformed_patch.diff")
+    assert not is_patch_valid(diff)


### PR DESCRIPTION
## Summary
- validate candidate patches in SelfRewriteOperator by running pytest, ruff and bandit in a temporary clone
- mark malformed patches as invalid
- add regression test covering malformed patches

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_self_rewrite.py tests/test_patch_validation.py`
- `pre-commit run --files src/simulation/mats_ops.py src/utils/patch_guard.py tests/fixtures/malformed_patch.diff tests/test_patch_validation.py` *(fails: failed to fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683a07ab30648333ad5cfab92234fdeb