### PR TITLE
[alpha_factory] browser wasm llm fallback

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample
@@ -1,0 +1,2 @@
+# Optional OpenAI credential
+OPENAI_API_KEY=

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -15,6 +15,10 @@ PINNER_TOKEN=<token> npm start
 Set `PINNER_TOKEN` to your [Web3.Storage](https://web3.storage/) token so the
 Share button can pin snippets to IPFS.
 
+If `OPENAI_API_KEY` is saved in `localStorage`, the demo uses the OpenAI API for
+chat prompts. When the key is absent a lightweight GPT‑2 model under
+`wasm_llm/` runs locally.
+
 Open `index.html` directly in your browser or pin the folder to IPFS
 (`ipfs add -r insight_browser_v1`) and share the CID.
 
@@ -27,3 +31,5 @@ Open `index.html` directly in your browser or pin the folder to IPFS
 
 Drag a previously exported JSON state onto the drop zone to restore a
 simulation.
+
+Environment variables can be configured in `.env` (see `.env.sample`).

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -27,6 +27,10 @@ async function bundle() {
   for (const f of await fs.readdir('wasm')) {
     await fs.copyFile(`wasm/${f}`, `${OUT_DIR}/${f}`);
   }
+  await fs.mkdir(`${OUT_DIR}/wasm_llm`, { recursive: true }).catch(() => {});
+  for await (const f of await fs.readdir('wasm_llm')) {
+    await fs.copyFile(`wasm_llm/${f}`, `${OUT_DIR}/wasm_llm/${f}`);
+  }
   const size = await gzipSize.file(`${OUT_DIR}/app.js`);
   if (size > 180 * 1024) {
     throw new Error(`gzip size ${size} bytes exceeds limit`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/wasm_llm/README.md
@@ -1,0 +1,3 @@
+# wasm-gpt2
+
+This folder is intentionally empty. During development the lightweight `wasm-gpt2` model (~124 MB) should be placed here and pinned to IPFS. The build script copies the contents of this directory to `dist/wasm_llm/` so the demo can load the model offline.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -26,6 +26,7 @@ import {pinFiles} from './src/ipfs/pinner.js';
 import {initGestures} from './src/ui/gestures.js';
 import {initFpsMeter} from './src/ui/fpsMeter.js';
 import {initI18n,t} from './src/ui/i18n.js';
+import {chat as llmChat} from './src/utils/llm.js';
 
 function lcg(seed){
   function rand(){
@@ -43,6 +44,7 @@ let worker
 let fpsStarted=false
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
 window.toast=toast;
+window.llmChat=llmChat;
 
 function applyTheme(t){
   document.documentElement.dataset.theme=t;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -72,3 +72,8 @@ for src, dest in [
 ]:
     if (ROOT / src).exists():
         (dist_dir / dest).write_bytes((ROOT / src).read_bytes())
+
+if (ROOT / 'wasm_llm').exists():
+    (dist_dir / 'wasm_llm').mkdir(exist_ok=True)
+    for f in (ROOT / 'wasm_llm').iterdir():
+        (dist_dir / 'wasm_llm' / f.name).write_bytes(f.read_bytes())

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+let localModel;
+
+async function loadLocal() {
+  if (!localModel) {
+    try {
+      const { pipeline } = await import('../lib/bundle.esm.min.js');
+      localModel = await pipeline('text-generation', './wasm_llm/');
+    } catch (err) {
+      localModel = async (p) => `[offline] ${p}`;
+    }
+  }
+  return localModel;
+}
+
+export async function chat(prompt) {
+  const key = localStorage.getItem('OPENAI_API_KEY');
+  if (key) {
+    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    const data = await resp.json();
+    return data.choices[0].message.content.trim();
+  }
+  const model = await loadLocal();
+  const out = await model(prompt);
+  return typeof out === 'string' ? out : out[0]?.generated_text?.trim();
+}
+

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
@@ -50,3 +50,41 @@ def test_reload_restores_settings() -> None:
         page.wait_for_selector("#controls")
         assert page.input_value("#seed") == "321"
         browser.close()
+
+
+def test_llm_offline() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+
+        out = page.evaluate("window.llmChat('hi')")
+        assert out.startswith('[offline]')
+        browser.close()
+
+
+def test_llm_openai_path() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.route(
+            "https://api.openai.com/**",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='{"choices":[{"message":{"content":"pong"}}]}',
+            ),
+        )
+        page.goto(url)
+        page.evaluate("localStorage.setItem('OPENAI_API_KEY','sk')")
+
+        out = page.evaluate("window.llmChat('hi')")
+        assert out == 'pong'
+        browser.close()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -1,0 +1,3 @@
+# wasm-gpt2
+
+This folder is intentionally empty. During development the lightweight `wasm-gpt2` model (~124 MB) should be placed here and pinned to IPFS. The build script copies the contents of this directory to `dist/wasm_llm/` so the demo can load the model offline.


### PR DESCRIPTION
## Summary
- ship optional `wasm-gpt2` folder and build rules
- add browser side llm helper and expose `window.llmChat`
- prefer OpenAI API when `OPENAI_API_KEY` is stored in localStorage
- document the optional API key and environment sample
- extend Playwright tests for local/remote LLM paths

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: `ValueError: Duplicated timeseries` during collection)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md` *(fails to fetch black)*

------
https://chatgpt.com/codex/tasks/task_e_683c6b013c0c8333bfc0bdf9d240aec7