### PR TITLE
[alpha_factory] add dp-scrub hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,8 @@ repos:
         entry: python tools/check_env_table.py
         language: python
         pass_filenames: false
+      - id: dp-scrub
+        name: Detect private text in commit
+        entry: python scripts/dp_scrubber.py
+        language: python
+        pass_filenames: false

--- a/scripts/dp_scrubber.py
+++ b/scripts/dp_scrubber.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Pre-commit hook to detect private or pay-walled text in staged files."""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+# Basic corpus representing proprietary content. Real implementation would load
+# a hashed corpus or database.
+PROPRIETARY_CORPUS = {
+    "exclusive",
+    "dataset",
+    "paywalled",
+    "examplecorp",
+}
+
+TOKEN_LIMIT = 64
+
+
+def classify_with_llm(text: str) -> bool:
+    """Placeholder LLM classifier for ambiguous snippets."""
+    lower = text.lower()
+    return "paywalled" in lower or "proprietary" in lower
+
+
+def tokenize(text: str) -> List[str]:
+    return re.findall(r"\b\w+\b", text.lower())
+
+
+def is_proprietary_content(text: str) -> bool:
+    tokens = tokenize(text)
+    count = 0
+    for tok in tokens:
+        if tok in PROPRIETARY_CORPUS:
+            count += 1
+            if count >= TOKEN_LIMIT:
+                return True
+        else:
+            if 0 < count < TOKEN_LIMIT and classify_with_llm(" ".join(tokens)):
+                return True
+            count = 0
+    if 0 < count < TOKEN_LIMIT and classify_with_llm(text):
+        return True
+    return False
+
+
+def scan_file(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return False
+    return is_proprietary_content(text)
+
+
+def staged_files() -> Iterable[Path]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    for line in result.stdout.splitlines():
+        p = Path(line)
+        if p.is_file():
+            yield p
+
+
+def main() -> int:
+    if os.getenv("ALLOW_PRIVATE_TEXT") == "1":
+        return 0
+
+    flagged: List[str] = []
+    for path in staged_files():
+        if scan_file(path):
+            flagged.append(str(path))
+
+    if flagged:
+        sys.stderr.write(
+            "Private or pay-walled text detected in:\n" + "\n".join(flagged) + "\n"
+        )
+        sys.stderr.write("Set ALLOW_PRIVATE_TEXT=1 to override.\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dp_scrubber.py
+++ b/tests/test_dp_scrubber.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for dp_scrubber hook."""
+from pathlib import Path
+
+from scripts import dp_scrubber
+
+
+def test_blocks_paywalled_excerpt(tmp_path):
+    text = ("paywalled " * 65).strip()
+    f = tmp_path / "secret.txt"
+    f.write_text(text)
+
+    assert dp_scrubber.scan_file(Path(f)) is True


### PR DESCRIPTION
## Summary
- add dp_scrubber hook to scan commits for private text
- register dp-scrub in pre-commit config
- test paywalled excerpt detection

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_dp_scrubber.py`
- `pre-commit run --files scripts/dp_scrubber.py .pre-commit-config.yaml tests/test_dp_scrubber.py` *(fails: unable to fetch repositories)*

------
https://chatgpt.com/codex/tasks/task_e_683b0c2a7ec48333b1e4755bc1c911a7