### PR TITLE
[alpha_factory] add revive rate controller

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/loop.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/loop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import time
+import random
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
@@ -26,6 +27,7 @@ class Result:
     state: State
     cycles: int
     cost: float
+    revives: int = 0
 
 
 def run_loop(
@@ -34,6 +36,9 @@ def run_loop(
     wallclock: float | None = None,
     cost_per_cycle: float = 1.0,
     state_file: str = "loop_state.json",
+    revive_rate: int = 0,
+    agents: dict[str, bool] | None = None,
+    rng: random.Random | None = None,
 ) -> Result:
     """Run the FSM until budgets are exhausted.
 
@@ -42,15 +47,22 @@ def run_loop(
         wallclock: Optional wall-clock limit in seconds.
         cost_per_cycle: Cost incurred per complete cycle.
         state_file: Path used when persisting state on ``KeyboardInterrupt``.
+        revive_rate: Attempt revival every ``revive_rate`` cycles (0 disables).
+        agents: Mapping of agent names to active state.
+        rng: Random generator for deterministic tests.
 
     Returns:
-        :class:`Result` with final state, completed cycles and cost spent.
+        :class:`Result` with final state, completed cycles, cost spent and
+        the number of agents revived.
     """
 
     state = State.SELECT
     cycles = 0
     cost_spent = 0.0
     start = time.time()
+    rng = rng or random.Random()
+    agents = agents or {}
+    revive_count = 0
 
     try:
         while True:
@@ -66,6 +78,14 @@ def run_loop(
                 continue
             if state is State.ARCHIVE:
                 cycles += 1
+                if revive_rate and cycles % revive_rate == 0:
+                    inactive = [a for a, active in agents.items() if not active]
+                    if inactive:
+                        revived = rng.choice(inactive)
+                        agents[revived] = True
+                        revive_count += 1
+                        state = State.SELF_MOD
+                        continue
                 state = State.SELECT
                 if cost_budget is not None and cost_spent >= cost_budget:
                     break
@@ -75,6 +95,6 @@ def run_loop(
         Path(state_file).write_text(
             json.dumps({"state": state.name, "cycles": cycles, "cost": cost_spent})
         )
-        return Result(state=state, cycles=cycles, cost=cost_spent)
+        return Result(state=state, cycles=cycles, cost=cost_spent, revives=revive_count)
 
-    return Result(state=state, cycles=cycles, cost=cost_spent)
+    return Result(state=state, cycles=cycles, cost=cost_spent, revives=revive_count)

--- a/tests/test_revive_rate.py
+++ b/tests/test_revive_rate.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import loop
+import random
+
+
+def test_revive_rate() -> None:
+    rng = random.Random(12345)
+    agents = {"A": True, "B": False}
+    result = loop.run_loop(
+        cost_budget=100.0,
+        cost_per_cycle=1.0,
+        revive_rate=10,
+        agents=agents,
+        rng=rng,
+    )
+    assert result.revives >= 1


### PR DESCRIPTION
## Summary
- implement revive logic in Insight demo loop controller
- return revival count in result snapshot
- integration test for agent revival

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 56 failed, 466 passed, 27 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683a4e56d7b48333906785c7825ce2dc