### PR TITLE
[alpha_factory] add PWA service worker

### DIFF
--- a/src/interface/web_client/index.html
+++ b/src/interface/web_client/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0d0e2e" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <title>AGI Dashboard</title>
   </head>
   <body>

--- a/src/interface/web_client/package.json
+++ b/src/interface/web_client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && workbox injectManifest workbox.config.js",
     "preview": "vite preview",
     "test": "echo \"Running smoke test\" && exit 0",
     "test:e2e": "playwright test"
@@ -25,6 +25,7 @@
     "@vitejs/plugin-vue": "^5.0.0",
     "typescript": "^5.3.0",
     "vite": "^4.2.0",
-    "@playwright/test": "^1.39.0"
+    "@playwright/test": "^1.39.0",
+    "workbox-build": "^6.5.4"
   }
 }

--- a/src/interface/web_client/public/icon.svg
+++ b/src/interface/web_client/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#0d0e2e"/>
+  <text x="32" y="44" text-anchor="middle" font-size="40" fill="#fff">α</text>
+</svg>

--- a/src/interface/web_client/public/manifest.webmanifest
+++ b/src/interface/web_client/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "AGI Dashboard",
+  "short_name": "AGI",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#0d0e2e",
+  "theme_color": "#0d0e2e",
+  "icons": [
+    {
+      "src": "icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -41,3 +41,19 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <App />
   </IntlProvider>,
 );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((err) => {
+      console.error('SW registration failed', err);
+    });
+  });
+}
+
+window.addEventListener('beforeinstallprompt', (e) => {
+  e.preventDefault();
+  const promptEvent = e as any;
+  if (window.confirm('Add to Home Screen?')) {
+    promptEvent.prompt();
+  }
+});

--- a/src/interface/web_client/src/sw.js
+++ b/src/interface/web_client/src/sw.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-restricted-globals */
+import {precacheAndRoute} from 'workbox-precaching';
+import {registerRoute} from 'workbox-routing';
+import {CacheFirst} from 'workbox-strategies';
+import {ExpirationPlugin} from 'workbox-expiration';
+
+precacheAndRoute(self.__WB_MANIFEST);
+
+registerRoute(
+  ({request, url}) =>
+    request.destination === 'script' ||
+    request.destination === 'worker' ||
+    request.destination === 'font' ||
+    url.pathname.endsWith('.wasm'),
+  new CacheFirst({
+    cacheName: 'assets-cache',
+    plugins: [
+      new ExpirationPlugin({maxEntries: 50, maxAgeSeconds: 30 * 24 * 60 * 60})
+    ],
+  })
+);
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/src/interface/web_client/vite.config.ts
+++ b/src/interface/web_client/vite.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
   root: '.',
   envPrefix: 'VITE_',
   build: {
-    outDir: 'dist'
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/[name].[hash].[ext]'
+      }
+    }
   }
 });

--- a/src/interface/web_client/workbox.config.js
+++ b/src/interface/web_client/workbox.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  globDirectory: 'dist/',
+  globPatterns: ['**/*.{js,css,html,wasm,woff2}'],
+  swSrc: 'src/sw.js',
+  swDest: 'dist/sw.js',
+};


### PR DESCRIPTION
## Summary
- build React client as an installable PWA
- add manifest with theme color and icon
- generate Workbox service worker after Vite build
- register the service worker and show Add to Home Screen prompt
- hash output assets for cache busting

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/interface/web_client/index.html src/interface/web_client/package.json src/interface/web_client/public/icon.svg src/interface/web_client/public/manifest.webmanifest src/interface/web_client/src/main.tsx src/interface/web_client/src/sw.js src/interface/web_client/vite.config.ts src/interface/web_client/workbox.config.js` *(fails: unable to access 'https://github.com/psf/black/' - couldn't connect to server)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683c75e84ac4833387c8492a0616d284