### PR TITLE
[alpha_factory] Add JS critics and spider chart

### DIFF
--- a/src/interface/web_client/src/D3LineageTree.tsx
+++ b/src/interface/web_client/src/D3LineageTree.tsx
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
+import SpiderChart from './SpiderChart';
+import RationaleModal from './RationaleModal';
+import { LogicCritic, loadExamples as loadLogicExamples } from './critics/logic';
+import { FeasibilityCritic } from './critics/feas';
 
 export interface LineageNode {
   id: number;
@@ -15,7 +19,19 @@ interface Props {
 
 export default function D3LineageTree({ data }: Props) {
   const ref = useRef<SVGSVGElement | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<LineageNode | null>(null);
+  const [open, setOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [logic, setLogic] = useState<LogicCritic | null>(null);
+  const [feas, setFeas] = useState<FeasibilityCritic | null>(null);
+  const [scores, setScores] = useState<{ logic: number; feas: number }>({ logic: 0, feas: 0 });
+
+  useEffect(() => {
+    loadLogicExamples().then((ex) => {
+      setLogic(new LogicCritic(ex));
+      setFeas(new FeasibilityCritic(ex));
+    });
+  }, []);
 
   useEffect(() => {
     const svg = d3.select(ref.current);
@@ -53,18 +69,66 @@ export default function D3LineageTree({ data }: Props) {
       .attr('r', 4)
       .attr('fill', (d) => d3.interpolateBlues(d.data.pass_rate))
       .style('cursor', 'pointer')
-      .on('click', (event, d) => setSelected(d.data.diff ?? null));
+      .on('click', (_, d) => {
+        setSelected(d.data);
+        setOpen((o) => !o);
+      });
 
     node.append('title').text((d) => `pass=${d.data.pass_rate}`);
   }, [data]);
+
+  useEffect(() => {
+    if (!selected || !logic || !feas) return;
+    const diff = selected.diff ?? '';
+    setScores({ logic: logic.score(diff), feas: feas.score(diff) });
+  }, [selected, logic, feas]);
 
   return (
     <div>
       <svg ref={ref} width={840} height={440} />
       {selected && (
-        <pre className="diff" style={{ color: '#000', backgroundColor: '#fff' }}>
-          {selected}
-        </pre>
+        <div>
+          <button type="button" onClick={() => setOpen((o) => !o)}>
+            {open ? 'Hide' : 'Show'} details
+          </button>
+          {open && (
+            <div>
+              <SpiderChart
+                labels={['pass', 'logic', 'feas']}
+                values={[selected.pass_rate, scores.logic, scores.feas]}
+              />
+              <table className="critic-lattice">
+                <tbody>
+                  <tr>
+                    <th>pass</th>
+                    <td>{selected.pass_rate.toFixed(2)}</td>
+                  </tr>
+                  <tr>
+                    <th>logic</th>
+                    <td>{scores.logic.toFixed(2)}</td>
+                  </tr>
+                  <tr>
+                    <th>feas</th>
+                    <td>{scores.feas.toFixed(2)}</td>
+                  </tr>
+                </tbody>
+              </table>
+              {selected.diff && (
+                <pre className="diff" style={{ color: '#000', backgroundColor: '#fff' }}>
+                  {selected.diff}
+                </pre>
+              )}
+              <button type="button" onClick={() => setModalOpen(true)}>
+                Learn more
+              </button>
+              <RationaleModal
+                open={modalOpen}
+                onClose={() => setModalOpen(false)}
+                docUrl="/alpha_factory_v1/docs/alpha_agi_agent.md"
+              />
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/interface/web_client/src/RationaleModal.tsx
+++ b/src/interface/web_client/src/RationaleModal.tsx
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  docUrl: string;
+}
+
+export default function RationaleModal({ open, onClose, docUrl }: Props) {
+  if (!open) return null;
+  return (
+    <div
+      className="modal-overlay"
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)' }}
+    >
+      <div
+        className="modal-content"
+        style={{ background: '#fff', margin: '10% auto', padding: 20, maxWidth: 400 }}
+      >
+        <p>
+          See <a href={docUrl} target="_blank" rel="noopener noreferrer">documentation</a>{' '}
+          for the rationale behind these scores.
+        </p>
+        <button type="button" onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}

--- a/src/interface/web_client/src/SpiderChart.tsx
+++ b/src/interface/web_client/src/SpiderChart.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+interface Props {
+  labels: string[];
+  values: number[];
+  size?: number;
+}
+
+export default function SpiderChart({ labels, values, size = 200 }: Props) {
+  const center = size / 2;
+  const radius = center - 20;
+  const step = (Math.PI * 2) / labels.length;
+
+  const points = labels
+    .map((_, i) => {
+      const angle = i * step - Math.PI / 2;
+      const r = radius * (values[i] ?? 0);
+      const x = center + r * Math.cos(angle);
+      const y = center + r * Math.sin(angle);
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width={size} height={size}>
+      {labels.map((label, i) => {
+        const angle = i * step - Math.PI / 2;
+        const x = center + radius * Math.cos(angle);
+        const y = center + radius * Math.sin(angle);
+        const tx = center + (radius + 12) * Math.cos(angle);
+        const ty = center + (radius + 12) * Math.sin(angle);
+        return (
+          <g key={label}>
+            <line x1={center} y1={center} x2={x} y2={y} stroke="#ccc" />
+            <text x={tx} y={ty} textAnchor="middle" dominantBaseline="middle" fontSize="10">
+              {label}
+            </text>
+          </g>
+        );
+      })}
+      <polygon points={points} fill="rgba(0,100,250,0.3)" stroke="blue" />
+    </svg>
+  );
+}

--- a/src/interface/web_client/src/critics/feas.ts
+++ b/src/interface/web_client/src/critics/feas.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+export async function loadExamples(url = '/data/critics/innovations.txt'): Promise<string[]> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const text = await res.text();
+    return text
+      .split(/\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export class FeasibilityCritic {
+  examples: string[];
+
+  constructor(examples: string[] = []) {
+    this.examples = examples;
+  }
+
+  private static jaccard(a: string[], b: string[]): number {
+    const sa = new Set(a);
+    const sb = new Set(b);
+    if (!sa.size || !sb.size) return 0;
+    let intersection = 0;
+    for (const x of sa) if (sb.has(x)) intersection++;
+    const union = new Set([...a, ...b]).size;
+    return intersection / union;
+  }
+
+  score(genome: string | number[]): number {
+    const tokens = String(genome).toLowerCase().split(/\s+/);
+    let best = 0;
+    for (const ex of this.examples) {
+      const sim = FeasibilityCritic.jaccard(tokens, ex.toLowerCase().split(/\s+/));
+      if (sim > best) best = sim;
+    }
+    const noise = Math.random() * 0.001;
+    const val = best + noise;
+    return Math.min(1, Math.max(0, val));
+  }
+}

--- a/src/interface/web_client/src/critics/logic.ts
+++ b/src/interface/web_client/src/critics/logic.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+export async function loadExamples(url = '/data/critics/innovations.txt'): Promise<string[]> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const text = await res.text();
+    return text
+      .split(/\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export class LogicCritic {
+  examples: string[];
+  index: Record<string, number>;
+  scale: number;
+
+  constructor(examples: string[] = []) {
+    this.examples = examples;
+    this.index = {};
+    this.examples.forEach((e, i) => {
+      this.index[e.toLowerCase()] = i;
+    });
+    this.scale = Math.max(this.examples.length - 1, 1);
+  }
+
+  score(genome: string | number[]): number {
+    const key = String(genome).toLowerCase();
+    const pos = this.index[key] ?? -1;
+    const base = pos >= 0 ? (pos + 1) / (this.scale + 1) : 0;
+    const noise = Math.random() * 0.001;
+    const val = base + noise;
+    return Math.min(1, Math.max(0, val));
+  }
+}


### PR DESCRIPTION
## Summary
- port `logic_critic` and `feasibility_critic` to TypeScript
- add `SpiderChart` and `RationaleModal` components
- enhance `D3LineageTree` with critic lattice and spider chart

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/interface/web_client/src/D3LineageTree.tsx src/interface/web_client/src/SpiderChart.tsx src/interface/web_client/src/RationaleModal.tsx src/interface/web_client/src/critics/feas.ts src/interface/web_client/src/critics/logic.ts` *(fails: Failed to connect to proxy)*
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `cd src/interface/web_client && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683c71b114c88333a36c0553b82e8f30