### PR TITLE
[alpha_factory] add pareto parent selector

### DIFF
--- a/src/simulation/__init__.py
+++ b/src/simulation/__init__.py
@@ -3,12 +3,14 @@
 
 from .mats_ops import GaussianParam, PromptRewrite, CodePatch, SelfRewriteOperator
 from .replay import Scenario, available_scenarios, load_scenario, run_scenario
+from .selector import select_parent
 
 __all__ = [
     "GaussianParam",
     "PromptRewrite",
     "CodePatch",
     "SelfRewriteOperator",
+    "select_parent",
     "Scenario",
     "available_scenarios",
     "load_scenario",

--- a/src/simulation/mats_ops.py
+++ b/src/simulation/mats_ops.py
@@ -7,7 +7,7 @@ from typing import Any, List
 
 import ast
 from src.self_edit.safety import is_code_safe
-from src.archive.selector import select_parent
+from src.simulation.selector import select_parent
 
 
 class GaussianParam:
@@ -154,9 +154,9 @@ def backtrack_boost(
     if not pop:
         raise ValueError("population is empty")
     if rate <= 0.0:
-        return select_parent(pop, beta=beta, gamma=gamma)
+        return select_parent(pop, epsilon=0.1)
     if random.random() < rate:
         ranked = sorted(archive, key=lambda c: getattr(c, "fitness", 0.0))
         bottom = ranked[: max(1, len(ranked) // 2)]
         return random.choice(bottom)
-    return select_parent(pop, beta=beta, gamma=gamma)
+    return select_parent(pop, epsilon=0.1)

--- a/src/simulation/selector.py
+++ b/src/simulation/selector.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pareto based parent selection helpers."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Mapping, Sequence
+
+
+__all__ = ["select_parent"]
+
+
+def _metrics(item: Any) -> tuple[float, float, float]:
+    """Return (rmse, inference_ms, gasCost) triple for ``item``."""
+    if isinstance(item, Mapping):
+        rmse = float(item.get("rmse", item.get("RMSE", 0.0)))
+        inf = float(item.get("inference_ms", 0.0))
+        gas = float(item.get("gasCost", item.get("gas_cost", 0.0)))
+        return rmse, inf, gas
+    rmse = float(getattr(item, "rmse", getattr(item, "RMSE", 0.0)))
+    inf = float(getattr(item, "inference_ms", 0.0))
+    gas = float(getattr(item, "gasCost", getattr(item, "gas_cost", 0.0)))
+    return rmse, inf, gas
+
+
+def _pareto_ranks(pop: Sequence[Any]) -> list[int]:
+    metrics = [_metrics(p) for p in pop]
+    ranks = [1 for _ in pop]
+    for i, a in enumerate(metrics):
+        for j, b in enumerate(metrics):
+            if i == j:
+                continue
+            if all(bk <= ak for bk, ak in zip(b, a)) and any(bk < ak for bk, ak in zip(b, a)):
+                ranks[i] += 1
+    return ranks
+
+
+def select_parent(pop: Sequence[Any], *, epsilon: float = 0.1, rng: random.Random | None = None) -> Any:
+    """Return a parent from ``pop`` via Pareto rank with epsilon-greedy randomness."""
+    if not pop:
+        raise ValueError("population is empty")
+    rng = rng or random.Random()
+    if rng.random() < epsilon:
+        return rng.choice(list(pop))
+    ranks = _pareto_ranks(pop)
+    best = min(ranks)
+    candidates = [ind for ind, r in zip(pop, ranks) if r == best]
+    return rng.choice(candidates)

--- a/tests/test_sim_selector.py
+++ b/tests/test_sim_selector.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from src.simulation.selector import select_parent
+
+
+@dataclass(slots=True)
+class Candidate:
+    rmse: float
+    inference_ms: float
+    gasCost: float
+
+
+def test_pareto_rank_deterministic() -> None:
+    pop = [
+        Candidate(0.8, 40, 10),
+        Candidate(0.9, 45, 20),
+        Candidate(0.6, 60, 15),
+    ]
+    rng = random.Random(0)
+    selections = [select_parent(pop, epsilon=0.0, rng=rng) for _ in range(100)]
+    assert all(s is not pop[1] for s in selections)
+
+
+def test_epsilon_randomness() -> None:
+    pop = [
+        Candidate(0.8, 40, 10),
+        Candidate(0.9, 45, 20),
+        Candidate(0.6, 60, 15),
+    ]
+    rng = random.Random(0)
+    count = 0
+    for _ in range(500):
+        if select_parent(pop, epsilon=0.1, rng=rng) is pop[1]:
+            count += 1
+    rate = count / 500.0
+    assert 0.05 < rate < 0.15


### PR DESCRIPTION
## Summary
- add Pareto-based parent selection helper
- hook backtrack boost to use epsilon-greedy Pareto selector
- export selector from simulation package
- unit test Pareto ranking and epsilon randomness

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 28 failed, 196 passed, 21 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683b07b4f7988333970192c0dc53599a