### PR TITLE
[alpha_factory] add Playwright browser ui test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install pytest pytest-cov pytest-benchmark mutmut
+      - name: Install Playwright browsers
+        run: playwright install chromium
       - name: Install proto compiler
         run: pip install grpcio-tools
       - name: Verify protobuf

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
@@ -1,0 +1,30 @@
+import time
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_slider_updates_hash_and_restarts() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+
+        initial_hash = page.evaluate("location.hash")
+        seed_input = page.locator("#seed")
+        seed_input.fill("999")
+        seed_input.dispatch_event("change")
+
+        page.wait_for_function("location.hash !== '%s'" % initial_hash)
+        assert page.evaluate("location.hash") != initial_hash
+
+        page.wait_for_selector("#toast.show")
+        assert "restarted" in page.inner_text("#toast")
+        browser.close()


### PR DESCRIPTION
## Summary
- add Playwright test for insight browser
- install Playwright browsers in CI

## Testing
- `python check_env.py --auto-install`
- `pytest alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py` *(fails: BrowserType.launch executable doesn't exist)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py .github/workflows/ci.yml` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683c5138a8908333a3557241995409a1