### PR TITLE
[alpha_factory] add archive merkle cron

### DIFF
--- a/src/archive/archive.py
+++ b/src/archive/archive.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Archive entry insertion with Merkle root tracking."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Mapping, Iterable
+
+
+_DEFAULT_DB = Path(os.getenv("ARCHIVE_PATH", "archive.db"))
+
+
+def _ensure(path: Path) -> None:
+    with sqlite3.connect(path) as cx:
+        cx.execute(
+            """
+            CREATE TABLE IF NOT EXISTS entries(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                parent TEXT,
+                child TEXT,
+                metrics TEXT,
+                hash TEXT,
+                ts REAL
+            )
+            """
+        )
+        cx.execute(
+            "CREATE TABLE IF NOT EXISTS merkle(date TEXT PRIMARY KEY, root TEXT)"
+        )
+
+
+def _compute_root(hashes: Iterable[str]) -> str:
+    nodes = [hashlib.sha256(h.encode()).digest() for h in sorted(hashes)]
+    if not nodes:
+        return ""
+    while len(nodes) > 1:
+        if len(nodes) % 2 == 1:
+            nodes.append(nodes[-1])
+        nodes = [
+            hashlib.sha256(nodes[i] + nodes[i + 1]).digest()
+            for i in range(0, len(nodes), 2)
+        ]
+    return nodes[0].hex()
+
+
+def merkle_root(*, db_path: str | Path = _DEFAULT_DB) -> str:
+    path = Path(db_path)
+    _ensure(path)
+    with sqlite3.connect(path) as cx:
+        hashes = [r[0] for r in cx.execute("SELECT hash FROM entries ORDER BY id")]
+    return _compute_root(hashes)
+
+
+def _update_root(path: Path) -> str:
+    root = merkle_root(db_path=path)
+    date = time.strftime("%Y-%m-%d")
+    with sqlite3.connect(path) as cx:
+        cx.execute("INSERT OR REPLACE INTO merkle(date, root) VALUES(?,?)", (date, root))
+    return root
+
+
+def insert(
+    parent_hash: str,
+    child_hash: str,
+    metrics: Mapping[str, float],
+    *,
+    db_path: str | Path = _DEFAULT_DB,
+) -> str:
+    """Insert ``child_hash`` with ``parent_hash`` and return updated Merkle root."""
+    path = Path(db_path)
+    _ensure(path)
+    record = {
+        "parent": parent_hash,
+        "child": child_hash,
+        "metrics": dict(metrics),
+    }
+    h = hashlib.sha256(json.dumps(record, sort_keys=True).encode()).hexdigest()
+    with sqlite3.connect(path) as cx:
+        cx.execute(
+            "INSERT INTO entries(parent, child, metrics, hash, ts) VALUES(?,?,?,?,?)",
+            (parent_hash, child_hash, json.dumps(record["metrics"]), h, time.time()),
+        )
+    return _update_root(path)
+
+
+__all__ = ["insert", "merkle_root"]

--- a/src/archive/cron.py
+++ b/src/archive/cron.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler for publishing archive Merkle roots."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+try:
+    from rocketry import Rocketry
+    from rocketry.conds import daily
+except Exception:  # pragma: no cover - optional dependency
+    Rocketry = None  # type: ignore
+    daily = None  # type: ignore
+
+from .hash_archive import HashArchive
+
+
+def publish_root(*, db_path: str | Path | None = None, out_file: str | Path = "archive_root.json") -> str:
+    """Publish today's Merkle root and store it in ``out_file``."""
+    path = Path(db_path or os.getenv("ARCHIVE_PATH", "archive.db"))
+    arch = HashArchive(path)
+    cid = arch.publish_daily_root()
+    Path(out_file).write_text(json.dumps({"cid": cid}), encoding="utf-8")
+    return cid
+
+
+def create_scheduler(
+    *, db_path: str | Path | None = None, out_file: str | Path = "archive_root.json"
+) -> Rocketry | None:
+    """Return a ``Rocketry`` app publishing the archive root daily."""
+    if Rocketry is None or daily is None:
+        return None
+
+    app = Rocketry(execution="async")
+
+    @app.task(daily)
+    def _job() -> None:  # pragma: no cover - Rocketry callback
+        publish_root(db_path=db_path, out_file=out_file)
+
+    return app
+
+
+__all__ = ["publish_root", "create_scheduler"]

--- a/tests/test_archive_cron.py
+++ b/tests/test_archive_cron.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from src.archive.archive import insert, merkle_root
+from src.archive.cron import publish_root
+from src.archive.hash_archive import HashArchive
+
+
+def _manual_root(hashes: list[str]) -> str:
+    nodes = [hashlib.sha256(h.encode()).digest() for h in sorted(hashes)]
+    if not nodes:
+        return ""
+    while len(nodes) > 1:
+        if len(nodes) % 2 == 1:
+            nodes.append(nodes[-1])
+        nodes = [
+            hashlib.sha256(nodes[i] + nodes[i + 1]).digest()
+            for i in range(0, len(nodes), 2)
+        ]
+    return nodes[0].hex()
+
+
+def test_merkle_root_tracking(tmp_path: Path) -> None:
+    db = tmp_path / "arch.db"
+    h1 = hashlib.sha256(json.dumps({"parent": "p", "child": "c1", "metrics": {"s": 1}}, sort_keys=True).encode()).hexdigest()
+    insert("p", "c1", {"s": 1}, db_path=db)
+    h2 = hashlib.sha256(json.dumps({"parent": "c1", "child": "c2", "metrics": {"s": 2}}, sort_keys=True).encode()).hexdigest()
+    insert("c1", "c2", {"s": 2}, db_path=db)
+    root = merkle_root(db_path=db)
+    assert root == _manual_root([h1, h2])
+
+
+def test_cron_writes_root(tmp_path: Path, monkeypatch) -> None:
+    db = tmp_path / "hash.db"
+    arch = HashArchive(db)
+    tar = tmp_path / "a.tar"
+    tar.write_text("a", encoding="utf-8")
+    arch.add_tarball(tar)
+    out = tmp_path / "root.json"
+    monkeypatch.setenv("ARCHIVE_PATH", str(db))
+    cid = publish_root(out_file=out)
+    assert json.loads(out.read_text())["cid"] == cid


### PR DESCRIPTION
## Summary
- implement archive entry insertion with Merkle root tracking
- add Rockery-based cron task to publish daily root
- test Merkle root computation and cron file creation

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_archive_cron.py`
- `pre-commit run --files src/archive/archive.py src/archive/cron.py tests/test_archive_cron.py` *(failed: unable to access remote URLs)*

------
https://chatgpt.com/codex/tasks/task_e_683affad31e8833388167e152f96275c