### PR TITLE
[alpha_factory] Add telemetry opt-in with OTLP support

### DIFF
--- a/src/interface/web_client/package.json
+++ b/src/interface/web_client/package.json
@@ -16,7 +16,10 @@
     "plotly.js-dist": "^2.24.2",
     "react-router-dom": "^6.17.0",
     "vue": "^3.3.4",
-    "d3": "^7.9.0"
+    "d3": "^7.9.0",
+    "@opentelemetry/api": "^1.8.0",
+    "@opentelemetry/sdk-trace-web": "^1.8.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^1.8.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/interface/web_client/src/Telemetry.ts
+++ b/src/interface/web_client/src/Telemetry.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { trace } from '@opentelemetry/api';
+
+interface TelemetryEvent {
+  name: string;
+  attributes?: Record<string, number | string>;
+}
+
+const BUFFER_KEY = 'telemetryBuffer';
+const CONSENT_KEY = 'telemetryConsent';
+
+class Telemetry {
+  private enabled = false;
+  private provider: WebTracerProvider | null = null;
+  private tracer = trace.getTracer('web-client');
+
+  requestConsent(): void {
+    const stored = localStorage.getItem(CONSENT_KEY);
+    if (stored === null) {
+      const allow = window.confirm('Allow anonymous telemetry?');
+      localStorage.setItem(CONSENT_KEY, String(allow));
+      this.enabled = allow;
+    } else {
+      this.enabled = stored === 'true';
+    }
+    if (this.enabled) {
+      this.start();
+    }
+    window.addEventListener('online', () => this.flush());
+  }
+
+  private start(): void {
+    const url = import.meta.env.VITE_OTEL_EXPORTER_OTLP_ENDPOINT;
+    if (!url) return;
+    const exporter = new OTLPTraceExporter({ url });
+    this.provider = new WebTracerProvider();
+    this.provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    this.provider.register();
+    this.flush();
+  }
+
+  recordRun(generations: number): void {
+    this.send({ name: 'generation_run', attributes: { generations } });
+  }
+
+  recordShare(): void {
+    this.send({ name: 'share_click' });
+  }
+
+  private queue(evt: TelemetryEvent): void {
+    const buf = JSON.parse(localStorage.getItem(BUFFER_KEY) ?? '[]');
+    buf.push(evt);
+    localStorage.setItem(BUFFER_KEY, JSON.stringify(buf));
+  }
+
+  private send(evt: TelemetryEvent): void {
+    if (!this.enabled) return;
+    const attempt = () => {
+      if (!this.provider) return;
+      const span = this.tracer.startSpan(evt.name);
+      for (const [k, v] of Object.entries(evt.attributes ?? {})) {
+        span.setAttribute(k, v);
+      }
+      span.end();
+      this.provider.forceFlush().catch(() => this.queue(evt));
+    };
+
+    if (navigator.onLine) {
+      try {
+        attempt();
+      } catch {
+        this.queue(evt);
+      }
+    } else {
+      this.queue(evt);
+    }
+  }
+
+  flush(): void {
+    if (!this.enabled || !navigator.onLine) return;
+    const buf = JSON.parse(localStorage.getItem(BUFFER_KEY) ?? '[]');
+    localStorage.removeItem(BUFFER_KEY);
+    for (const evt of buf) {
+      this.send(evt);
+    }
+  }
+}
+
+export default new Telemetry();

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Archive from './pages/Archive';
 import { IntlProvider, useI18n } from './IntlContext';
+import telemetry from './Telemetry';
 
 function Nav() {
   const { lang, setLang, t } = useI18n();
@@ -41,6 +42,8 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <App />
   </IntlProvider>,
 );
+
+telemetry.requestConsent();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {

--- a/src/interface/web_client/tests/telemetry.spec.ts
+++ b/src/interface/web_client/tests/telemetry.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('no telemetry when disabled', async ({ page }) => {
+  const requests: string[] = [];
+  await page.route('**/v1/traces', route => {
+    requests.push(route.request().url());
+    route.fulfill({ status: 200, body: '' });
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem('telemetryConsent', 'false');
+  });
+  await page.goto('/');
+  await page.click('text=Run');
+  await page.waitForTimeout(1000);
+  expect(requests.length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add OpenTelemetry web dependencies
- implement Telemetry module with offline buffering
- prompt for telemetry consent on first load
- record generation runs and share clicks
- test that disabling telemetry prevents OTLP requests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683c7994f5b083338419773e8e737ba7