### PR TITLE
[alpha_factory] Add Pareto3D visualization

### DIFF
--- a/src/interface/web_client/package.json
+++ b/src/interface/web_client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"Running smoke test\" && exit 0"
+    "test": "echo \"Running smoke test\" && exit 0",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -23,6 +24,7 @@
     "@vitejs/plugin-react": "^4.2.0",
     "@vitejs/plugin-vue": "^5.0.0",
     "typescript": "^5.3.0",
-    "vite": "^4.2.0"
+    "vite": "^4.2.0",
+    "@playwright/test": "^1.39.0"
   }
 }

--- a/src/interface/web_client/playwright.config.ts
+++ b/src/interface/web_client/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'pnpm dev',
+    port: 5173,
+    reuseExistingServer: true,
+  },
+});

--- a/src/interface/web_client/src/LineageTimeline.tsx
+++ b/src/interface/web_client/src/LineageTimeline.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect } from 'react';
+import Plotly from 'plotly.js-dist';
+
+export interface LineageNode {
+  id: number;
+  parent?: number | null;
+  diff?: string | null;
+  pass_rate: number;
+}
+
+interface Props {
+  data: LineageNode[];
+}
+
+function computeDepths(nodes: LineageNode[]): Map<number, number> {
+  const map = new Map<number, LineageNode>();
+  for (const n of nodes) map.set(n.id, n);
+  const depths = new Map<number, number>();
+  function depth(id: number): number {
+    const cached = depths.get(id);
+    if (cached !== undefined) return cached;
+    const node = map.get(id);
+    if (!node || !node.parent) {
+      depths.set(id, 0);
+      return 0;
+    }
+    const d = depth(node.parent) + 1;
+    depths.set(id, d);
+    return d;
+  }
+  for (const n of nodes) depth(n.id);
+  return depths;
+}
+
+export default function LineageTimeline({ data }: Props) {
+  useEffect(() => {
+    if (!data.length) return;
+    const nodes = [...data].sort((a, b) => a.id - b.id);
+    const index = new Map<number, number>();
+    nodes.forEach((n, i) => index.set(n.id, i));
+    const depths = computeDepths(nodes);
+
+    const lines: Plotly.Data[] = [];
+    for (const n of nodes) {
+      if (!n.parent) continue;
+      const px = index.get(n.parent);
+      const py = depths.get(n.parent);
+      const cx = index.get(n.id);
+      const cy = depths.get(n.id);
+      if (px === undefined || py === undefined || cx === undefined || cy === undefined) continue;
+      lines.push({
+        x: [px, cx],
+        y: [py, cy],
+        mode: 'lines',
+        type: 'scatter',
+        line: { color: '#888' },
+        hoverinfo: 'skip',
+        showlegend: false,
+      });
+    }
+
+    lines.push({
+      x: nodes.map((_, i) => i),
+      y: nodes.map((n) => depths.get(n.id) ?? 0),
+      text: nodes.map((n) => String(n.id)),
+      mode: 'markers+text',
+      type: 'scatter',
+      marker: { color: nodes.map((n) => n.pass_rate), colorscale: 'Blues', size: 8 },
+    });
+
+    Plotly.react('lineage-timeline', lines, {
+      margin: { t: 20 },
+      xaxis: { title: 'Generation' },
+      yaxis: { title: 'Depth' },
+      hovermode: 'closest',
+    });
+  }, [data]);
+
+  return <div id="lineage-timeline" style={{ width: '100%', height: 400 }} />;
+}

--- a/src/interface/web_client/src/Pareto3D.tsx
+++ b/src/interface/web_client/src/Pareto3D.tsx
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect } from 'react';
+import Plotly from 'plotly.js-dist';
+
+export interface PopulationMember {
+  effectiveness: number;
+  risk: number;
+  complexity: number;
+  rank: number;
+}
+
+interface Props {
+  data: PopulationMember[];
+}
+
+export default function Pareto3D({ data }: Props) {
+  useEffect(() => {
+    if (!data.length) return;
+    Plotly.react(
+      'pareto3d',
+      [
+        {
+          x: data.map((p) => p.effectiveness),
+          y: data.map((p) => p.risk),
+          z: data.map((p) => p.complexity),
+          mode: 'markers',
+          type: 'scatter3d',
+          marker: { color: data.map((p) => p.rank), size: 3 },
+        },
+      ],
+      {
+        margin: { t: 0 },
+        scene: {
+          xaxis: { title: 'Effectiveness' },
+          yaxis: { title: 'Risk' },
+          zaxis: { title: 'Complexity' },
+        },
+      },
+    );
+  }, [data]);
+
+  return <div id="pareto3d" style={{ width: '100%', height: 400 }} />;
+}

--- a/src/interface/web_client/tests/dashboard.spec.ts
+++ b/src/interface/web_client/tests/dashboard.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('renders pareto front and timeline', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('#lineage-tree');
+  await expect(page.locator('#pareto3d')).toBeVisible();
+  await expect(page.locator('#lineage-timeline')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Pareto3D and LineageTimeline components
- update dashboard to stream progress via `/ws/progress`
- show 3-D Pareto front and lineage timeline
- include Playwright setup and test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files src/interface/web_client/src/Pareto3D.tsx src/interface/web_client/src/LineageTimeline.tsx src/interface/web_client/src/pages/Dashboard.tsx src/interface/web_client/package.json src/interface/web_client/playwright.config.ts src/interface/web_client/tests/dashboard.spec.ts` *(fails: could not fetch hooks due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683b38b95dbc83339aa7cf084992d2d6