### PR TITLE
[alpha_factory] Enforce Insight bundle size

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 # Summary
 - Provide a concise description of your changes.
+<!-- Reminder: keep the Insight Browser bundle under 180&nbsp;KB -->
 
 # Checks
 - [ ] I ran `pre-commit run --files <paths>`

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
@@ -31,10 +31,13 @@ jobs:
         id: size
         run: echo "bytes=$(npm run --silent size)" >> "$GITHUB_OUTPUT"
       - name: Fail if oversized
-        if: ${{ steps.size.outputs.bytes > '184320' }}
         run: |
-          echo "Build too large: ${{ steps.size.outputs.bytes }} bytes"
-          exit 1
+          bytes=${{ steps.size.outputs.bytes }}
+          echo "Bundle size: $bytes bytes"
+          if [ "$bytes" -gt 180000 ]; then
+            echo "Build too large: $bytes bytes"
+            exit 1
+          fi
       - name: Show CID
         if: ${{ secrets.WEB3_STORAGE_TOKEN != '' }}
         run: cat dist/CID.txt


### PR DESCRIPTION
## Summary
- fail the Insight Browser build if bundle exceeds 180000 bytes
- remind contributors about the 180 KB limit in the PR template

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files .github/pull_request_template.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml` *(fails to fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683c607a6db083338e1992b8f000e0c0