### PR TITLE
[alpha_factory] Export tools for browser demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -6,6 +6,7 @@
 
 <div id="controls"></div>
 <div id="toast"></div>
+<div id="toolbar"></div>
 <script src="d3.v7.min.js"></script>
 <script type="module">
 import {parseHash,toHash} from './src/config/params.js';
@@ -14,6 +15,8 @@ import {paretoFront} from './src/utils/pareto.js';
 import {renderFrontier,addGlow} from './src/render/frontier.js';
 import {save,load} from './src/state/serializer.js';
 import {initDragDrop} from './src/ui/dragdrop.js';
+import {toCSV} from './src/utils/csv.js';
+import {svg2png} from './src/render/svg2png.js';
 
 function lcg(seed){
   function rand(){
@@ -79,6 +82,25 @@ function exportState(){
   URL.revokeObjectURL(a.href)
 }
 
+function exportCSV(data){
+  const csv = toCSV(data);
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(new Blob([csv], {type: "text/csv"}));
+  a.download = "population.csv";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+async function exportPNG(){
+  if(!svg) return;
+  const blob = await svg2png(svg.node ? svg.node() : svg.node());
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "frontier.png";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
 function loadState(text){
   try{
     const s=load(text)
@@ -100,6 +122,15 @@ window.addEventListener('DOMContentLoaded',()=>{
   pauseBtn=panel.pauseBtn
   exportBtn=panel.exportBtn
   dropZone=panel.dropZone
+  const tb=document.getElementById("toolbar");
+  const csvBtn=document.createElement("button");
+  csvBtn.textContent="CSV";
+  const pngBtn=document.createElement("button");
+  pngBtn.textContent="PNG";
+  tb.appendChild(csvBtn);
+  tb.appendChild(pngBtn);
+  csvBtn.addEventListener("click",()=>exportCSV(pop));
+  pngBtn.addEventListener("click",exportPNG);
   pauseBtn.addEventListener('click',togglePause)
   exportBtn.addEventListener('click',exportState)
   initDragDrop(dropZone,loadState)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/svg2png.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/svg2png.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+export async function svg2png(svg) {
+  const xml = new XMLSerializer().serializeToString(svg);
+  const blob = new Blob([xml], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  const img = new Image();
+  const loaded = new Promise((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = reject;
+    img.src = url;
+  });
+  await loaded;
+  const canvas = document.createElement('canvas');
+  const vb = svg.viewBox.baseVal;
+  canvas.width = vb && vb.width ? vb.width : svg.clientWidth;
+  canvas.height = vb && vb.height ? vb.height : svg.clientHeight;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  URL.revokeObjectURL(url);
+  return new Promise((resolve) => canvas.toBlob((b) => resolve(b), 'image/png'));
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/csv.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/csv.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+export function toCSV(rows, headers) {
+  if (!rows.length) return '';
+  const keys = headers || Object.keys(rows[0]);
+  const escape = (v) => `"${String(v).replace(/"/g, '""')}"`;
+  const lines = [keys.join(',')];
+  for (const row of rows) {
+    lines.push(keys.map((k) => escape(row[k])).join(','));
+  }
+  return lines.join('\n');
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
@@ -5,3 +5,5 @@ svg{display:block;margin:auto;background:#181818;border:1px solid #333}
   svg{background:#fafafa;border-color:#ccc}
 }
 #tooltip{position:absolute;display:none;pointer-events:none;background:rgba(0,0,0,0.7);color:#fff;padding:2px 4px;border-radius:3px;font-size:12px}
+#toolbar{position:fixed;bottom:10px;left:10px}
+#toolbar button{margin-right:4px}


### PR DESCRIPTION
## Summary
- add CSV utility for web export
- convert SVG to PNG for saving graphs
- expose CSV/PNG download toolbar in the in-browser Pareto explorer

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/svg2png.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/csv.js` *(fails: Could not fetch psf/black)*

------
https://chatgpt.com/codex/tasks/task_e_683bdeded71083339d719f079c0b02ff