### PR TITLE
[alpha_factory] Add Cypress E2E and release docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install pytest pytest-cov pytest-benchmark mutmut
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Install web dependencies
+        run: pnpm --dir src/interface/web_client install
+      - name: Cypress E2E tests with Percy
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_TOKEN_E2E: ${{ secrets.PERCY_TOKEN }}
+        run: pnpm --dir src/interface/web_client run percy:cypress
       - name: Install Playwright browsers
         run: playwright install chromium
       - name: Install proto compiler
@@ -166,6 +179,20 @@ PY
           docker tag $DOCKER_IMAGE:ci ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
           docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.ref_name }}
           docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Build web client
+        run: make build_web
+      - name: Pack release assets
+        run: tar -czf web-client.tar.gz -C src/interface/web_client/dist .
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: web-client.tar.gz
       - name: Rollback on failure
         if: failure()
         run: |

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,0 +1,6 @@
+version: 2
+snapshot:
+  widths: [375, 768, 1280]
+  minimum_height: 800
+failure:
+  diff_threshold: 0.1

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -1,0 +1,14 @@
+# Release Checklist
+
+1. Run `pre-commit run --all-files`.
+2. Run `python check_env.py --auto-install`.
+3. Execute `pytest -q` and ensure all tests pass.
+4. Build the web client with `make build_web`.
+5. Update `docs/CHANGELOG.md` with the new version.
+6. Commit changes and tag the release: `git tag -s vX.Y.Z -m "vX.Y.Z"`.
+7. Push commits and tags to GitHub.
+8. The `CI` workflow builds the image and uploads release artifacts.
+
+## Tweet Copy
+
+> 🚀 New Alpha-Factory release! Offline dashboard, responsive UI and automated visual tests powered by Percy. Check it out: https://github.com/AGI-Factory/AGI-Alpha-Agent-v0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 **Out‑learn · Out‑think · Out‑design · Out‑strategise · Out‑execute**
 
+![CI](https://github.com/AGI-Factory/AGI-Alpha-Agent-v0/actions/workflows/ci.yml/badge.svg)
+![Release](https://github.com/AGI-Factory/AGI-Alpha-Agent-v0/actions/workflows/ci.yml/badge.svg)
+
 ---
 
 # 🚀 [ 🎖️ α‑AGI Ascension 🌌 ]
@@ -1028,6 +1031,12 @@ Our **AGI ALPHA AGENT**, fuelled by the strictly‑utility **$AGIALPHA** token
 This project is distributed under the [Apache 2.0](LICENSE) license.
 All community members are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 Please report security issues via the process outlined in our [Security Policy](SECURITY.md).
+
+### Release Tweet
+
+```
+🚀 New Alpha-Factory release! Offline dashboard, responsive UI and automated visual tests powered by Percy.
+```
 
 <a name="16-final-note"></a>
 ## 16 · Final Note

--- a/src/interface/web_client/cypress.config.ts
+++ b/src/interface/web_client/cypress.config.ts
@@ -4,6 +4,8 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5173',
-    supportFile: false,
+    supportFile: 'cypress/support/e2e.ts',
+    viewportWidth: 1280,
+    viewportHeight: 720,
   },
 });

--- a/src/interface/web_client/cypress/e2e/responsive.cy.ts
+++ b/src/interface/web_client/cypress/e2e/responsive.cy.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+const viewports: Array<[number, number]> = [
+  [375, 667], // mobile
+  [768, 1024], // tablet
+  [1280, 720], // desktop
+];
+
+describe('responsive dashboard', () => {
+  viewports.forEach(([w, h]) => {
+    it(`renders at ${w}x${h}`, () => {
+      cy.viewport(w, h);
+      cy.visit('/');
+      cy.get('#lineage-tree').should('be.visible');
+    });
+  });
+
+  it('loads while offline after first visit', () => {
+    cy.visit('/');
+    cy.intercept('GET', '**/*', { forceNetworkError: true }).as('offline');
+    cy.reload();
+    cy.get('#lineage-tree').should('be.visible');
+  });
+
+  it('copies share link', () => {
+    cy.visit('/');
+    cy.window().then((win) => {
+      cy.stub(win.navigator, 'clipboard', {
+        writeText: cy.stub().as('copy'),
+      });
+    });
+    cy.get('button[type="submit"]').click();
+    cy.contains('Share').click();
+    cy.get('@copy').should('be.called');
+  });
+});

--- a/src/interface/web_client/cypress/support/e2e.ts
+++ b/src/interface/web_client/cypress/support/e2e.ts
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+import '@percy/cypress';

--- a/src/interface/web_client/package.json
+++ b/src/interface/web_client/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && workbox injectManifest workbox.config.js",
     "preview": "vite preview",
     "test": "echo \"Running smoke test\" && exit 0",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:cypress": "cypress run",
+    "percy:cypress": "percy exec -- cypress run"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -29,6 +31,9 @@
     "typescript": "^5.3.0",
     "vite": "^4.2.0",
     "@playwright/test": "^1.39.0",
-    "workbox-build": "^6.5.4"
+    "workbox-build": "^6.5.4",
+    "cypress": "^13.0.0",
+    "@percy/cli": "^1.34.0",
+    "@percy/cypress": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Cypress v13 tests with Percy integration
- create LAUNCH.md with release steps and tweet copy
- show build/release badges in README
- run Percy-enabled Cypress in CI and attach release assets

## Testing
- `pre-commit run --files README.md LAUNCH.md src/interface/web_client/package.json src/interface/web_client/cypress.config.ts src/interface/web_client/cypress/support/e2e.ts src/interface/web_client/cypress/e2e/responsive.cy.ts .percy.yml .github/workflows/ci.yml` *(failed: couldn't fetch hook repositories)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683c7b219e08833383756b107c265813