### PR TITLE
[alpha_factory] integrate prediction metrics

### DIFF
--- a/data/sector_shock_10/sample_prediction.json
+++ b/data/sector_shock_10/sample_prediction.json
@@ -1,0 +1,7 @@
+{
+  "name": "sample_prediction",
+  "capabilities": [0.1, 0.2, 0.3],
+  "shocks": [false, false, true],
+  "pred_capabilities": [0.3, 0.2, 0.1],
+  "pred_shocks": [false, true, false]
+}

--- a/src/eval/foresight.py
+++ b/src/eval/foresight.py
@@ -33,10 +33,16 @@ def evaluate(repo_path: Path) -> dict[str, float]:
     leads: list[float] = []
     for path in sorted(ds_dir.glob("*.json")):
         data = json.loads(path.read_text())
-        truth_caps = data.get("capabilities", [])
-        truth_shocks = data.get("shocks", [])
-        pred_caps = truth_caps[:]  # deterministic baseline
-        pred_shocks = truth_shocks[:]
+        truth_caps = [float(v) for v in data.get("capabilities", [])]
+        truth_shocks = [bool(v) for v in data.get("shocks", [])]
+
+        preds = data.get("predictions", {})
+        pred_caps = preds.get("capabilities", data.get("pred_capabilities", truth_caps))
+        pred_shocks = preds.get("shocks", data.get("pred_shocks", truth_shocks))
+
+        pred_caps = [float(v) for v in pred_caps]
+        pred_shocks = [bool(v) for v in pred_shocks]
+
         rmses.append(_rmse(truth_caps, pred_caps))
         leads.append(_lead_time(truth_shocks, pred_shocks))
     if not rmses:

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli  # noqa: E402
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging, messaging  # noqa: E402
+from src.eval.foresight import evaluate as foresight_evaluate  # noqa: E402
 
 os.environ.setdefault("API_TOKEN", "test-token")
 
@@ -337,3 +338,10 @@ def test_simulate_seed_reproducible(tmp_path: Path) -> None:
     digest1 = hashlib.sha256(res1.output.encode()).hexdigest()
     digest2 = hashlib.sha256(res2.output.encode()).hexdigest()
     assert digest1 == digest2
+
+
+def test_foresight_evaluate_nonzero_metrics() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    scores = foresight_evaluate(repo)
+    assert scores["rmse"] > 0
+    assert scores["lead_time"] != 0


### PR DESCRIPTION
## Summary
- compute foresight evaluation metrics using predictions in dataset files
- add sample predictions to the Sector-Shock-10 dataset
- ensure demo CLI tests check for non-zero scores

## Testing
- `pre-commit run --files src/eval/foresight.py tests/test_demo_cli.py data/sector_shock_10/sample_prediction.json` *(failed: Could not fetch psf/black)*
- `pytest -q` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683bd23086dc83338ae726dc042870a5