### PR TITLE
[alpha_factory] add gestures and theme toggle

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>α-AGI Insight – in-browser Pareto explorer</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="src/ui/controls.css" />
@@ -21,6 +22,7 @@ import {svg2png} from './src/render/svg2png.js';
 import {mutate} from './src/evolve/mutate.js';
 import {strategyColors} from './src/render/colors.js';
 import {pinFiles} from './src/ipfs/pinner.js';
+import {initGestures} from './src/ui/gestures.js';
 
 function lcg(seed){
   function rand(){
@@ -33,17 +35,36 @@ function lcg(seed){
 }
 
 let panel,pauseBtn,exportBtn,dropZone
-let current,rand,pop,gen,svg,x,y,info,running=true
+let current,rand,pop,gen,svg,view,x,y,info,running=true
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
 window.toast=toast;
 
+function applyTheme(t){
+  document.documentElement.dataset.theme=t;
+}
+function loadTheme(){
+  const saved=localStorage.getItem('theme');
+  if(saved) applyTheme(saved);
+  else if(window.matchMedia('(prefers-color-scheme:light)').matches) applyTheme('light');
+}
+function toggleTheme(){
+  const cur=document.documentElement.dataset.theme==='light'?'light':'dark';
+  const next=cur==='light'?'dark':'light';
+  applyTheme(next);
+  localStorage.setItem('theme',next);
+}
+
 function setupView(){
   d3.select('svg').remove();
-  svg=d3.select('body').append('svg').attr('viewBox','0 0 500 500')
+  svg=d3.select('body').append('svg')
+        .attr('viewBox','0 0 500 500')
+        .style('touch-action','none');
+  view=svg.append('g');
   x=d3.scaleLinear().domain([0,1]).range([40,460])
   y=d3.scaleLinear().domain([0,1]).range([460,40])
   addGlow(svg)
   info=svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
+  initGestures(svg.node(), view.node ? view.node() : view)
 }
 
 function updateLegend(strats){
@@ -76,7 +97,7 @@ function start(p){
 
 function step(){
   info.text(`gen ${gen}`)
-  renderFrontier(svg,pop,x,y)
+  renderFrontier(view,pop,x,y)
   if(!running){requestAnimationFrame(step);return}
   if(gen++>=current.gen)return
   pop=mutate(pop,rand,current.mutations)
@@ -138,6 +159,7 @@ function loadState(text){
 function apply(p){location.hash=toHash(p)}
 
 window.addEventListener('DOMContentLoaded',()=>{
+  loadTheme()
   panel=initControls(parseHash(),apply)
   pauseBtn=panel.pauseBtn
   exportBtn=panel.exportBtn
@@ -149,9 +171,12 @@ window.addEventListener('DOMContentLoaded',()=>{
   pngBtn.textContent="PNG";
   const shareBtn=document.createElement("button");
   shareBtn.textContent="Share";
+  const themeBtn=document.createElement("button");
+  themeBtn.textContent="Theme";
   tb.appendChild(csvBtn);
   tb.appendChild(pngBtn);
   tb.appendChild(shareBtn);
+  tb.appendChild(themeBtn);
   csvBtn.addEventListener("click",()=>exportCSV(pop));
   pngBtn.addEventListener("click",exportPNG);
   shareBtn.addEventListener("click",async()=>{
@@ -164,6 +189,7 @@ window.addEventListener('DOMContentLoaded',()=>{
       await pinFiles([file]);
     }
   });
+  themeBtn.addEventListener("click",toggleTheme);
   pauseBtn.addEventListener('click',togglePause)
   exportBtn.addEventListener('click',exportState)
   initDragDrop(dropZone,loadState)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
@@ -6,3 +6,7 @@
 #toast{position:fixed;bottom:10px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,.8);color:#fff;padding:4px 8px;opacity:0;transition:opacity .3s}
 #toast.show{opacity:1}
 @media(prefers-color-scheme:light){#controls{background:rgba(255,255,255,.9);color:#000}#toast{background:rgba(238,238,238,.9);color:#000}#drop{border-color:#aaa}#drop.drag{background:rgba(0,0,0,.05)}}
+:root[data-theme="light"] #controls{background:rgba(255,255,255,.9);color:#000}
+:root[data-theme="light"] #toast{background:rgba(238,238,238,.9);color:#000}
+:root[data-theme="light"] #drop{border-color:#aaa}
+:root[data-theme="light"] #drop.drag{background:rgba(0,0,0,.05)}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/gestures.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/gestures.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initGestures(svg, view) {
+  const state = { pointers: new Map(), lastDist: 0 };
+  svg.addEventListener('pointerdown', (e) => {
+    svg.setPointerCapture(e.pointerId);
+    state.pointers.set(e.pointerId, [e.clientX, e.clientY]);
+  });
+  svg.addEventListener('pointermove', (e) => {
+    if (!state.pointers.has(e.pointerId)) return;
+    const prev = state.pointers.get(e.pointerId);
+    const curr = [e.clientX, e.clientY];
+    state.pointers.set(e.pointerId, curr);
+    if (state.pointers.size === 1) {
+      const dx = curr[0] - prev[0];
+      const dy = curr[1] - prev[1];
+      const t = view.transform.baseVal.consolidate();
+      const m = t ? t.matrix : svg.createSVGMatrix();
+      view.setAttribute('transform', m.translate(dx, dy).toString());
+    } else if (state.pointers.size === 2) {
+      const pts = Array.from(state.pointers.values());
+      const dist = Math.hypot(pts[0][0]-pts[1][0], pts[0][1]-pts[1][1]);
+      if (state.lastDist) {
+        const scale = dist / state.lastDist;
+        const t = view.transform.baseVal.consolidate();
+        const m = t ? t.matrix : svg.createSVGMatrix();
+        const cx = (pts[0][0]+pts[1][0]) / 2;
+        const cy = (pts[0][1]+pts[1][1]) / 2;
+        const matrix = m
+          .translate(cx, cy)
+          .scale(scale)
+          .translate(-cx, -cy);
+        view.setAttribute('transform', matrix.toString());
+      }
+      state.lastDist = dist;
+    }
+  });
+  svg.addEventListener('pointerup', (e) => {
+    state.pointers.delete(e.pointerId);
+    if (state.pointers.size < 2) state.lastDist = 0;
+  });
+  svg.addEventListener('pointercancel', (e) => {
+    state.pointers.delete(e.pointerId);
+    if (state.pointers.size < 2) state.lastDist = 0;
+  });
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
@@ -1,10 +1,14 @@
 body{margin:0;font-family:Inter,Helvetica,Arial,sans-serif;background:#111;color:#eee}
-svg{display:block;margin:auto;background:#181818;border:1px solid #333}
+svg{display:block;margin:auto;background:#181818;border:1px solid #333;touch-action:none}
 @media(prefers-color-scheme:light){
   body{background:#fff;color:#000}
   svg{background:#fafafa;border-color:#ccc}
   #legend{color:#000}
 }
+#legend{color:#eee}
+:root[data-theme="light"] body{background:#fff;color:#000}
+:root[data-theme="light"] svg{background:#fafafa;border-color:#ccc}
+:root[data-theme="light"] #legend{color:#000}
 #tooltip{position:absolute;display:none;pointer-events:none;background:rgba(0,0,0,0.7);color:#fff;padding:2px 4px;border-radius:3px;font-size:12px}
 #toolbar{position:fixed;bottom:10px;left:10px}
 #toolbar button{margin-right:4px}


### PR DESCRIPTION
## Summary
- enable pinch-zoom and panning for the browser demo
- theme button chooses light/dark using localStorage
- add viewport meta tag and light theme styles

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/gestures.js` *(fails: Failed to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683be525c4588333ac805c63f19dc496