### PR TITLE
[alpha_factory] add API rate limit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,10 @@ Install the project in editable mode so tests resolve imports:
 pip install -e .
 ```
 
+The suite includes `tests/test_api_rate_limit.py` which spins up
+`api_server.app` with `API_RATE_LIMIT=2` and verifies that exceeding the
+limit returns HTTP `429`.
+
 <a name="62-marketplace-demo-example"></a>
 ### 6.2 · Marketplace Demo Example 🛒
 A minimal snippet queues the sample job once the orchestrator is running:

--- a/tests/test_api_rate_limit.py
+++ b/tests/test_api_rate_limit.py
@@ -14,13 +14,19 @@ os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 
 def test_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify API returns 429 when the request limit is exceeded."""
+
     monkeypatch.setenv("API_RATE_LIMIT", "2")
-    from src.interface import api_server as api
-    api = importlib.reload(api)
+
+    from src.interface import api_server
+
+    api = importlib.reload(api_server)
+
     client = TestClient(cast(Any, api.app))
     headers = {"Authorization": "Bearer test-token"}
 
     assert client.get("/runs", headers=headers).status_code == 200
     assert client.get("/runs", headers=headers).status_code == 200
+
     resp = client.get("/runs", headers=headers)
     assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- add a short README note on the API rate limit test
- verify API limit enforcement with TestClient

## Testing
- `pre-commit run --files tests/test_api_rate_limit.py README.md` *(fails: could not fetch psf/black)*
- `python check_env.py --auto-install`
- `pytest -q tests/test_api_rate_limit.py`

------
https://chatgpt.com/codex/tasks/task_e_683b934db2608333949e5d24d6e51e4e