### PR TITLE
[alpha_factory] add solution archive

### DIFF
--- a/src/archive/selector.py
+++ b/src/archive/selector.py
@@ -39,3 +39,24 @@ def select_parent(population: Sequence[Any], beta: float = 1.0, gamma: float = 0
     index = int(np.random.choice(len(population), p=probs))
     metrics.dgm_parents_selected_total.inc()
     return population[index]
+
+
+def select_parent_weighted(population: Sequence[Any]) -> Any:
+    """Return a parent weighted by fitness × children-with-edit-ability."""
+    if not population:
+        raise ValueError("population is empty")
+    weights = []
+    for ind in population:
+        fitness = float(getattr(ind, "fitness", getattr(ind, "score", 0.0)))
+        edits = float(getattr(ind, "edit_children_count", 0.0))
+        weights.append(max(fitness * edits, 0.0))
+    total = sum(weights)
+    if total <= 0:
+        index = int(np.random.choice(len(population)))
+    else:
+        probs = np.asarray(weights, dtype=float) / total
+        index = int(np.random.choice(len(population), p=probs))
+    metrics.dgm_parents_selected_total.inc()
+    return population[index]
+
+__all__ = ["select_parent", "select_parent_weighted"]

--- a/src/archive/solution_archive.py
+++ b/src/archive/solution_archive.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DuckDB backed archive storing solutions by sector and approach."""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+try:
+    import duckdb  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    duckdb = None
+
+
+@dataclass(slots=True)
+class Solution:
+    sector: str
+    approach: str
+    score: float
+    data: Mapping[str, Any]
+    ts: float
+
+
+class SolutionArchive:
+    """Archive storing solutions in bins keyed by ``(sector, approach, band)``."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        if duckdb is not None:
+            self.conn = duckdb.connect(str(self.path))
+        else:  # pragma: no cover - fallback
+            self.conn = sqlite3.connect(str(self.path))
+        self._ensure()
+
+    def _ensure(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS solutions(
+                sector TEXT,
+                approach TEXT,
+                score DOUBLE,
+                band INTEGER,
+                data TEXT,
+                ts DOUBLE
+            )
+            """
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bins ON solutions(sector, approach, band)"
+        )
+        if isinstance(self.conn, sqlite3.Connection):
+            self.conn.commit()
+
+    @staticmethod
+    def _band(score: float) -> int:
+        return int(score // 10)
+
+    def add(self, sector: str, approach: str, score: float, data: Mapping[str, Any]) -> None:
+        band = self._band(score)
+        self.conn.execute(
+            "INSERT INTO solutions(sector, approach, score, band, data, ts) VALUES (?,?,?,?,?,?)",
+            (sector, approach, score, band, json.dumps(dict(data)), time.time()),
+        )
+        if isinstance(self.conn, sqlite3.Connection):  # pragma: no cover - sqlite
+            self.conn.commit()
+
+    def query(
+        self,
+        sector: str | None = None,
+        approach: str | None = None,
+        band: int | None = None,
+    ) -> list[Solution]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if sector is not None:
+            clauses.append("sector=?")
+            params.append(sector)
+        if approach is not None:
+            clauses.append("approach=?")
+            params.append(approach)
+        if band is not None:
+            clauses.append("band=?")
+            params.append(band)
+        sql = "SELECT sector, approach, score, data, ts FROM solutions"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        cur = self.conn.execute(sql, params)
+        rows = cur.fetchall()
+        result = [
+            Solution(
+                sector=row[0],
+                approach=row[1],
+                score=float(row[2]),
+                data=json.loads(row[3]),
+                ts=float(row[4]),
+            )
+            for row in rows
+        ]
+        return result
+
+    def diversity_histogram(self) -> dict[tuple[str, str], int]:
+        cur = self.conn.execute(
+            "SELECT sector, approach, COUNT(*) FROM solutions GROUP BY sector, approach"
+        )
+        rows = cur.fetchall()
+        return {(r[0], r[1]): int(r[2]) for r in rows}
+
+    def close(self) -> None:
+        if self.conn:
+            self.conn.close()
+            self.conn = None  # type: ignore[assignment]
+
+
+__all__ = ["Solution", "SolutionArchive"]

--- a/tests/test_solution_archive.py
+++ b/tests/test_solution_archive.py
@@ -1,0 +1,14 @@
+import time
+from src.archive.solution_archive import SolutionArchive
+
+def test_query_speed_and_histogram(tmp_path) -> None:
+    arch = SolutionArchive(tmp_path / "sol.duckdb")
+    for i in range(10000):
+        arch.add("sec", "app", float(i % 100), {"i": i})
+    start = time.perf_counter()
+    res = arch.query(sector="sec")
+    duration = time.perf_counter() - start
+    assert len(res) == 10000
+    assert duration < 0.2
+    hist = arch.diversity_histogram()
+    assert hist[("sec", "app")] == 10000


### PR DESCRIPTION
## Summary
- implement DuckDB-backed `SolutionArchive`
- extend parent selector with weighted function
- store evolution outcomes in orchestrator's new archive
- test solution archive query speed and histogram

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/archive/solution_archive.py src/archive/selector.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py tests/test_solution_archive.py` *(fails: unable to access 'https://github.com/psf/black/' ...)*
- `pytest -q tests/test_solution_archive.py`

------
https://chatgpt.com/codex/tasks/task_e_683b4271fbd48333828f19e40d667d77