### PR TITLE
[alpha_factory] strengthen browser CSP

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'wasm-unsafe-eval'" />
 <title>α-AGI Insight – in-browser Pareto explorer</title>
 <link rel="icon" href="favicon.svg" type="image/svg+xml" />
 <link rel="manifest" href="manifest.json" />
@@ -11,5 +12,5 @@
 <div id="toast"></div>
 <div id="toolbar"></div>
 <div id="legend"></div>
-<script src="d3.v7.min.js"></script>
+<script src="d3.v7.min.js" integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8" crossorigin="anonymous"></script>
 <script src="app.js"></script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src 'self' 'wasm-unsafe-eval'"
+    />
     <title>α-AGI Insight – in-browser Pareto explorer</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="manifest.json" />
@@ -33,7 +37,11 @@
     <div id="toast"></div>
     <div id="toolbar"></div>
     <div id="legend"></div>
-    <script src="d3.v7.min.js"></script>
+    <script
+      src="d3.v7.min.js"
+      integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8"
+      crossorigin="anonymous"
+    ></script>
 <script type="module">
 import {parseHash,toHash} from './src/config/params.js';
 import {initControls} from './src/ui/ControlsPanel.js';

--- a/tests/security/test_csp.py
+++ b/tests/security/test_csp.py
@@ -1,0 +1,32 @@
+import pytest
+from pathlib import Path
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_csp_no_violations() -> None:
+    dist = Path(__file__).resolve().parents[2] / (
+        "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html"
+    )
+    url = dist.as_uri()
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            violations = []
+            page.on(
+                "console",
+                lambda msg: violations.append(msg.text)
+                if "Content Security Policy" in msg.text
+                else None,
+            )
+            page.on("pageerror", lambda err: violations.append(str(err)))
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            assert not any("Content Security Policy" in v for v in violations)
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")
+


### PR DESCRIPTION
## Summary
- enforce a CSP meta tag in insight_browser HTML
- secure d3 script with Subresource Integrity
- add a security test for CSP violations

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/security/test_csp.py` *(fails: skipped because Playwright browsers not installed)*
- `pre-commit run --all-files` *(fails: couldn't fetch hooks offline)*
- `npm audit --audit-level=high` *(fails: requires package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_683c774d74948333ad7944ea53c369e9