### PR TITLE
[alpha_factory] Bandit early stopper

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -610,12 +610,18 @@ def archive_ls(proof: bool, db_path: str) -> None:
     type=float,
     help="Edit children count weight",
 )
+@click.option(
+    "--max-cost-per-gain",
+    type=float,
+    help="Stop if GPU seconds per fitness gain exceed this value",
+)
 def evolve_cmd(
     max_cost: float,
     wallclock: float | None,
     backtrack_rate: float,
     beta: float,
     gamma: float,
+    max_cost_per_gain: float | None,
 ) -> None:
     """Run the minimal asynchronous evolution demo."""
     from src import evolve as _evolve
@@ -635,6 +641,7 @@ def evolve_cmd(
             backtrack_rate=backtrack_rate,
             beta=beta,
             gamma=gamma,
+            cost_threshold=max_cost_per_gain,
         )
     )
 

--- a/src/monitoring/metrics.py
+++ b/src/monitoring/metrics.py
@@ -89,6 +89,12 @@ if Counter is not None and Gauge is not None:
         "GPU hours per unit fitness gain",
         [],
     )
+    dgm_gpu_seconds_per_gain = get_metric(
+        Gauge,
+        "dgm_gpu_seconds_per_gain",
+        "GPU seconds per unit fitness gain",
+        [],
+    )
 else:  # pragma: no cover - prometheus not installed
 
     class _N:
@@ -113,4 +119,4 @@ else:  # pragma: no cover - prometheus not installed
         dgm_gpu_hours_total
     ) = (
         dgm_fitness_gain_total
-    ) = dgm_gpu_hours_per_gain = _N()
+    ) = dgm_gpu_hours_per_gain = dgm_gpu_seconds_per_gain = _N()

--- a/tests/test_evolve.py
+++ b/tests/test_evolve.py
@@ -21,3 +21,33 @@ def test_evolve_stops_on_cost_cap():
     asyncio.run(run())
     # seed + at least two children added
     assert len(arch.all()) >= 3
+
+
+def test_bandit_early_stop_reduces_cost() -> None:
+    gains = [1.0, 0.2, 0.0, 0.0]
+
+    async def run(threshold: float | None) -> InMemoryArchive:
+        arch = InMemoryArchive()
+        await arch.accept(Candidate(0.0, fitness=0.0, novelty=1.0))
+        await evolve(_op, eval_genome, arch, max_cost=5.0, cost_threshold=threshold)
+        return arch
+
+    log: list[float] = []
+
+    async def eval_genome(_g: float) -> tuple[float, float]:
+        val = gains[len(log)] if len(log) < len(gains) else 0.0
+        log.append(val)
+        return val, 1.0
+
+    naive_arch = asyncio.run(run(None))
+    naive_cost = sum(c.cost for c in naive_arch.all()[1:])
+    naive_gain = max(c.fitness for c in naive_arch.all())
+
+    log.clear()
+    early_arch = asyncio.run(run(1.5))
+    early_cost = sum(c.cost for c in early_arch.all()[1:])
+    early_gain = max(c.fitness for c in early_arch.all())
+
+    naive_ratio = naive_cost / naive_gain
+    early_ratio = early_cost / early_gain
+    assert early_ratio <= 0.75 * naive_ratio


### PR DESCRIPTION
## Summary
- add `dgm_gpu_seconds_per_gain` metric
- implement `BanditEarlyStopper` and integrate with demo loop controller
- expose early stopping through evolve CLI and Insight CLI
- ensure cost efficiency via new unit test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 93 failed, 498 passed)*
- `pre-commit run --files src/monitoring/metrics.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/loop.py src/evolve.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py tests/test_evolve.py` *(fails: could not fetch black)*

------
https://chatgpt.com/codex/tasks/task_e_683b2f0e21508333891d689cb0dc9601