### PR TITLE
[alpha_factory] add wasm bridge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -23,6 +23,10 @@ async function bundle() {
   await fs.copyFile('src/ui/controls.css', `${OUT_DIR}/controls.css`);
   await fs.copyFile('d3.v7.min.js', `${OUT_DIR}/d3.v7.min.js`);
   await fs.copyFile('lib/bundle.esm.min.js', `${OUT_DIR}/bundle.esm.min.js`);
+  await fs.copyFile('lib/pyodide.js', `${OUT_DIR}/pyodide.js`);
+  for (const f of await fs.readdir('wasm')) {
+    await fs.copyFile(`wasm/${f}`, `${OUT_DIR}/${f}`);
+  }
   const size = await gzipSize.file(`${OUT_DIR}/app.js`);
   if (size > 180 * 1024) {
     throw new Error(`gzip size ${size} bytes exceeds limit`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/lib/pyodide.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/lib/pyodide.js
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+export async function loadPyodide(opts) {
+  if (typeof window.loadPyodide === 'function') {
+    return window.loadPyodide(opts);
+  }
+  throw new Error('pyodide.js not bundled');
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+import { loadPyodide } from '../lib/pyodide.js';
+
+// simple linear congruential generator
+function lcg(seed) {
+  function rand() {
+    seed = Math.imul(1664525, seed) + 1013904223 >>> 0;
+    return seed / 2 ** 32;
+  }
+  rand.state = () => seed;
+  rand.set = (s) => { seed = s >>> 0; };
+  return rand;
+}
+
+let pyodideReady;
+async function initPy() {
+  if (!pyodideReady) {
+    pyodideReady = loadPyodide({ indexURL: './wasm/' });
+  }
+  return pyodideReady;
+}
+
+export async function run(params = {}) {
+  const pyodide = await initPy();
+  const seed = params.seed ?? 0;
+  await pyodide.runPythonAsync(`import random; random.seed(${seed})`);
+  const code = `\nfrom forecast import forecast_disruptions\nfrom simulation import sector\nres = forecast_disruptions([sector.Sector('x')], 1, seed=${seed})\nimport json\nprint(json.dumps([{'year': r.year, 'capability': r.capability} for r in res]))`;
+  await pyodide.runPythonAsync('import forecast, mats');
+  const out = pyodide.runPython(code);
+  return JSON.parse(out);
+}
+
+window.Insight = { run };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_wasm_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_wasm_bridge.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Insight WASM bridge."""
+
+import json
+import subprocess
+from pathlib import Path
+from click.testing import CliRunner
+from unittest.mock import patch
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli
+
+
+def _cli_output(seed: int) -> list[dict]:
+    with patch.object(cli.orchestrator, "Orchestrator"):
+        res = CliRunner().invoke(
+            cli.main,
+            [
+                "simulate",
+                "--horizon",
+                "1",
+                "--offline",
+                "--sectors",
+                "1",
+                "--pop-size",
+                "1",
+                "--generations",
+                "1",
+                "--seed",
+                str(seed),
+                "--curve",
+                "linear",
+                "--export",
+                "json",
+            ],
+        )
+    return json.loads(res.output)
+
+
+def test_insight_run_matches_cli():
+    cli_res = _cli_output(1)
+    script = Path(__file__).resolve().parents[1] / "src/wasm/bridge.js"
+    node_code = f"""
+    import {{ run }} from '{script.as_posix()}';
+    global.loadPyodide = async function() {{
+      return {{
+        runPython: c => require('child_process').spawnSync('python', ['-'], {{input:c,encoding:'utf8'}}).stdout.trim(),
+        runPythonAsync: async c => require('child_process').spawnSync('python', ['-'], {{input:c,encoding:'utf8'}}).stdout.trim()
+      }};
+    }};
+    run({{seed:1}}).then(r => console.log(JSON.stringify(r)));
+    """
+    out = subprocess.run(["node", "-e", node_code], capture_output=True, text=True)
+    js_res = json.loads(out.stdout.strip())
+    assert js_res == cli_res


### PR DESCRIPTION
## Summary
- build step copies wasm assets and pyodide loader
- add Pyodide bridge for Insight browser demo
- pre-compiled forecast and mats modules for wasm
- unit test for bridge output
- copy pyodide.js in build step and add license header to test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*


------
https://chatgpt.com/codex/tasks/task_e_683c62fca36483339432c616370fc5f1