### PR TITLE
[alpha_factory] add insider trading policy

### DIFF
--- a/policies/deny_insider.rego
+++ b/policies/deny_insider.rego
@@ -1,0 +1,6 @@
+package safety
+
+deny[msg] {
+    re_match("(?i)buy [A-Z]{1,5} tomorrow", input.text)
+    msg := "insider trading advice blocked"
+}

--- a/tests/test_codegen_safety.py
+++ b/tests/test_codegen_safety.py
@@ -1,0 +1,63 @@
+import asyncio
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+
+
+class DummyBus:
+    def __init__(self, settings: config.Settings) -> None:
+        self.settings = settings
+        self.published: list[tuple[str, messaging.Envelope]] = []
+
+    def publish(self, topic: str, env: messaging.Envelope) -> None:
+        self.published.append((topic, env))
+
+    def subscribe(self, _t: str, _h) -> None:  # pragma: no cover - dummy
+        pass
+
+
+class DummyLedger:
+    def __init__(self) -> None:
+        self.logged: list[messaging.Envelope] = []
+
+    def log(self, env: messaging.Envelope) -> None:  # type: ignore[override]
+        self.logged.append(env)
+
+    def start_merkle_task(self, *_a, **_kw) -> None:  # pragma: no cover - dummy
+        pass
+
+    async def stop_merkle_task(self) -> None:  # pragma: no cover - interface
+        pass
+
+    def close(self) -> None:  # pragma: no cover - dummy
+        pass
+
+
+def _make_agent() -> safety_agent.SafetyGuardianAgent:
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    return safety_agent.SafetyGuardianAgent(bus, led)
+
+
+def test_blocks_insider_message() -> None:
+    agent = _make_agent()
+    env = messaging.Envelope(
+        sender="market",
+        recipient="safety",
+        payload={"analysis": "buy AAPL tomorrow"},
+        ts=0.0,
+    )
+    asyncio.run(agent.handle(env))
+    assert agent.bus.published[-1][1].payload["status"] == "blocked"
+
+
+def test_allows_normal_message() -> None:
+    agent = _make_agent()
+    env = messaging.Envelope(
+        sender="market",
+        recipient="safety",
+        payload={"analysis": "hold position"},
+        ts=0.0,
+    )
+    asyncio.run(agent.handle(env))
+    assert agent.bus.published[-1][1].payload["status"] == "ok"


### PR DESCRIPTION
## Summary
- block insider trading text via OPA policy
- evaluate insider policy in SafetyGuardianAgent
- add regression test for insider policy

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_codegen_safety.py -q` *(fails: AttributeError: get)*


------
https://chatgpt.com/codex/tasks/task_e_683b3264aa988333a1c769a160dfd8c3