### PR TITLE
[alpha_factory] Secure tar extraction in evolution worker

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -483,6 +483,8 @@ push; only green builds are released to GHCR.
 * **Encrypted transport** – all agent traffic uses mTLS.
 * **Immutable ledger** – every A2A envelope hashed with BLAKE3; Merkle root
   pinned hourly to a public chain for tamper-evidence.
+* **Secure tar extraction** – the `/mutate` endpoint validates archive members to
+  block path traversal.
 
 ---
 

--- a/tests/test_evolution_worker_safe_extract.py
+++ b/tests/test_evolution_worker_safe_extract.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+import socket
+import threading
+import time
+from typing import Iterator
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+uvicorn = pytest.importorskip("uvicorn")
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import evolution_worker
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture()
+def server() -> Iterator[str]:
+    port = _free_port()
+    config = uvicorn.Config(evolution_worker.app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if server.started:
+            break
+        time.sleep(0.1)
+    yield f"http://127.0.0.1:{port}"
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+def test_mutate_rejects_traversal(server: str) -> None:
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        info = tarfile.TarInfo(name="../evil.txt")
+        data = b"bad"
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+
+    with httpx.Client(base_url=server) as client:
+        files = {"tar": ("bad.tar", buf.read())}
+        r = client.post("/mutate", files=files)
+        assert r.status_code == 400


### PR DESCRIPTION
## Summary
- validate tar members in the evolution worker before extraction
- add regression test covering path traversal rejection
- document secure extraction in the Insight demo README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py tests/test_evolution_worker_safe_extract.py` *(fails: Failed to connect to proxy port 8080)*
- `pytest -q` *(fails: duplicated timeseries error)*

------
https://chatgpt.com/codex/tasks/task_e_683b700526788333aab1c3f9010ece46