### PR TITLE
[alpha_factory] Add in-browser state export and pause controls

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -12,39 +12,98 @@ import {parseHash,toHash} from './src/config/params.js';
 import {initControls} from './src/ui/ControlsPanel.js';
 import {paretoFront} from './src/utils/pareto.js';
 import {renderFrontier,addGlow} from './src/render/frontier.js';
+import {save,load} from './src/state/serializer.js';
+import {initDragDrop} from './src/ui/dragdrop.js';
 
-function lcg(seed){return()=>((seed=Math.imul(1664525,seed)+1013904223)>>>0)/2**32}
+function lcg(seed){
+  function rand(){
+    seed=Math.imul(1664525,seed)+1013904223>>>0;
+    return seed/2**32;
+  }
+  rand.state=()=>seed;
+  rand.set=s=>{seed=s>>>0;};
+  return rand;
+}
 
-let panel
+let panel,pauseBtn,exportBtn,dropZone
+let current,rand,pop,gen,svg,x,y,info,running=true
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
 
-function start(p){
-  const rand=lcg(p.seed)
-  let pop=Array.from({length:p.pop},()=>({logic:rand(),feasible:rand()}))
-  const svg=d3.select('body').append('svg').attr('viewBox','0 0 500 500')
-  const x=d3.scaleLinear().domain([0,1]).range([40,460]),
-        y=d3.scaleLinear().domain([0,1]).range([460,40])
+function setupView(){
+  d3.select('svg').remove();
+  svg=d3.select('body').append('svg').attr('viewBox','0 0 500 500')
+  x=d3.scaleLinear().domain([0,1]).range([40,460])
+  y=d3.scaleLinear().domain([0,1]).range([460,40])
   addGlow(svg)
-  const info=svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
-  let gen=0
-  const step=()=>{
-    info.text(`gen ${gen}`)
-    renderFrontier(svg,pop,x,y)
-    if(gen++>=p.gen)return
-    pop=pop.concat(pop.map(d=>({
-      logic:Math.min(1,Math.max(0,d.logic+(rand()-.5)*.12)),
-      feasible:Math.min(1,Math.max(0,d.feasible+(rand()-.5)*.12))
-    })))
-    const front=paretoFront(pop)
-    pop.forEach(d=>d.front=front.includes(d))
-    pop=front.concat(d3.shuffle(pop).slice(0,p.pop-10))
-    requestAnimationFrame(step)
-  }
+  info=svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
+}
+
+function start(p){
+  current=p
+  rand=lcg(p.seed)
+  pop=Array.from({length:p.pop},()=>({logic:rand(),feasible:rand()}))
+  gen=0
+  running=true
+  setupView()
   step()
+}
+
+function step(){
+  info.text(`gen ${gen}`)
+  renderFrontier(svg,pop,x,y)
+  if(!running){requestAnimationFrame(step);return}
+  if(gen++>=current.gen)return
+  pop=pop.concat(pop.map(d=>({
+    logic:Math.min(1,Math.max(0,d.logic+(rand()-.5)*.12)),
+    feasible:Math.min(1,Math.max(0,d.feasible+(rand()-.5)*.12))
+  })))
+  const front=paretoFront(pop)
+  pop.forEach(d=>d.front=front.includes(d))
+  pop=front.concat(d3.shuffle(pop).slice(0,current.pop-10))
+  requestAnimationFrame(step)
+}
+
+function togglePause(){
+  running=!running
+  pauseBtn.textContent=running?'Pause':'Resume'
+  if(running)requestAnimationFrame(step)
+}
+
+function exportState(){
+  pop.gen=gen
+  const json=save(pop,rand.state())
+  const a=document.createElement('a')
+  a.href=URL.createObjectURL(new Blob([json],{type:'application/json'}))
+  a.download='state.json'
+  a.click()
+  URL.revokeObjectURL(a.href)
+}
+
+function loadState(text){
+  try{
+    const s=load(text)
+    pop=s.pop
+    gen=s.gen
+    rand=lcg(0);rand.set(s.rngState)
+    running=true
+    pauseBtn.textContent='Pause'
+    setupView()
+    step()
+    toast('state loaded')
+  }catch{toast('invalid file')}
 }
 
 function apply(p){location.hash=toHash(p)}
 
-window.addEventListener('DOMContentLoaded',()=>{panel=initControls(parseHash(),apply);window.dispatchEvent(new HashChangeEvent('hashchange'))})
-window.addEventListener('hashchange',()=>{const p=parseHash();panel.setValues(p);d3.select('svg').remove();start(p);toast('simulation restarted')})
+window.addEventListener('DOMContentLoaded',()=>{
+  panel=initControls(parseHash(),apply)
+  pauseBtn=panel.pauseBtn
+  exportBtn=panel.exportBtn
+  dropZone=panel.dropZone
+  pauseBtn.addEventListener('click',togglePause)
+  exportBtn.addEventListener('click',exportState)
+  initDragDrop(dropZone,loadState)
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+})
+window.addEventListener('hashchange',()=>{const p=parseHash();panel.setValues(p);start(p);toast('simulation restarted')})
 </script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/state/serializer.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/state/serializer.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+export function save(pop, rngState) {
+  const data = {
+    gen: pop.gen ?? 0,
+    pop: Array.from(pop, (d) => ({ logic: d.logic, feasible: d.feasible, front: d.front })),
+    rngState,
+  };
+  return JSON.stringify(data);
+}
+
+export function load(json) {
+  const data = JSON.parse(json);
+  if (!Array.isArray(data.pop)) throw new Error('Invalid population');
+  const pop = data.pop.map((d) => ({ logic: d.logic, feasible: d.feasible, front: d.front }));
+  pop.gen = data.gen ?? 0;
+  return { pop, rngState: data.rngState, gen: data.gen ?? 0 };
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
@@ -3,7 +3,10 @@ export function initControls(params,onChange){
   const root=document.getElementById('controls');
   root.innerHTML=`<label>Seed <input id="seed" type="number" min="0"></label>
 <label>Population <input id="pop" type="number" min="1"></label>
-<label>Generations <input id="gen" type="number" min="1"></label>`;
+<label>Generations <input id="gen" type="number" min="1"></label>
+<button id="pause">Pause</button>
+<button id="export">Export</button>
+<div id="drop">Drop JSON here</div>`;
   const seed=root.querySelector('#seed'),
         pop=root.querySelector('#pop'),
         gen=root.querySelector('#gen');
@@ -19,5 +22,8 @@ export function initControls(params,onChange){
   seed.addEventListener('change',emit);
   pop.addEventListener('change',emit);
   gen.addEventListener('change',emit);
-  return{setValues:update};
+  const pause=root.querySelector('#pause'),
+        exportBtn=root.querySelector('#export'),
+        drop=root.querySelector('#drop');
+  return{setValues:update,pauseBtn:pause,exportBtn,dropZone:drop};
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
@@ -1,5 +1,8 @@
 #controls{position:fixed;top:10px;right:10px;background:rgba(0,0,0,.7);padding:8px;color:#fff;font:14px sans-serif}
 #controls label{display:block;margin-bottom:4px}
+#controls button{margin-right:4px;margin-top:4px}
+#drop{margin-top:4px;padding:10px;border:1px dashed #888;text-align:center;font-size:12px}
+#drop.drag{background:rgba(255,255,255,.1)}
 #toast{position:fixed;bottom:10px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,.8);color:#fff;padding:4px 8px;opacity:0;transition:opacity .3s}
 #toast.show{opacity:1}
-@media(prefers-color-scheme:light){#controls{background:rgba(255,255,255,.9);color:#000}#toast{background:rgba(238,238,238,.9);color:#000}}
+@media(prefers-color-scheme:light){#controls{background:rgba(255,255,255,.9);color:#000}#toast{background:rgba(238,238,238,.9);color:#000}#drop{border-color:#aaa}#drop.drag{background:rgba(0,0,0,.05)}}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/dragdrop.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/dragdrop.js
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initDragDrop(el, onDrop) {
+  function over(ev) {
+    ev.preventDefault();
+    el.classList.add('drag');
+  }
+  function leave() {
+    el.classList.remove('drag');
+  }
+  function drop(ev) {
+    ev.preventDefault();
+    el.classList.remove('drag');
+    const file = ev.dataTransfer.files && ev.dataTransfer.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => onDrop(reader.result);
+    reader.readAsText(file);
+  }
+  el.addEventListener('dragover', over);
+  el.addEventListener('dragleave', leave);
+  el.addEventListener('drop', drop);
+}


### PR DESCRIPTION
## Summary
- implement state serializer for Insight browser demo
- add drag-drop handling and pause/resume controls
- support exporting and loading simulation state
- update styles for new controls

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683bdd68e6a88333865225c7d5389400