### PR TITLE
[alpha_factory] enhance bus handshake security

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -54,6 +54,7 @@ class Settings(SettingsBase):
     bus_token: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_TOKEN")
     bus_cert: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_CERT")
     bus_key: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_KEY")
+    bus_fail_limit: int = Field(default=3, alias="AGI_INSIGHT_BUS_FAIL_LIMIT")
     alert_webhook_url: Optional[str] = Field(default=None, alias="ALERT_WEBHOOK_URL")
     allow_insecure: bool = Field(default=False, alias="AGI_INSIGHT_ALLOW_INSECURE")
     broadcast: bool = Field(default=True, alias="AGI_INSIGHT_BROADCAST")

--- a/src/utils/a2a_pb2.py
+++ b/src/utils/a2a_pb2.py
@@ -7,6 +7,7 @@ from google.protobuf.internal import builder as _builder
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import symbol_database as _symbol_database
+from google.protobuf import struct_pb2 as _struct_pb2  # noqa: F401
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -103,7 +103,7 @@ def test_grpc_bus_tls_message_exchange(tmp_path: Path) -> None:
             creds = grpc.ssl_channel_credentials(root_certificates=ca)
             async with grpc.aio.secure_channel(f"localhost:{port}", creds) as ch:
                 stub = ch.unary_unary("/bus.Bus/Send")
-                await stub(b"proto_schema=1")
+                await stub(f"{messaging.A2ABus.PROTO_VERSION} n1".encode())
                 payload = {
                     "sender": "a",
                     "recipient": "b",
@@ -131,7 +131,7 @@ def test_grpc_bus_tls_bad_token(tmp_path: Path) -> None:
             creds = grpc.ssl_channel_credentials(root_certificates=ca)
             async with grpc.aio.secure_channel(f"localhost:{port}", creds) as ch:
                 stub = ch.unary_unary("/bus.Bus/Send")
-                await stub(b"proto_schema=1")
+                await stub(f"{messaging.A2ABus.PROTO_VERSION} n2".encode())
                 payload = {
                     "sender": "a",
                     "recipient": "b",

--- a/tests/test_bus_ssl_gen.py
+++ b/tests/test_bus_ssl_gen.py
@@ -45,7 +45,7 @@ def test_bus_tls_with_script(tmp_path: Path) -> None:
             creds = grpc.ssl_channel_credentials(root_certificates=ca)
             async with grpc.aio.secure_channel(f"localhost:{port}", creds) as ch:
                 stub = ch.unary_unary("/bus.Bus/Send")
-                await stub(b"proto_schema=1")
+                await stub(f"{messaging.A2ABus.PROTO_VERSION} n1".encode())
                 payload = {
                     "sender": "a",
                     "recipient": "b",

--- a/tests/test_bus_tls.py
+++ b/tests/test_bus_tls.py
@@ -73,7 +73,7 @@ def test_bus_tls_accept(tmp_path: Path) -> None:
             creds = grpc.ssl_channel_credentials(root_certificates=ca)
             async with grpc.aio.secure_channel(f"localhost:{port}", creds) as ch:
                 stub = ch.unary_unary("/bus.Bus/Send")
-                await stub(b"proto_schema=1")
+                await stub(f"{messaging.A2ABus.PROTO_VERSION} n1".encode())
                 payload = {
                     "sender": "a",
                     "recipient": "b",
@@ -100,7 +100,7 @@ def test_bus_tls_reject_bad_token(tmp_path: Path) -> None:
             creds = grpc.ssl_channel_credentials(root_certificates=ca)
             async with grpc.aio.secure_channel(f"localhost:{port}", creds) as ch:
                 stub = ch.unary_unary("/bus.Bus/Send")
-                await stub(b"proto_schema=1")
+                await stub(f"{messaging.A2ABus.PROTO_VERSION} n2".encode())
                 payload = {
                     "sender": "a",
                     "recipient": "b",

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -81,7 +81,7 @@ def test_publish_grpc() -> None:
         async with bus:
             async with grpc.aio.insecure_channel(f"localhost:{port}") as ch:
                 stub = ch.unary_unary("/bus.Bus/Send")
-                await stub(b"proto_schema=1")
+                await stub(f"{messaging.A2ABus.PROTO_VERSION} n1".encode())
                 payload = {
                     "sender": "a",
                     "recipient": "x",
@@ -136,7 +136,7 @@ def test_new_connection_requires_handshake() -> None:
             # first client performs handshake and sends message
             async with grpc.aio.insecure_channel(f"localhost:{port}") as ch1:
                 stub1 = ch1.unary_unary("/bus.Bus/Send")
-                await stub1(b"proto_schema=1")
+                await stub1(f"{messaging.A2ABus.PROTO_VERSION} n1".encode())
                 payload = {
                     "sender": "a",
                     "recipient": "x",

--- a/tests/test_orchestrator_bus_tls_env.py
+++ b/tests/test_orchestrator_bus_tls_env.py
@@ -85,7 +85,7 @@ def test_orchestrator_bus_tls_env(tmp_path: Path) -> None:
                 creds = grpc.ssl_channel_credentials(root_certificates=ca)
                 async with grpc.aio.secure_channel(f"localhost:{port}", creds) as ch:
                     stub = ch.unary_unary("/bus.Bus/Send")
-                    await stub(b"proto_schema=1")
+                    await stub(f"{messaging.A2ABus.PROTO_VERSION} n1".encode())
                     payload = {
                         "sender": "a",
                         "recipient": "b",


### PR DESCRIPTION
## Summary
- track handshake failures with TTL and drop repeat offenders
- include nonce in bus handshake messages
- allow configuring the failure limit via `AGI_INSIGHT_BUS_FAIL_LIMIT`
- reject replayed handshakes and invalid tokens in secure bus tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683ba1cf4b308333b7ecf6daeb86449a