### PR TITLE
[alpha_factory] add i18n and accessibility updates

### DIFF
--- a/src/interface/web_client/i18n/en.json
+++ b/src/interface/web_client/i18n/en.json
@@ -1,0 +1,23 @@
+{
+  "nav.dashboard": "Dashboard",
+  "nav.archive": "Archive",
+  "title.dashboard": "AGI Simulation Dashboard",
+  "title.archive": "Agent Archive",
+  "label.horizon": "Horizon",
+  "label.population": "Population size",
+  "label.generations": "Generations",
+  "label.energy": "Initial energy",
+  "label.entropy": "Initial entropy",
+  "label.curve": "Curve",
+  "option.logistic": "logistic",
+  "option.linear": "linear",
+  "option.exponential": "exponential",
+  "button.run": "Run",
+  "label.runId": "Run ID",
+  "label.download": "download",
+  "label.parent": "Parent",
+  "aria.language": "Language selector",
+  "aria.progress": "Simulation progress",
+  "label.refresh": "Refresh summaries",
+  "heading.lastRuns": "Last 20 simulations"
+}

--- a/src/interface/web_client/i18n/fr.json
+++ b/src/interface/web_client/i18n/fr.json
@@ -1,0 +1,23 @@
+{
+  "nav.dashboard": "Tableau de bord",
+  "nav.archive": "Archive",
+  "title.dashboard": "Tableau de bord de simulation AGI",
+  "title.archive": "Archive des agents",
+  "label.horizon": "Horizon",
+  "label.population": "Taille de population",
+  "label.generations": "Générations",
+  "label.energy": "Énergie initiale",
+  "label.entropy": "Entropie initiale",
+  "label.curve": "Courbe",
+  "option.logistic": "logistique",
+  "option.linear": "linéaire",
+  "option.exponential": "exponentielle",
+  "button.run": "Lancer",
+  "label.runId": "ID d'exécution",
+  "label.download": "télécharger",
+  "label.parent": "Parent",
+  "aria.language": "Sélecteur de langue",
+  "aria.progress": "Progression de la simulation",
+  "label.refresh": "Rafraîchir les résumés",
+  "heading.lastRuns": "20 dernières simulations"
+}

--- a/src/interface/web_client/src/App.tsx
+++ b/src/interface/web_client/src/App.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState, FormEvent } from 'react';
 import Plotly from 'plotly.js-dist';
+import { useI18n } from './IntlContext';
 
 interface SectorData {
   name: string;
@@ -31,6 +32,7 @@ interface RunsResponse {
 }
 
 export default function App() {
+  const { t } = useI18n();
   const [horizon, setHorizon] = useState(5);
   const [popSize, setPopSize] = useState(6);
   const [generations, setGenerations] = useState(3);
@@ -141,39 +143,36 @@ export default function App() {
 
   return (
     <div>
-      <h1>AGI Simulation Dashboard</h1>
+      <h1>{t('title.dashboard')}</h1>
       <form onSubmit={onSubmit}>
-        <label>
-          Horizon
-          <input
-            type="number"
-            value={horizon}
-            onChange={(e) => setHorizon(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Population
-          <input
-            type="number"
-            value={popSize}
-            onChange={(e) => setPopSize(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Generations
-          <input
-            type="number"
-            value={generations}
-            onChange={(e) => setGenerations(Number(e.target.value))}
-          />
-        </label>
-        <button type="submit">Run simulation</button>
+        <label htmlFor="horizon-input-app">{t('label.horizon')}</label>
+        <input
+          id="horizon-input-app"
+          type="number"
+          value={horizon}
+          onChange={(e) => setHorizon(Number(e.target.value))}
+        />
+        <label htmlFor="pop-input-app">{t('label.population')}</label>
+        <input
+          id="pop-input-app"
+          type="number"
+          value={popSize}
+          onChange={(e) => setPopSize(Number(e.target.value))}
+        />
+        <label htmlFor="gen-input-app">{t('label.generations')}</label>
+        <input
+          id="gen-input-app"
+          type="number"
+          value={generations}
+          onChange={(e) => setGenerations(Number(e.target.value))}
+        />
+        <button type="submit">{t('button.run')}</button>
       </form>
-      <button type="button" onClick={refreshRuns}>Refresh summaries</button>
-      <div id="sectors" style={{ width: '100%', height: 300 }} />
-      <div id="capability" style={{ width: '100%', height: 300 }} />
-      <div id="pareto" style={{ width: '100%', height: 400 }} />
-      <h2>Last 20 simulations</h2>
+      <button type="button" onClick={refreshRuns}>{t('label.refresh')}</button>
+      <div id="sectors" role="img" aria-label="sectors" style={{ width: '100%', height: 300 }} />
+      <div id="capability" role="img" aria-label="capability" style={{ width: '100%', height: 300 }} />
+      <div id="pareto" role="img" aria-label="pareto" style={{ width: '100%', height: 400 }} />
+      <h2>{t('heading.lastRuns')}</h2>
       <ul>
         {runs.map((r) => (
           <li key={r}>{r}</li>

--- a/src/interface/web_client/src/D3LineageTree.tsx
+++ b/src/interface/web_client/src/D3LineageTree.tsx
@@ -61,7 +61,11 @@ export default function D3LineageTree({ data }: Props) {
   return (
     <div>
       <svg ref={ref} width={840} height={440} />
-      {selected && <pre className="diff">{selected}</pre>}
+      {selected && (
+        <pre className="diff" style={{ color: '#000', backgroundColor: '#fff' }}>
+          {selected}
+        </pre>
+      )}
     </div>
   );
 }

--- a/src/interface/web_client/src/IntlContext.tsx
+++ b/src/interface/web_client/src/IntlContext.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+import React, { createContext, ReactNode, useState, useEffect, useContext } from 'react';
+import en from '../i18n/en.json';
+import fr from '../i18n/fr.json';
+
+export type Messages = Record<string, string>;
+
+const dictionaries: Record<string, Messages> = { en, fr };
+
+interface IntlValue {
+  lang: string;
+  messages: Messages;
+  setLang: (lang: string) => void;
+}
+
+const fallback = 'en';
+
+export const IntlContext = createContext<IntlValue>({
+  lang: fallback,
+  messages: dictionaries[fallback],
+  setLang: () => {},
+});
+
+export function IntlProvider({ children }: { children: ReactNode }) {
+  const browserLang = typeof navigator !== 'undefined' ? navigator.language : fallback;
+  const defaultLang = browserLang.toLowerCase().startsWith('fr') ? 'fr' : 'en';
+  const [lang, setLang] = useState<string>(defaultLang);
+  const [messages, setMessages] = useState<Messages>(dictionaries[defaultLang]);
+
+  useEffect(() => {
+    setMessages(dictionaries[lang] || dictionaries[fallback]);
+  }, [lang]);
+
+  return (
+    <IntlContext.Provider value={{ lang, messages, setLang }}>
+      {children}
+    </IntlContext.Provider>
+  );
+}
+
+export function useI18n() {
+  const { lang, messages, setLang } = useContext(IntlContext);
+  const t = (key: string) => messages[key] ?? key;
+  return { lang, setLang, t };
+}

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -4,13 +4,30 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Archive from './pages/Archive';
+import { IntlProvider, useI18n } from './IntlContext';
+
+function Nav() {
+  const { lang, setLang, t } = useI18n();
+  return (
+    <nav>
+      <Link to="/">{t('nav.dashboard')}</Link> |{' '}
+      <Link to="/archive">{t('nav.archive')}</Link>{' '}
+      <select
+        aria-label={t('aria.language')}
+        value={lang}
+        onChange={(e) => setLang(e.target.value)}
+      >
+        <option value="en">English</option>
+        <option value="fr">Français</option>
+      </select>
+    </nav>
+  );
+}
 
 function App() {
   return (
     <BrowserRouter>
-      <nav>
-        <Link to="/">Dashboard</Link> | <Link to="/archive">Archive</Link>
-      </nav>
+      <Nav />
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/archive" element={<Archive />} />
@@ -20,5 +37,7 @@ function App() {
 }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <App />,
+  <IntlProvider>
+    <App />
+  </IntlProvider>,
 );

--- a/src/interface/web_client/src/pages/Archive.tsx
+++ b/src/interface/web_client/src/pages/Archive.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
+import { useI18n } from '../IntlContext';
 
 interface Agent {
   hash: string;
@@ -15,6 +16,7 @@ interface TimelinePoint {
 const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
 
 export default function Archive() {
+  const { t } = useI18n();
   const [agents, setAgents] = useState<Agent[]>([]);
   const [diff, setDiff] = useState('');
   const [timeline, setTimeline] = useState<TimelinePoint[]>([]);
@@ -45,22 +47,22 @@ export default function Archive() {
 
   return (
     <div>
-      <h1>Agent Archive</h1>
+      <h1>{t('title.archive')}</h1>
       <ul>
         {agents.map((a) => (
           <li key={a.hash} className="agent-row">
             <button type="button" onClick={() => select(a)}>{a.hash}</button>
             <a href={`${API_BASE}/archive/${a.hash}/diff`} download>
-              download
+              {t('label.download')}
             </a>
           </li>
         ))}
       </ul>
       {diff && (
         <div>
-          <pre className="diff">{diff}</pre>
+          <pre className="diff" style={{ color: '#000', backgroundColor: '#fff' }}>{diff}</pre>
           {parent && (
-            <a href={`/archive/${parent}`} className="parent-link">Parent</a>
+            <a href={`/archive/${parent}`} className="parent-link">{t('label.parent')}</a>
           )}
           <ul>
             {timeline.map((t) => (

--- a/src/interface/web_client/src/pages/Dashboard.tsx
+++ b/src/interface/web_client/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import Plotly from 'plotly.js-dist';
 import D3LineageTree, { LineageNode } from '../D3LineageTree';
 import Pareto3D, { PopulationMember } from '../Pareto3D';
 import LineageTimeline from '../LineageTimeline';
+import { useI18n } from '../IntlContext';
 
 interface SectorData {
   name: string;
@@ -18,6 +19,7 @@ interface ForecastPoint {
 }
 
 export default function Dashboard() {
+  const { t } = useI18n();
   const [horizon, setHorizon] = useState(5);
   const [popSize, setPopSize] = useState(6);
   const [generations, setGenerations] = useState(3);
@@ -163,65 +165,67 @@ export default function Dashboard() {
 
   return (
     <div>
-      <h1>AGI Simulation Dashboard</h1>
+      <h1>{t('title.dashboard')}</h1>
       <form onSubmit={onSubmit}>
-        <label>
-          Horizon
-          <input
-            type="number"
-            value={horizon}
-            onChange={(e) => setHorizon(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Population size
-          <input
-            type="number"
-            value={popSize}
-            onChange={(e) => setPopSize(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Generations
-          <input
-            type="number"
-            value={generations}
-            onChange={(e) => setGenerations(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Initial energy
-          <input
-            type="number"
-            step="any"
-            value={energy}
-            onChange={(e) => setEnergy(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Initial entropy
-          <input
-            type="number"
-            step="any"
-            value={entropy}
-            onChange={(e) => setEntropy(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Curve
-          <select value={curve} onChange={(e) => setCurve(e.target.value)}>
-            <option value="logistic">logistic</option>
-            <option value="linear">linear</option>
-            <option value="exponential">exponential</option>
-          </select>
-        </label>
-        <button type="submit">Run</button>
+        <label htmlFor="horizon-input">{t('label.horizon')}</label>
+        <input
+          id="horizon-input"
+          type="number"
+          value={horizon}
+          onChange={(e) => setHorizon(Number(e.target.value))}
+        />
+        <label htmlFor="pop-input">{t('label.population')}</label>
+        <input
+          id="pop-input"
+          type="number"
+          value={popSize}
+          onChange={(e) => setPopSize(Number(e.target.value))}
+        />
+        <label htmlFor="gen-input">{t('label.generations')}</label>
+        <input
+          id="gen-input"
+          type="number"
+          value={generations}
+          onChange={(e) => setGenerations(Number(e.target.value))}
+        />
+        <label htmlFor="energy-input">{t('label.energy')}</label>
+        <input
+          id="energy-input"
+          type="number"
+          step="any"
+          value={energy}
+          onChange={(e) => setEnergy(Number(e.target.value))}
+        />
+        <label htmlFor="entropy-input">{t('label.entropy')}</label>
+        <input
+          id="entropy-input"
+          type="number"
+          step="any"
+          value={entropy}
+          onChange={(e) => setEntropy(Number(e.target.value))}
+        />
+        <label htmlFor="curve-select">{t('label.curve')}</label>
+        <select
+          id="curve-select"
+          value={curve}
+          onChange={(e) => setCurve(e.target.value)}
+        >
+          <option value="logistic">{t('option.logistic')}</option>
+          <option value="linear">{t('option.linear')}</option>
+          <option value="exponential">{t('option.exponential')}</option>
+        </select>
+        <button type="submit">{t('button.run')}</button>
       </form>
-      {runId && <p>Run ID: {runId}</p>}
-      <progress value={progress} max={1} style={{ width: '100%' }} />
-      <div id="sectors" style={{ width: '100%', height: 300 }} />
-      <div id="capability" style={{ width: '100%', height: 300 }} />
-      <div id="pareto" style={{ width: '100%', height: 400 }} />
+      {runId && <p>{t('label.runId')}: {runId}</p>}
+      <progress
+        aria-label={t('aria.progress')}
+        value={progress}
+        max={1}
+        style={{ width: '100%' }}
+      />
+      <div id="sectors" role="img" aria-label="sectors" style={{ width: '100%', height: 300 }} />
+      <div id="capability" role="img" aria-label="capability" style={{ width: '100%', height: 300 }} />
+      <div id="pareto" role="img" aria-label="pareto" style={{ width: '100%', height: 400 }} />
       <Pareto3D data={population} />
       <LineageTimeline data={lineage} />
       <D3LineageTree data={lineage} />


### PR DESCRIPTION
## Summary
- extract UI strings to i18n/en.json and i18n/fr.json
- auto-select language based on `navigator.language`
- add language dropdown in the nav
- label form fields and graphs for accessibility
- ensure diff text uses high contrast colors

## Testing
- `pre-commit run --files src/interface/web_client/src/App.tsx src/interface/web_client/src/D3LineageTree.tsx src/interface/web_client/src/main.tsx src/interface/web_client/src/pages/Archive.tsx src/interface/web_client/src/pages/Dashboard.tsx src/interface/web_client/src/IntlContext.tsx src/interface/web_client/i18n/en.json src/interface/web_client/i18n/fr.json` *(failed: Could not fetch black)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683be72075dc83339481acf327cb19b4