### PR TITLE
[alpha_factory] add score proof generation

### DIFF
--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -556,6 +556,18 @@ async def _background_run(sim_id: str, cfg: SimRequest) -> None:
     )
     _save_result(result)
 
+    try:
+        from src.snark import publish_score_proof
+        from src.archive.db import ArchiveDB
+
+        threshold = float(os.getenv("PROOF_THRESHOLD", "0.5"))
+        score_a = traj[-1].capability if traj else 0.0
+        score_b = pop_data[0].effectiveness if pop_data else 0.0
+        db = ArchiveDB(Path(os.getenv("ARCHIVE_DB", "archive.db")))
+        publish_score_proof(_results_dir / f"{sim_id}.json", sim_id, [score_a, score_b], threshold, db)
+    except Exception as exc:  # pragma: no cover - best effort
+        _log.debug("Proof generation failed: %s", exc)
+
 
 if app is not None:
 

--- a/src/snark/__init__.py
+++ b/src/snark/__init__.py
@@ -1,2 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Circom circuits for SNARK/Bulletproof demos."""
+
+from .proof import (
+    generate_score_proof,
+    publish_score_proof,
+    verify_score_proof,
+    verify_onchain,
+)
+
+__all__ = [
+    "generate_score_proof",
+    "publish_score_proof",
+    "verify_score_proof",
+    "verify_onchain",
+]

--- a/src/snark/proof.py
+++ b/src/snark/proof.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight proof helpers using ``score.circom``.
+
+These utilities emulate zero-knowledge proof generation over the
+``score.circom`` circuit. They do not require `circom` at runtime and
+are suitable for CI environments without a full zkSNARK stack.
+"""
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from pathlib import Path
+from typing import Sequence
+
+from src.utils.snark import _ipfs_add
+from src.archive.db import ArchiveDB
+
+__all__ = [
+    "generate_score_proof",
+    "publish_score_proof",
+    "verify_score_proof",
+    "verify_onchain",
+]
+
+
+def _hash_scores(scores: Sequence[float]) -> str:
+    data = ",".join(f"{s:.8f}" for s in scores).encode()
+    return sha256(data).hexdigest()
+
+
+def generate_score_proof(scores: Sequence[float], threshold: float) -> str:
+    """Return proof that the weighted score exceeds ``threshold``."""
+    # hidden evaluator weights
+    weighted = 0.7 * scores[0] + 0.3 * scores[1]
+    if weighted < threshold:
+        raise ValueError("score below threshold")
+    h = _hash_scores(scores)
+    blob = json.dumps({"hash": h, "threshold": threshold}, separators=(",", ":")).encode()
+    return sha256(blob).hexdigest()
+
+
+def publish_score_proof(
+    transcript_path: str | Path,
+    agent_hash: str,
+    scores: Sequence[float],
+    threshold: float,
+    db: ArchiveDB,
+) -> str:
+    """Generate proof, publish to IPFS and store CID in ``db``."""
+    proof = generate_score_proof(scores, threshold)
+    path = Path(transcript_path).with_suffix(".proof")
+    path.write_text(proof, encoding="utf-8")
+    cid = _ipfs_add(path)
+    db.set_proof_cid(agent_hash, cid)
+    return cid
+
+
+def verify_score_proof(
+    scores: Sequence[float], threshold: float, proof: str
+) -> bool:
+    """Return ``True`` if ``proof`` matches ``generate_score_proof``."""
+    try:
+        expected = generate_score_proof(scores, threshold)
+    except ValueError:
+        return False
+    return proof == expected
+
+
+def verify_onchain(proof: str) -> bool:
+    """Placeholder for on-chain verification."""
+    return bool(proof) and all(c in "0123456789abcdef" for c in proof)

--- a/tests/test_score_proof.py
+++ b/tests/test_score_proof.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.archive.db import ArchiveDB, ArchiveEntry
+from src.snark import (
+    generate_score_proof,
+    publish_score_proof,
+    verify_score_proof,
+    verify_onchain,
+)
+
+
+def test_score_proof_roundtrip(tmp_path: Path) -> None:
+    transcript = tmp_path / "run.json"
+    data = {
+        "forecast": [{"year": 1, "capability": 0.8}],
+        "population": [{"effectiveness": 0.4}],
+    }
+    transcript.write_text(json.dumps(data), encoding="utf-8")
+
+    db = ArchiveDB(tmp_path / "arch.db")
+    db.add(ArchiveEntry("a1b2", None, 0.0, 0.0, True, 1.0))
+
+    cid = publish_score_proof(transcript, "a1b2", [0.8, 0.4], 0.5, db)
+    assert db.get_proof_cid("a1b2") == cid
+
+    proof = transcript.with_suffix(".proof").read_text()
+    assert verify_score_proof([0.8, 0.4], 0.5, proof)
+    assert verify_onchain(proof)
+


### PR DESCRIPTION
## Summary
- add a minimal SNARK proof helper module
- export proof helpers from `snark.__init__`
- generate a proof when a simulation finishes
- test round-trip proof generation and onchain verification stub

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_score_proof.py`

------
https://chatgpt.com/codex/tasks/task_e_683b378116e88333b0ee4ef3ebff0ced