### PR TITLE
[alpha_factory] adjust Insight browser size limit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Summary
 - Provide a concise description of your changes.
-<!-- Reminder: keep the Insight Browser bundle under 180&nbsp;KB -->
+<!-- Reminder: keep the Insight Browser bundle under 6&nbsp;MB -->
 
 # Checks
 - [ ] I ran `pre-commit run --files <paths>`

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           bytes=${{ steps.size.outputs.bytes }}
           echo "Bundle size: $bytes bytes"
-          if [ "$bytes" -gt 180000 ]; then
+          if [ "$bytes" -gt 6291456 ]; then
             echo "Build too large: $bytes bytes"
             exit 1
           fi

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -52,7 +52,8 @@ async function bundle() {
     ],
   });
   const size = await gzipSize.file(`${OUT_DIR}/app.js`);
-  if (size > 180 * 1024) {
+  const MAX_GZIP_SIZE = 6 * 1024 * 1024; // 6 MiB
+  if (size > MAX_GZIP_SIZE) {
     throw new Error(`gzip size ${size} bytes exceeds limit`);
   }
   if (process.env.WEB3_STORAGE_TOKEN) {


### PR DESCRIPTION
## Summary
- increase Insight browser gzipped bundle limit to 6MB
- bump workflow check limit accordingly
- update PR template reminder

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files .github/pull_request_template.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js` *(failed: could not fetch hooks due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683c893595948333ad82aa48374b4982