### PR TITLE
[alpha_factory] docs: add Windows OpenSSL example

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -25,6 +25,19 @@ AGI_INSIGHT_BUS_KEY=/path/to/certs/bus.key
 AGI_INSIGHT_BUS_TOKEN=change_this_token
 ```
 
+### Windows (PowerShell)
+
+Install the [OpenSSL Windows binaries](https://slproweb.com/products/Win32OpenSSL.html) and run the equivalent commands:
+
+```powershell
+New-Item -ItemType Directory -Force -Path certs
+openssl req -x509 -newkey rsa:4096 -nodes `
+  -keyout certs/bus.key `
+  -out certs/bus.crt `
+  -days 365 `
+  -subj "/CN=localhost"
+```
+
 ## Docker and Docker Compose
 
 Place `bus.crt` and `bus.key` under `./certs` next to `docker-compose.yml` and mount the directory:


### PR DESCRIPTION
## Summary
- document generating bus.crt and bus.key on Windows

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683b9cae8a08833392288ccdd247a0c1