### PR TITLE
[alpha_factory] Add client-side critic panel

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -56,6 +56,8 @@
 import {parseHash,toHash} from './src/config/params.js';
 import {initControls} from './src/ui/ControlsPanel.js';
 import {renderFrontier} from './src/render/frontier.js';
+import {initCriticPanel} from './src/ui/CriticPanel.js';
+import {loadExamples as loadCriticExamples, LogicCritic, FeasibilityCritic} from './src/wasm/critics.js';
 import {save,load} from './src/state/serializer.js';
 import {initDragDrop} from './src/ui/dragdrop.js';
 import {toCSV} from './src/utils/csv.js';
@@ -78,6 +80,7 @@ function lcg(seed){
 }
 
 let panel,pauseBtn,exportBtn,dropZone
+let criticPanel,logicCritic,feasCritic
 let current,rand,pop,gen,svg,view,info,running=true
 let worker
 let fpsStarted=false;
@@ -148,9 +151,22 @@ function start(p){
   step()
 }
 
+function selectPoint(d, elem){
+  const scores={
+    logic:d.logic??0,
+    feasible:d.feasible??0
+  };
+  if(logicCritic&&feasCritic){
+    scores.logicCritic=logicCritic.score(`${d.logic}`);
+    scores.feasCritic=feasCritic.score(`${d.feasible}`);
+    scores.average=(scores.logicCritic+scores.feasCritic)/2;
+  }
+  if(criticPanel) criticPanel.show(scores,elem);
+}
+
 function step(){
   info.text(`gen ${gen}`)
-  renderFrontier(view.node ? view.node() : view,pop)
+  renderFrontier(view.node ? view.node() : view,pop,selectPoint)
   if(!running)return
   if(gen++>=current.gen){worker.terminate();return}
   worker.postMessage({pop,rngState:rand.state(),mutations:current.mutations,popSize:current.pop})
@@ -219,6 +235,10 @@ function apply(p){location.hash=toHash(p)}
 window.addEventListener('DOMContentLoaded',async()=>{
   await initI18n()
   loadTheme()
+  const ex=await loadCriticExamples()
+  logicCritic=new LogicCritic(ex)
+  feasCritic=new FeasibilityCritic(ex)
+  criticPanel=initCriticPanel()
   panel=initControls(parseHash(),apply)
   pauseBtn=panel.pauseBtn
   exportBtn=panel.exportBtn

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
@@ -4,7 +4,7 @@ import { plotCanvas } from '@observablehq/plot-canvas';
 import { paretoFront } from '../utils/pareto.js';
 import { credibilityColor } from './colors.js';
 
-export function renderFrontier(container, pop) {
+export function renderFrontier(container, pop, onSelect) {
   const front = paretoFront(pop).sort((a, b) => a.logic - b.logic);
 
   const dotOptions = {
@@ -38,4 +38,9 @@ export function renderFrontier(container, pop) {
 
   container.innerHTML = '';
   container.append(plot);
+  if (onSelect) {
+    d3.select(plot).selectAll('circle').on('click', function (_, d) {
+      onSelect(d, this);
+    });
+  }
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/CriticPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/CriticPanel.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initCriticPanel() {
+  const root = document.createElement('div');
+  root.id = 'critic-panel';
+  Object.assign(root.style, {
+    position: 'fixed',
+    top: '10px',
+    right: '10px',
+    background: 'rgba(0,0,0,0.7)',
+    color: '#fff',
+    padding: '8px',
+    font: '14px sans-serif',
+    display: 'none',
+    zIndex: 1000,
+  });
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '200');
+  svg.setAttribute('height', '200');
+  svg.id = 'critic-chart';
+
+  const table = document.createElement('table');
+  table.id = 'critic-table';
+  table.style.marginTop = '4px';
+  table.style.fontSize = '12px';
+
+  root.appendChild(svg);
+  root.appendChild(table);
+  document.body.appendChild(root);
+
+  let highlighted = null;
+
+  function drawSpider(scores) {
+    const labels = Object.keys(scores);
+    const values = Object.values(scores);
+    const size = 200;
+    const center = size / 2;
+    const radius = center - 20;
+    const step = (Math.PI * 2) / labels.length;
+    svg.innerHTML = '';
+    const pts = [];
+    labels.forEach((label, i) => {
+      const angle = i * step - Math.PI / 2;
+      const r = radius * (values[i] ?? 0);
+      const x = center + r * Math.cos(angle);
+      const y = center + r * Math.sin(angle);
+      pts.push(`${x},${y}`);
+      const lx = center + radius * Math.cos(angle);
+      const ly = center + radius * Math.sin(angle);
+      const tx = center + (radius + 12) * Math.cos(angle);
+      const ty = center + (radius + 12) * Math.sin(angle);
+      const line = document.createElementNS('http://www.w3.org/2000/svg','line');
+      line.setAttribute('x1', center);
+      line.setAttribute('y1', center);
+      line.setAttribute('x2', lx);
+      line.setAttribute('y2', ly);
+      line.setAttribute('stroke', '#ccc');
+      svg.appendChild(line);
+      const text = document.createElementNS('http://www.w3.org/2000/svg','text');
+      text.setAttribute('x', tx);
+      text.setAttribute('y', ty);
+      text.setAttribute('font-size', '10');
+      text.setAttribute('text-anchor', 'middle');
+      text.setAttribute('dominant-baseline', 'middle');
+      text.textContent = label;
+      svg.appendChild(text);
+    });
+    const poly = document.createElementNS('http://www.w3.org/2000/svg','polygon');
+    poly.setAttribute('points', pts.join(' '));
+    poly.setAttribute('fill', 'rgba(0,100,250,0.3)');
+    poly.setAttribute('stroke', 'blue');
+    svg.appendChild(poly);
+  }
+
+  function show(scores, element) {
+    if (highlighted) highlighted.removeAttribute('stroke');
+    if (element) {
+      element.setAttribute('stroke', 'yellow');
+      highlighted = element;
+    }
+    drawSpider(scores);
+    table.innerHTML = Object.entries(scores)
+      .map(([k,v]) => `<tr><th>${k}</th><td>${v.toFixed(2)}</td></tr>`) 
+      .join('');
+    root.style.display = 'block';
+  }
+
+  return { show };
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+export async function loadExamples(url = '../data/critics/innovations.txt') {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const text = await res.text();
+    return text.split(/\n/).map(l => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export class LogicCritic {
+  constructor(examples = []) {
+    this.examples = examples;
+    this.index = {};
+    this.examples.forEach((e, i) => {
+      this.index[e.toLowerCase()] = i;
+    });
+    this.scale = Math.max(this.examples.length - 1, 1);
+  }
+
+  score(genome) {
+    const key = String(genome).toLowerCase();
+    const pos = this.index[key] ?? -1;
+    const base = pos >= 0 ? (pos + 1) / (this.scale + 1) : 0;
+    const noise = Math.random() * 0.001;
+    const val = base + noise;
+    return Math.min(1, Math.max(0, val));
+  }
+}
+
+export class FeasibilityCritic {
+  constructor(examples = []) {
+    this.examples = examples;
+  }
+
+  static jaccard(a, b) {
+    const sa = new Set(a);
+    const sb = new Set(b);
+    if (!sa.size || !sb.size) return 0;
+    let inter = 0;
+    for (const x of sa) if (sb.has(x)) inter++;
+    const union = new Set([...a, ...b]).size;
+    return inter / union;
+  }
+
+  score(genome) {
+    const tokens = String(genome).toLowerCase().split(/\s+/);
+    let best = 0;
+    for (const ex of this.examples) {
+      const sim = FeasibilityCritic.jaccard(tokens, ex.toLowerCase().split(/\s+/));
+      if (sim > best) best = sim;
+    }
+    const noise = Math.random() * 0.001;
+    const val = best + noise;
+    return Math.min(1, Math.max(0, val));
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_critic_panel.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_critic_panel.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+import time
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_critic_panel_updates_fast() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("svg circle")
+        start = time.perf_counter()
+        page.click("svg circle")
+        page.wait_for_selector("#critic-panel", state="visible")
+        elapsed = (time.perf_counter() - start) * 1000
+        assert elapsed < 100
+        browser.close()


### PR DESCRIPTION
## Summary
- add critic heuristics JS module
- implement CriticPanel with spider chart
- highlight points and open panel on click
- adjust frontier renderer
- test panel latency with Playwright

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683c93d1707c8333adfb4b20d05709cc