### PR TITLE
[alpha_factory] add LLMMutator

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/mutators/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/mutators/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mutation helpers for Insight agents."""
+
+from .code_diff import propose_diff
+from .llm_mutator import LLMMutator
+
+__all__ = ["propose_diff", "LLMMutator"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/mutators/llm_mutator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/mutators/llm_mutator.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LLM-driven mutator mixing AI output with random edits."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from ...utils.logging import Ledger
+from src.tools.diff_mutation import propose_diff as _fallback_diff
+from .code_diff import _parse_spec, _sync_chat, _offline
+
+__all__ = ["LLMMutator"]
+
+
+class LLMMutator:
+    """Generate diffs from recent logs using an LLM with random noise."""
+
+    def __init__(self, ledger: Ledger, *, rng: random.Random | None = None) -> None:
+        self.ledger = ledger
+        self._rng = rng or random.Random()
+
+    def _log_slice(self, count: int = 5) -> str:
+        rows = self.ledger.tail(count)
+        lines = []
+        for r in rows:
+            lines.append(f"{r.get('sender')}->{r.get('recipient')}: {r.get('payload')}")
+        return "\n".join(lines)
+
+    def _random_patch(self, file_path: str) -> str:
+        goal = f"random-{self._rng.randint(0, 9999)}"
+        return _fallback_diff(file_path, goal)
+
+    def generate_diff(self, repo_path: str, spec: str, *, lines: int = 5) -> str:
+        """Return a unified diff implementing ``spec`` inside ``repo_path``."""
+        rel, goal = _parse_spec(spec)
+        file_path = str(Path(repo_path) / rel)
+
+        patch = ""
+        if not _offline():
+            prompt = (
+                f"Repository: {repo_path}\n"
+                f"Change: {spec}\n"
+                f"Recent logs:\n{self._log_slice(lines)}\n"
+                "Produce a unified diff."
+            )
+            try:
+                patch = _sync_chat(prompt)
+            except Exception:
+                patch = ""
+
+        if not patch:
+            patch = _fallback_diff(file_path, goal)
+
+        if self._rng.random() < 0.3:
+            patch += self._random_patch(file_path)
+
+        if not patch.endswith("\n"):
+            patch += "\n"
+        return patch

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import random
+from unittest import mock
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.mutators import llm_mutator
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging as insight_logging, messaging
+from alpha_factory_v1.demos.self_healing_repo import patcher_core
+from src.tools.diff_mutation import propose_diff
+
+
+def _ledger(tmp: Path) -> insight_logging.Ledger:
+    led = insight_logging.Ledger(str(tmp / "led.db"), broadcast=False)
+    env = messaging.Envelope(sender="a", recipient="b", payload={"v": 1}, ts=0.0)
+    led.log(env)
+    return led
+
+
+def test_llm_mutator_offline(tmp_path: Path, monkeypatch) -> None:
+    ledger = _ledger(tmp_path)
+    target = tmp_path / "demo.py"
+    target.write_text("def demo():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setenv("AGI_INSIGHT_OFFLINE", "1")
+    mut = llm_mutator.LLMMutator(ledger, rng=random.Random(1))
+    diff = mut.generate_diff(str(tmp_path), "demo.py:feat")
+    patcher_core.apply_patch(diff, repo_path=tmp_path)
+    assert "feat" in target.read_text(encoding="utf-8")
+
+
+def test_llm_mutator_online(tmp_path: Path, monkeypatch) -> None:
+    ledger = _ledger(tmp_path)
+    target = tmp_path / "demo.py"
+    target.write_text("def demo():\n    return 1\n", encoding="utf-8")
+    patch = propose_diff(str(target), "improve")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    with mock.patch.object(llm_mutator, "_sync_chat", return_value=patch):
+        mut = llm_mutator.LLMMutator(ledger, rng=random.Random(2))
+        diff = mut.generate_diff(str(tmp_path), "demo.py:improve")
+    patcher_core.apply_patch(diff, repo_path=tmp_path)
+    assert "improve" in target.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- implement `LLMMutator` that uses recent ledger logs when prompting the LLM
- export the class from the mutators package
- test diff creation and application

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_mutator.py`

------
https://chatgpt.com/codex/tasks/task_e_683b3c06e9e48333afb65219b88e53a4