### PR TITLE
[alpha_factory] Add surrogate fitness aggregator

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py
@@ -15,6 +15,7 @@ from typing import Callable, List, Tuple
 import numpy as np
 
 from src.evaluators.novelty import NoveltyIndex
+from src.simulation import surrogate_fitness
 
 __all__ = [
     "Individual",
@@ -34,6 +35,7 @@ class Individual:
     fitness: Tuple[float, ...] | None = None
     crowd: float = 0.0
     rank: int = 0
+    score: float = 0.0
 
 
 Population = List[Individual]
@@ -54,6 +56,11 @@ def evaluate(
             ind.fitness = base + (div,)
         else:
             ind.fitness = base
+
+    fits = [ind.fitness or () for ind in pop]
+    scores = surrogate_fitness.aggregate(fits)
+    for ind, sc in zip(pop, scores):
+        ind.score = sc
 
 
 def _crowding(pop: Population) -> None:

--- a/src/simulation/surrogate_fitness.py
+++ b/src/simulation/surrogate_fitness.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pareto rank scalarisation utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import yaml
+
+__all__ = ["aggregate", "load_weights"]
+
+
+_DEFAULT_YAML = Path(__file__).with_suffix(".yaml")
+
+
+def load_weights(path: str | Path | None = None) -> dict[str, float | Sequence[float]]:
+    """Return weight configuration loaded from YAML."""
+    p = Path(path) if path is not None else _DEFAULT_YAML
+    try:
+        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except Exception:
+        data = {}
+    return data or {}
+
+
+def _non_dominated_sort(values: Sequence[Sequence[float]]) -> tuple[list[int], list[list[int]]]:
+    n = len(values)
+    ranks = [0] * n
+    S = [set() for _ in range(n)]
+    dominated = [0] * n
+    for i, a in enumerate(values):
+        for j, b in enumerate(values):
+            if i == j:
+                continue
+            if all(ai <= bj for ai, bj in zip(a, b)) and any(ai < bj for ai, bj in zip(a, b)):
+                S[i].add(j)
+            elif all(bj <= ai for ai, bj in zip(a, b)) and any(bj < ai for ai, bj in zip(a, b)):
+                dominated[i] += 1
+        if dominated[i] == 0:
+            ranks[i] = 0
+    fronts = [[i for i, d in enumerate(dominated) if d == 0]]
+    i = 0
+    while i < len(fronts):
+        nxt: list[int] = []
+        for p in fronts[i]:
+            for q in S[p]:
+                dominated[q] -= 1
+                if dominated[q] == 0:
+                    ranks[q] = i + 1
+                    nxt.append(q)
+        if nxt:
+            fronts.append(nxt)
+        i += 1
+    return ranks, fronts
+
+
+def _crowding(values: Sequence[Sequence[float]], fronts: Iterable[Iterable[int]]) -> list[float]:
+    n = len(values)
+    m = len(values[0]) if n else 0
+    crowd = [0.0] * n
+    for front in fronts:
+        f = list(front)
+        if not f:
+            continue
+        for idx in f:
+            crowd[idx] = 0.0
+        for i in range(m):
+            f.sort(key=lambda idx: values[idx][i])
+            crowd[f[0]] = float("inf")
+            crowd[f[-1]] = float("inf")
+            fmin = values[f[0]][i]
+            fmax = values[f[-1]][i]
+            span = fmax - fmin or 1.0
+            for j in range(1, len(f) - 1):
+                prev_v = values[f[j - 1]][i]
+                next_v = values[f[j + 1]][i]
+                crowd[f[j]] += (next_v - prev_v) / span
+    return crowd
+
+
+def aggregate(
+    values: Sequence[Sequence[float]],
+    *,
+    weights: dict[str, float | Sequence[float]] | None = None,
+    weights_path: str | Path | None = None,
+) -> list[float]:
+    """Return scalar surrogate scores for ``values``."""
+    cfg = weights if weights is not None else load_weights(weights_path)
+    rank_w = float(cfg.get("rank", 1.0))
+    crowd_w = float(cfg.get("crowd", 0.0))
+    obj_w = cfg.get("objectives", [])
+    if not isinstance(obj_w, Sequence):
+        obj_w = []
+    obj_w = list(obj_w) + [0.0] * (len(values[0]) - len(obj_w))
+    ranks, fronts = _non_dominated_sort(values)
+    crowds = _crowding(values, fronts)
+    scores = []
+    for idx, vec in enumerate(values):
+        s = rank_w * ranks[idx] + crowd_w * crowds[idx]
+        s += sum(w * v for w, v in zip(obj_w, vec))
+        scores.append(float(s))
+    return scores

--- a/src/simulation/surrogate_fitness.yaml
+++ b/src/simulation/surrogate_fitness.yaml
@@ -1,0 +1,3 @@
+rank: 1.0
+crowd: 0.0
+objectives: []

--- a/tests/test_surrogate_fitness.py
+++ b/tests/test_surrogate_fitness.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+from src.simulation import surrogate_fitness
+
+
+def _manual_nsga2_ranks(values: list[tuple[float, ...]]) -> list[int]:
+    n = len(values)
+    ranks = [0] * n
+    S = [set() for _ in range(n)]
+    dominated = [0] * n
+    for i, a in enumerate(values):
+        for j, b in enumerate(values):
+            if i == j:
+                continue
+            if all(ai <= bj for ai, bj in zip(a, b)) and any(ai < bj for ai, bj in zip(a, b)):
+                S[i].add(j)
+            elif all(bj <= ai for ai, bj in zip(a, b)) and any(bj < ai for ai, bj in zip(a, b)):
+                dominated[i] += 1
+        if dominated[i] == 0:
+            ranks[i] = 0
+    fronts = [[i for i, d in enumerate(dominated) if d == 0]]
+    i = 0
+    while i < len(fronts):
+        nxt: list[int] = []
+        for p in fronts[i]:
+            for q in S[p]:
+                dominated[q] -= 1
+                if dominated[q] == 0:
+                    ranks[q] = i + 1
+                    nxt.append(q)
+        if nxt:
+            fronts.append(nxt)
+        i += 1
+    return ranks
+
+
+def test_surrogate_fitness_ordering() -> None:
+    values = [(0.0, 0.0), (0.5, 1.0), (1.0, 0.5), (1.0, 1.0)]
+    manual = _manual_nsga2_ranks(values)
+    scores = surrogate_fitness.aggregate(values)
+    order_manual = sorted(range(len(values)), key=lambda i: manual[i])
+    order_scores = sorted(range(len(values)), key=lambda i: scores[i])
+    assert order_manual == order_scores


### PR DESCRIPTION
## Summary
- add NSGA-II surrogate aggregator via `surrogate_fitness.py`
- load weights from `surrogate_fitness.yaml`
- expose scalar score in MATS `evaluate`
- test surrogate fitness ranking

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_surrogate_fitness.py`
- `pytest -q` *(fails: ValueError in tests/test_llm_cache.py)*
- `pre-commit run --files src/simulation/surrogate_fitness.py src/simulation/surrogate_fitness.yaml alpha_factory_v1/demos/alpha_agi_insight_v1/src/simulation/mats.py tests/test_surrogate_fitness.py` *(fails: Failed to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683b407a7d5083339a89872f6e56a139