### PR TITLE
[alpha_factory] add theme css variables

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>α-AGI Insight – in-browser Pareto explorer</title>
+<link rel="stylesheet" href="src/style/theme.css" />
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="src/ui/controls.css" />
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/style/theme.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/style/theme.css
@@ -1,0 +1,26 @@
+:root {
+  --color-bg: #111;
+  --color-bg-alt: #181818;
+  --color-text: #eee;
+  --color-border: #333;
+  --size-xs: 2px;
+  --size-s: 4px;
+  --size-m: 10px;
+  --size-l: 12px;
+}
+
+[data-theme="light"] {
+  --color-bg: #fff;
+  --color-bg-alt: #fafafa;
+  --color-text: #000;
+  --color-border: #ccc;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --color-bg: #fff;
+    --color-bg-alt: #fafafa;
+    --color-text: #000;
+    --color-border: #ccc;
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
@@ -1,16 +1,8 @@
-body{margin:0;font-family:Inter,Helvetica,Arial,sans-serif;background:#111;color:#eee}
-svg{display:block;margin:auto;background:#181818;border:1px solid #333;touch-action:none}
-@media(prefers-color-scheme:light){
-  body{background:#fff;color:#000}
-  svg{background:#fafafa;border-color:#ccc}
-  #legend{color:#000}
-}
-#legend{color:#eee}
-:root[data-theme="light"] body{background:#fff;color:#000}
-:root[data-theme="light"] svg{background:#fafafa;border-color:#ccc}
-:root[data-theme="light"] #legend{color:#000}
-#tooltip{position:absolute;display:none;pointer-events:none;background:rgba(0,0,0,0.7);color:#fff;padding:2px 4px;border-radius:3px;font-size:12px}
-#toolbar{position:fixed;bottom:10px;left:10px}
-#toolbar button{margin-right:4px}
-#legend{position:fixed;bottom:10px;right:10px;font-size:12px}
-#legend span{margin-left:6px}
+body{margin:0;font-family:Inter,Helvetica,Arial,sans-serif;background:var(--color-bg);color:var(--color-text)}
+svg{display:block;margin:auto;background:var(--color-bg-alt);border:1px solid var(--color-border);touch-action:none}
+#legend{color:var(--color-text)}
+#tooltip{position:absolute;display:none;pointer-events:none;background:rgba(0,0,0,0.7);color:#fff;padding:var(--size-xs) var(--size-s);border-radius:3px;font-size:var(--size-l)}
+#toolbar{position:fixed;bottom:var(--size-m);left:var(--size-m)}
+#toolbar button{margin-right:var(--size-s)}
+#legend{position:fixed;bottom:var(--size-m);right:var(--size-m);font-size:var(--size-l)}
+#legend span{margin-left:var(--size-s)}


### PR DESCRIPTION
## Summary
- add theme.css with color and size variables
- refactor browser style.css to use tokens
- load theme.css in index.html before style.css

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/style/theme.css` *(fails: cannot fetch hooks due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_683c558e5c4883338a760c5488650685