### PR TITLE
[alpha_factory] integrate OPA policy and static gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
     hooks:
       - id: mypy
         args: ["--config-file", "mypy.ini"]
+  - repo: https://github.com/semgrep/semgrep
+    rev: v1.61.0
+    hooks:
+      - id: semgrep
+        args: ["--config", "semgrep.yml"]
   - repo: local
     hooks:
       - id: proto-verify

--- a/policies/deny_finance.rego
+++ b/policies/deny_finance.rego
@@ -1,0 +1,15 @@
+package codegen
+
+# Deny outbound finance APIs
+banned_hosts = {
+    "api.alpaca.markets",
+    "api.binance.com",
+    "api.polygon.io"
+}
+
+deny[msg] {
+    some host
+    host := banned_hosts[_]
+    input.url == host
+    msg := "finance API blocked"
+}

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -1,0 +1,11 @@
+rules:
+  - id: solidity-tx-origin
+    languages: [solidity]
+    pattern: tx.origin
+    message: Avoid tx.origin for authorization
+    severity: ERROR
+  - id: solidity-call-value
+    languages: [solidity]
+    pattern: ".call.value("
+    message: Unsafe call.value detected
+    severity: ERROR

--- a/src/utils/opa_policy.py
+++ b/src/utils/opa_policy.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight helpers for evaluating OPA policies."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_POLICY_DIR = Path(__file__).resolve().parents[2] / "policies"
+
+
+def _load_banned_hosts() -> set[str]:
+    policy_path = _POLICY_DIR / "deny_finance.rego"
+    try:
+        text = policy_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return set()
+    m = re.search(r"banned_hosts\s*=\s*{([^}]*)}", text, re.DOTALL)
+    if not m:
+        return set()
+    hosts = [h.strip().strip('"') for h in m.group(1).split(',') if h.strip()]
+    return set(hosts)
+
+
+_BANNED_HOSTS = _load_banned_hosts()
+
+
+def violates_finance_policy(code: str) -> bool:
+    """Return ``True`` if ``code`` references a banned finance API host."""
+    for host in _BANNED_HOSTS:
+        if host in code:
+            return True
+    return False

--- a/tests/test_codegen_agent.py
+++ b/tests/test_codegen_agent.py
@@ -2,8 +2,6 @@
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import codegen_agent
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils.logging import Ledger
-import sys
-import shutil
 
 
 def _make_agent() -> codegen_agent.CodeGenAgent:
@@ -14,73 +12,30 @@ def _make_agent() -> codegen_agent.CodeGenAgent:
 
 
 def test_execute_in_sandbox_stdout(monkeypatch) -> None:
-    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: None)
+    called = {}
+
+    def fake_run(cmd):
+        called['cmd'] = cmd
+        class P:
+            stdout = '{"stdout":"x\\n","stderr":""}'
+            stderr = ''
+            returncode = 0
+        return P()
+
+    monkeypatch.setattr(codegen_agent, "secure_run", fake_run)
     agent = _make_agent()
     out, err = agent.execute_in_sandbox("print('x')")
+    assert called['cmd'][0].endswith('python') or 'python' in called['cmd'][0]
     assert out == "x\n"
     assert err == ""
 
 
 def test_execute_in_sandbox_exception(monkeypatch) -> None:
-    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: None)
+    def fake_run(cmd):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(codegen_agent, "secure_run", fake_run)
     agent = _make_agent()
     out, err = agent.execute_in_sandbox("1/0")
     assert out == ""
-    assert "ZeroDivisionError" in err
-
-
-def test_sandbox_env_limits(monkeypatch) -> None:
-    recorded: list[tuple[int, tuple[int, int]]] = []
-
-    def fake_setrlimit(res: int, limits: tuple[int, int]) -> None:
-        recorded.append((res, limits))
-
-    def fake_run(*args, **kwargs):
-        if kwargs.get("preexec_fn"):
-            kwargs["preexec_fn"]()
-
-        class P:
-            stdout = "{}"
-            stderr = ""
-
-        return P()
-
-    monkeypatch.setenv("SANDBOX_CPU_SEC", "1")
-    monkeypatch.setenv("SANDBOX_MEM_MB", "64")
-    monkeypatch.setattr(codegen_agent.subprocess, "run", fake_run)
-    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: None)
-    fake_resource = type(
-        "R",
-        (),
-        {"RLIMIT_CPU": 0, "RLIMIT_AS": 1, "setrlimit": fake_setrlimit},
-    )
-    monkeypatch.setitem(sys.modules, "resource", fake_resource)
-
-    agent = _make_agent()
-    agent.execute_in_sandbox("print('hi')")
-    assert (0, (1, 1)) in recorded
-    assert (1, (64 * 1024 * 1024, 64 * 1024 * 1024)) in recorded
-
-
-def test_firejail_used_when_available(monkeypatch) -> None:
-    calls: dict[str, list] = {}
-
-    def fake_run(cmd, **kwargs):
-        calls["cmd"] = cmd
-        calls["preexec_fn"] = kwargs.get("preexec_fn")
-
-        class P:
-            stdout = "{}"
-            stderr = ""
-
-        return P()
-
-    monkeypatch.setattr(codegen_agent.shutil, "which", lambda n: "/usr/bin/firejail")
-    monkeypatch.setattr(codegen_agent.subprocess, "run", fake_run)
-
-    agent = _make_agent()
-    agent.execute_in_sandbox("print('hi')")
-
-    assert calls["cmd"][0] == "/usr/bin/firejail"
-    assert "--net=none" in calls["cmd"]
-    assert calls["preexec_fn"] is None
+    assert "boom" in err

--- a/tests/test_static_gate.py
+++ b/tests/test_static_gate.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end test for the static Semgrep gate."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+SEMGRP_BIN = shutil.which("semgrep")
+
+@pytest.mark.skipif(not SEMGRP_BIN, reason="semgrep not installed")
+def test_semgrep_blocks_malicious_diff() -> None:
+    bad_sol = """
+    contract Bad {
+        function attack() public {
+            tx.origin;
+        }
+    }
+    """
+    with tempfile.NamedTemporaryFile("w", suffix=".sol", delete=False) as fh:
+        fh.write(bad_sol)
+        path = fh.name
+    try:
+        result = subprocess.run(
+            [SEMGRP_BIN, "--config", "semgrep.yml", path],
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
## Summary
- sandbox CodeGen snippets using the DGM Docker jail via `secure_run`
- enforce outbound finance API policy with new `deny_finance.rego`
- evaluate policy in `opa_policy.py`
- scan diffs for Solidity exploits via `semgrep` hook
- add unit tests for the sandbox and Semgrep gate

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py src/utils/opa_policy.py semgrep.yml .pre-commit-config.yaml policies/deny_finance.rego tests/test_codegen_agent.py tests/test_static_gate.py` *(fails: couldn't fetch pre-commit dependencies)*
- `pytest -q tests/test_codegen_agent.py tests/test_static_gate.py`


------
https://chatgpt.com/codex/tasks/task_e_683a7c6a3f74833391d85fddf3d05c05