### PR TITLE
[alpha_factory] Add prompt sampler utility

### DIFF
--- a/src/agents/prompt_sampler.py
+++ b/src/agents/prompt_sampler.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt generation helpers."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+__all__ = ["load_templates", "construct_prompt"]
+
+
+def load_templates(path: str | Path) -> dict[str, Mapping[str, Any]]:
+    """Return prompt templates loaded from ``path``."""
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("template file must map names to templates")
+    return {str(k): dict(v) for k, v in raw.items()}
+
+
+def construct_prompt(parent_diff: str, exemplars: Sequence[str], template: Mapping[str, Any]) -> str:
+    """Return a prompt populated with ``parent_diff`` and ``exemplars``.
+
+    ``template`` must provide a ``user`` string and may include ``system`` and
+    ``tokens``. The ``{diff}`` and ``{exemplars}`` placeholders are replaced with
+    the given parameters. A random entry from ``tokens`` (when present) fills the
+    ``{token}`` placeholder.
+    """
+    tokens = list(template.get("tokens", []))
+    token = random.choice(tokens) if tokens else ""
+    user = str(template.get("user", "")).format(
+        diff=parent_diff,
+        exemplars="\n".join(exemplars),
+        token=token,
+    )
+    system = template.get("system")
+    if system:
+        return f"{system}\n{user}"
+    return user

--- a/src/prompts/prompt_sampler.yaml
+++ b/src/prompts/prompt_sampler.yaml
@@ -1,0 +1,23 @@
+gpt-4o:
+  system: "Generate a concise patch with GPT-4o."
+  user: |
+    {diff}
+
+    {exemplars}
+
+    {token}
+  tokens:
+    - "#patch"
+    - "#fix"
+
+gemini-flash:
+  system: "Generate a concise patch with Gemini 2 Flash."
+  user: |
+    {diff}
+
+    {exemplars}
+
+    {token}
+  tokens:
+    - "#apply"
+    - "#refine"

--- a/tests/test_prompt_sampler.py
+++ b/tests/test_prompt_sampler.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from src.agents.prompt_sampler import construct_prompt
+
+TEMPLATE = {
+    "system": "sys",
+    "user": "{diff}|{exemplars}|{token}",
+    "tokens": ["t1", "t2", "t3"],
+}
+
+
+def test_prompt_variants() -> None:
+    parent = "diff-123"
+    exemplars = ["ex1", "ex2", "ex3"]
+    seen = {construct_prompt(parent, exemplars, TEMPLATE) for _ in range(10)}
+    assert len(seen) >= 3
+
+
+def test_placeholders_stable() -> None:
+    parent = "pdiff"
+    exemplars = ["a", "b"]
+    prefix = f"sys\n{parent}|{'\n'.join(exemplars)}|"
+    for _ in range(5):
+        prompt = construct_prompt(parent, exemplars, TEMPLATE)
+        assert prompt.startswith(prefix)
+        assert prompt[len(prefix):] in TEMPLATE["tokens"]


### PR DESCRIPTION
## Summary
- implement prompt sampler helper for constructing prompts
- provide model templates for GPT-4o and Gemini Flash
- test prompt variations and placeholder replacement

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_prompt_sampler.py -q`
- `pre-commit` *(fails: unable to access 'https://github.com/psf/black/' during initialization)*

------
https://chatgpt.com/codex/tasks/task_e_683a7356f81083339554f5f1e802cb8e