### PR TITLE
[alpha_factory] add favicon and manifest

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -2,6 +2,8 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>α-AGI Insight – in-browser Pareto explorer</title>
+<link rel="icon" href="favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="manifest.json" />
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="controls.css" />
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/favicon.svg
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -2,6 +2,8 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>α-AGI Insight – in-browser Pareto explorer</title>
+<link rel="icon" href="favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="manifest.json" />
 <link rel="stylesheet" href="src/style/theme.css" />
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="src/ui/controls.css" />

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "α-AGI Insight",
+  "short_name": "Insight",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add favicon.svg and manifest.json for the browser-only Insight demo
- link to favicon and manifest in the HTML source and dist output

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector...)*

------
https://chatgpt.com/codex/tasks/task_e_683c618b41288333aa250c84731d37d6