### PR TITLE
[alpha_factory] expose env vars in browser build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -8,10 +8,12 @@ A zero-backend Pareto explorer lives in
 ## Build & Run
 ```bash
 npm ci           # deterministic install
-npm run build    # compile to dist/
+npm run build    # compile to dist/ and embed env vars
 ```
 Copy `.env.sample` to `.env` and fill in variables like `PINNER_TOKEN` and
 `OTEL_ENDPOINT` before building or running.
+The build script reads `.env` automatically and writes `window.PINNER_TOKEN`,
+`window.OPENAI_API_KEY` and `window.OTEL_ENDPOINT` to `dist/index.html`.
 Place the Pyodide 0.25 files in `wasm/` before building. The script copies them
 to `dist/wasm` so the demo can run offline.
 ```bash

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -7,6 +7,9 @@ import { createHash } from 'crypto';
 import gzipSize from 'gzip-size';
 import { Web3Storage, File } from 'web3.storage';
 import { injectManifest } from 'workbox-build';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 const OUT_DIR = 'dist';
 
@@ -38,10 +41,19 @@ async function bundle() {
   const bundleSri = await sha384('bundle.esm.min.js');
   const pyodideSri = await sha384('pyodide.js');
 
+  const envScript = `<script>window.PINNER_TOKEN=${JSON.stringify(
+    process.env.PINNER_TOKEN || ''
+  )};window.OPENAI_API_KEY=${JSON.stringify(
+    process.env.OPENAI_API_KEY || ''
+  )};window.OTEL_ENDPOINT=${JSON.stringify(
+    process.env.OTEL_ENDPOINT || ''
+  )};</script>`;
+
   outHtml = outHtml.replace(
     '</body>',
     `<script src="bundle.esm.min.js" integrity="${bundleSri}" crossorigin="anonymous"></script>\n` +
-    `<script src="pyodide.js" integrity="${pyodideSri}" crossorigin="anonymous"></script>\n</body>`
+    `<script src="pyodide.js" integrity="${pyodideSri}" crossorigin="anonymous"></script>\n` +
+    `${envScript}\n</body>`
   );
   await fs.writeFile(`${OUT_DIR}/index.html`, outHtml);
   await fs.mkdir(`${OUT_DIR}/wasm`, { recursive: true });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -19,6 +19,7 @@
     "@observablehq/plot-canvas": "^0.2.3",
     "tailwindcss": "^3.4.0",
     "daisyui": "^4.0.7",
-    "workbox-build": "^6.5.4"
+    "workbox-build": "^6.5.4",
+    "dotenv": "^16.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- load `.env` with dotenv in the browser build script
- append env values to `dist/index.html`
- document env injection in README
- add Playwright test ensuring build exposes `window.PINNER_TOKEN`
- include dotenv dev dependency

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_683c9aa12c088333ba982e2c316fa3ad