### PR TITLE
[alpha_factory] code diff mutator

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -23,8 +23,11 @@ except Exception:  # pragma: no cover - offline stub
 
     def tool(fn=None, **_):  # type: ignore
         return (lambda f: f)(fn) if fn else lambda f: f
+
+
 from src.self_edit.safety import is_code_safe
-from src.tools.diff_mutation import propose_diff as generate_diff
+from pathlib import Path
+from .mutators.code_diff import propose_diff as generate_diff
 from src.utils.opa_policy import violates_finance_policy
 from src.utils.secure_run import secure_run
 
@@ -67,7 +70,9 @@ class CodeGenAgent(BaseAgent):
 
     @tool(description="Propose a minimal diff implementing the given goal")
     def propose_diff(self, file_path: str, goal: str) -> str:  # noqa: D401
-        return generate_diff(file_path, goal)
+        repo_root = str(Path(file_path).resolve().parent)
+        spec = f"{Path(file_path).name}:{goal}"
+        return generate_diff(repo_root, spec)
 
     def execute_in_sandbox(self, code: str) -> tuple[str, str]:
         """Run ``code`` inside a subprocess with resource limits."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/mutators/code_diff.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/mutators/code_diff.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unified diff generator for repository mutations."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from pathlib import Path
+
+from src.tools.diff_mutation import propose_diff as _fallback_diff
+
+__all__ = ["propose_diff"]
+
+
+def _offline() -> bool:
+    return not os.getenv("OPENAI_API_KEY") or os.getenv("AGI_INSIGHT_OFFLINE") == "1"
+
+
+def _parse_spec(spec: str) -> tuple[str, str]:
+    if ":" in spec:
+        path, goal = spec.split(":", 1)
+    else:
+        parts = spec.split(maxsplit=1)
+        if len(parts) != 2:
+            raise ValueError("spec must contain 'path goal'")
+        path, goal = parts
+    return path.strip(), goal.strip()
+
+
+def _sync_chat(prompt: str) -> str:
+    """Synchronously invoke the async chat helper."""
+    from alpha_factory_v1.backend.llm_provider import chat
+
+    async def _call() -> str:
+        return await chat(prompt, max_tokens=512)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_call())
+
+    result: list[str] = []
+
+    def _worker() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        task = loop.create_task(_call())
+        try:
+            result.append(loop.run_until_complete(task))
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join()
+    return result[0]
+
+
+def propose_diff(repo_path: str, spec: str) -> str:
+    """Return a git diff implementing ``spec`` inside ``repo_path``."""
+    rel, goal = _parse_spec(spec)
+    file_path = str(Path(repo_path) / rel)
+    if _offline():
+        return _fallback_diff(file_path, goal)
+    prompt = (
+        "Generate a unified git diff for the repository at '{repo}'.\n"
+        "Apply the following change: {spec}".format(repo=repo_path, spec=spec)
+    )
+    try:
+        diff = _sync_chat(prompt)
+        if not diff.endswith("\n"):
+            diff += "\n"
+        return diff
+    except Exception:
+        return _fallback_diff(file_path, goal)

--- a/tests/test_code_diff.py
+++ b/tests/test_code_diff.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import subprocess
+import sys
+from unittest import mock
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.mutators import code_diff
+from alpha_factory_v1.demos.self_healing_repo import patcher_core
+
+
+def test_code_diff_offline(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "demo.py"
+    target.write_text("def demo():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setenv("AGI_INSIGHT_OFFLINE", "1")
+    diff = code_diff.propose_diff(str(tmp_path), "demo.py:extra")
+    patcher_core.apply_patch(diff, repo_path=tmp_path)
+    assert "extra" in target.read_text(encoding="utf-8")
+    subprocess.check_call([sys.executable, "-m", "py_compile", str(target)])
+
+
+def test_code_diff_online(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "demo.py"
+    target.write_text("def demo():\n    return 1\n", encoding="utf-8")
+    from src.tools.diff_mutation import propose_diff
+
+    patch = propose_diff(str(target), "increase")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    with mock.patch.object(code_diff, "_sync_chat", return_value=patch):
+        diff = code_diff.propose_diff(str(tmp_path), "demo.py:increase")
+    patcher_core.apply_patch(diff, repo_path=tmp_path)
+    assert "# TODO: increase" in target.read_text(encoding="utf-8")
+    subprocess.check_call([sys.executable, "-m", "py_compile", str(target)])


### PR DESCRIPTION
## Summary
- add GPT-4o based `propose_diff` helper with offline fallback
- hook new mutator into `CodeGenAgent`
- test applying diffs from the mutator

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_code_diff.py tests/test_diff_mutation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683b221bd9a083339b67f807b2a35cfd