### PR TITLE
[alpha_factory] add offline doc & docker quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,9 +649,28 @@ For evolutionary experiments you can run the optional
 [evolution worker](docs/DESIGN.md#evolution-worker) container and POST a tarball
 of agent code to `/mutate`.
 
-## Quick Start with Docker
+## Docker Quickstart
+Start the full stack using Docker Compose:
+```bash
 docker compose up --build
-# browse http://localhost:8080
+```
+Browse the dashboard at <http://localhost:8080>.
+
+The same configuration can be installed via Helm:
+```bash
+helm upgrade --install alpha-demo ./infrastructure/helm-chart \
+  --values ./infrastructure/helm-chart/values.yaml \
+  --set env.RUN_MODE=web
+```
+This deploys the services to your local Kubernetes cluster.
+
+Generate TLS certificates for the gRPC bus using the bundled helper:
+```bash
+./infrastructure/gen_bus_certs.sh > .env.bus
+source .env.bus
+```
+The script prints `AGI_INSIGHT_BUS_CERT`, `AGI_INSIGHT_BUS_KEY` and
+`AGI_INSIGHT_BUS_TOKEN` which you can append to your `.env` file.
 
 ### .env Setup & Security
 Before running the orchestrator, copy `alpha_factory_v1/.env.sample` to `.env` and

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -1,0 +1,48 @@
+# Offline Setup Guide
+
+This guide explains how to prepare and use a wheelhouse so `check_env.py` and the
+setup scripts work without internet access.
+
+## Build the wheelhouse
+
+Run the following commands on a machine with connectivity:
+
+```bash
+mkdir -p /media/wheels
+pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r requirements-dev.txt -w /media/wheels
+```
+
+You can optionally compile a lock file from these wheels:
+
+```bash
+pip-compile --no-index --find-links /media/wheels --generate-hashes \
+    --output-file requirements.lock requirements.txt
+```
+
+Copy the resulting directory to the offline host.
+
+## Environment variables
+
+Set `WHEELHOUSE` to the directory containing your wheels and enable automatic
+installation:
+
+```bash
+export WHEELHOUSE=/media/wheels
+export AUTO_INSTALL_MISSING=1
+```
+
+`check_env.py` uses these variables to install missing packages via `pip` without
+contacting PyPI. When a `wheels/` directory exists in the repository root the
+setup script automatically sets `WHEELHOUSE` for you.
+
+## Running `check_env.py`
+
+Invoke the helper with the `--wheelhouse` flag to verify dependencies:
+
+```bash
+python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+```
+
+The command prints `Environment OK` when all required packages are available.
+


### PR DESCRIPTION
## Summary
- add docs/OFFLINE.md with wheelhouse creation and offline check_env usage
- extend README with Docker Quickstart, Helm notes and bus TLS setup instructions

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683ba75c2c208333a3b0d8a2e2e06e07