### PR TITLE
[alpha_factory] Add archive patch manager

### DIFF
--- a/src/archive/__init__.py
+++ b/src/archive/__init__.py
@@ -13,6 +13,7 @@ from typing import Any, List
 from src.monitoring import metrics
 
 from .db import ArchiveDB, ArchiveEntry
+from .manager import PatchManager
 
 
 @dataclass(slots=True)
@@ -69,4 +70,4 @@ class Archive:
         return chosen
 
 
-__all__ = ["Agent", "Archive", "ArchiveDB", "ArchiveEntry"]
+__all__ = ["Agent", "Archive", "ArchiveDB", "ArchiveEntry", "PatchManager"]

--- a/src/archive/manager.py
+++ b/src/archive/manager.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch admission controller for the archive."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+
+from src.eval.preflight import run_preflight
+from src.self_edit.tools import REPO_ROOT, edit, undo_last_edit
+
+from .db import ArchiveDB, ArchiveEntry
+
+
+def _tool_roundtrip() -> bool:
+    """Return ``True`` if edit/undo leaves no changes."""
+    path = REPO_ROOT / "_roundtrip.txt"
+    path.write_text("a\nb\n", encoding="utf-8")
+    baseline = path.read_text(encoding="utf-8")
+    edit(path, 1, 2, "x")
+    undo_last_edit()
+    ok = path.read_text(encoding="utf-8") == baseline
+    path.unlink(missing_ok=True)  # type: ignore[call-arg]
+    return ok
+
+
+class PatchManager:
+    """Control patch acceptance and persist history."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db = ArchiveDB(db_path)
+
+    def admit(self, diff: str, parent: str, repo_dir: str | Path | None = None) -> bool:
+        """Validate and store ``diff`` with its parent hash."""
+
+        repo = Path(repo_dir) if repo_dir else REPO_ROOT
+        try:
+            run_preflight(repo)
+        except Exception:
+            return False
+        if not _tool_roundtrip():
+            return False
+
+        h = hashlib.sha1(diff.encode()).hexdigest()
+        entry = json.dumps({"diff": diff, "parent": parent})
+        self.db.set_state(f"patch:{h}", entry)
+        self.db.add(
+            ArchiveEntry(hash=h, parent=parent, score=0.0, novelty=0.0, is_live=True, ts=time.time())
+        )
+        return True

--- a/tests/test_archive_policy.py
+++ b/tests/test_archive_policy.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from src.archive.manager import PatchManager, _tool_roundtrip
+import src.archive.manager as manager
+
+
+def test_tool_roundtrip(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(manager, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr("src.self_edit.tools.REPO_ROOT", tmp_path)
+    assert _tool_roundtrip()
+
+
+def test_admit_policy(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(manager, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr("src.self_edit.tools.REPO_ROOT", tmp_path)
+    db_path = tmp_path / "arch.db"
+    mgr = PatchManager(db_path)
+    diff = "--- a/foo\n+++ b/foo\n@@\n-a\n+b\n"
+    parent = "root"
+
+    monkeypatch.setattr(manager, "run_preflight", lambda _repo: None)
+    monkeypatch.setattr(manager, "_tool_roundtrip", lambda: True)
+    assert mgr.admit(diff, parent)
+    h = hashlib.sha1(diff.encode()).hexdigest()
+    stored = mgr.db.get_state(f"patch:{h}")
+    assert json.loads(stored) == {"diff": diff, "parent": parent}
+
+    diff2 = "--- a/foo\n+++ b/foo\n@@\n-a\n+c\n"
+    monkeypatch.setattr(manager, "run_preflight", lambda _repo: (_ for _ in ()).throw(RuntimeError()))
+    assert not mgr.admit(diff2, parent)
+    h2 = hashlib.sha1(diff2.encode()).hexdigest()
+    assert mgr.db.get_state(f"patch:{h2}") is None
+
+    diff3 = "--- a/foo\n+++ b/foo\n@@\n-a\n+d\n"
+    monkeypatch.setattr(manager, "run_preflight", lambda _repo: None)
+    monkeypatch.setattr(manager, "_tool_roundtrip", lambda: False)
+    assert not mgr.admit(diff3, parent)
+    h3 = hashlib.sha1(diff3.encode()).hexdigest()
+    assert mgr.db.get_state(f"patch:{h3}") is None


### PR DESCRIPTION
## Summary
- implement PatchManager controlling patch admission
- gate on preflight and edit/undo tool test
- record diff and parent hash in ArchiveDB
- test policy logic

## Testing
- `pre-commit run --files src/archive/manager.py src/archive/__init__.py tests/test_archive_policy.py` *(fails: unable to access 'https://github.com/psf/black/' )*
- `python check_env.py --auto-install`
- `pytest -q tests/test_archive_policy.py`
- `pytest -q` *(fails: 59 failed, 470 passed, 29 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683a4b773a888333991cdad8c1a98893