### PR TITLE
[alpha_factory] add SNARK proof skeleton

### DIFF
--- a/scripts/verify_snark.py
+++ b/scripts/verify_snark.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Verify SNARK proof for an evaluation transcript."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from src.utils.snark import generate_proof
+
+
+def parse_score(text: str) -> Sequence[float]:
+    return [float(x) for x in text.split(",")]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify SNARK proof")
+    parser.add_argument("transcript", help="Path to evaluation transcript")
+    parser.add_argument("agent_hash", help="Agent hash")
+    parser.add_argument("score", help="Comma separated score tuple")
+    parser.add_argument("proof", help="Proof string")
+    args = parser.parse_args(argv)
+
+    try:
+        score = parse_score(args.score)
+    except ValueError:
+        parser.error("score must be comma separated floats")
+        return 1
+
+    expected = generate_proof(Path(args.transcript), args.agent_hash, score)
+    if expected == args.proof:
+        print("proof verified")
+        return 0
+    print("verification failed")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/archive/db.py
+++ b/src/archive/db.py
@@ -122,3 +122,13 @@ class ArchiveDB:
         with Session(self.engine) as session:
             session.merge(_StateRow(key=key, value=value))
             session.commit()
+
+    # snark helpers -----------------------------------------------------
+
+    def set_proof_cid(self, agent_hash: str, cid: str) -> None:
+        """Store the IPFS CID of the SNARK proof for ``agent_hash``."""
+        self.set_state(f"snark:{agent_hash}", cid)
+
+    def get_proof_cid(self, agent_hash: str) -> str | None:
+        """Return the stored proof CID for ``agent_hash`` if present."""
+        return self.get_state(f"snark:{agent_hash}")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,5 +4,15 @@
 from .config import CFG, get_secret
 from .visual import plot_pareto
 from .file_ops import view, str_replace
+from .snark import generate_proof, publish_proof, verify_proof
 
-__all__ = ["CFG", "get_secret", "plot_pareto", "view", "str_replace"]
+__all__ = [
+    "CFG",
+    "get_secret",
+    "plot_pareto",
+    "view",
+    "str_replace",
+    "generate_proof",
+    "publish_proof",
+    "verify_proof",
+]

--- a/src/utils/snark.py
+++ b/src/utils/snark.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal SNARK-style proof helpers.
+
+These utilities generate a deterministic proof that a particular
+``(agent-hash, score-tuple)`` entry exists in an evaluation transcript.
+The proof is a simple SHA-256 digest derived from the transcript and the
+provided tuple. This acts as a stand-in for a real zero-knowledge proof
+in constrained test environments.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+__all__ = ["generate_proof", "publish_proof", "verify_proof"]
+
+
+def _find_entry(transcript: Path, agent_hash: str, score: Sequence[float]) -> bool:
+    data = json.loads(transcript.read_text())
+    for item in data:
+        if item.get("hash") == agent_hash and tuple(item.get("score", [])) == tuple(score):
+            return True
+    return False
+
+
+def _ipfs_add(path: Path) -> str:
+    cmd = shutil.which("ipfs")
+    if cmd:
+        try:
+            proc = subprocess.run([cmd, "add", "-Q", str(path)], capture_output=True, text=True, check=True)
+            return proc.stdout.strip()
+        except Exception:
+            pass
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def generate_proof(transcript_path: str | Path, agent_hash: str, score: Sequence[float]) -> str:
+    """Return deterministic proof string for the transcript entry."""
+    transcript = Path(transcript_path)
+    if not _find_entry(transcript, agent_hash, score):
+        raise ValueError("entry not found in transcript")
+    transcript_hash = hashlib.sha256(transcript.read_bytes()).hexdigest()
+    blob = json.dumps({"hash": agent_hash, "score": list(score), "transcript": transcript_hash}, separators=(",", ":")).encode()
+    return hashlib.sha256(blob).hexdigest()
+
+
+def publish_proof(
+    transcript_path: str | Path,
+    agent_hash: str,
+    score: Sequence[float],
+    db: "ArchiveDB",
+) -> str:
+    """Generate proof, publish to IPFS and store CID in ``db``."""
+    proof = generate_proof(transcript_path, agent_hash, score)
+    proof_path = Path(transcript_path).with_suffix(".proof")
+    proof_path.write_text(proof, encoding="utf-8")
+    cid = _ipfs_add(proof_path)
+    db.set_state(f"snark:{agent_hash}", cid)
+    return cid
+
+
+def verify_proof(transcript_path: str | Path, agent_hash: str, score: Sequence[float], proof: str) -> bool:
+    """Return ``True`` if ``proof`` matches the generated value."""
+    expected = generate_proof(transcript_path, agent_hash, score)
+    return proof == expected

--- a/tests/test_snark.py
+++ b/tests/test_snark.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+
+from src.archive.db import ArchiveDB, ArchiveEntry
+from src.utils.snark import publish_proof, verify_proof
+
+
+def test_snark_roundtrip(tmp_path: Path) -> None:
+    transcript = tmp_path / "eval.json"
+    entry = {"hash": "a1b2", "score": [0.5, 1.2]}
+    transcript.write_text(json.dumps([entry]), encoding="utf-8")
+
+    db = ArchiveDB(tmp_path / "arch.db")
+    db.add(ArchiveEntry("a1b2", None, 0.5, 0.0, True, 1.0))
+
+    cid = publish_proof(transcript, entry["hash"], entry["score"], db)
+    assert db.get_proof_cid(entry["hash"]) == cid
+
+    proof = transcript.with_suffix(".proof").read_text()
+    assert verify_proof(transcript, entry["hash"], entry["score"], proof)
+
+    expected_cid = hashlib.sha256(proof.encode()).hexdigest()
+    assert cid == expected_cid


### PR DESCRIPTION
## Summary
- implement a simple SNARK-like proof generator
- expose proof helpers from utils
- record proof CID in the archive database
- add verifier script and unit test

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/utils/snark.py src/utils/__init__.py src/archive/db.py scripts/verify_snark.py tests/test_snark.py` *(fails: couldn't fetch pre-commit hooks)*
- `pytest -q tests/test_snark.py`

------
https://chatgpt.com/codex/tasks/task_e_683a7ea20eb88333a27c02f5571c7a1a