### PR TITLE
[alpha_factory] Add offline PWA test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PWA offline behavior tests for the Insight demo."""
+
+import pytest
+from pathlib import Path
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+CID = "bafytestcid"
+
+def test_offline_pwa_and_share() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context()
+        page = context.new_page()
+
+        page.goto(url)
+        page.wait_for_selector("#controls")
+
+        # Service worker should be ready
+        page.wait_for_function("navigator.serviceWorker && navigator.serviceWorker.controller || navigator.serviceWorker.ready")
+
+        # Go offline and reload
+        context.route("**", lambda route: route.abort())
+        page.reload()
+        page.wait_for_selector("#controls")
+
+        # Stub Web3Storage to avoid network
+        page.evaluate(
+            f"window.PINNER_TOKEN='tok'; window.Web3Storage = class {{ async put() {{ return '{CID}'; }} }}"
+        )
+
+        page.click("text=Share")
+        page.wait_for_selector("#toast.show")
+        assert CID in page.inner_text("#toast")
+        browser.close()


### PR DESCRIPTION
## Summary
- test service worker, offline reload and share button

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry and missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_683c8461a3248333980dc43a5dd27b63