### PR TITLE
[alpha_factory] Pareto frontier visual updates

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -10,10 +10,10 @@
 <script type="module">
 import {parseHash,toHash} from './src/config/params.js';
 import {initControls} from './src/ui/ControlsPanel.js';
+import {paretoFront} from './src/utils/pareto.js';
+import {renderFrontier,addGlow} from './src/render/frontier.js';
 
 function lcg(seed){return()=>((seed=Math.imul(1664525,seed)+1013904223)>>>0)/2**32}
-function nonDominated(pop){return pop.filter(a=>!pop.some(b=>
- (b.logic>=a.logic && b.feasible>=a.feasible) && (b.logic>a.logic||b.feasible>a.feasible)))}
 
 let panel
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
@@ -24,23 +24,20 @@ function start(p){
   const svg=d3.select('body').append('svg').attr('viewBox','0 0 500 500')
   const x=d3.scaleLinear().domain([0,1]).range([40,460]),
         y=d3.scaleLinear().domain([0,1]).range([460,40])
-  const dot=svg.append('g')
+  addGlow(svg)
   const info=svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
   let gen=0
   const step=()=>{
     info.text(`gen ${gen}`)
-    dot.selectAll('circle').data(pop)
-       .join('circle')
-       .attr('cx',d=>x(d.logic)).attr('cy',d=>y(d.feasible))
-       .attr('r',3).attr('fill',d=>d.front?'#00afff':'#666')
+    renderFrontier(svg,pop,x,y)
     if(gen++>=p.gen)return
     pop=pop.concat(pop.map(d=>({
       logic:Math.min(1,Math.max(0,d.logic+(rand()-.5)*.12)),
       feasible:Math.min(1,Math.max(0,d.feasible+(rand()-.5)*.12))
     })))
-    pop.forEach(d=>d.front=false)
-    nonDominated(pop).forEach(d=>d.front=true)
-    pop=nonDominated(pop).concat(d3.shuffle(pop).slice(0,p.pop-10))
+    const front=paretoFront(pop)
+    pop.forEach(d=>d.front=front.includes(d))
+    pop=front.concat(d3.shuffle(pop).slice(0,p.pop-10))
     requestAnimationFrame(step)
   }
   step()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as d3 from 'd3';
+import { showTooltip, hideTooltip } from '../ui/Tooltip.js';
+import { paretoFront } from '../utils/pareto.js';
+
+export function addGlow(svg) {
+  const defs = svg.append('defs');
+  const filter = defs.append('filter').attr('id', 'glow');
+  filter.append('feGaussianBlur').attr('stdDeviation', 2).attr('result', 'blur');
+  const merge = filter.append('feMerge');
+  merge.append('feMergeNode').attr('in', 'blur');
+  merge.append('feMergeNode').attr('in', 'SourceGraphic');
+}
+
+export function renderFrontier(svg, pop, x, y) {
+  const front = paretoFront(pop).sort((a, b) => a.logic - b.logic);
+
+  const area = d3
+    .area()
+    .x((d) => x(d.logic))
+    .y0(y.range()[0])
+    .y1((d) => y(d.feasible));
+
+  let g = svg.select('g#frontier');
+  if (g.empty()) g = svg.append('g').attr('id', 'frontier');
+
+  g.selectAll('path')
+    .data([front])
+    .join('path')
+    .attr('fill', 'rgba(0,175,255,0.2)')
+    .attr('stroke', 'none')
+    .attr('d', area);
+
+  let dots = svg.select('g#dots');
+  if (dots.empty()) dots = svg.append('g').attr('id', 'dots');
+
+  dots
+    .selectAll('circle')
+    .data(pop)
+    .join('circle')
+    .attr('cx', (d) => x(d.logic))
+    .attr('cy', (d) => y(d.feasible))
+    .attr('r', 3)
+    .attr('fill', (d) => (front.includes(d) ? '#00afff' : '#666'))
+    .attr('filter', (d) => (front.includes(d) ? 'url(#glow)' : null))
+    .on('mousemove', (ev, d) =>
+      showTooltip(ev.pageX + 6, ev.pageY + 6, `logic: ${d.logic.toFixed(2)}\nfeas: ${d.feasible.toFixed(2)}`)
+    )
+    .on('mouseleave', hideTooltip);
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/Tooltip.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/Tooltip.js
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+export function showTooltip(x, y, text) {
+  let tip = document.getElementById('tooltip');
+  if (!tip) {
+    tip = document.createElement('div');
+    tip.id = 'tooltip';
+    tip.style.position = 'absolute';
+    tip.style.pointerEvents = 'none';
+    tip.style.background = 'rgba(0,0,0,0.7)';
+    tip.style.color = '#fff';
+    tip.style.padding = '2px 4px';
+    tip.style.borderRadius = '3px';
+    tip.style.fontSize = '12px';
+    document.body.appendChild(tip);
+  }
+  tip.style.left = `${x}px`;
+  tip.style.top = `${y}px`;
+  tip.textContent = text;
+  tip.style.display = 'block';
+}
+
+export function hideTooltip() {
+  const tip = document.getElementById('tooltip');
+  if (tip) {
+    tip.style.display = 'none';
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.js
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+export function paretoFront(pop) {
+  const front = [];
+  for (const a of pop) {
+    let dominated = false;
+    for (const b of pop) {
+      if (a === b) continue;
+      if (
+        b.logic >= a.logic &&
+        b.feasible >= a.feasible &&
+        (b.logic > a.logic || b.feasible > a.feasible)
+      ) {
+        dominated = true;
+        break;
+      }
+    }
+    if (!dominated) front.push(a);
+  }
+  return front;
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
@@ -4,3 +4,4 @@ svg{display:block;margin:auto;background:#181818;border:1px solid #333}
   body{background:#fff;color:#000}
   svg{background:#fafafa;border-color:#ccc}
 }
+#tooltip{position:absolute;display:none;pointer-events:none;background:rgba(0,0,0,0.7);color:#fff;padding:2px 4px;border-radius:3px;font-size:12px}


### PR DESCRIPTION
## Summary
- compute Pareto frontier with new `paretoFront` util
- render polygon and glowing points for the frontier
- show tooltip with logic/feasibility values

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/Tooltip.js`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683bdaadcb008333a4c86cd3693a4f17