### PR TITLE
[alpha_factory] Harden tar extraction

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_evolution_worker.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_evolution_worker.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the evolution worker."""
+import io
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+
+def _make_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("STORAGE_PATH", str(tmp_path))
+    from alpha_factory_v1.demos.alpha_agi_insight_v1.src import evolution_worker
+
+    return TestClient(evolution_worker.app)
+
+
+def _make_tar(member: tarfile.TarInfo) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(mode="w", fileobj=buf) as tf:
+        tf.addfile(member)
+    return buf.getvalue()
+
+
+def test_rejects_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _make_client(tmp_path, monkeypatch)
+
+    info = tarfile.TarInfo("link")
+    info.type = tarfile.SYMTYPE
+    info.linkname = "../evil"
+    payload = _make_tar(info)
+
+    resp = client.post("/mutate", files={"tar": ("bad.tar", payload, "application/x-tar")})
+    assert resp.status_code == 400
+
+
+def test_rejects_absolute_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _make_client(tmp_path, monkeypatch)
+
+    info = tarfile.TarInfo("/abs.txt")
+    info.size = 0
+    payload = _make_tar(info)
+
+    resp = client.post("/mutate", files={"tar": ("bad.tar", payload, "application/x-tar")})
+    assert resp.status_code == 400

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -85,8 +85,10 @@ and returns the resulting child genome.
 
 Typical usage is to run the container and POST agent source code to `/mutate`.
 The returned genome can seed another agent or be stored for analysis. A
-`_safe_extract` helper guards against path traversal attacks during tar
-extraction.
+`_safe_extract` validates each archive member before extraction. Symlinks and
+hard links are rejected and paths are normalised so absolute or parent
+directories cannot be written outside the target directory. Verified members are
+then extracted individually to avoid surprises.
 
 ## Security considerations
 


### PR DESCRIPTION
## Summary
- prevent symlink attacks when extracting uploaded tar files
- test that /mutate rejects archives with symlinks or absolute paths
- document the stricter extraction rules

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_evolution_worker.py docs/DESIGN.md` *(fails: Failed to connect to proxy port 8080)*
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_evolution_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_683b7e4b909c833393d9058939e6ff95