### PR TITLE
[alpha_factory] add client telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,7 @@ for instructions and example volume mounts.
 | `SANDBOX_CPU_SEC` | `2` | CPU time limit for sandboxed code. |
 | `SANDBOX_MEM_MB` | `256` | Memory cap for sandboxed code in MB. |
 | `MAX_RESULTS` | `100` | Maximum stored simulation results. |
+| `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 
 The values above mirror `.env.sample`. When running the stack with Docker
 Compose, adjust the environment section of

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample
@@ -1,2 +1,4 @@
 # Optional OpenAI credential
 OPENAI_API_KEY=
+# Anonymous telemetry endpoint
+OTEL_ENDPOINT=

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
@@ -507,6 +507,7 @@ let panel,pauseBtn,exportBtn,dropZone
 let criticPanel,logicCritic,feasCritic
 let current,rand,pop,gen,svg,view,info,running=true
 let worker
+let telemetry={recordRun(){},recordShare(){}}
 let fpsStarted=false
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');clearTimeout(toast.id);toast.id=setTimeout(()=>t.classList.remove('show'),2e3)}
 window.toast=toast;
@@ -584,6 +585,7 @@ function step(){
   renderFrontier(view,pop,selectPoint)
   if(!running)return
   if(gen++>=current.gen){worker.terminate();return}
+  telemetry.recordRun(1)
   worker.postMessage({pop,rngState:rand.state(),mutations:current.mutations,popSize:current.pop})
 }
 
@@ -648,6 +650,7 @@ function loadState(text){
 function apply(p){location.hash=toHash(p)}
 
 window.addEventListener('DOMContentLoaded',async()=>{
+  telemetry=window.telemetry||telemetry;
   await initI18n()
   loadTheme()
   const ex=await loadCriticExamples()
@@ -674,6 +677,7 @@ window.addEventListener('DOMContentLoaded',async()=>{
   csvBtn.addEventListener("click",()=>exportCSV(pop));
   pngBtn.addEventListener("click",exportPNG);
   shareBtn.addEventListener("click",async()=>{
+    telemetry.recordShare();
     const url=location.origin+location.pathname+location.hash;
     let pinned=null;
     if(window.PINNER_TOKEN){

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -17,3 +17,7 @@
 <script src="bundle.esm.min.js" integrity="sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax" crossorigin="anonymous"></script>
 <script src="pyodide.js" integrity="sha384-4lQJt6JNK5sYso6mEO1s2l1EnmbkIm958N+CAuWcYFBPuizBJ5nENroO7dtV8upW" crossorigin="anonymous"></script>
 <script src="app.js"></script>
+<script type="module">
+import { initTelemetry } from '../../../../../src/telemetry.js';
+window.telemetry = initTelemetry();
+</script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -68,6 +68,7 @@ import {initGestures} from './src/ui/gestures.js';
 import {initFpsMeter} from './src/ui/fpsMeter.js';
 import {initI18n,t} from './src/ui/i18n.js';
 import {chat as llmChat} from './src/utils/llm.js';
+import { initTelemetry } from '../../../../src/telemetry.js';
 
 function lcg(seed){
   function rand(){
@@ -83,6 +84,7 @@ let panel,pauseBtn,exportBtn,dropZone
 let criticPanel,logicCritic,feasCritic
 let current,rand,pop,gen,svg,view,info,running=true
 let worker
+let telemetry
 let fpsStarted=false;
 function toast(msg) {
   const t = document.getElementById('toast');
@@ -169,6 +171,7 @@ function step(){
   renderFrontier(view.node ? view.node() : view,pop,selectPoint)
   if(!running)return
   if(gen++>=current.gen){worker.terminate();return}
+  telemetry.recordRun(1)
   worker.postMessage({pop,rngState:rand.state(),mutations:current.mutations,popSize:current.pop})
 }
 
@@ -233,6 +236,7 @@ function loadState(text){
 function apply(p){location.hash=toHash(p)}
 
 window.addEventListener('DOMContentLoaded',async()=>{
+  telemetry = initTelemetry();
   await initI18n()
   loadTheme()
   const ex=await loadCriticExamples()
@@ -259,6 +263,7 @@ window.addEventListener('DOMContentLoaded',async()=>{
   csvBtn.addEventListener("click",()=>exportCSV(pop));
   pngBtn.addEventListener("click",exportPNG);
   shareBtn.addEventListener("click", async () => {
+    telemetry.recordShare();
     const url = location.origin + location.pathname + location.hash;
     let pinned = null;
     if (window.PINNER_TOKEN) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py
@@ -1,0 +1,26 @@
+import pytest
+from pathlib import Path
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_send_beacon_opt_in() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.evaluate(
+            "window.OTEL_ENDPOINT='https://example.com';"
+            "window.confirm=() => true;"
+            "navigator.sendBeacon=(...a)=>{window.beacon=a;return true;}"
+        )
+        page.reload()
+        page.wait_for_selector("#controls")
+        page.click("text=Share")
+        page.evaluate("window.dispatchEvent(new Event('beforeunload'))")
+        assert page.evaluate("Array.isArray(window.beacon)")
+        browser.close()


### PR DESCRIPTION
## Summary
- hook up telemetry in the insight browser demo
- record generations and shares
- expose `OTEL_ENDPOINT` in `.env.sample`
- document telemetry env var
- test that a beacon is sent when users opt in

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py` *(fails: couldn't fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683c9671ccb8833393250bb1cae1daa7