### PR TITLE
[alpha_factory] concurrent experiment orchestration

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -288,12 +288,13 @@ if app is not None:
         scenario = hashlib.sha1(sim_id.encode()).hexdigest()
         orch = getattr(app_f.state, "orchestrator", None)
         if orch is not None:
-            pop = orch.evolve(
+            pop = await orch.evolve(
                 scenario,
                 eval_fn,
                 2,
                 population_size=cfg.pop_size,
                 generations=cfg.generations,
+                experiment_id=sim_id,
             )
         else:
             pop = mats.run_evolution(

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,50 @@
+import asyncio
+import json
+import time
+from unittest import mock
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config
+
+
+def test_concurrent_experiments(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ARCHIVE_PATH", str(tmp_path / "arch.db"))
+    monkeypatch.setenv("SOLUTION_ARCHIVE_PATH", str(tmp_path / "sol.duckdb"))
+    settings = config.Settings(bus_port=0)
+    with mock.patch.object(orchestrator.Orchestrator, "_init_agents", lambda self: []):
+        orch = orchestrator.Orchestrator(settings)
+
+    import numpy as np
+
+    monkeypatch.setattr("src.evaluators.novelty.embed", lambda _t: np.zeros((1, 1), dtype="float32"))
+    monkeypatch.setattr("src.simulation.surrogate_fitness.aggregate", lambda vals, **kw: [0.0 for _ in vals])
+    times = []
+
+    def dummy_run(*_a, **_kw):
+        times.append(time.perf_counter())
+        time.sleep(0.2)
+        ind = orchestrator.mats.Individual([0.0])
+        ind.score = 0.0
+        return [ind]
+
+    monkeypatch.setattr(orchestrator.mats, "run_evolution", dummy_run)
+
+    def fn(genome: list[float]) -> tuple[float]:
+        time.sleep(0.2)
+        return (sum(genome),)
+
+    async def run() -> None:
+        await asyncio.gather(
+            orch.evolve("a", fn, 1, experiment_id="exp1", population_size=2, generations=1),
+            orch.evolve("b", fn, 1, experiment_id="exp2", population_size=2, generations=1),
+        )
+
+    asyncio.run(run())
+    assert len(times) == 2
+    assert abs(times[0] - times[1]) < 0.05
+    assert "exp1" in orch.experiment_pops
+    assert "exp2" in orch.experiment_pops
+    assert orch.experiment_pops["exp1"] is not orch.experiment_pops["exp2"]
+
+    specs = [json.loads(row[0])["experiment_id"] for row in orch.archive.conn.execute("SELECT spec FROM entries")]
+    assert {"exp1", "exp2"} <= set(specs)


### PR DESCRIPTION
## Summary
- orchestrator records experiment populations
- memory limited to 8GB for all populations
- evolutions can run concurrently via experiment IDs
- store experiment results in the archive
- test experiment concurrency and isolation

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_experiments.py`

------
https://chatgpt.com/codex/tasks/task_e_683b508c61d48333bcc2aefc54101df0