### PR TITLE
[alpha_factory] enhance selector with beta/gamma weights

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -549,7 +549,21 @@ def replay(since: float | None, count: int | None) -> None:
     type=float,
     help="Probability of selecting low-scoring parents",
 )
-def evolve_cmd(max_cost: float, wallclock: float | None, backtrack_rate: float) -> None:
+@click.option("--beta", default=1.0, show_default=True, type=float, help="Score weight")
+@click.option(
+    "--gamma",
+    default=0.0,
+    show_default=True,
+    type=float,
+    help="Edit children count weight",
+)
+def evolve_cmd(
+    max_cost: float,
+    wallclock: float | None,
+    backtrack_rate: float,
+    beta: float,
+    gamma: float,
+) -> None:
     """Run the minimal asynchronous evolution demo."""
     from src import evolve as _evolve
 
@@ -566,6 +580,8 @@ def evolve_cmd(max_cost: float, wallclock: float | None, backtrack_rate: float) 
             max_cost=max_cost,
             wallclock=wallclock,
             backtrack_rate=backtrack_rate,
+            beta=beta,
+            gamma=gamma,
         )
     )
 

--- a/src/simulation/mats_ops.py
+++ b/src/simulation/mats_ops.py
@@ -136,7 +136,14 @@ class SelfRewriteOperator:
         return True
 
 
-def backtrack_boost(pop: List[Any], archive: List[Any], rate: float) -> Any:
+def backtrack_boost(
+    pop: List[Any],
+    archive: List[Any],
+    rate: float,
+    *,
+    beta: float = 1.0,
+    gamma: float = 0.0,
+) -> Any:
     """Return a parent possibly selected from weaker individuals.
 
     With probability ``rate`` the parent is drawn uniformly from the
@@ -147,9 +154,9 @@ def backtrack_boost(pop: List[Any], archive: List[Any], rate: float) -> Any:
     if not pop:
         raise ValueError("population is empty")
     if rate <= 0.0:
-        return select_parent(pop, temp=1.0)
+        return select_parent(pop, beta=beta, gamma=gamma)
     if random.random() < rate:
         ranked = sorted(archive, key=lambda c: getattr(c, "fitness", 0.0))
         bottom = ranked[: max(1, len(ranked) // 2)]
         return random.choice(bottom)
-    return select_parent(pop, temp=1.0)
+    return select_parent(pop, beta=beta, gamma=gamma)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -9,8 +9,8 @@ from src.archive.selector import select_parent
 
 @dataclass(slots=True)
 class Candidate:
-    fitness: float
-    novelty: float
+    score: float
+    edit_children_count: int
 
 
 def softmax(arr: np.ndarray) -> np.ndarray:
@@ -18,34 +18,34 @@ def softmax(arr: np.ndarray) -> np.ndarray:
     return exp / exp.sum()
 
 
-def sample_distribution(pop, temp, runs=20000):
+def sample_distribution(pop, beta, gamma, runs=20000):
     np.random.seed(42)
     counts = {id(ind): 0 for ind in pop}
     for _ in range(runs):
-        ind = select_parent(pop, temp)
+        ind = select_parent(pop, beta=beta, gamma=gamma)
         counts[id(ind)] += 1
     return np.asarray([counts[id(ind)] / runs for ind in pop])
 
 
 def test_select_parent_softmax() -> None:
     pop = [
-        Candidate(1.0, 1.0),
-        Candidate(0.5, 2.0),
-        Candidate(2.0, 0.5),
+        Candidate(1.0, 0),
+        Candidate(0.5, 1),
+        Candidate(2.0, 2),
     ]
-    temp = 1.0
-    expected = softmax(np.asarray([p.fitness * p.novelty for p in pop]) / temp)
-    observed = sample_distribution(pop, temp)
+    beta, gamma = 1.0, 0.0
+    expected = softmax(np.asarray([beta * p.score + gamma * p.edit_children_count for p in pop]))
+    observed = sample_distribution(pop, beta, gamma)
     assert np.allclose(observed, expected, atol=0.02)
 
 
-def test_select_parent_temperature() -> None:
+def test_select_parent_weighting() -> None:
     pop = [
-        Candidate(1.0, 1.0),
-        Candidate(0.5, 2.0),
-        Candidate(2.0, 0.5),
+        Candidate(1.0, 0),
+        Candidate(0.5, 1),
+        Candidate(2.0, 2),
     ]
-    temp = 0.5
-    expected = softmax(np.asarray([p.fitness * p.novelty for p in pop]) / temp)
-    observed = sample_distribution(pop, temp)
+    beta, gamma = 0.5, 1.0
+    expected = softmax(np.asarray([beta * p.score + gamma * p.edit_children_count for p in pop]))
+    observed = sample_distribution(pop, beta, gamma)
     assert np.allclose(observed, expected, atol=0.02)

--- a/tests/test_selector_v2.py
+++ b/tests/test_selector_v2.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+from src.archive.selector import select_parent
+
+
+def softmax(arr: np.ndarray) -> np.ndarray:
+    exp = np.exp(arr - np.max(arr))
+    return exp / exp.sum()
+
+
+@dataclass(slots=True)
+class Candidate:
+    score: float
+    edit_children_count: int
+
+
+def sample_distribution(pop, beta, gamma, runs=20000):
+    np.random.seed(123)
+    counts = {id(ind): 0 for ind in pop}
+    for _ in range(runs):
+        ind = select_parent(pop, beta=beta, gamma=gamma)
+        counts[id(ind)] += 1
+    return np.asarray([counts[id(ind)] / runs for ind in pop])
+
+
+def test_selector_frequency_monte_carlo() -> None:
+    pop = [
+        Candidate(1.0, 0),
+        Candidate(0.2, 3),
+        Candidate(1.5, 1),
+    ]
+    beta, gamma = 0.7, 0.3
+    logits = np.asarray([beta * p.score + gamma * p.edit_children_count for p in pop])
+    expected = softmax(logits)
+    observed = sample_distribution(pop, beta, gamma, runs=50000)
+    assert np.allclose(observed, expected, atol=0.02)


### PR DESCRIPTION
## Summary
- expand selector softmax to `beta * score + gamma * edit_children_count`
- update simulation backtrack boost with beta/gamma
- expose beta/gamma via evolve CLI and Insight demo CLI
- add tests for new selector behaviour

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: many tests error out)*

------
https://chatgpt.com/codex/tasks/task_e_683a4129e0a0833393c17c9fd3760620