### PR TITLE
[alpha_factory] Add optional telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,9 @@ as **Jaeger**, set ``OTEL_EXPORTER_OTLP_ENDPOINT`` and start Jaeger locally:
 docker run -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
 ```
 
+Set ``OTEL_ENDPOINT`` to enable anonymous dashboard telemetry. Users are
+prompted for consent before any metrics are sent.
+
 ---
 
 <a name="10-safety--security"></a>

--- a/src/interface/web_client/src/Telemetry.ts
+++ b/src/interface/web_client/src/Telemetry.ts
@@ -1,91 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { trace } from '@opentelemetry/api';
+import { initTelemetry } from '../../../telemetry.js';
 
-interface TelemetryEvent {
-  name: string;
-  attributes?: Record<string, number | string>;
+interface Recorder {
+  recordRun: (n: number) => void;
+  recordShare: () => void;
 }
 
-const BUFFER_KEY = 'telemetryBuffer';
-const CONSENT_KEY = 'telemetryConsent';
-
 class Telemetry {
-  private enabled = false;
-  private provider: WebTracerProvider | null = null;
-  private tracer = trace.getTracer('web-client');
+  private rec: Recorder = { recordRun() {}, recordShare() {} };
 
   requestConsent(): void {
-    const stored = localStorage.getItem(CONSENT_KEY);
-    if (stored === null) {
-      const allow = window.confirm('Allow anonymous telemetry?');
-      localStorage.setItem(CONSENT_KEY, String(allow));
-      this.enabled = allow;
-    } else {
-      this.enabled = stored === 'true';
-    }
-    if (this.enabled) {
-      this.start();
-    }
-    window.addEventListener('online', () => this.flush());
-  }
-
-  private start(): void {
-    const url = import.meta.env.VITE_OTEL_EXPORTER_OTLP_ENDPOINT;
-    if (!url) return;
-    const exporter = new OTLPTraceExporter({ url });
-    this.provider = new WebTracerProvider();
-    this.provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
-    this.provider.register();
-    this.flush();
+    this.rec = initTelemetry();
   }
 
   recordRun(generations: number): void {
-    this.send({ name: 'generation_run', attributes: { generations } });
+    this.rec.recordRun(generations);
   }
 
   recordShare(): void {
-    this.send({ name: 'share_click' });
-  }
-
-  private queue(evt: TelemetryEvent): void {
-    const buf = JSON.parse(localStorage.getItem(BUFFER_KEY) ?? '[]');
-    buf.push(evt);
-    localStorage.setItem(BUFFER_KEY, JSON.stringify(buf));
-  }
-
-  private send(evt: TelemetryEvent): void {
-    if (!this.enabled) return;
-    const attempt = () => {
-      if (!this.provider) return;
-      const span = this.tracer.startSpan(evt.name);
-      for (const [k, v] of Object.entries(evt.attributes ?? {})) {
-        span.setAttribute(k, v);
-      }
-      span.end();
-      this.provider.forceFlush().catch(() => this.queue(evt));
-    };
-
-    if (navigator.onLine) {
-      try {
-        attempt();
-      } catch {
-        this.queue(evt);
-      }
-    } else {
-      this.queue(evt);
-    }
-  }
-
-  flush(): void {
-    if (!this.enabled || !navigator.onLine) return;
-    const buf = JSON.parse(localStorage.getItem(BUFFER_KEY) ?? '[]');
-    localStorage.removeItem(BUFFER_KEY);
-    for (const evt of buf) {
-      this.send(evt);
-    }
+    this.rec.recordShare();
   }
 }
 

--- a/src/interface/web_client/tests/telemetry.spec.ts
+++ b/src/interface/web_client/tests/telemetry.spec.ts
@@ -2,11 +2,13 @@ import { test, expect } from '@playwright/test';
 
 test('no telemetry when disabled', async ({ page }) => {
   const requests: string[] = [];
-  await page.route('**/v1/traces', route => {
+  await page.route('**/telemetry', route => {
     requests.push(route.request().url());
     route.fulfill({ status: 200, body: '' });
   });
   await page.addInitScript(() => {
+    // provide endpoint so requests would fire if consented
+    (window as any).OTEL_ENDPOINT = 'https://example.com/telemetry';
     localStorage.setItem('telemetryConsent', 'false');
   });
   await page.goto('/');

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Lightweight telemetry helper.
+ * Prompts for user consent and sends anonymous metrics to the OTLP endpoint.
+ */
+
+export function initTelemetry() {
+  const endpoint =
+    (typeof process !== 'undefined' && process.env.OTEL_ENDPOINT) ||
+    (typeof window !== 'undefined' && window.OTEL_ENDPOINT) ||
+    (typeof import.meta !== 'undefined' && import.meta.env.VITE_OTEL_ENDPOINT);
+
+  if (!endpoint) {
+    return { recordRun() {}, recordShare() {} };
+  }
+
+  const consentKey = 'telemetryConsent';
+  let consent = localStorage.getItem(consentKey);
+  if (consent === null) {
+    const allow = window.confirm('Allow anonymous telemetry?');
+    consent = allow ? 'true' : 'false';
+    localStorage.setItem(consentKey, consent);
+  }
+
+  const enabled = consent === 'true';
+  const metrics = { ts: Date.now(), generations: 0, shares: 0 };
+
+  function flush() {
+    if (!enabled) return;
+    navigator.sendBeacon(endpoint, JSON.stringify(metrics));
+  }
+  window.addEventListener('beforeunload', flush);
+
+  return {
+    recordRun(n) {
+      if (enabled) metrics.generations += n;
+    },
+    recordShare() {
+      if (enabled) metrics.shares += 1;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- provide initTelemetry helper with consent prompt
- hook web client into new helper
- ensure telemetry disabled when user declines
- document OTEL_ENDPOINT option

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683c8cee274c83338973ad13bf9baa0d