### PR TITLE
[alpha_factory] add insight browser controls

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -2,28 +2,30 @@
 <meta charset="utf-8" />
 <title>α-AGI Insight – in-browser Pareto explorer</title>
 <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="src/ui/controls.css" />
 
+<div id="controls"></div>
+<div id="toast"></div>
 <script src="d3.v7.min.js"></script>
-<script>
-// tiny linear-congruential RNG for determinism
-function lcg(seed){return()=>((seed=Math.imul(1664525,seed)+1013904223)>>>0)/2**32}
+<script type="module">
+import {parseHash,toHash} from './src/config/params.js';
+import {initControls} from './src/ui/ControlsPanel.js';
 
+function lcg(seed){return()=>((seed=Math.imul(1664525,seed)+1013904223)>>>0)/2**32}
 function nonDominated(pop){return pop.filter(a=>!pop.some(b=>
  (b.logic>=a.logic && b.feasible>=a.feasible) && (b.logic>a.logic||b.feasible>a.feasible)))}
 
-document.addEventListener('DOMContentLoaded',()=>{
-  const qs   = new URLSearchParams(location.search)
-  const seed = +qs.get('seed')||42, popN=+qs.get('pop')||80, gens=+qs.get('gen')||60
-  const rand = lcg(seed)
+let panel
+function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
 
-  let pop   = Array.from({length:popN},()=>({logic:rand(),feasible:rand()}))
-  const svg = d3.select('body').append('svg').attr('viewBox','0 0 500 500')
-  const x   = d3.scaleLinear().domain([0,1]).range([40,460]),
-        y   = d3.scaleLinear().domain([0,1]).range([460,40])
-
-  const dot = svg.append('g')
-  const info= svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
-
+function start(p){
+  const rand=lcg(p.seed)
+  let pop=Array.from({length:p.pop},()=>({logic:rand(),feasible:rand()}))
+  const svg=d3.select('body').append('svg').attr('viewBox','0 0 500 500')
+  const x=d3.scaleLinear().domain([0,1]).range([40,460]),
+        y=d3.scaleLinear().domain([0,1]).range([460,40])
+  const dot=svg.append('g')
+  const info=svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
   let gen=0
   const step=()=>{
     info.text(`gen ${gen}`)
@@ -31,19 +33,21 @@ document.addEventListener('DOMContentLoaded',()=>{
        .join('circle')
        .attr('cx',d=>x(d.logic)).attr('cy',d=>y(d.feasible))
        .attr('r',3).attr('fill',d=>d.front?'#00afff':'#666')
-
-    if(gen++>=gens)return
-    // mutate
+    if(gen++>=p.gen)return
     pop=pop.concat(pop.map(d=>({
-      logic:Math.min(1,Math.max(0,d.logic   +(rand()-.5)*.12)),
+      logic:Math.min(1,Math.max(0,d.logic+(rand()-.5)*.12)),
       feasible:Math.min(1,Math.max(0,d.feasible+(rand()-.5)*.12))
     })))
-    // select
     pop.forEach(d=>d.front=false)
     nonDominated(pop).forEach(d=>d.front=true)
-    pop = nonDominated(pop).concat(d3.shuffle(pop).slice(0,popN-10))
+    pop=nonDominated(pop).concat(d3.shuffle(pop).slice(0,p.pop-10))
     requestAnimationFrame(step)
   }
   step()
-})
+}
+
+function apply(p){location.hash=toHash(p)}
+
+window.addEventListener('DOMContentLoaded',()=>{panel=initControls(parseHash(),apply);window.dispatchEvent(new HashChangeEvent('hashchange'))})
+window.addEventListener('hashchange',()=>{const p=parseHash();panel.setValues(p);d3.select('svg').remove();start(p);toast('simulation restarted')})
 </script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+export const defaults={seed:42,pop:80,gen:60};
+export function parseHash(h=window.location.hash){
+  const q=new URLSearchParams(h.replace(/^#/,''));
+  return{seed:+q.get('seed')||defaults.seed,pop:+q.get('pop')||defaults.pop,gen:+q.get('gen')||defaults.gen};
+}
+export function toHash(p){
+  const q=new URLSearchParams();
+  q.set('seed',p.seed);q.set('pop',p.pop);q.set('gen',p.gen);
+  return'#'+q.toString();
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initControls(params,onChange){
+  const root=document.getElementById('controls');
+  root.innerHTML=`<label>Seed <input id="seed" type="number" min="0"></label>
+<label>Population <input id="pop" type="number" min="1"></label>
+<label>Generations <input id="gen" type="number" min="1"></label>`;
+  const seed=root.querySelector('#seed'),
+        pop=root.querySelector('#pop'),
+        gen=root.querySelector('#gen');
+  function update(p){
+    seed.value=p.seed;
+    pop.value=p.pop;
+    gen.value=p.gen;
+  }
+  update(params);
+  function emit(){
+    onChange({seed:+seed.value,pop:+pop.value,gen:+gen.value});
+  }
+  seed.addEventListener('change',emit);
+  pop.addEventListener('change',emit);
+  gen.addEventListener('change',emit);
+  return{setValues:update};
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
@@ -1,0 +1,5 @@
+#controls{position:fixed;top:10px;right:10px;background:rgba(0,0,0,.7);padding:8px;color:#fff;font:14px sans-serif}
+#controls label{display:block;margin-bottom:4px}
+#toast{position:fixed;bottom:10px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,.8);color:#fff;padding:4px 8px;opacity:0;transition:opacity .3s}
+#toast.show{opacity:1}
+@media(prefers-color-scheme:light){#controls{background:rgba(255,255,255,.9);color:#000}#toast{background:rgba(238,238,238,.9);color:#000}}


### PR DESCRIPTION
## Summary
- add ControlsPanel module for interactive controls
- expose default parameters in params.js
- add panel CSS and toast style
- wire up panel in insight browser index.html

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683bd9904e548333a96c77130204bb2f