### PR TITLE
[alpha_factory] Enforce API token for status check

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -478,6 +478,10 @@ def agents_status(watch: bool) -> None:
     base = os.getenv("BUSINESS_HOST", "http://localhost:8000").rstrip("/")
     token = os.getenv("API_TOKEN", "")
 
+    if not token:
+        click.echo("API_TOKEN not configured")
+        raise SystemExit(1)
+
     def _fetch() -> list[dict[str, object]]:
         resp = requests.get(
             f"{base}/status",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
 
+os.environ.setdefault("API_TOKEN", "test-token")
+
 
 def test_agents_status_lists_names() -> None:
     class Dummy:

--- a/tests/test_cli_runner_ext.py
+++ b/tests/test_cli_runner_ext.py
@@ -2,11 +2,14 @@
 """Additional CLI tests using click CliRunner."""
 
 import csv
+import os
 from io import StringIO
 from unittest.mock import patch
 from click.testing import CliRunner
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
+
+os.environ.setdefault("API_TOKEN", "test-token")
 
 SAMPLE_LEDGER_ROW = {"ts": 1.0, "sender": "a", "recipient": "b", "payload": {"x": 1}}
 

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -14,6 +14,8 @@ from click.testing import CliRunner
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli  # noqa: E402
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging, messaging  # noqa: E402
 
+os.environ.setdefault("API_TOKEN", "test-token")
+
 
 def test_simulate_without_flag_does_not_start() -> None:
     runner = CliRunner()
@@ -92,6 +94,15 @@ def test_agents_status_lists_all_agents(tmp_path) -> None:
     get.assert_called_once()
     assert "AgentA" in result.output and "AgentB" in result.output
     assert "last_beat" in result.output
+
+
+def test_agents_status_requires_token(monkeypatch) -> None:
+    monkeypatch.delenv("API_TOKEN", raising=False)
+    with patch.object(cli.requests, "get") as get:
+        res = CliRunner().invoke(cli.main, ["agents-status"])
+    get.assert_not_called()
+    assert res.exit_code == 1
+    assert "API_TOKEN not configured" in res.output
 
 
 def test_plain_table_handles_no_rows() -> None:

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 import unittest
+from prometheus_client import CollectorRegistry
+import prometheus_client
+import importlib
 
+prometheus_client.REGISTRY = CollectorRegistry()
+prometheus_client.REGISTRY._names_to_collectors.clear()
 os.environ.setdefault("OPENAI_API_KEY", "stub")
-from alpha_factory_v1.backend.utils import llm_provider as llm
+import alpha_factory_v1.backend.utils.llm_provider as llm
+llm = importlib.reload(llm)
 
 
 class TestLLMCacheLRU(unittest.TestCase):


### PR DESCRIPTION
## Summary
- require `API_TOKEN` in CLI agents-status request
- update CLI tests for new token requirement
- clear Prometheus registry in llm cache tests

## Testing
- `pre-commit` *(failed: couldn't access network)*
- `pytest -q` *(failed: tests/test_llm_cache.py - ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683baab3034483339dec01ba0442a7cc