### PR TITLE
[alpha_factory] switch to Observable Plot for frontier rendering

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -16,7 +16,7 @@
 <script type="module">
 import {parseHash,toHash} from './src/config/params.js';
 import {initControls} from './src/ui/ControlsPanel.js';
-import {renderFrontier,addGlow} from './src/render/frontier.js';
+import {renderFrontier} from './src/render/frontier.js';
 import {save,load} from './src/state/serializer.js';
 import {initDragDrop} from './src/ui/dragdrop.js';
 import {toCSV} from './src/utils/csv.js';
@@ -39,7 +39,7 @@ function lcg(seed){
 }
 
 let panel,pauseBtn,exportBtn,dropZone
-let current,rand,pop,gen,svg,view,x,y,info,running=true
+let current,rand,pop,gen,svg,view,info,running=true
 let worker
 let fpsStarted=false
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
@@ -67,9 +67,6 @@ function setupView(){
         .attr('viewBox','0 0 500 500')
         .style('touch-action','none');
   view=svg.append('g');
-  x=d3.scaleLinear().domain([0,1]).range([40,460])
-  y=d3.scaleLinear().domain([0,1]).range([460,40])
-  addGlow(svg)
   info=svg.append('text').attr('x',20).attr('y',30).attr('fill','#fff')
   initGestures(svg.node(), view.node ? view.node() : view)
 }
@@ -108,7 +105,7 @@ function start(p){
 
 function step(){
   info.text(`gen ${gen}`)
-  renderFrontier(view,pop,x,y)
+  renderFrontier(view.node ? view.node() : view,pop)
   if(!running)return
   if(gen++>=current.gen){worker.terminate();return}
   worker.postMessage({pop,rngState:rand.state(),mutations:current.mutations,popSize:current.pop})

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -14,6 +14,8 @@
     "eslint": "^8.57.0",
     "gzip-size-cli": "^5.1.1",
     "serve": "^14.2.0",
-    "web3.storage": "^5.1.0"
+    "web3.storage": "^5.1.0",
+    "@observablehq/plot": "^0.6.9",
+    "@observablehq/plot-canvas": "^0.2.3"
   }
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js
@@ -7,3 +7,9 @@ export const strategyColors = {
   front: '#00afff',
   base: '#666',
 };
+
+export function credibilityColor(v) {
+  const clamped = Math.max(0, Math.min(1, v ?? 0));
+  const hue = 120 * clamped; // red -> green
+  return `hsl(${hue},70%,50%)`;
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
@@ -1,72 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
-import * as d3 from 'd3';
-import { showTooltip, hideTooltip } from '../ui/Tooltip.js';
+import * as Plot from '@observablehq/plot';
+import { plotCanvas } from '@observablehq/plot-canvas';
 import { paretoFront } from '../utils/pareto.js';
-import { strategyColors } from './colors.js';
-import { drawPoints } from './canvasLayer.js';
+import { credibilityColor } from './colors.js';
 
-export function addGlow(svg) {
-  const defs = svg.append('defs');
-  const filter = defs.append('filter').attr('id', 'glow');
-  filter.append('feGaussianBlur').attr('stdDeviation', 2).attr('result', 'blur');
-  const merge = filter.append('feMerge');
-  merge.append('feMergeNode').attr('in', 'blur');
-  merge.append('feMergeNode').attr('in', 'SourceGraphic');
-}
-
-export function renderFrontier(svg, pop, x, y) {
+export function renderFrontier(container, pop) {
   const front = paretoFront(pop).sort((a, b) => a.logic - b.logic);
 
-  const area = d3
-    .area()
-    .x((d) => x(d.logic))
-    .y0(y.range()[0])
-    .y1((d) => y(d.feasible));
+  const dotOptions = {
+    x: 'logic',
+    y: 'feasible',
+    r: 3,
+    fill: (d) => credibilityColor(d.insightCredibility ?? 0),
+    title: (d) => `${d.summary ?? ''}\n${d.critic ?? ''}`,
+  };
 
-  let g = svg.select('g#frontier');
-  if (g.empty()) g = svg.append('g').attr('id', 'frontier');
+  const marks = [
+    Plot.areaY(front, {
+      x: 'logic',
+      y: 'feasible',
+      fill: 'rgba(0,175,255,0.2)',
+      stroke: null,
+    }),
+  ];
 
-  g.selectAll('path')
-    .data([front])
-    .join('path')
-    .attr('fill', 'rgba(0,175,255,0.2)')
-    .attr('stroke', 'none')
-    .attr('d', area);
+  marks.push(
+    pop.length > 10000 ? plotCanvas(Plot.dot(pop, dotOptions)) : Plot.dot(pop, dotOptions),
+  );
 
-  let dots = svg.select('g#dots');
-  if (dots.empty()) dots = svg.append('g').attr('id', 'dots');
+  const plot = Plot.plot({
+    width: 500,
+    height: 500,
+    x: { domain: [0, 1] },
+    y: { domain: [0, 1] },
+    marks,
+  });
 
-  if (pop.length > 5000) {
-    dots.selectAll('circle').remove();
-    const frontSet = new Set(front);
-    drawPoints(dots, pop, x, y, (d) => {
-      if (frontSet.has(d)) return strategyColors.front;
-      return strategyColors[d.strategy] || strategyColors.base;
-    });
-  } else {
-    const node = dots.node();
-    const fo = node.querySelector('foreignObject#canvas-layer');
-    if (fo) fo.remove();
-
-    dots
-      .selectAll('circle')
-      .data(pop)
-      .join('circle')
-      .attr('cx', (d) => x(d.logic))
-      .attr('cy', (d) => y(d.feasible))
-      .attr('r', 3)
-      .attr('fill', (d) => {
-        if (front.includes(d)) return strategyColors.front;
-        return strategyColors[d.strategy] || strategyColors.base;
-      })
-      .attr('filter', (d) => (front.includes(d) ? 'url(#glow)' : null))
-      .on('mousemove', (ev, d) =>
-        showTooltip(
-          ev.pageX + 6,
-          ev.pageY + 6,
-          `logic: ${d.logic.toFixed(2)}\nfeas: ${d.feasible.toFixed(2)}`
-        )
-      )
-      .on('mouseleave', hideTooltip);
-  }
+  container.innerHTML = '';
+  container.append(plot);
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py
@@ -1,0 +1,24 @@
+import time
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_frontier_60fps() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri() + "#seed=1&pop=5000&gen=1"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#fps-meter")
+        page.wait_for_timeout(2000)
+        fps_text = page.inner_text("#fps-meter")
+        fps = float(fps_text.split()[0])
+        assert fps >= 60.0
+        browser.close()
+


### PR DESCRIPTION
## Summary
- add credibilityColor helper
- replace frontier D3 rendering with Observable Plot
- adjust index.html to call new renderer
- include Observable Plot deps
- add Playwright perf test

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683c6ddd89c083339c231f577b174b27