### PR TITLE
[alpha_factory] support multi-backend islands

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/adk_summariser_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/adk_summariser_agent.py
@@ -11,8 +11,15 @@ from ..utils.tracing import span
 class ADKSummariserAgent(BaseAgent):
     """Collect research updates and produce a summary using ADK."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
-        super().__init__("summariser", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("summariser", bus, ledger, backend=backend, island=island)
         self._records: list[str] = []
 
     async def run_cycle(self) -> None:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -42,8 +42,15 @@ from ..utils.tracing import span
 class CodeGenAgent(BaseAgent):
     """Generate code snippets from market analysis."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
-        super().__init__("codegen", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("codegen", bus, ledger, backend=backend, island=island)
 
     async def run_cycle(self) -> None:
         """No-op background loop."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
@@ -18,8 +18,15 @@ from ..utils.tracing import span
 class MarketAgent(BaseAgent):
     """Analyse markets and forward results to the code generator."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
-        super().__init__("market", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("market", bus, ledger, backend=backend, island=island)
 
     async def run_cycle(self) -> None:
         """Emit a periodic market snapshot."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -19,8 +19,16 @@ from pathlib import Path
 class MemoryAgent(BaseAgent):
     """Persist artefacts produced by other agents."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger", store_path: str | None = None) -> None:
-        super().__init__("memory", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        store_path: str | None = None,
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("memory", bus, ledger, backend=backend, island=island)
         self.records: list[dict[str, object]] = []
         self._store = Path(store_path) if store_path else None
         if self._store and self._store.exists():

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
@@ -18,8 +18,15 @@ from ..utils.tracing import span
 class PlanningAgent(BaseAgent):
     """Generate research plans for downstream agents."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
-        super().__init__("planning", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("planning", bus, ledger, backend=backend, island=island)
 
     async def run_cycle(self) -> None:
         """Emit a high level research request."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -21,8 +21,15 @@ from ..utils.tracing import span
 class ResearchAgent(BaseAgent):
     """Perform simple research based on plans from :class:`PlanningAgent`."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
-        super().__init__("research", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("research", bus, ledger, backend=backend, island=island)
 
     async def run_cycle(self) -> None:
         """Periodic sweep using a tiny evolutionary loop."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
@@ -18,8 +18,15 @@ from src.utils.opa_policy import violates_insider_policy
 class SafetyGuardianAgent(BaseAgent):
     """Validate generated code before persistence."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
-        super().__init__("safety", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("safety", bus, ledger, backend=backend, island=island)
 
     async def run_cycle(self) -> None:
         """No-op periodic check."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
@@ -18,8 +18,15 @@ from ..utils.tracing import span
 class StrategyAgent(BaseAgent):
     """Turn research output into actionable strategy."""
 
-    def __init__(self, bus: messaging.A2ABus, ledger: "Ledger") -> None:
-        super().__init__("strategy", bus, ledger)
+    def __init__(
+        self,
+        bus: messaging.A2ABus,
+        ledger: "Ledger",
+        *,
+        backend: str = "gpt-4o",
+        island: str = "default",
+    ) -> None:
+        super().__init__("strategy", bus, ledger, backend=backend, island=island)
 
     async def run_cycle(self) -> None:
         """No-op periodic loop."""

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 
 from alpha_factory_v1.utils.config_common import (
     SettingsBase,
@@ -65,9 +65,22 @@ class Settings(SettingsBase):
     context_window: int = Field(default=8192, alias="AGI_CONTEXT_WINDOW")
     json_logs: bool = Field(default=False, alias="AGI_INSIGHT_JSON_LOGS")
     db_type: str = Field(default="sqlite", alias="AGI_INSIGHT_DB")
+    island_backends: Dict[str, str] = Field(
+        default_factory=lambda: {"default": "gpt-4o"},
+        alias="AGI_ISLAND_BACKENDS",
+    )
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - exercised in tests
         super().__init__(**data)
+        raw = os.getenv("AGI_ISLAND_BACKENDS")
+        if raw and not data.get("island_backends"):
+            mapping = {}
+            for part in raw.split(","):
+                if "=" in part:
+                    k, v = part.split("=", 1)
+                    mapping[k.strip()] = v.strip()
+            if mapping:
+                self.island_backends = mapping
         if not self.openai_api_key:
             _log.warning("OPENAI_API_KEY missing – offline mode enabled")
             self.offline = True

--- a/tests/test_island_backends.py
+++ b/tests/test_island_backends.py
@@ -1,0 +1,27 @@
+import unittest
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config
+
+
+class TestIslandBackends(unittest.TestCase):
+    def test_multiple_backends_agents_created(self) -> None:
+        settings = config.Settings(
+            bus_port=0,
+            offline=True,
+            island_backends={"openai": "gpt-4o", "anth": "claude-opus"},
+        )
+        orch = orchestrator.Orchestrator(settings)
+        self.assertEqual(orch.island_backends, settings.island_backends)
+        # eight agents per island
+        self.assertEqual(len(orch.runners), 16)
+        islands = {name.split("_")[-1] if "_" in name else "openai" for name in orch.runners}
+        self.assertIn("openai", islands)
+        self.assertIn("anth", islands)
+        for name, runner in orch.runners.items():
+            if name.endswith("_anth"):
+                self.assertEqual(runner.agent.backend, "claude-opus")
+            elif name.endswith("_openai") or name == "planning":
+                # default island uses openai when island name 'openai'
+                pass
+
+


### PR DESCRIPTION
## Summary
- allow config to specify `AGI_ISLAND_BACKENDS`
- tag orchestrator islands with their backend
- initialise backend in BaseAgent
- propagate backend/island into all demo agents
- add integration test for multi-backend orchestration

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683b35729da883339f2dc172f44e3770