### PR TITLE
[alpha_factory] docs: prefer npm ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ uvicorn src.interface.api_server:app --reload
 streamlit run src/interface/web_app.py
 # React client
 cd src/interface/web_client
-npm install
+npm ci  # use a deterministic install
 npm run dev       # http://localhost:5173
 # build production assets
 pnpm build

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -7,7 +7,7 @@ A zero-backend Pareto explorer lives in
 
 ## Build & Run
 ```bash
-npm install
+npm ci           # deterministic install
 npm run build    # compile to dist/
 ```
 Place the Pyodide 0.25 files in `wasm/` before building. The script copies them


### PR DESCRIPTION
## Summary
- instruct using `npm ci`

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: could not fetch psf/black)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683c8a82398483338c521c359cf830a5