### PR TITLE
[alpha_factory] document new environment variables

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -413,6 +413,9 @@ local development or customization. See the
 | `MAX_RESULTS` | Number of results to keep on disk | `100` |
 | `BUSINESS_HOST` | Base orchestrator URL for bridges | `"http://localhost:8000"` |
 | `API_TOKEN` | Bearer token required by the REST API | `REPLACE_ME_TOKEN` |
+| `API_RATE_LIMIT` | Requests allowed per minute for the API server | `60` |
+| `AGI_ISLAND_BACKENDS` | Comma-separated mapping of island names to LLM backends | `default=gpt-4o` |
+| `ALERT_WEBHOOK_URL` | Optional URL for orchestrator alert messages | _unset_ |
 
 `BUSINESS_HOST` sets the orchestrator URL used by helper commands to reach the REST API.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,6 +47,9 @@ or pass the variable when launching Docker:
 docker run -e API_TOKEN=mysecret <image>
 ```
 
+Rate limiting is controlled via `API_RATE_LIMIT` (default `60` requests per
+minute per IP).
+
 Start the server with:
 
 ```bash
@@ -228,6 +231,9 @@ wscat -c "ws://localhost:8000/ws/progress" \
 
 The server honours environment variables defined in `.env` such as `PORT` (HTTP port) and `OPENAI_API_KEY`. When a prebuilt React dashboard exists under `src/interface/web_client/dist`, it is automatically served at the root path (`/`). CORS headers are configured via `API_CORS_ORIGINS` (default `"*"`).
 Sandbox CPU and memory limits can be set via `SANDBOX_CPU_SEC` and `SANDBOX_MEM_MB`.
+Alert notifications can be forwarded when `ALERT_WEBHOOK_URL` is set. Islands may
+target different backends by defining `AGI_ISLAND_BACKENDS`, for example
+`default=gpt-4o,eval=mistral-small`.
 The OpenAPI specification can be fetched from `/openapi.json` when the server is
 running.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 - Synced `openai`, `openai-agents` and `uvicorn` pins across requirements files
   and clarified why `requests` and `rich` differ between layers.
+- Documented `API_RATE_LIMIT`, `AGI_ISLAND_BACKENDS` and `ALERT_WEBHOOK_URL`
+  environment variables.
 - Added [`src/tools/analyse_backtrack.py`](../src/tools/analyse_backtrack.py) for visualising archive backtracks.
 - Added CI workflow running lint, type checks, tests and Docker build with
   automated image deployment on tags and rollback on failure. Metrics are


### PR DESCRIPTION
## Summary
- document API_RATE_LIMIT, AGI_ISLAND_BACKENDS and ALERT_WEBHOOK_URL in the Insight README
- mention these variables in API docs and changelog

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/README.md docs/CHANGELOG.md docs/API.md` *(fails: could not fetch psf/black)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683b82d4e34c8333b01aeb6c1a8145ff