### PR TITLE
[alpha_factory] add fps meter overlay

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -22,6 +22,7 @@ import {svg2png} from './src/render/svg2png.js';
 import {strategyColors} from './src/render/colors.js';
 import {pinFiles} from './src/ipfs/pinner.js';
 import {initGestures} from './src/ui/gestures.js';
+import {initFpsMeter} from './src/ui/fpsMeter.js';
 
 function lcg(seed){
   function rand(){
@@ -36,6 +37,7 @@ function lcg(seed){
 let panel,pauseBtn,exportBtn,dropZone
 let current,rand,pop,gen,svg,view,x,y,info,running=true
 let worker
+let fpsStarted=false
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
 window.toast=toast;
 
@@ -91,6 +93,7 @@ function start(p){
   gen=0
   running=true
   setupView()
+  if(!fpsStarted){initFpsMeter(() => running);fpsStarted=true;}
   updateLegend(p.mutations)
   if(worker) worker.terminate()
   worker=new Worker('./worker/evolver.js',{type:'module'})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/fpsMeter.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/fpsMeter.js
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initFpsMeter(isRunning) {
+  if (document.getElementById('fps-meter')) return;
+  const el = document.createElement('div');
+  el.id = 'fps-meter';
+  Object.assign(el.style, {
+    position: 'fixed',
+    right: '4px',
+    bottom: '4px',
+    background: 'rgba(0,0,0,0.6)',
+    color: '#0f0',
+    fontFamily: 'monospace',
+    fontSize: '12px',
+    padding: '2px 4px',
+    zIndex: 1000
+  });
+  document.body.appendChild(el);
+  let last = 0;
+  function frame(ts) {
+    if (isRunning()) {
+      if (last) {
+        const fps = 1000 / (ts - last);
+        el.textContent = `${fps.toFixed(1)} fps`;
+      }
+      last = ts;
+    } else {
+      last = ts;
+    }
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+}


### PR DESCRIPTION
## Summary
- add a simple FPS meter overlay
- initialize the meter in the Insight browser demo

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector...)*

------
https://chatgpt.com/codex/tasks/task_e_683c58aa03f883339a3ab1a4d064ad5f