### PR TITLE
[alpha_factory] Implement kill switch and regression guard

### DIFF
--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,0 +1,38 @@
+import asyncio
+import contextlib
+import time
+
+from alpha_factory_v1.backend import orchestrator
+from src.monitoring import metrics
+
+class DummyRunner:
+    def __init__(self) -> None:
+        async def _run() -> None:
+            while True:
+                await asyncio.sleep(0.1)
+        self.task = asyncio.create_task(_run())
+
+def test_regression_guard(monkeypatch) -> None:
+    alerts: list[str] = []
+    monkeypatch.setattr(orchestrator.alerts, "send_alert", lambda m: alerts.append(m))
+    runner = DummyRunner()
+    runners = {"aiga_evolver": runner}
+
+    async def drive() -> float:
+        guard = asyncio.create_task(orchestrator._regression_guard(runners))
+        start = time.time()
+        for v in [1.0, 0.7, 0.5, 0.3]:
+            metrics.dgm_best_score.set(v)
+            await asyncio.sleep(0.2)
+        await asyncio.sleep(0.5)
+        duration = time.time() - start
+        guard.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await guard
+        return duration
+
+    dur = asyncio.run(drive())
+    assert runner.task.cancelled
+    assert dur < 10
+    assert alerts
+


### PR DESCRIPTION
## Summary
- add metric regression guard in orchestrator
- implement 2-of-3 kill switch API and weekly static analysis job
- test guard logic in governance tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 59 failed, 472 passed, 27 skipped)*
- `pre-commit run --files src/interface/api_server.py alpha_factory_v1/backend/orchestrator.py tests/test_governance.py` *(fails: could not fetch pre-commit dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683af57f60008333a213f281da3a2d01