### PR TITLE
[alpha_factory] add typing stubs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,6 @@ cryptography
 hypothesis
 grpcio-tools
 pytest-httpx
+
+types-PyYAML
+types-requests


### PR DESCRIPTION
## Summary
- add missing stub packages to requirements-dev

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 63 failed, 503 passed, 29 skipped)*
- `mypy --config-file mypy.ini .` *(fails: missing stubs)*
- `pre-commit run --files requirements-dev.txt requirements.lock` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_683a5f3f5998833388e5e80dc65452a9