### PR TITLE
[alpha_factory] add pwa theme colors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="theme-color" content="#0d0e2e" />
 <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'wasm-unsafe-eval'" />
 <title>α-AGI Insight – in-browser Pareto explorer</title>
 <link rel="icon" href="favicon.svg" type="image/svg+xml" />

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0d0e2e" />
     <meta
       http-equiv="Content-Security-Policy"
       content="script-src 'self' 'wasm-unsafe-eval'"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json
@@ -3,6 +3,8 @@
   "short_name": "Insight",
   "start_url": "./index.html",
   "display": "standalone",
+  "theme_color": "#0d0e2e",
+  "background_color": "#0d0e2e",
   "icons": [
     {
       "src": "favicon.svg",


### PR DESCRIPTION
## Summary
- update the insight demo manifest with theme and background colors
- add matching `theme-color` meta tag in demo HTML

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html` *(failed: could not fetch pre-commit hooks)*
- `pytest -q` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683c7f0328708333859cd44807103bf2