### PR TITLE
[alpha_factory] persist UI params

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
@@ -8,6 +8,20 @@ function Web3Storage(){ throw new Error('web3.storage not bundled'); }
 // SPDX-License-Identifier: Apache-2.0
 const defaults={seed:42,pop:80,gen:60,mutations:['gaussian']};
 function parseHash(h=window.location.hash){
+  if(!h||h==='#'){
+    try{
+      const stored=localStorage.getItem('insightParams');
+      if(stored){
+        const p=JSON.parse(stored);
+        return{
+          seed:p.seed??defaults.seed,
+          pop:p.pop??defaults.pop,
+          gen:p.gen??defaults.gen,
+          mutations:p.mutations??defaults.mutations
+        };
+      }
+    }catch{}
+  }
   const q=new URLSearchParams(h.replace(/^#/,''));
   return{
     seed:+q.get('seed')||defaults.seed,
@@ -56,7 +70,9 @@ function initControls(params,onChange){
   update(params);
   function emit(){
     const muts=[gauss,swap,jump,scramble].filter(c=>c.checked).map(c=>c.id);
-    onChange({seed:+seed.value,pop:+pop.value,gen:+gen.value,mutations:muts});
+    const p={seed:+seed.value,pop:+pop.value,gen:+gen.value,mutations:muts};
+    try{localStorage.setItem('insightParams',JSON.stringify(p));}catch{}
+    onChange(p);
   }
   seed.addEventListener('change',emit);
   pop.addEventListener('change',emit);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
@@ -1,6 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 export const defaults={seed:42,pop:80,gen:60,mutations:['gaussian']};
 export function parseHash(h=window.location.hash){
+  if(!h || h==='#'){
+    try{
+      const stored=localStorage.getItem('insightParams');
+      if(stored){
+        const p=JSON.parse(stored);
+        return{
+          seed:p.seed??defaults.seed,
+          pop:p.pop??defaults.pop,
+          gen:p.gen??defaults.gen,
+          mutations:p.mutations??defaults.mutations
+        };
+      }
+    }catch{}
+  }
   const q=new URLSearchParams(h.replace(/^#/,''));
   return{
     seed:+q.get('seed')||defaults.seed,

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
@@ -31,7 +31,9 @@ export function initControls(params,onChange){
   update(params);
   function emit(){
     const muts=[gauss,swap,jump,scramble].filter(c=>c.checked).map(c=>c.id);
-    onChange({seed:+seed.value,pop:+pop.value,gen:+gen.value,mutations:muts});
+    const p={seed:+seed.value,pop:+pop.value,gen:+gen.value,mutations:muts};
+    try{localStorage.setItem('insightParams',JSON.stringify(p));}catch{}
+    onChange(p);
   }
   seed.addEventListener('change',emit);
   pop.addEventListener('change',emit);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
@@ -28,3 +28,25 @@ def test_slider_updates_hash_and_restarts() -> None:
         page.wait_for_selector("#toast.show")
         assert "restarted" in page.inner_text("#toast")
         browser.close()
+
+
+def test_reload_restores_settings() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+
+        seed_input = page.locator("#seed")
+        seed_input.fill("321")
+        seed_input.dispatch_event("change")
+        page.wait_for_function("location.hash.includes('seed=321')")
+
+        page.evaluate("location.hash = ''")
+        page.reload()
+        page.wait_for_selector("#controls")
+        assert page.input_value("#seed") == "321"
+        browser.close()


### PR DESCRIPTION
## Summary
- persist controls state to `localStorage` on every change
- fall back to the stored parameters when no hash is present
- rebuild dist bundle
- add regression test verifying reload restores settings

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py` *(fails to fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683c56d067508333bb7492e1cf2be019