### PR TITLE
[alpha_factory] implement archive service

### DIFF
--- a/src/archive/service.py
+++ b/src/archive/service.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Append-only archive storing agent specs and evaluator scores."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping, List
+
+try:
+    from blake3 import blake3
+except Exception:  # pragma: no cover - fallback
+    from hashlib import sha256 as blake3
+
+try:  # optional dependency
+    from solana.rpc.async_api import AsyncClient
+    from solana.transaction import Transaction
+    from solana.publickey import PublicKey
+    from solana.transaction import TransactionInstruction
+except Exception:  # pragma: no cover - offline fallback
+    AsyncClient = None  # type: ignore
+
+_log = logging.getLogger(__name__)
+
+_DEFAULT_DB = Path(os.getenv("ARCHIVE_PATH", "archive.db"))
+
+
+def _merkle_root(hashes: Iterable[str]) -> str:
+    nodes: List[bytes] = [bytes.fromhex(h) for h in hashes]
+    if not nodes:
+        return blake3(b"\x00").hexdigest()
+
+    while len(nodes) > 1:
+        if len(nodes) % 2 == 1:
+            nodes.append(nodes[-1])
+        next_lvl: List[bytes] = []
+        for i in range(0, len(nodes), 2):
+            next_lvl.append(blake3(nodes[i] + nodes[i + 1]).digest())
+        nodes = next_lvl
+    return nodes[0].hex()
+
+
+class ArchiveService:
+    """Simple append-only archive with Merkle root broadcasting."""
+
+    def __init__(
+        self,
+        path: str | Path = _DEFAULT_DB,
+        *,
+        rpc_url: str | None = None,
+        wallet: str | None = None,
+        broadcast: bool = True,
+    ) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(self.path))
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS entries(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                parent TEXT,
+                spec TEXT,
+                scores TEXT,
+                hash TEXT,
+                ts REAL
+            )
+            """
+        )
+        self.conn.commit()
+        self.rpc_url = rpc_url
+        self.wallet = wallet
+        self.broadcast = broadcast
+        self._task: asyncio.Task[None] | None = None
+
+    def last_hash(self) -> str | None:
+        cur = self.conn.execute("SELECT hash FROM entries ORDER BY id DESC LIMIT 1")
+        row = cur.fetchone()
+        return row[0] if row else None
+
+    def compute_merkle_root(self) -> str:
+        cur = self.conn.execute("SELECT hash FROM entries ORDER BY id")
+        hashes = [row[0] for row in cur.fetchall() if isinstance(row[0], str)]
+        valid: List[str] = []
+        for h in hashes:
+            try:
+                bytes.fromhex(h)
+            except Exception:
+                continue
+            valid.append(h)
+        return _merkle_root(valid)
+
+    def insert_entry(
+        self,
+        spec: Mapping[str, Any],
+        scores: Mapping[str, float],
+        *,
+        parent: str | None = None,
+    ) -> str:
+        parent = parent or self.last_hash()
+        record = {"parent": parent, "spec": spec, "scores": dict(scores)}
+        digest = blake3(json.dumps(record, sort_keys=True).encode()).hexdigest()
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO entries(parent, spec, scores, hash, ts) VALUES(?,?,?,?,?)",
+                (parent, json.dumps(spec), json.dumps(record["scores"]), digest, time.time()),
+            )
+        return self.compute_merkle_root()
+
+    async def broadcast_merkle_root(self) -> None:
+        try:
+            root = self.compute_merkle_root()
+        except Exception as exc:  # pragma: no cover - corruption
+            _log.warning("Failed to compute Merkle root: %s", exc)
+            return
+        if AsyncClient is None or not self.broadcast:
+            _log.info("Merkle root %s", root)
+            return
+        try:
+            client = AsyncClient(self.rpc_url or "https://api.testnet.solana.com")
+            memo_prog = PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
+            tx = Transaction().add(TransactionInstruction(program_id=memo_prog, data=root.encode(), keys=[]))
+            signer = None
+            if self.wallet:
+                try:  # pragma: no cover - optional dependency
+                    from solana.keypair import Keypair
+
+                    signer = Keypair.from_secret_key(bytes.fromhex(self.wallet))
+                except Exception as exc:  # noqa: BLE001 - invalid key
+                    _log.warning("Invalid wallet key: %s", exc)
+            if signer:
+                await client.send_transaction(tx, signer)
+            else:
+                await client.send_transaction(tx)
+            _log.info("Broadcasted Merkle root %s", root)
+        except Exception as exc:  # pragma: no cover - network errors
+            _log.warning("Failed to broadcast Merkle root: %s", exc)
+        finally:
+            try:
+                await client.close()
+            except Exception:  # pragma: no cover - ignore close errors
+                pass
+
+    async def _loop(self, interval: int) -> None:
+        while True:
+            await asyncio.sleep(interval)
+            await self.broadcast_merkle_root()
+
+    def start_merkle_task(self, interval: int = 86_400) -> None:
+        if self._task is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:  # pragma: no cover - no loop in sync context
+                _log.warning("Merkle task requires a running event loop")
+                return
+            self._task = loop.create_task(self._loop(interval))
+
+    async def stop_merkle_task(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:  # pragma: no cover - expected
+                pass
+            self._task = None
+
+    def close(self) -> None:
+        if self.conn:
+            self.conn.close()
+            self.conn = None  # type: ignore[assignment]
+
+    def __enter__(self) -> "ArchiveService":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "ArchiveService":
+        self.start_merkle_task()
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        await self.stop_merkle_task()
+        self.close()
+
+
+__all__ = ["ArchiveService"]

--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -560,7 +560,7 @@ async def _background_run(sim_id: str, cfg: SimRequest) -> None:
 if app is not None:
 
     @app.post("/simulate", response_model=SimStartResponse)
-    async def simulate(req: SimRequest, _: None = Depends(verify_token)) -> SimStartResponse | JSONResponse:
+    async def simulate(req: SimRequest, _: None = Depends(verify_token)) -> Any:
         """Start a simulation and return its identifier."""
 
         start = time.perf_counter()
@@ -577,7 +577,7 @@ if app is not None:
             REQ_LAT.labels("POST", "/simulate").observe(time.perf_counter() - start)
 
     @app.get("/results/{sim_id}", response_model=ResultsResponse)
-    async def get_results(sim_id: str, _: None = Depends(verify_token)) -> ResultsResponse | JSONResponse:
+    async def get_results(sim_id: str, _: None = Depends(verify_token)) -> Any:
         """Return final forecast data for ``sim_id`` if available."""
 
         start = time.perf_counter()
@@ -596,7 +596,7 @@ if app is not None:
             REQ_LAT.labels("GET", "/results/{sim_id}").observe(time.perf_counter() - start)
 
     @app.get("/results", response_model=ResultsResponse)
-    async def get_latest(_: None = Depends(verify_token)) -> ResultsResponse | JSONResponse:
+    async def get_latest(_: None = Depends(verify_token)) -> Any:
         """Return the most recently completed simulation."""
 
         start = time.perf_counter()
@@ -618,7 +618,7 @@ if app is not None:
             REQ_LAT.labels("GET", "/results").observe(time.perf_counter() - start)
 
     @app.get("/population/{sim_id}", response_model=PopulationResponse)
-    async def get_population(sim_id: str, _: None = Depends(verify_token)) -> PopulationResponse | JSONResponse:
+    async def get_population(sim_id: str, _: None = Depends(verify_token)) -> Any:
         """Return the final population for ``sim_id`` if available."""
 
         start = time.perf_counter()
@@ -716,7 +716,7 @@ if app is not None:
         return {"status": f"{len(_pending_votes)}/2 confirmations"}
 
     @app.post("/stake", response_model=StakeResponse)
-    async def set_stake(req: StakeRequest, _: None = Depends(verify_token)) -> StakeResponse | JSONResponse:
+    async def set_stake(req: StakeRequest, _: None = Depends(verify_token)) -> Any:
         """Register ``req.agent_id`` with ``req.amount`` tokens."""
 
         start = time.perf_counter()
@@ -735,7 +735,7 @@ if app is not None:
             REQ_LAT.labels("POST", "/stake").observe(time.perf_counter() - start)
 
     @app.post("/dispatch")
-    async def trigger_dispatch(_: None = Depends(verify_token)) -> dict[str, str] | JSONResponse:
+    async def trigger_dispatch(_: None = Depends(verify_token)) -> Any:
         """Trigger a GitHub workflow dispatch."""
 
         start = time.perf_counter()
@@ -760,7 +760,7 @@ if app is not None:
             REQ_LAT.labels("POST", "/dispatch").observe(time.perf_counter() - start)
 
     @app.get("/proof/{agent_id}", response_model=ProofResponse)
-    async def get_proof(agent_id: str, _: None = Depends(verify_token)) -> ProofResponse | JSONResponse:
+    async def get_proof(agent_id: str, _: None = Depends(verify_token)) -> Any:
         """Return stored proof CID for ``agent_id`` if present."""
 
         start = time.perf_counter()
@@ -781,7 +781,7 @@ if app is not None:
             REQ_LAT.labels("GET", "/proof/{agent_id}").observe(time.perf_counter() - start)
 
     @app.post("/insight", response_model=InsightResponse)
-    async def insight(req: InsightRequest, _: None = Depends(verify_token)) -> InsightResponse | JSONResponse:
+    async def insight(req: InsightRequest, _: None = Depends(verify_token)) -> Any:
         """Return aggregated forecast data across runs."""
 
         try:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -6,6 +6,10 @@ import json
 import pytest
 
 from src.archive.db import ArchiveDB, ArchiveEntry
+from src.archive.service import ArchiveService
+import src.archive.service as service
+import asyncio
+from unittest import mock
 
 
 @pytest.fixture
@@ -37,3 +41,68 @@ def test_archive_migration(TestArchiveMigration) -> None:
     db = TestArchiveMigration(entries)
     assert db.get("a") is not None
     assert db.get("b").parent == "a"
+
+
+def test_archive_service_chain_growth(tmp_path) -> None:
+    svc = ArchiveService(tmp_path / "arch.db", broadcast=False)
+    root1 = svc.insert_entry({"id": 1}, {"score": 0.1})
+    first_hash = svc.last_hash()
+    root2 = svc.insert_entry({"id": 2}, {"score": 0.2})
+    second_hash = svc.last_hash()
+    assert first_hash != second_hash
+    assert svc.conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0] == 2
+    parent = svc.conn.execute("SELECT parent FROM entries WHERE hash=?", (second_hash,)).fetchone()[0]
+    assert parent == first_hash
+    assert root1 != ""
+    assert root2 != ""
+
+
+def _dummy_classes(raise_err: bool = False):
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, url: str) -> None:
+            captured["url"] = url
+
+        async def send_transaction(self, tx: object, *args: object) -> None:
+            if raise_err:
+                raise RuntimeError("fail")
+            captured["root"] = tx.instructions[0].data.decode()
+
+        async def close(self) -> None:  # pragma: no cover - dummy
+            pass
+
+    class DummyTx:
+        def __init__(self) -> None:
+            self.instructions = []
+
+        def add(self, instr: object) -> "DummyTx":
+            self.instructions.append(instr)
+            return self
+
+    class DummyInstr:
+        def __init__(self, program_id: object, data: bytes, keys: list[object]):
+            self.data = data
+
+    class DummyPk:
+        def __init__(self, val: str) -> None:  # pragma: no cover - dummy
+            pass
+
+    return captured, DummyClient, DummyTx, DummyInstr, DummyPk
+
+
+def test_archive_service_broadcast(tmp_path) -> None:
+    svc = ArchiveService(tmp_path / "arch.db", rpc_url="http://rpc.test", broadcast=True)
+    svc.insert_entry({"id": 1}, {"score": 0.1})
+    root = svc.compute_merkle_root()
+    captured, DummyClient, DummyTx, DummyInstr, DummyPk = _dummy_classes()
+    with (
+        mock.patch.object(service, "AsyncClient", DummyClient, create=True),
+        mock.patch.object(service, "Transaction", DummyTx, create=True),
+        mock.patch.object(service, "TransactionInstruction", DummyInstr, create=True),
+        mock.patch.object(service, "PublicKey", DummyPk, create=True),
+    ):
+        asyncio.run(svc.broadcast_merkle_root())
+    assert captured["url"] == "http://rpc.test"
+    assert captured["root"] == root
+


### PR DESCRIPTION
## Summary
- implement ArchiveService storing agent specs and evaluator scores
- schedule nightly Merkle root broadcast
- update API server typing for pydantic2 compatibility
- extend archive tests for chain growth and broadcast

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 33 failed, 224 passed, 21 skipped)*
- `pre-commit run --files src/archive/service.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py tests/test_archive.py src/interface/api_server.py` *(fails: could not fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683b1cc60c2883338dbf0a20e6a929eb