### PR TITLE
[alpha_factory] Add FSM loop

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/loop.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/loop.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal finite-state loop for Insight demos."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+
+
+class State(Enum):
+    """Execution state."""
+
+    SELECT = auto()
+    SELF_MOD = auto()
+    BENCHMARK = auto()
+    ARCHIVE = auto()
+
+
+@dataclass(slots=True)
+class Result:
+    """Loop termination snapshot."""
+
+    state: State
+    cycles: int
+    cost: float
+
+
+def run_loop(
+    *,
+    cost_budget: float | None = None,
+    wallclock: float | None = None,
+    cost_per_cycle: float = 1.0,
+    state_file: str = "loop_state.json",
+) -> Result:
+    """Run the FSM until budgets are exhausted.
+
+    Args:
+        cost_budget: Optional cost limit.
+        wallclock: Optional wall-clock limit in seconds.
+        cost_per_cycle: Cost incurred per complete cycle.
+        state_file: Path used when persisting state on ``KeyboardInterrupt``.
+
+    Returns:
+        :class:`Result` with final state, completed cycles and cost spent.
+    """
+
+    state = State.SELECT
+    cycles = 0
+    cost_spent = 0.0
+    start = time.time()
+
+    try:
+        while True:
+            if state is State.SELECT:
+                state = State.SELF_MOD
+                continue
+            if state is State.SELF_MOD:
+                state = State.BENCHMARK
+                continue
+            if state is State.BENCHMARK:
+                cost_spent += cost_per_cycle
+                state = State.ARCHIVE
+                continue
+            if state is State.ARCHIVE:
+                cycles += 1
+                state = State.SELECT
+                if cost_budget is not None and cost_spent >= cost_budget:
+                    break
+                if wallclock is not None and time.time() - start >= wallclock:
+                    break
+    except KeyboardInterrupt:  # pragma: no cover - interactive
+        Path(state_file).write_text(
+            json.dumps({"state": state.name, "cycles": cycles, "cost": cost_spent})
+        )
+        return Result(state=state, cycles=cycles, cost=cost_spent)
+
+    return Result(state=state, cycles=cycles, cost=cost_spent)

--- a/tests/test_loop_fsm.py
+++ b/tests/test_loop_fsm.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import loop
+
+
+def test_fsm_cycles_three() -> None:
+    result = loop.run_loop(cost_budget=3.0, cost_per_cycle=1.0)
+    assert result.cycles == 3
+    assert result.state is loop.State.SELECT


### PR DESCRIPTION
## Summary
- implement simple finite-state loop cycling through SELECT, SELF_MOD, BENCHMARK and ARCHIVE
- persist on `KeyboardInterrupt`
- add unit test exercising three cycles

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 62 failed, 494 passed, 28 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683a3e87d74c83339b2d109bd932ee6f