### PR TITLE
[alpha_factory] web demo permalink update

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -12,8 +12,8 @@ npm run build    # compile to dist/
 PINNER_TOKEN=<token> npm start
 ```
 `npm start` serves the `dist/` folder on `http://localhost:3000` by default.
-Set `PINNER_TOKEN` to your [Web3.Storage](https://web3.storage/) token so the
-Share button can pin snippets to IPFS.
+Set `PINNER_TOKEN` to your [Web3.Storage](https://web3.storage/) token so
+exported JSON results can be pinned.
 
 If `OPENAI_API_KEY` is saved in `localStorage`, the demo uses the OpenAI API for
 chat prompts. When the key is absent a lightweight GPT‑2 model under
@@ -21,12 +21,13 @@ chat prompts. When the key is absent a lightweight GPT‑2 model under
 
 Open `index.html` directly in your browser or pin the folder to IPFS
 (`ipfs add -r insight_browser_v1`) and share the CID.
+The URL fragment encodes parameters such as `#/s=42&p=120&g=80`.
 
 ## Toolbar & Controls
 - **CSV** – export the current population as `population.csv`.
 - **PNG** – download a `frontier.png` screenshot of the chart.
-- **Share** – copy an embeddable iframe snippet to the clipboard and, when
-  `PINNER_TOKEN` is set, pin it to IPFS.
+- **Share** – copy a permalink to the clipboard. When `PINNER_TOKEN` is set,
+  exported JSON is pinned to Web3.Storage and the CID appears in a toast.
 - **Theme** – toggle between light and dark mode.
 
 Drag a previously exported JSON state onto the drop zone to restore a

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -144,14 +144,19 @@ function togglePause(){
   if(running)requestAnimationFrame(step)
 }
 
-function exportState(){
+async function exportState(){
   pop.gen=gen
   const json=save(pop,rand.state())
+  const blob=new Blob([json],{type:'application/json'})
   const a=document.createElement('a')
-  a.href=URL.createObjectURL(new Blob([json],{type:'application/json'}))
+  a.href=URL.createObjectURL(blob)
   a.download='state.json'
   a.click()
   URL.revokeObjectURL(a.href)
+  if(window.PINNER_TOKEN){
+    const file=new File([json],'state.json',{type:'application/json'})
+    await pinFiles([file])
+  }
 }
 
 function exportCSV(data){
@@ -216,14 +221,10 @@ window.addEventListener('DOMContentLoaded',async()=>{
   csvBtn.addEventListener("click",()=>exportCSV(pop));
   pngBtn.addEventListener("click",exportPNG);
   shareBtn.addEventListener("click",async()=>{
-    const snippet=`<iframe src="${location.origin+location.pathname+location.hash}"></iframe>`;
+    const url=location.origin+location.pathname+location.hash;
     if(navigator.clipboard){
-      try{await navigator.clipboard.writeText(snippet);}catch{}}
-    toast(t('iframe_copied'));
-    if(window.PINNER_TOKEN){
-      const file=new File([snippet],"snippet.html",{type:"text/html"});
-      await pinFiles([file]);
-    }
+      try{await navigator.clipboard.writeText(url);}catch{}}
+    toast(t('link_copied'));
   });
   themeBtn.addEventListener("click",toggleTheme);
   pauseBtn.addEventListener('click',togglePause)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js
@@ -15,17 +15,17 @@ export function parseHash(h=window.location.hash){
       }
     }catch{}
   }
-  const q=new URLSearchParams(h.replace(/^#/,''));
+  const q=new URLSearchParams(h.replace(/^#\/?/,''));
   return{
-    seed:+q.get('seed')||defaults.seed,
-    pop:+q.get('pop')||defaults.pop,
-    gen:+q.get('gen')||defaults.gen,
-    mutations:(q.get('mut')||defaults.mutations.join(',')).split(',').filter(Boolean)
+    seed:+q.get('s')||defaults.seed,
+    pop:+q.get('p')||defaults.pop,
+    gen:+q.get('g')||defaults.gen,
+    mutations:(q.get('m')||defaults.mutations.join(',')).split(',').filter(Boolean)
   };
 }
 export function toHash(p){
   const q=new URLSearchParams();
-  q.set('seed',p.seed);q.set('pop',p.pop);q.set('gen',p.gen);
-  if(p.mutations) q.set('mut',p.mutations.join(','));
-  return'#'+q.toString();
+  q.set('s',p.seed);q.set('p',p.pop);q.set('g',p.gen);
+  if(p.mutations) q.set('m',p.mutations.join(','));
+  return'#/'+q.toString();
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
@@ -15,6 +15,7 @@
   "share": "Share",
   "theme": "Theme",
   "iframe_copied": "iframe snippet copied",
+  "link_copied": "permalink copied",
   "state_loaded": "state loaded",
   "invalid_file": "invalid file",
   "simulation_restarted": "simulation restarted"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
@@ -15,6 +15,7 @@
   "share": "Partager",
   "theme": "Thème",
   "iframe_copied": "extrait d'iframe copié",
+  "link_copied": "lien copié",
   "state_loaded": "état chargé",
   "invalid_file": "fichier invalide",
   "simulation_restarted": "simulation redémarrée"


### PR DESCRIPTION
## Summary
- use short query params in `toHash()`
- copy permalink instead of iframe in the Share button
- pin exported JSON to Web3.Storage when `PINNER_TOKEN` is set
- show pinned CID in a toast
- document permalink and pinning in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json` *(fails: cannot fetch black)*

------
https://chatgpt.com/codex/tasks/task_e_683c744506b88333b038b6e477eeeeb1