### PR TITLE
[alpha_factory] optimize rate limiter

### DIFF
--- a/tests/test_api_server_static.py
+++ b/tests/test_api_server_static.py
@@ -3,6 +3,7 @@ import importlib
 import os
 import time
 from typing import Any, cast
+from collections import deque
 
 import pytest
 
@@ -16,6 +17,7 @@ os.environ.setdefault("API_RATE_LIMIT", "1000")
 def test_throttle_alert(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("API_RATE_LIMIT", "1")
     from src.interface import api_server as mod
+
     api = importlib.reload(mod)
 
     sent: list[str] = []
@@ -31,7 +33,7 @@ def test_throttle_alert(monkeypatch: pytest.MonkeyPatch) -> None:
     metrics = stack.app.app
     limiter = metrics.app
     metrics.window_start = time.time() - 61
-    limiter.counters["testclient"] = (0, time.time())
+    limiter.counters["testclient"] = deque()
 
     client.get("/runs", headers=headers)
 


### PR DESCRIPTION
## Summary
- use TTLCache+deque for SimpleRateLimiter
- adjust demos and tests
- add regression test for throttling

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py tests/test_rate_limiter_eviction.py tests/test_api_server_static.py` *(fails: could not fetch black)*
- `mypy --config-file mypy.ini src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py tests/test_rate_limiter_eviction.py tests/test_api_server_static.py` *(fails: many errors)*
- `pytest -q tests/test_rate_limiter_eviction.py tests/test_api_server_static.py`

------
https://chatgpt.com/codex/tasks/task_e_683a659fc3748333bf8a6dbe3a466de4