### PR TITLE
[alpha_factory] update mutation controls

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -7,6 +7,7 @@
 <div id="controls"></div>
 <div id="toast"></div>
 <div id="toolbar"></div>
+<div id="legend"></div>
 <script src="d3.v7.min.js"></script>
 <script type="module">
 import {parseHash,toHash} from './src/config/params.js';
@@ -17,6 +18,8 @@ import {save,load} from './src/state/serializer.js';
 import {initDragDrop} from './src/ui/dragdrop.js';
 import {toCSV} from './src/utils/csv.js';
 import {svg2png} from './src/render/svg2png.js';
+import {mutate} from './src/evolve/mutate.js';
+import {strategyColors} from './src/render/colors.js';
 
 function lcg(seed){
   function rand(){
@@ -41,13 +44,31 @@ function setupView(){
   info=svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
 }
 
+function updateLegend(strats){
+  const legend=document.getElementById('legend');
+  legend.innerHTML='';
+  for(const s of strats){
+    const span=document.createElement('span');
+    const sw=document.createElement('i');
+    sw.style.background=strategyColors[s];
+    sw.style.display='inline-block';
+    sw.style.width='10px';
+    sw.style.height='10px';
+    sw.style.marginRight='4px';
+    span.appendChild(sw);
+    span.append(s);
+    legend.appendChild(span);
+  }
+}
+
 function start(p){
   current=p
   rand=lcg(p.seed)
-  pop=Array.from({length:p.pop},()=>({logic:rand(),feasible:rand()}))
+  pop=Array.from({length:p.pop},()=>({logic:rand(),feasible:rand(),strategy:'base'}))
   gen=0
   running=true
   setupView()
+  updateLegend(p.mutations)
   step()
 }
 
@@ -56,10 +77,7 @@ function step(){
   renderFrontier(svg,pop,x,y)
   if(!running){requestAnimationFrame(step);return}
   if(gen++>=current.gen)return
-  pop=pop.concat(pop.map(d=>({
-    logic:Math.min(1,Math.max(0,d.logic+(rand()-.5)*.12)),
-    feasible:Math.min(1,Math.max(0,d.feasible+(rand()-.5)*.12))
-  })))
+  pop=mutate(pop,rand,current.mutations)
   const front=paretoFront(pop)
   pop.forEach(d=>d.front=front.includes(d))
   pop=front.concat(d3.shuffle(pop).slice(0,current.pop-10))

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-export const defaults={seed:42,pop:80,gen:60};
+export const defaults={seed:42,pop:80,gen:60,mutations:['gaussian']};
 export function parseHash(h=window.location.hash){
   const q=new URLSearchParams(h.replace(/^#/,''));
-  return{seed:+q.get('seed')||defaults.seed,pop:+q.get('pop')||defaults.pop,gen:+q.get('gen')||defaults.gen};
+  return{
+    seed:+q.get('seed')||defaults.seed,
+    pop:+q.get('pop')||defaults.pop,
+    gen:+q.get('gen')||defaults.gen,
+    mutations:(q.get('mut')||defaults.mutations.join(',')).split(',').filter(Boolean)
+  };
 }
 export function toHash(p){
   const q=new URLSearchParams();
   q.set('seed',p.seed);q.set('pop',p.pop);q.set('gen',p.gen);
+  if(p.mutations) q.set('mut',p.mutations.join(','));
   return'#'+q.toString();
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+export function mutate(pop, rand, strategies) {
+  const clamp = (v) => Math.min(1, Math.max(0, v));
+  const mutants = [];
+  for (const d of pop) {
+    for (const s of strategies) {
+      switch (s) {
+        case 'gaussian':
+          mutants.push({
+            logic: clamp(d.logic + (rand() - 0.5) * 0.12),
+            feasible: clamp(d.feasible + (rand() - 0.5) * 0.12),
+            strategy: s,
+          });
+          break;
+        case 'swap': {
+          const other = pop[Math.floor(rand() * pop.length)];
+          mutants.push({ logic: other.logic, feasible: d.feasible, strategy: s });
+          break;
+        }
+        case 'jump':
+          mutants.push({ logic: rand(), feasible: rand(), strategy: s });
+          break;
+        case 'scramble': {
+          const other = pop[Math.floor(rand() * pop.length)];
+          mutants.push({ logic: d.logic, feasible: other.feasible, strategy: s });
+          break;
+        }
+      }
+    }
+  }
+  return pop.concat(mutants);
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+export const strategyColors = {
+  gaussian: '#ff7f0e',
+  swap: '#2ca02c',
+  jump: '#d62728',
+  scramble: '#9467bd',
+  front: '#00afff',
+  base: '#666',
+};

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
@@ -2,6 +2,7 @@
 import * as d3 from 'd3';
 import { showTooltip, hideTooltip } from '../ui/Tooltip.js';
 import { paretoFront } from '../utils/pareto.js';
+import { strategyColors } from './colors.js';
 
 export function addGlow(svg) {
   const defs = svg.append('defs');
@@ -41,7 +42,10 @@ export function renderFrontier(svg, pop, x, y) {
     .attr('cx', (d) => x(d.logic))
     .attr('cy', (d) => y(d.feasible))
     .attr('r', 3)
-    .attr('fill', (d) => (front.includes(d) ? '#00afff' : '#666'))
+    .attr('fill', (d) => {
+      if (front.includes(d)) return strategyColors.front;
+      return strategyColors[d.strategy] || strategyColors.base;
+    })
     .attr('filter', (d) => (front.includes(d) ? 'url(#glow)' : null))
     .on('mousemove', (ev, d) =>
       showTooltip(ev.pageX + 6, ev.pageY + 6, `logic: ${d.logic.toFixed(2)}\nfeas: ${d.feasible.toFixed(2)}`)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/state/serializer.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/state/serializer.js
@@ -2,7 +2,12 @@
 export function save(pop, rngState) {
   const data = {
     gen: pop.gen ?? 0,
-    pop: Array.from(pop, (d) => ({ logic: d.logic, feasible: d.feasible, front: d.front })),
+    pop: Array.from(pop, (d) => ({
+      logic: d.logic,
+      feasible: d.feasible,
+      front: d.front,
+      strategy: d.strategy,
+    })),
     rngState,
   };
   return JSON.stringify(data);
@@ -11,7 +16,12 @@ export function save(pop, rngState) {
 export function load(json) {
   const data = JSON.parse(json);
   if (!Array.isArray(data.pop)) throw new Error('Invalid population');
-  const pop = data.pop.map((d) => ({ logic: d.logic, feasible: d.feasible, front: d.front }));
+  const pop = data.pop.map((d) => ({
+    logic: d.logic,
+    feasible: d.feasible,
+    front: d.front,
+    strategy: d.strategy,
+  }));
   pop.gen = data.gen ?? 0;
   return { pop, rngState: data.rngState, gen: data.gen ?? 0 };
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
@@ -4,24 +4,42 @@ export function initControls(params,onChange){
   root.innerHTML=`<label>Seed <input id="seed" type="number" min="0"></label>
 <label>Population <input id="pop" type="number" min="1"></label>
 <label>Generations <input id="gen" type="number" min="1"></label>
+<label><input id="gaussian" type="checkbox"> gaussian</label>
+<label><input id="swap" type="checkbox"> swap</label>
+<label><input id="jump" type="checkbox"> jump</label>
+<label><input id="scramble" type="checkbox"> scramble</label>
 <button id="pause">Pause</button>
 <button id="export">Export</button>
 <div id="drop">Drop JSON here</div>`;
   const seed=root.querySelector('#seed'),
         pop=root.querySelector('#pop'),
-        gen=root.querySelector('#gen');
+        gen=root.querySelector('#gen'),
+        gauss=root.querySelector('#gaussian'),
+        swap=root.querySelector('#swap'),
+        jump=root.querySelector('#jump'),
+        scramble=root.querySelector('#scramble');
   function update(p){
     seed.value=p.seed;
     pop.value=p.pop;
     gen.value=p.gen;
+    const set=new Set(p.mutations||[]);
+    gauss.checked=set.has('gaussian');
+    swap.checked=set.has('swap');
+    jump.checked=set.has('jump');
+    scramble.checked=set.has('scramble');
   }
   update(params);
   function emit(){
-    onChange({seed:+seed.value,pop:+pop.value,gen:+gen.value});
+    const muts=[gauss,swap,jump,scramble].filter(c=>c.checked).map(c=>c.id);
+    onChange({seed:+seed.value,pop:+pop.value,gen:+gen.value,mutations:muts});
   }
   seed.addEventListener('change',emit);
   pop.addEventListener('change',emit);
   gen.addEventListener('change',emit);
+  gauss.addEventListener('change',emit);
+  swap.addEventListener('change',emit);
+  jump.addEventListener('change',emit);
+  scramble.addEventListener('change',emit);
   const pause=root.querySelector('#pause'),
         exportBtn=root.querySelector('#export'),
         drop=root.querySelector('#drop');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
@@ -3,7 +3,10 @@ svg{display:block;margin:auto;background:#181818;border:1px solid #333}
 @media(prefers-color-scheme:light){
   body{background:#fff;color:#000}
   svg{background:#fafafa;border-color:#ccc}
+  #legend{color:#000}
 }
 #tooltip{position:absolute;display:none;pointer-events:none;background:rgba(0,0,0,0.7);color:#fff;padding:2px 4px;border-radius:3px;font-size:12px}
 #toolbar{position:fixed;bottom:10px;left:10px}
 #toolbar button{margin-right:4px}
+#legend{position:fixed;bottom:10px;right:10px;font-size:12px}
+#legend span{margin-left:6px}


### PR DESCRIPTION
## Summary
- add mutation strategies: gaussian, swap, jump and scramble
- color dots per strategy and show legend
- parse `mut` values from hash
- persist strategy property in saved state

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: `ValueError: Duplicated timeseries in CollectorRegistry`)*

------
https://chatgpt.com/codex/tasks/task_e_683be0e9fc348333bc9a1ad7d495b0a5