### PR TITLE
[alpha_factory] add workbox service worker

### DIFF
--- a/src/interface/web_client/README.md
+++ b/src/interface/web_client/README.md
@@ -11,6 +11,9 @@ pnpm dev        # start the development server
 pnpm build      # build production assets in `dist/`
 ```
 
+The build step uses Workbox to generate `service-worker.js` and precache the
+site's assets so the demo can load offline.
+
 Set `VITE_API_BASE_URL` to change the API path prefix and `VITE_API_TOKEN` to
 embed the API bearer token at build time:
 

--- a/src/interface/web_client/dist/index.html
+++ b/src/interface/web_client/dist/index.html
@@ -8,6 +8,13 @@
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://cdn.plot.ly/plotly-2.24.2.min.js"></script>
     <script src="app.js" defer></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/service-worker.js');
+        });
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/interface/web_client/dist/service-worker.js
+++ b/src/interface/web_client/dist/service-worker.js
@@ -1,0 +1,26 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+
+workbox.routing.registerRoute(
+  ({request, url}) =>
+    request.destination === 'script' ||
+    request.destination === 'worker' ||
+    request.destination === 'font' ||
+    url.pathname.endsWith('.wasm'),
+  new workbox.strategies.CacheFirst({
+    cacheName: 'assets-cache',
+    plugins: [
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 30 * 24 * 60 * 60,
+      }),
+    ],
+  })
+);
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/src/interface/web_client/index.html
+++ b/src/interface/web_client/index.html
@@ -11,5 +11,12 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/service-worker.js');
+        });
+      }
+    </script>
   </body>
 </html>

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -45,14 +45,6 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 
 telemetry.requestConsent();
 
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((err) => {
-      console.error('SW registration failed', err);
-    });
-  });
-}
-
 window.addEventListener('beforeinstallprompt', (e) => {
   e.preventDefault();
   const promptEvent = e as any;

--- a/src/interface/web_client/workbox.config.js
+++ b/src/interface/web_client/workbox.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   globDirectory: 'dist/',
-  globPatterns: ['**/*.{js,css,html,wasm,woff2}'],
+  globPatterns: ['**/*.{js,css,html,wasm,woff2,svg,webmanifest,json}'],
   swSrc: 'src/sw.js',
-  swDest: 'dist/sw.js',
+  swDest: 'dist/service-worker.js',
 };


### PR DESCRIPTION
## Summary
- generate service-worker with Workbox injectManifest
- precache assets for offline use
- register the service worker from `index.html`
- document offline support

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files src/interface/web_client/index.html src/interface/web_client/src/main.tsx src/interface/web_client/workbox.config.js src/interface/web_client/dist/index.html src/interface/web_client/dist/service-worker.js src/interface/web_client/README.md` *(fails: couldn't fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683c7ffee1e083339d46c6fdf5bece7c