### PR TITLE
[alpha_factory] add dual critic service

### DIFF
--- a/src/critics/__init__.py
+++ b/src/critics/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Critic services evaluating agent outputs."""
+
+from .dual_critic_service import DualCriticService, create_app
+
+__all__ = ["DualCriticService", "create_app"]

--- a/src/critics/dual_critic_service.py
+++ b/src/critics/dual_critic_service.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Simple dual critic service exposing REST and gRPC endpoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterable, List, Tuple
+
+try:
+    import grpc  # type: ignore
+except Exception:  # pragma: no cover - optional
+    grpc = None  # type: ignore
+
+try:
+    from fastapi import FastAPI, Body
+    from pydantic import BaseModel
+    from fastapi.responses import JSONResponse
+except Exception:  # pragma: no cover - optional
+    FastAPI = None  # type: ignore
+    BaseModel = object  # type: ignore
+    JSONResponse = None  # type: ignore
+
+if FastAPI is not None:
+    class CritiqueRequest(BaseModel):
+        context: str
+        response: str
+
+
+__all__ = [
+    "DualCriticService",
+    "create_app",
+]
+
+log = logging.getLogger(__name__)
+
+
+# ────────────────────────────── Utilities ──────────────────────────────
+class VectorDB:
+    """Minimal in-memory vector store using Jaccard similarity."""
+
+    def __init__(self, docs: Iterable[str] | None = None) -> None:
+        self.docs = list(docs or [])
+
+    @staticmethod
+    def _score(a: str, b: str) -> float:
+        a_tokens = set(a.lower().split())
+        b_tokens = set(b.lower().split())
+        if not a_tokens or not b_tokens:
+            return 0.0
+        return len(a_tokens & b_tokens) / len(a_tokens | b_tokens)
+
+    def search(self, query: str, k: int = 3) -> List[Tuple[str, float]]:
+        results = [(d, self._score(query, d)) for d in self.docs]
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:k]
+
+
+# ────────────────────────────── Core logic ──────────────────────────────
+class DualCriticService:
+    """Evaluate logical consistency and context feasibility."""
+
+    def __init__(self, docs: Iterable[str] | None = None) -> None:
+        self.db = VectorDB(docs)
+        self._server: "grpc.aio.Server" | None = None
+
+    # ------------------------------------------------------------------
+    def logic_score(self, context: str, response: str) -> float:
+        """Return a naive logic score based on substring matching."""
+        if not context or not response:
+            return 0.0
+        return 1.0 if response.lower() in context.lower() else 0.0
+
+    def feasibility_score(self, response: str) -> Tuple[float, List[str]]:
+        """Score feasibility via similarity search."""
+        hits = self.db.search(response)
+        score = hits[0][1] if hits else 0.0
+        citations = [h[0] for h in hits]
+        return score, citations
+
+    def score(self, context: str, response: str) -> Dict[str, Any]:
+        logic = self.logic_score(context, response)
+        feas, cites = self.feasibility_score(response)
+        reasons = []
+        if logic < 0.5:
+            reasons.append("response not supported by context")
+        if feas < 0.5:
+            reasons.append("low similarity to known facts")
+        if not reasons:
+            reasons.append("looks good")
+        return {
+            "logic": logic,
+            "feas": feas,
+            "reasons": reasons,
+            "citations": cites,
+        }
+
+    # ------------------------------------------------------------------
+    def create_app(self) -> "FastAPI":
+        if FastAPI is None:
+            raise RuntimeError("FastAPI not installed")
+
+        app = FastAPI(title="Dual Critic Service")
+
+        @app.post("/critique")
+        async def _critique(req: CritiqueRequest = Body(...)) -> Any:  # noqa: D401
+            result = self.score(req.context, req.response)
+            return JSONResponse(result)
+
+        CritiqueRequest.model_rebuild()
+
+        return app
+
+    # ------------------------------------------------------------------
+    async def _handle_rpc(self, request: bytes, _ctx: Any) -> bytes:
+        data = json.loads(request.decode())
+        result = self.score(data.get("context", ""), data.get("response", ""))
+        return json.dumps(result).encode()
+
+    async def start_grpc(self, port: int) -> None:
+        if grpc is None:
+            raise RuntimeError("grpc not installed")
+        server = grpc.aio.server()
+        method = grpc.unary_unary_rpc_method_handler(
+            self._handle_rpc,
+            request_deserializer=lambda b: b,
+            response_serializer=lambda b: b,
+        )
+        service = grpc.method_handlers_generic_handler("critics.Critic", {"Score": method})
+        server.add_generic_rpc_handlers((service,))
+        server.add_insecure_port(f"[::]:{port}")
+        await server.start()
+        self._server = server
+
+    async def stop_grpc(self) -> None:
+        if self._server:
+            await self._server.stop(0)
+            self._server = None
+
+
+# ─────────────────────────── FastAPI helper ─────────────────────────────
+
+def create_app(service: DualCriticService) -> "FastAPI":
+    return service.create_app()

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the DualCriticService."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from statistics import quantiles
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("grpc")
+from fastapi.testclient import TestClient
+import grpc
+
+from src.critics import DualCriticService, create_app
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("localhost", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_rest_scoring() -> None:
+    service = DualCriticService(["Paris is the capital of France."])
+    client = TestClient(create_app(service))
+    ok = client.post(
+        "/critique",
+        json={"context": "Paris is the capital of France.", "response": "Paris is the capital of France."},
+    )
+    assert ok.status_code == 200
+    data = ok.json()
+    assert data["logic"] > 0.5
+    assert data["feas"] > 0.0
+
+    bad = client.post(
+        "/critique",
+        json={"context": "Paris is the capital of France.", "response": "Berlin is the capital."},
+    )
+    assert bad.status_code == 200
+    assert bad.json()["logic"] < 0.5
+
+
+def test_grpc_scoring() -> None:
+    service = DualCriticService(["Rome is the capital of Italy."])
+    port = _free_port()
+
+    async def run() -> None:
+        await service.start_grpc(port)
+        async with grpc.aio.insecure_channel(f"localhost:{port}") as ch:
+            stub = ch.unary_unary("/critics.Critic/Score")
+            payload = {
+                "context": "Rome is the capital of Italy.",
+                "response": "Rome is the capital of Italy.",
+            }
+            reply = await stub(json.dumps(payload).encode())
+            data = json.loads(reply.decode())
+            assert data["logic"] == 1.0
+        await service.stop_grpc()
+
+    asyncio.run(run())
+
+
+pytest.importorskip("pytest_benchmark")
+
+@pytest.mark.benchmark(group="critics")  # type: ignore[misc]
+def test_latency_benchmark(benchmark: Any) -> None:
+    service = DualCriticService(["alpha"])
+
+    def run() -> None:
+        service.score("alpha", "alpha")
+
+    result = benchmark(run)
+    p95 = 0.0
+    if getattr(result, "stats", None) and result.stats["data"]:
+        p95 = quantiles(result.stats["data"], n=20)[18]
+    assert p95 >= 0.0


### PR DESCRIPTION
## Summary
- add critics package with DualCriticService exposing REST and gRPC
- store documents in a simple vector DB
- return logic/feasibility scores with reasons & citations
- validate via unit tests and benchmark

## Testing
- `pre-commit run --files src/critics/__init__.py src/critics/dual_critic_service.py tests/test_critics.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `python check_env.py --auto-install`
- `pytest -q tests/test_critics.py`

------
https://chatgpt.com/codex/tasks/task_e_683b3d9dd80c8333bdca850f9dc3ec37