### PR TITLE
[alpha_factory] PWA offline cache

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -5,6 +5,7 @@ import { promises as fs } from 'fs';
 import { execSync } from 'child_process';
 import gzipSize from 'gzip-size';
 import { Web3Storage, File } from 'web3.storage';
+import { injectManifest } from 'workbox-build';
 
 const OUT_DIR = 'dist';
 
@@ -36,6 +37,20 @@ async function bundle() {
   for await (const f of await fs.readdir('wasm_llm')) {
     await fs.copyFile(`wasm_llm/${f}`, `${OUT_DIR}/wasm_llm/${f}`);
   }
+  await injectManifest({
+    swSrc: 'sw.js',
+    swDest: `${OUT_DIR}/sw.js`,
+    globDirectory: OUT_DIR,
+    globPatterns: [
+      'index.html',
+      'app.js',
+      'style.css',
+      'd3.v7.min.js',
+      'pyodide.*',
+      'wasm_llm/*',
+      'wasm/*',
+    ],
+  });
   const size = await gzipSize.file(`${OUT_DIR}/app.js`);
   if (size > 180 * 1024) {
     throw new Error(`gzip size ${size} bytes exceeds limit`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -43,6 +43,13 @@
       integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8"
       crossorigin="anonymous"
     ></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('sw.js');
+        });
+      }
+    </script>
 <script type="module">
 import {parseHash,toHash} from './src/config/params.js';
 import {initControls} from './src/ui/ControlsPanel.js';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -18,6 +18,7 @@
     "@observablehq/plot": "^0.6.9",
     "@observablehq/plot-canvas": "^0.2.3",
     "tailwindcss": "^3.4.0",
-    "daisyui": "^4.0.7"
+    "daisyui": "^4.0.7",
+    "workbox-build": "^6.5.4"
   }
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-env serviceworker */
+import {precacheAndRoute} from 'workbox-precaching';
+
+precacheAndRoute(self.__WB_MANIFEST);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
@@ -30,6 +30,10 @@ def test_offline_pwa_and_share() -> None:
         page.reload()
         page.wait_for_selector("#controls")
 
+        assert page.evaluate("navigator.serviceWorker.controller !== null")
+        assert page.evaluate("typeof d3 !== 'undefined'")
+        assert page.evaluate('document.querySelector("link[href=\'style.css\']").sheet !== null')
+
         # Stub Web3Storage to avoid network
         page.evaluate(
             f"window.PINNER_TOKEN='tok'; window.Web3Storage = class {{ async put() {{ return '{CID}'; }} }}"
@@ -39,3 +43,4 @@ def test_offline_pwa_and_share() -> None:
         page.wait_for_selector("#toast.show")
         assert CID in page.inner_text("#toast")
         browser.close()
+


### PR DESCRIPTION
## Summary
- add Workbox service worker implementation
- register service worker in browser demo
- cache browser demo assets via build script
- verify service worker caches offline resources

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683c87809d0483339248be542ec8a16e