### PR TITLE
[alpha_factory] add evolution worker service

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Simple NSGA-II evolution worker.
+
+This service exposes a ``/mutate`` endpoint that accepts an uploaded tarball
+or a repository URL. It runs a single NSGA-II step on a dummy fitness function
+and returns the resulting child genome. The goal is to demonstrate how a
+self-improving agent could be evolved inside a container.
+"""
+
+from __future__ import annotations
+
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import List, Tuple
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from .simulation import mats
+
+GPU_TYPE = os.getenv("GPU_TYPE", "cpu")
+MAX_GENERATIONS = int(os.getenv("MAX_GENERATIONS", "10"))
+STORAGE_PATH = Path(os.getenv("STORAGE_PATH", "/tmp/evolution"))
+
+app = FastAPI(title="Evolution Worker")
+
+
+class MutationResponse(BaseModel):
+    child: List[float]
+
+
+@app.on_event("startup")
+async def _prepare() -> None:
+    STORAGE_PATH.mkdir(parents=True, exist_ok=True)
+
+
+@app.post("/mutate", response_model=MutationResponse)
+async def mutate(
+    tar: UploadFile | None = File(None),
+    repo_url: str | None = Form(None),
+) -> MutationResponse:
+    """Return a mutated child from one evolution step."""
+
+    if tar is None and not repo_url:
+        raise HTTPException(status_code=400, detail="tar or repo_url required")
+
+    tmp = tempfile.mkdtemp(dir=STORAGE_PATH)
+    tmp_path = Path(tmp)
+    try:
+        if tar is not None:
+            with tarfile.open(fileobj=tar.file) as tf:
+                tf.extractall(tmp_path)
+        if repo_url:
+            (tmp_path / "repo.txt").write_text(repo_url)
+
+        pop = mats.run_evolution(
+            lambda g: (g[0] ** 2, g[1] ** 2),
+            2,
+            population_size=4,
+            generations=1,
+            seed=42,
+        )
+        child = pop[0].genome
+        return MutationResponse(child=child)
+    finally:
+        for p in tmp_path.rglob("*"):
+            if p.is_file():
+                p.unlink()
+        tmp_path.rmdir()
+
+
+@app.get("/healthz")
+async def healthz() -> str:
+    """Liveness probe."""
+
+    return "ok"

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -31,6 +31,24 @@ services:
       <<: *default_healthcheck
       test: ["CMD", "curl", "-sf", "http://localhost:8000/healthz"]
 
+  evolution_worker:
+    build:
+      context: ..
+      dockerfile: infrastructure/evolution_worker.Dockerfile
+    image: evolution-worker:latest
+    env_file:
+      - ../.env
+    environment:
+      GPU_TYPE: ${GPU_TYPE:-cpu}
+      MAX_GENERATIONS: ${MAX_GENERATIONS:-10}
+      STORAGE_PATH: ${STORAGE_PATH:-/tmp/evolution}
+    ports:
+      - "7865:8000"
+    restart: unless-stopped
+    healthcheck:
+      <<: *default_healthcheck
+      test: ["CMD", "curl", "-sf", "http://localhost:8000/healthz"]
+
   agents:
     image: alpha-demo:latest             # reuse the demo image
     env_file:

--- a/infrastructure/evolution_worker.Dockerfile
+++ b/infrastructure/evolution_worker.Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1 /app/alpha_factory_v1/demos/alpha_agi_insight_v1
+EXPOSE 8000
+CMD ["uvicorn", "alpha_factory_v1.demos.alpha_agi_insight_v1.src.evolution_worker:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tests/test_evolution_worker.py
+++ b/tests/test_evolution_worker.py
@@ -1,0 +1,55 @@
+import socket
+import threading
+import time
+from typing import Iterator
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+uvicorn = pytest.importorskip("uvicorn")
+
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import evolution_worker
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture()
+def server() -> Iterator[str]:
+    port = _free_port()
+    config = uvicorn.Config(evolution_worker.app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if server.started:
+            break
+        time.sleep(0.1)
+    yield f"http://127.0.0.1:{port}"
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+def test_mutate_returns_child(server: str) -> None:
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        info = tarfile.TarInfo(name="README.txt")
+        data = b"demo"
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+
+    with httpx.Client(base_url=server) as client:
+        files = {"tar": ("dummy.tar", buf.read())}
+        r = client.post("/mutate", files=files)
+        assert r.status_code == 200
+        data = r.json()
+        assert "child" in data
+        assert isinstance(data["child"], list)


### PR DESCRIPTION
## Summary
- implement evolution_worker FastAPI app
- provide Dockerfile & compose entry
- unit test for mutate endpoint

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py tests/test_evolution_worker.py infrastructure/evolution_worker.Dockerfile infrastructure/docker-compose.yml` *(fails: Could not fetch black)*
- `pytest tests/test_evolution_worker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683a6e349de48333bf038f917448a501