### PR TITLE
[alpha_factory] island evolution support

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -14,6 +14,7 @@ import contextlib
 import importlib
 import json
 import os
+import hashlib
 import secrets
 import time
 from collections import OrderedDict, deque
@@ -284,12 +285,24 @@ if app is not None:
             x, y = genome
             return x**2, y**2, (x + y) ** 2
 
-        pop = mats.run_evolution(
-            eval_fn,
-            2,
-            population_size=cfg.pop_size,
-            generations=cfg.generations,
-        )
+        scenario = hashlib.sha1(sim_id.encode()).hexdigest()
+        orch = getattr(app_f.state, "orchestrator", None)
+        if orch is not None:
+            pop = orch.evolve(
+                scenario,
+                eval_fn,
+                2,
+                population_size=cfg.pop_size,
+                generations=cfg.generations,
+            )
+        else:
+            pop = mats.run_evolution(
+                eval_fn,
+                2,
+                population_size=cfg.pop_size,
+                generations=cfg.generations,
+                scenario_hash=scenario,
+            )
 
         pop_data = [
             PopulationMember(

--- a/tests/test_mats.py
+++ b/tests/test_mats.py
@@ -44,3 +44,20 @@ def test_run_evolution_three_objectives() -> None:
     pop = mats.run_evolution(fn, 2, population_size=4, generations=2, seed=42)
 
     assert all(len(ind.fitness or ()) == 3 for ind in pop)
+
+
+def test_pareto_front_after_five_generations() -> None:
+    def fn(genome: list[float]) -> tuple[float, float]:
+        x, y = genome
+        return x**2, y**2
+
+    pop = mats.run_evolution(
+        fn,
+        2,
+        population_size=20,
+        generations=5,
+        seed=42,
+        scenario_hash="test",
+    )
+    front = mats.pareto_front(pop)
+    assert len(front) >= 10


### PR DESCRIPTION
## Summary
- extend NSGA-II helper with multi-island support keyed by scenario hashes
- store island populations in orchestrator and expose an `evolve` helper
- allow API server to send scenario hashes to `run_evolution`
- test Pareto front size after several generations

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py tests/test_mats.py` *(fails: couldn't connect to github.com)*
- `pytest -q` *(fails: 69 failed, 517 passed, 31 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_683b1f57f95483339e1ad962edc4f947