### PR TITLE
[alpha_factory] add bulletproof circuit stub

### DIFF
--- a/src/snark/__init__.py
+++ b/src/snark/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Circom circuits for SNARK/Bulletproof demos."""

--- a/src/snark/build.sh
+++ b/src/snark/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Build the Circom circuit for score aggregation.
+# Requires circom and snarkjs installed locally.
+set -euo pipefail
+
+CIRCUIT_DIR="$(dirname "$0")"
+cd "$CIRCUIT_DIR"
+
+circom score.circom --r1cs --wasm
+snarkjs groth16 setup score.r1cs pot12_final.ptau score_0000.zkey
+snarkjs zkey contribute score_0000.zkey score_final.zkey --name "Alpha" -v -e="random"
+snarkjs zkey export verificationkey score_final.zkey verification_key.json

--- a/src/snark/score.circom
+++ b/src/snark/score.circom
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma circom 2.0.0;
+
+// Simple circuit that hashes a pair of scores.
+// This placeholder circuit demonstrates how aggregated
+// proofs could be built for evaluation transcripts.
+
+include "circomlib/sha256.circom";
+
+template ScoreHash() {
+    signal input scores[2];
+    signal output hash[2];
+
+    component hasher = Sha256(64);
+    for (var i = 0; i < 2; i++) {
+        hasher.in[i] <== scores[i];
+    }
+    for (var i = 2; i < 64; i++) {
+        hasher.in[i] <== 0;
+    }
+    hash[0] <== hasher.out[0];
+    hash[1] <== hasher.out[1];
+}
+
+component main = ScoreHash();

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,7 +4,13 @@
 from .config import CFG, get_secret
 from .visual import plot_pareto
 from .file_ops import view, str_replace
-from .snark import generate_proof, publish_proof, verify_proof
+from .snark import (
+    generate_proof,
+    publish_proof,
+    verify_proof,
+    aggregate_proof,
+    verify_aggregate_proof,
+)
 
 __all__ = [
     "CFG",
@@ -15,4 +21,6 @@ __all__ = [
     "generate_proof",
     "publish_proof",
     "verify_proof",
+    "aggregate_proof",
+    "verify_aggregate_proof",
 ]

--- a/tests/test_snark.py
+++ b/tests/test_snark.py
@@ -6,7 +6,12 @@ import hashlib
 from pathlib import Path
 
 from src.archive.db import ArchiveDB, ArchiveEntry
-from src.utils.snark import publish_proof, verify_proof
+from src.utils.snark import (
+    publish_proof,
+    verify_proof,
+    aggregate_proof,
+    verify_aggregate_proof,
+)
 
 
 def test_snark_roundtrip(tmp_path: Path) -> None:
@@ -25,3 +30,17 @@ def test_snark_roundtrip(tmp_path: Path) -> None:
 
     expected_cid = hashlib.sha256(proof.encode()).hexdigest()
     assert cid == expected_cid
+
+
+def test_snark_aggregate(tmp_path: Path) -> None:
+    transcript = tmp_path / "eval.json"
+    entries = [
+        {"hash": "a1", "score": [1.0, 2.0]},
+        {"hash": "b2", "score": [0.3, 0.7]},
+    ]
+    transcript.write_text(json.dumps(entries), encoding="utf-8")
+
+    proof = aggregate_proof(transcript, [(e["hash"], e["score"]) for e in entries])
+    assert verify_aggregate_proof(
+        transcript, [(e["hash"], e["score"]) for e in entries], proof
+    )


### PR DESCRIPTION
## Summary
- add Circom score circuit and build script
- update snark utilities to aggregate proofs
- export new helpers and test aggregated proof

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_snark.py`
- ❌ `pytest -q` *(fails: many unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_683b16f2bca88333b5cbe16e98218534