### PR TITLE
[alpha_factory] split evolve phases

### DIFF
--- a/tests/test_phase_order.py
+++ b/tests/test_phase_order.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from src.evolve import InMemoryArchive, evolve, Phase
+
+
+class TestPhaseOrder:
+    def test_task_waits_for_self_mod(self) -> None:
+        archive = InMemoryArchive()
+        events: list[Phase] = []
+        current: Phase | None = None
+
+        def hook(p: Phase) -> None:
+            nonlocal current
+            current = p
+
+        def op(g):
+            return g + 1
+
+        async def evaluate(_g):
+            events.append(current)
+            return 0.0, 0.01
+
+        asyncio.run(
+            evolve(op, evaluate, archive, max_cost=0.02, phase_hook=hook)
+        )
+
+        assert Phase.SELF_MOD in events
+        assert Phase.TASK_SOLVE in events
+        first_task = events.index(Phase.TASK_SOLVE)
+        assert all(e == Phase.SELF_MOD for e in events[:first_task])
+


### PR DESCRIPTION
## Summary
- add `Phase` enum to track self-mod and task-solving
- break `evolve()` into phase helpers
- require self-mod completions before tasks start
- test ordering in `TestPhaseOrder`

## Testing
- `pre-commit run --files src/evolve.py tests/test_phase_order.py` *(fails: unable to access 'https://github.com/psf/black/')*
- `pytest -k TestPhaseOrder`

------
https://chatgpt.com/codex/tasks/task_e_683a22d86f2483338fca985e9198129f