### PR TITLE
[alpha_factory] restrict agents container

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,10 @@ docker compose up -d
 # Dashboard available at <http://localhost:8080>
 ```
 
+The Compose stack restricts the agents worker using Docker resource limits. The
+`agents` service runs with `mem_limit: 8g`, `pids_limit: 512` and
+`network_mode: none` to prevent outbound traffic.
+
 The Helm chart under `infrastructure/helm-chart` mirrors this Compose
 setup:
 

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -64,6 +64,9 @@ services:
       AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0} # set 1 for local models
       AGI_INSIGHT_BUS_PORT: ${AGI_INSIGHT_BUS_PORT:-6006} # gRPC event bus port
       AGI_INSIGHT_LEDGER_PATH: ${AGI_INSIGHT_LEDGER_PATH:-./ledger/audit.db} # audit ledger path
+    mem_limit: 8g
+    pids_limit: 512
+    network_mode: none
     depends_on:
       - orchestrator                     # wait for orchestrator
 

--- a/tests/test_no_network.py
+++ b/tests/test_no_network.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+if not shutil.which("docker"):
+    pytest.skip("docker not available", allow_module_level=True)
+
+COMPOSE_FILE = Path(__file__).resolve().parents[1] / "infrastructure" / "docker-compose.yml"
+
+
+@pytest.fixture(scope="module")
+def compose_stack() -> None:
+    subprocess.run([
+        "docker",
+        "compose",
+        "-f",
+        str(COMPOSE_FILE),
+        "up",
+        "-d",
+        "agents",
+    ], check=True)
+    try:
+        yield
+    finally:
+        subprocess.run([
+            "docker",
+            "compose",
+            "-f",
+            str(COMPOSE_FILE),
+            "down",
+            "-v",
+        ], check=False)
+
+
+def test_agents_no_outbound_network(compose_stack: None) -> None:
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(COMPOSE_FILE),
+            "exec",
+            "-T",
+            "agents",
+            "python",
+            "-c",
+            "import urllib.request,sys; urllib.request.urlopen('https://example.com')",
+        ],
+        capture_output=True,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- prevent outbound traffic from `agents` container
- cap container resources
- document limits in README
- add regression test to ensure the container has no network access

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_no_network.py` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683afe4a7c208333b44065ac5aa4184a