### PR TITLE
[alpha_factory] Log agent exceptions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
@@ -9,10 +9,12 @@ passed to the :class:`CodeGenAgent`.
 from __future__ import annotations
 
 from .base_agent import BaseAgent
-from ..utils import messaging
+from ..utils import messaging, logging as insight_logging
 from ..utils.logging import Ledger
 from ..utils.retry import with_retry
 from ..utils.tracing import span
+
+log = insight_logging.logging.getLogger(__name__)
 
 
 class MarketAgent(BaseAgent):
@@ -42,6 +44,6 @@ class MarketAgent(BaseAgent):
                 try:  # pragma: no cover
                     with span("openai.run"):
                         analysis = await with_retry(self.oai_ctx.run)(prompt=str(strategy))
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log.warning("openai.run failed: %s", exc)
             await self.emit("codegen", {"analysis": analysis})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -9,11 +9,13 @@ of stored items back to the orchestrator.
 from __future__ import annotations
 
 from .base_agent import BaseAgent
-from ..utils import messaging
+from ..utils import messaging, logging as insight_logging
 from ..utils.logging import Ledger
 from ..utils.tracing import span
 import json
 from pathlib import Path
+
+log = insight_logging.logging.getLogger(__name__)
 
 
 class MemoryAgent(BaseAgent):
@@ -38,8 +40,8 @@ class MemoryAgent(BaseAgent):
                     continue
                 try:
                     self.records.append(json.loads(line))
-                except Exception:  # noqa: BLE001 - ignore bad records
-                    pass
+                except Exception as exc:  # noqa: BLE001 - ignore bad records
+                    log.warning("invalid record: %s", exc)
 
     async def run_cycle(self) -> None:
         """Periodically report memory size."""

--- a/tests/test_agent_logging.py
+++ b/tests/test_agent_logging.py
@@ -1,0 +1,53 @@
+import asyncio
+from unittest import mock
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (
+    market_agent,
+    strategy_agent,
+    research_agent,
+)
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging, local_llm
+from tests.test_agent_handle_methods import DummyBus, DummyLedger
+
+
+class DummyCtx:
+    async def run(self, *a, **k):
+        raise RuntimeError("boom")
+
+
+def test_market_agent_logs_exception():
+    cfg = config.Settings(bus_port=0, openai_api_key="k")
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = market_agent.MarketAgent(bus, led)
+    agent.oai_ctx = DummyCtx()
+    env = messaging.Envelope("strategy", "market", {"strategy": "foo"}, 0.0)
+    with mock.patch.object(market_agent.log, "warning") as warn:
+        asyncio.run(agent.handle(env))
+        warn.assert_called_once()
+
+
+def test_strategy_agent_logs_exception(monkeypatch):
+    cfg = config.Settings(bus_port=0)
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = strategy_agent.StrategyAgent(bus, led)
+
+    monkeypatch.setattr(local_llm, "chat", lambda *_: (_ for _ in ()).throw(RuntimeError("boom")))
+    env = messaging.Envelope("research", "strategy", {"research": "foo"}, 0.0)
+    with mock.patch.object(strategy_agent.log, "warning") as warn:
+        asyncio.run(agent.handle(env))
+        warn.assert_called_once()
+
+
+def test_research_agent_logs_exception():
+    cfg = config.Settings(bus_port=0, openai_api_key="k")
+    bus = DummyBus(cfg)
+    led = DummyLedger()
+    agent = research_agent.ResearchAgent(bus, led)
+    agent.oai_ctx = DummyCtx()
+    env = messaging.Envelope("planning", "research", {"plan": "bar"}, 0.0)
+    with mock.patch.object(research_agent.log, "warning") as warn:
+        asyncio.run(agent.handle(env))
+        warn.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add module loggers to demo agents and warn when exceptions occur
- test that logging happens when agent components fail

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py tests/test_agent_logging.py` *(fails: unable to access https://github.com/psf/black/)*
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683b71b763808333a9336f956e92f2a2