### PR TITLE
[alpha_factory] add ledger verification and safety checks

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -16,6 +16,7 @@ import sys
 from google.protobuf import struct_pb2
 import tempfile
 import time
+from src.self_edit.safety import is_code_safe
 
 
 from .base_agent import BaseAgent
@@ -47,7 +48,8 @@ class CodeGenAgent(BaseAgent):
                         code = await with_retry(self.oai_ctx.run)(prompt=str(analysis))
                 except Exception:
                     pass
-            self.execute_in_sandbox(code)
+            if is_code_safe(code):
+                self.execute_in_sandbox(code)
             await self.emit("safety", {"code": code})
 
     def execute_in_sandbox(self, code: str) -> tuple[str, str]:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -183,6 +183,13 @@ class Orchestrator:
             log.warning("Merkle mismatch for %s", agent_id)
             self.slash(agent_id)
 
+    def verify_ledger(self, expected: str, agent_id: str) -> None:
+        """Slash ``agent_id`` when the current ledger root mismatches ``expected``."""
+        actual = self.ledger.compute_merkle_root()
+        if actual != expected:
+            log.warning("Merkle mismatch for %s", agent_id)
+            self.slash(agent_id)
+
     async def _monitor(self) -> None:
         while True:
             await asyncio.sleep(2)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_codegen_safety.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_codegen_safety.py
@@ -1,0 +1,53 @@
+import asyncio
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import codegen_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
+
+
+class DummyBus:
+    def __init__(self, settings: config.Settings) -> None:
+        self.settings = settings
+        self.published = []
+
+    def publish(self, topic: str, env: messaging.Envelope) -> None:
+        self.published.append((topic, env))
+
+    def subscribe(self, topic: str, handler) -> None:  # pragma: no cover - stub
+        pass
+
+
+class DummyLedger:
+    def log(self, env: messaging.Envelope) -> None:  # pragma: no cover - stub
+        pass
+
+    def start_merkle_task(self, *a, **kw) -> None:  # pragma: no cover - stub
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def close(self) -> None:  # pragma: no cover - stub
+        pass
+
+
+def test_skip_unsafe_execution(monkeypatch) -> None:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    ledger = DummyLedger()
+    agent = codegen_agent.CodeGenAgent(bus, ledger)
+
+    called = False
+
+    def fake_exec(code: str) -> tuple[str, str]:
+        nonlocal called
+        called = True
+        return "", ""
+
+    monkeypatch.setattr(codegen_agent, "is_code_safe", lambda c: False)
+    monkeypatch.setattr(agent, "execute_in_sandbox", fake_exec)
+
+    env = messaging.Envelope(sender="market", recipient="codegen", ts=0.0)
+    env.payload.update({"analysis": "x"})
+    asyncio.run(agent.handle(env))
+    assert not called

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_verify.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_verify.py
@@ -1,0 +1,15 @@
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+def test_verify_ledger_slashes(tmp_path, monkeypatch) -> None:
+    settings = config.Settings(bus_port=0, ledger_path=str(tmp_path / "ledger.db"))
+    monkeypatch.setattr(orchestrator.Orchestrator, "_init_agents", lambda self: [])
+    orch = orchestrator.Orchestrator(settings)
+    orch.registry.set_stake("A", 100)
+    original = orch.ledger.compute_merkle_root()
+    env = messaging.Envelope(sender="A", recipient="b", ts=0.0)
+    env.payload.update({"v": 1})
+    orch.ledger.log(env)
+    orch.verify_ledger(original, "A")
+    assert orch.registry.stakes["A"] == 90


### PR DESCRIPTION
## Summary
- integrate self_edit safety check before sandbox execution
- add verify_ledger method to orchestrator
- test safety skip and ledger verification

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_codegen_safety.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_verify.py`
- `pytest -k ledger_verify`

------
https://chatgpt.com/codex/tasks/task_e_683a39fc90cc83338724e79b2636f832