### PR TITLE
[alpha_factory] Add meta refinement agent

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Agent utilities."""
+
+from .meta_refinement_agent import MetaRefinementAgent
+
+__all__ = ["MetaRefinementAgent"]
+

--- a/src/agents/meta_refinement_agent.py
+++ b/src/agents/meta_refinement_agent.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Analyse orchestrator logs and propose refinement patches."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Mapping
+
+from src.governance.stake_registry import StakeRegistry
+from src.self_evolution import harness
+from src.tools.diff_mutation import propose_diff
+from src.tools import test_scribe
+
+__all__ = ["MetaRefinementAgent"]
+
+
+class MetaRefinementAgent:
+    """Generate diff proposals based on orchestrator log analysis."""
+
+    def __init__(self, repo: str | Path, log_dir: str | Path, registry: StakeRegistry | None = None) -> None:
+        self.repo = Path(repo)
+        self.log_dir = Path(log_dir)
+        self.registry = registry or StakeRegistry()
+        if "meta" not in self.registry.stakes:
+            self.registry.set_stake("meta", 1.0)
+
+    # ------------------------------------------------------------------
+    def _load_logs(self) -> List[Mapping[str, object]]:
+        records: List[Mapping[str, object]] = []
+        for file in sorted(self.log_dir.glob("*.json")):
+            for line in file.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        return records
+
+    @staticmethod
+    def _detect_bottleneck(entries: Iterable[Mapping[str, object]]) -> str | None:
+        prev_ts: float | None = None
+        max_delta = -1.0
+        target: str | None = None
+        for rec in entries:
+            ts = float(rec.get("ts", 0.0))
+            if prev_ts is not None:
+                delta = ts - prev_ts
+                if delta > max_delta:
+                    max_delta = delta
+                    target = str(rec.get("hash", ""))
+            prev_ts = ts
+        return target
+
+    def _create_patch(self, bottleneck: str) -> str:
+        goal = f"optimise around {bottleneck}"
+        metric = self.repo / "metric.txt"
+        if metric.exists():
+            try:
+                current = int(float(metric.read_text().strip()))
+            except Exception:
+                current = 0
+            new_val = current + 1
+            diff = (
+                "--- a/metric.txt\n"
+                "+++ b/metric.txt\n"
+                "@@\n"
+                f"-{current}\n"
+                f"+{new_val}\n"
+            )
+            return diff
+        return propose_diff(str(metric), goal)
+
+    # ------------------------------------------------------------------
+    def refine(self) -> bool:
+        logs = self._load_logs()
+        bottleneck = self._detect_bottleneck(logs)
+        if not bottleneck:
+            return False
+        diff = self._create_patch(bottleneck)
+        accepted = harness.vote_and_merge(self.repo, diff, self.registry, agent_id="meta")
+        if accepted:
+            test_scribe.generate_test(self.repo, "True")
+        return accepted

--- a/src/tools/test_scribe.py
+++ b/src/tools/test_scribe.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal helpers to generate test stubs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["generate_test"]
+
+
+def generate_test(repo: str | Path, check: str) -> Path:
+    """Create a simple test asserting ``check`` inside ``repo``."""
+    repo_path = Path(repo)
+    tests_dir = repo_path / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    idx = len(list(tests_dir.glob("test_generated_*.py")))
+    test_path = tests_dir / f"test_generated_{idx}.py"
+    code = f"def test_generated_{idx}():\n    assert {check}\n"
+    test_path.write_text(code, encoding="utf-8")
+    return test_path

--- a/tests/test_meta_refinement_agent.py
+++ b/tests/test_meta_refinement_agent.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from src.agents.meta_refinement_agent import MetaRefinementAgent
+from src.governance.stake_registry import StakeRegistry
+from src.self_evolution import harness
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "metric.txt").write_text("1\n", encoding="utf-8")
+    (repo / "test_dummy.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    return repo
+
+
+def test_refinement_merges_patch(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "log.json").write_text(
+        "\n".join([
+            '{"hash":"h0","ts":0}',
+            '{"hash":"h1","ts":1}',
+            '{"hash":"h2","ts":5}'
+        ]),
+        encoding="utf-8",
+    )
+
+    reg = StakeRegistry()
+    reg.set_stake("meta", 1.0)
+
+    with (
+        patch.object(harness, "_run_tests", return_value=0),
+        patch.object(harness, "run_preflight"),
+        patch.object(
+            harness.patcher_core,
+            "apply_patch",
+            lambda d, repo_path: (Path(repo_path) / "metric.txt").write_text("2\n"),
+        ),
+    ):
+        agent = MetaRefinementAgent(repo, logs, reg)
+        merged = agent.refine()
+
+    assert merged
+    assert (repo / "metric.txt").read_text().strip() == "2"
+    generated = list((repo / "tests").glob("test_generated_*.py"))
+    assert generated


### PR DESCRIPTION
## Summary
- implement `MetaRefinementAgent` for analysing orchestrator logs
- generate diff patches and tests via new `test_scribe` helper
- test that a patch is merged through the self-evolution harness

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_meta_refinement_agent.py`
- `pre-commit run --files src/agents/meta_refinement_agent.py src/tools/test_scribe.py src/agents/__init__.py tests/test_meta_refinement_agent.py` *(fails: unable to fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683b48c4bc608333ac373881df9cd933