### PR TITLE
[alpha_factory] add curriculum switcher

### DIFF
--- a/src/archive/db.py
+++ b/src/archive/db.py
@@ -40,6 +40,15 @@ class _ArchiveRow(Base):
     ts = Column(Float)
 
 
+class _StateRow(Base):
+    """Key/value storage for miscellaneous state."""
+
+    __tablename__ = "state"
+
+    key = Column(String, primary_key=True)
+    value = Column(String)
+
+
 class ArchiveDB:
     """Simple wrapper around ``sqlalchemy`` for archive access."""
 
@@ -99,3 +108,17 @@ class ArchiveDB:
             if not current.parent:
                 break
             current = self.get(current.parent)
+
+    # state helpers -----------------------------------------------------
+
+    def get_state(self, key: str, default: str | None = None) -> str | None:
+        """Return the stored value for ``key`` from the ``state`` table."""
+        with Session(self.engine) as session:
+            row = session.get(_StateRow, key)
+            return row.value if row is not None else default
+
+    def set_state(self, key: str, value: str) -> None:
+        """Store ``key`` as ``value`` in the ``state`` table."""
+        with Session(self.engine) as session:
+            session.merge(_StateRow(key=key, value=value))
+            session.commit()

--- a/tests/test_curriculum_switcher.py
+++ b/tests/test_curriculum_switcher.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from src.eval.fitness import compute_fitness, CurriculumSwitcher
+from src.archive.db import ArchiveDB
+
+
+def _results(dataset: str, rate: float, count: int = 10):
+    passed = int(rate * count)
+    items = []
+    for i in range(count):
+        items.append({"task_id": f"{dataset}/task_{i:03d}", "pass": i < passed, "time_ms": 1})
+    return items
+
+
+def test_curriculum_switch(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    switcher = CurriculumSwitcher(db_path, window=10)
+
+    # Start on mini dataset
+    assert switcher.dataset == "swe_mini"
+
+    rates = [0.2, 0.5, 0.6]
+    for r in rates:
+        metrics = compute_fitness(_results(switcher.dataset, r))
+        switcher.update(metrics)
+    assert switcher.dataset == "swebench_verified_mini"
+
+    rates = [0.6, 0.6, 0.6, 0.6]
+    for r in rates:
+        metrics = compute_fitness(_results(switcher.dataset, r))
+        switcher.update(metrics)
+    assert switcher.dataset == "polyglot_lite"
+
+    # state persisted
+    db = ArchiveDB(db_path)
+    assert db.get_state("dataset") == "polyglot_lite"


### PR DESCRIPTION
## Summary
- track rolling pass rate and switch datasets at 40/60% thresholds
- persist dataset state in archive.db
- add integration test verifying switching logic

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_curriculum_switcher.py`

------
https://chatgpt.com/codex/tasks/task_e_683a0971d684833386fb536b57739a88