### PR TITLE
[alpha_factory] add preflight checks

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/self_improver.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/self_improver.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Tuple
 
 from src.utils.patch_guard import is_patch_valid
+from src.eval.preflight import run_preflight
 
 try:
     import git
@@ -55,6 +56,8 @@ def improve_repo(repo_url: str, patch_file: str, metric_file: str, log_file: str
     repo.git.apply(patch_file)
     repo.index.add([metric_file])
     repo.index.commit("apply patch")
+    # run basic checks before scoring
+    run_preflight(repo_dir)
     new_score = _evaluate(repo_dir, metric_file)
     delta = new_score - baseline
     _log_delta(delta, Path(log_file))

--- a/src/eval/preflight.py
+++ b/src/eval/preflight.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight preflight checks for patches.
+
+Compiles all tracked Python files and runs a minimal
+unit test when available. Raises ``CalledProcessError``
+on failure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+__all__ = ["run_preflight"]
+
+
+def run_preflight(repo_dir: str | Path = ".") -> None:
+    """Run compilation and smoke tests inside ``repo_dir``."""
+
+    repo = Path(repo_dir)
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"], capture_output=True, text=True, cwd=repo
+    )
+    files = [f for f in result.stdout.splitlines() if f]
+    if files:
+        subprocess.run([sys.executable, "-m", "py_compile", *files], check=True, cwd=repo)
+
+    test_path = repo / "tests" / "basic_edit.py"
+    if test_path.exists():
+        subprocess.run(["pytest", "-q", str(test_path)], check=True, cwd=repo)
+
+
+def main(argv: list[str] | None = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    repo = Path(argv[0]) if argv else Path(".")
+    run_preflight(repo)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/src/tools/ablation_runner.py
+++ b/src/tools/ablation_runner.py
@@ -26,6 +26,7 @@ except Exception:  # pragma: no cover - optional dependency missing
 
 from alpha_factory_v1.demos.self_healing_repo.patcher_core import apply_patch
 from src.eval.fitness import compute_fitness
+from src.eval.preflight import run_preflight
 
 ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = ROOT / "benchmarks" / "patch_library"
@@ -72,6 +73,7 @@ def _evaluate_patch(patch: Path) -> Dict[str, float]:
         repo = Path(tmp)
         _clone_repo(repo)
         apply_patch(patch.read_text(), repo_path=tmp)
+        run_preflight(repo)
         base_flags = {n: True for n in INNOVATIONS}
         baseline = _run_bench(repo, base_flags)
         scores["baseline"] = baseline

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,36 @@
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import self_improver
+
+git = pytest.importorskip("git")
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _init_repo(path: Path) -> Any:
+    repo = git.Repo.init(path)
+    (path / "metric.txt").write_text("1\n")
+    (path / "foo.py").write_text("print('ok')\n")
+    test_dir = path / "tests"
+    test_dir.mkdir()
+    (test_dir / "basic_edit.py").write_text("def test_ok():\n    assert True\n")
+    repo.git.add(A=True)
+    repo.index.commit("init")
+    return repo
+
+
+def test_preflight_rejects_malformed_patch(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _init_repo(repo_dir)
+
+    patch_file = tmp_path / "bad.diff"
+    patch_file.write_text((FIXTURES / "malformed_patch.diff").read_text())
+    log_file = tmp_path / "log.json"
+
+    t0 = time.time()
+    with pytest.raises(ValueError):
+        self_improver.improve_repo(str(repo_dir), str(patch_file), "metric.txt", str(log_file))
+    assert time.time() - t0 < 30


### PR DESCRIPTION
## Summary
- add a simple Python/pytest preflight script
- run preflight in self-improver before scoring
- enforce preflight in the ablation benchmark flow
- test malformed patch rejection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_preflight.py`

------
https://chatgpt.com/codex/tasks/task_e_683a4828528083339eeb2160d434e515