### PR TITLE
[alpha_factory] Add cleanup to improve_repo

### DIFF
--- a/tests/test_self_improver.py
+++ b/tests/test_self_improver.py
@@ -27,7 +27,9 @@ def test_improve_repo(tmp_path: Path) -> None:
     patch_file.write_text(patch)
     log_file = tmp_path / "log.json"
 
-    delta, clone = self_improver.improve_repo(str(repo_dir), str(patch_file), "metric.txt", str(log_file))
+    delta, clone = self_improver.improve_repo(
+        str(repo_dir), str(patch_file), "metric.txt", str(log_file), cleanup=False
+    )
 
     assert delta == 1
     assert (clone / "metric.txt").read_text().strip() == "2"
@@ -48,6 +50,24 @@ def test_improve_repo_invalid_patch(tmp_path: Path) -> None:
         self_improver.improve_repo(
             str(repo_dir), str(patch_file), "metric.txt", str(log_file)
         )
+
+
+def test_improve_repo_cleanup(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _init_repo(repo_dir)
+
+    patch = """--- a/metric.txt\n+++ b/metric.txt\n@@\n-1\n+2\n"""
+    patch_file = tmp_path / "patch.diff"
+    patch_file.write_text(patch)
+    log_file = tmp_path / "log.json"
+
+    delta, clone = self_improver.improve_repo(
+        str(repo_dir), str(patch_file), "metric.txt", str(log_file), cleanup=True
+    )
+
+    assert delta == 1
+    assert not clone.exists()
 
 
 def test_improve_repo_requires_git(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow removing cloned repo after patching via `cleanup` flag
- document cleanup option
- test removal of temporary repo

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683b69ea7eac833389d80a5ab1c83fab