### PR TITLE
[alpha_factory] Add basic i18n support

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -23,6 +23,7 @@ import {strategyColors} from './src/render/colors.js';
 import {pinFiles} from './src/ipfs/pinner.js';
 import {initGestures} from './src/ui/gestures.js';
 import {initFpsMeter} from './src/ui/fpsMeter.js';
+import {initI18n,t} from './src/ui/i18n.js';
 
 function lcg(seed){
   function rand(){
@@ -111,7 +112,7 @@ function step(){
 
 function togglePause(){
   running=!running
-  pauseBtn.textContent=running?'Pause':'Resume'
+  pauseBtn.textContent=running?t('pause'):t('resume')
   if(running)requestAnimationFrame(step)
 }
 
@@ -151,20 +152,21 @@ function loadState(text){
     gen=s.gen
     rand=lcg(0);rand.set(s.rngState)
     running=true
-    pauseBtn.textContent='Pause'
+    pauseBtn.textContent=t('pause')
     setupView()
     updateLegend(current.mutations)
     if(worker) worker.terminate()
     worker=new Worker('./worker/evolver.js',{type:'module'})
     worker.onmessage=ev=>{pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)}
     step()
-    toast('state loaded')
-  }catch{toast('invalid file')}
+    toast(t('state_loaded'))
+  }catch{toast(t('invalid_file'))}
 }
 
 function apply(p){location.hash=toHash(p)}
 
-window.addEventListener('DOMContentLoaded',()=>{
+window.addEventListener('DOMContentLoaded',async()=>{
+  await initI18n()
   loadTheme()
   panel=initControls(parseHash(),apply)
   pauseBtn=panel.pauseBtn
@@ -172,13 +174,13 @@ window.addEventListener('DOMContentLoaded',()=>{
   dropZone=panel.dropZone
   const tb=document.getElementById("toolbar");
   const csvBtn=document.createElement("button");
-  csvBtn.textContent="CSV";
+  csvBtn.textContent=t('csv');
   const pngBtn=document.createElement("button");
-  pngBtn.textContent="PNG";
+  pngBtn.textContent=t('png');
   const shareBtn=document.createElement("button");
-  shareBtn.textContent="Share";
+  shareBtn.textContent=t('share');
   const themeBtn=document.createElement("button");
-  themeBtn.textContent="Theme";
+  themeBtn.textContent=t('theme');
   tb.appendChild(csvBtn);
   tb.appendChild(pngBtn);
   tb.appendChild(shareBtn);
@@ -189,7 +191,7 @@ window.addEventListener('DOMContentLoaded',()=>{
     const snippet=`<iframe src="${location.origin+location.pathname+location.hash}"></iframe>`;
     if(navigator.clipboard){
       try{await navigator.clipboard.writeText(snippet);}catch{}}
-    toast('iframe snippet copied');
+    toast(t('iframe_copied'));
     if(window.PINNER_TOKEN){
       const file=new File([snippet],"snippet.html",{type:"text/html"});
       await pinFiles([file]);
@@ -201,5 +203,5 @@ window.addEventListener('DOMContentLoaded',()=>{
   initDragDrop(dropZone,loadState)
   window.dispatchEvent(new HashChangeEvent('hashchange'))
 })
-window.addEventListener('hashchange',()=>{const p=parseHash();panel.setValues(p);start(p);toast('simulation restarted')})
+window.addEventListener('hashchange',()=>{const p=parseHash();panel.setValues(p);start(p);toast(t('simulation_restarted'))})
 </script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
@@ -1,0 +1,21 @@
+{
+  "seed": "Seed",
+  "population": "Population",
+  "generations": "Generations",
+  "gaussian": "gaussian",
+  "swap": "swap",
+  "jump": "jump",
+  "scramble": "scramble",
+  "pause": "Pause",
+  "resume": "Resume",
+  "export": "Export",
+  "drop": "Drop JSON here",
+  "csv": "CSV",
+  "png": "PNG",
+  "share": "Share",
+  "theme": "Theme",
+  "iframe_copied": "iframe snippet copied",
+  "state_loaded": "state loaded",
+  "invalid_file": "invalid file",
+  "simulation_restarted": "simulation restarted"
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
@@ -1,0 +1,21 @@
+{
+  "seed": "Graine",
+  "population": "Population",
+  "generations": "Générations",
+  "gaussian": "gaussienne",
+  "swap": "échange",
+  "jump": "saut",
+  "scramble": "mélange",
+  "pause": "Pause",
+  "resume": "Reprendre",
+  "export": "Exporter",
+  "drop": "Déposer le JSON ici",
+  "csv": "CSV",
+  "png": "PNG",
+  "share": "Partager",
+  "theme": "Thème",
+  "iframe_copied": "extrait d'iframe copié",
+  "state_loaded": "état chargé",
+  "invalid_file": "fichier invalide",
+  "simulation_restarted": "simulation redémarrée"
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
@@ -1,16 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
+import {t,setLanguage,currentLanguage} from './i18n.js';
 export function initControls(params,onChange){
   const root=document.getElementById('controls');
-  root.innerHTML=`<label>Seed <input id="seed" type="number" min="0" aria-label="Seed value" tabindex="1"></label>
-<label>Population <input id="pop" type="number" min="1" aria-label="Population size" tabindex="2"></label>
-<label>Generations <input id="gen" type="number" min="1" aria-label="Number of generations" tabindex="3"></label>
-<label><input id="gaussian" type="checkbox" aria-label="Enable gaussian mutation" tabindex="4"> gaussian</label>
-<label><input id="swap" type="checkbox" aria-label="Enable swap mutation" tabindex="5"> swap</label>
-<label><input id="jump" type="checkbox" aria-label="Enable jump mutation" tabindex="6"> jump</label>
-<label><input id="scramble" type="checkbox" aria-label="Enable scramble mutation" tabindex="7"> scramble</label>
-<button id="pause" role="button" aria-label="Pause simulation" tabindex="8">Pause</button>
-<button id="export" role="button" aria-label="Export data" tabindex="9">Export</button>
-<div id="drop" role="button" aria-label="Drop JSON here" tabindex="10">Drop JSON here</div>`;
+  root.innerHTML=`<label>${t('seed')} <input id="seed" type="number" min="0" aria-label="${t('seed')}" tabindex="1"></label>
+<label>${t('population')} <input id="pop" type="number" min="1" aria-label="${t('population')}" tabindex="2"></label>
+<label>${t('generations')} <input id="gen" type="number" min="1" aria-label="${t('generations')}" tabindex="3"></label>
+<label><input id="gaussian" type="checkbox" aria-label="${t('gaussian')}" tabindex="4"> ${t('gaussian')}</label>
+<label><input id="swap" type="checkbox" aria-label="${t('swap')}" tabindex="5"> ${t('swap')}</label>
+<label><input id="jump" type="checkbox" aria-label="${t('jump')}" tabindex="6"> ${t('jump')}</label>
+<label><input id="scramble" type="checkbox" aria-label="${t('scramble')}" tabindex="7"> ${t('scramble')}</label>
+<button id="pause" role="button" aria-label="${t('pause')}" tabindex="8">${t('pause')}</button>
+<button id="export" role="button" aria-label="${t('export')}" tabindex="9">${t('export')}</button>
+<div id="drop" role="button" aria-label="${t('drop')}" tabindex="10">${t('drop')}</div>
+<select id="lang" tabindex="11">
+  <option value="en">English</option>
+  <option value="fr">Français</option>
+</select>`;
   const seed=root.querySelector('#seed'),
         pop=root.querySelector('#pop'),
         gen=root.querySelector('#gen'),
@@ -44,6 +49,9 @@ export function initControls(params,onChange){
   scramble.addEventListener('change',emit);
   const pause=root.querySelector('#pause'),
         exportBtn=root.querySelector('#export'),
-        drop=root.querySelector('#drop');
+        drop=root.querySelector('#drop'),
+        langSel=root.querySelector('#lang');
+  langSel.value=currentLanguage;
+  langSel.addEventListener('change',async()=>{await setLanguage(langSel.value);location.reload();});
   return{setValues:update,pauseBtn:pause,exportBtn,dropZone:drop};
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+let strings={};
+export let currentLanguage='en';
+export async function initI18n(){
+  const saved=localStorage.getItem('lang');
+  const lang=(saved||navigator.language||'en').slice(0,2);
+  currentLanguage=lang.startsWith('fr')?'fr':'en';
+  const res=await fetch(`src/i18n/${currentLanguage}.json`);
+  strings=await res.json();
+}
+export async function setLanguage(lang){
+  currentLanguage=lang;
+  localStorage.setItem('lang',lang);
+  const res=await fetch(`src/i18n/${lang}.json`);
+  strings=await res.json();
+}
+export function t(key){
+  return strings[key]||key;
+}


### PR DESCRIPTION
## Summary
- add English and French locale files
- add i18n loader and translator
- translate UI strings in ControlsPanel and index.html
- allow switching language via dropdown

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json` *(fails: could not fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683c5c951b64833382cc84d4694ab713