### PR TITLE
[alpha_factory] add self evolution harness

### DIFF
--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal CLI exposing orchestrator utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+import click
+
+from src.self_evolution import harness
+from src.governance.stake_registry import StakeRegistry
+
+
+@click.group()
+def orch() -> None:
+    """Orchestrator commands."""
+
+
+@orch.command("self-test")
+@click.argument("patch", type=click.Path(exists=True))
+def self_test(patch: str) -> None:
+    """Apply PATCH and run sandboxed tests."""
+    registry = StakeRegistry()
+    registry.set_stake("orch", 1.0)
+    diff = Path(patch).read_text(encoding="utf-8")
+    accepted = harness.vote_and_merge(Path.cwd(), diff, registry)
+    click.echo("accepted" if accepted else "rejected")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    orch()

--- a/src/self_evolution/__init__.py
+++ b/src/self_evolution/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/src/self_evolution/harness.py
+++ b/src/self_evolution/harness.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch evaluation harness using Docker-in-Docker."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Tuple
+
+from src.eval.preflight import run_preflight
+from src.governance.stake_registry import StakeRegistry
+from alpha_factory_v1.demos.self_healing_repo import patcher_core
+
+IMAGE = os.getenv("SELF_EVOLUTION_IMAGE", "python:3.11-slim")
+
+
+def _run_tests(repo: Path) -> int:
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{repo}:/work",
+        "-w",
+        "/work",
+        IMAGE,
+        "pytest",
+        "-q",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    return proc.returncode
+
+
+def apply_patch(repo: str | Path, diff: str) -> Tuple[bool, Path]:
+    """Apply ``diff`` to ``repo`` inside a sandbox and run tests."""
+    src = Path(repo).resolve()
+    tmp = Path(tempfile.mkdtemp(prefix="self-evo-"))
+    shutil.copytree(src, tmp, dirs_exist_ok=True)
+    patcher_core.apply_patch(diff, repo_path=str(tmp))
+    run_preflight(tmp)
+    rc = _run_tests(tmp)
+    return rc == 0, tmp
+
+
+def vote_and_merge(repo: str | Path, diff: str, registry: StakeRegistry, agent_id: str = "orch") -> bool:
+    """Apply patch and merge if tests pass and fitness improves."""
+    repo_path = Path(repo).resolve()
+    proposal = hashlib.sha1(diff.encode()).hexdigest()
+    baseline = float((repo_path / "metric.txt").read_text().strip())
+    ok, patched = apply_patch(repo_path, diff)
+    if not ok:
+        registry.vote(proposal, agent_id, False)
+        shutil.rmtree(patched)
+        return False
+    new_score = float((patched / "metric.txt").read_text().strip())
+    improved = new_score > baseline
+    registry.vote(proposal, agent_id, improved)
+    accepted = improved and registry.accepted(proposal)
+    if accepted:
+        for src_file in patched.rglob("*"):
+            if src_file.is_file():
+                rel = src_file.relative_to(patched)
+                dest = repo_path / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src_file, dest)
+        registry.archive_accept(agent_id)
+    shutil.rmtree(patched)
+    return accepted

--- a/tests/test_self_evolution.py
+++ b/tests/test_self_evolution.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from src.self_evolution import harness
+from src.governance.stake_registry import StakeRegistry
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "metric.txt").write_text("1\n", encoding="utf-8")
+    (repo / "test_dummy.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    return repo
+
+
+def test_vote_and_merge_accepts_patch(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    diff = """--- a/metric.txt
++++ b/metric.txt
+@@
+-1
++2
+"""
+    reg = StakeRegistry()
+    reg.set_stake("orch", 1.0)
+    with (
+        patch.object(harness, "_run_tests", return_value=0),
+        patch.object(harness, "run_preflight"),
+        patch.object(
+            harness.patcher_core, "apply_patch", lambda d, repo_path: (Path(repo_path) / "metric.txt").write_text("2\n")
+        ),
+    ):
+        accepted = harness.vote_and_merge(repo, diff, reg)
+    assert accepted
+    assert (repo / "metric.txt").read_text().strip() == "2"
+
+
+def test_vote_and_merge_reverts_on_failure(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    diff = """--- a/metric.txt
++++ b/metric.txt
+@@
+-1
++0
+"""
+    reg = StakeRegistry()
+    reg.set_stake("orch", 1.0)
+    with (
+        patch.object(harness, "_run_tests", return_value=1),
+        patch.object(harness, "run_preflight"),
+        patch.object(
+            harness.patcher_core, "apply_patch", lambda d, repo_path: (Path(repo_path) / "metric.txt").write_text("0\n")
+        ),
+    ):
+        accepted = harness.vote_and_merge(repo, diff, reg)
+    assert not accepted
+    assert (repo / "metric.txt").read_text().strip() == "1"


### PR DESCRIPTION
## Summary
- implement Docker-based patch harness
- expose `orch.self-test` CLI for self evolution
- store governance merge logic in harness
- cover harness logic with unit tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_self_evolution.py`
- `pre-commit run --files src/self_evolution/harness.py src/interface/cli.py tests/test_self_evolution.py` *(fails: unable to fetch pre-commit dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683b455451bc8333ab09171f5605aa85