### PR TITLE
[alpha_factory] centralize rng module

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -32,6 +32,10 @@ async function bundle() {
   await fs.copyFile('d3.v7.min.js', `${OUT_DIR}/d3.v7.min.js`);
   await fs.copyFile('lib/bundle.esm.min.js', `${OUT_DIR}/bundle.esm.min.js`);
   await fs.copyFile('lib/pyodide.js', `${OUT_DIR}/pyodide.js`);
+  await fs.mkdir(`${OUT_DIR}/worker`, { recursive: true });
+  await fs.copyFile('worker/evolver.js', `${OUT_DIR}/worker/evolver.js`);
+  await fs.mkdir(`${OUT_DIR}/src/utils`, { recursive: true });
+  await fs.copyFile('src/utils/rng.js', `${OUT_DIR}/src/utils/rng.js`);
 
   const sha384 = async (file) => {
     const data = await fs.readFile(`${OUT_DIR}/${file}`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -69,16 +69,7 @@ import {initFpsMeter} from './src/ui/fpsMeter.js';
 import {initI18n,t} from './src/ui/i18n.js';
 import {chat as llmChat} from './src/utils/llm.js';
 import { initTelemetry } from '../../../../src/telemetry.js';
-
-function lcg(seed){
-  function rand(){
-    seed=Math.imul(1664525,seed)+1013904223>>>0;
-    return seed/2**32;
-  }
-  rand.state=()=>seed;
-  rand.set=s=>{seed=s>>>0;};
-  return rand;
-}
+import { lcg } from './src/utils/rng.js';
 
 let panel,pauseBtn,exportBtn,dropZone
 let criticPanel,logicCritic,feasCritic

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -69,9 +69,14 @@ for src, dest in [
     ('d3.v7.min.js', 'd3.v7.min.js'),
     ('lib/bundle.esm.min.js', 'bundle.esm.min.js'),
     ('lib/pyodide.js', 'pyodide.js'),
+    ('worker/evolver.js', 'worker/evolver.js'),
+    ('src/utils/rng.js', 'src/utils/rng.js'),
 ]:
-    if (ROOT / src).exists():
-        (dist_dir / dest).write_bytes((ROOT / src).read_bytes())
+    src_path = ROOT / src
+    if src_path.exists():
+        target = dist_dir / dest
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(src_path.read_bytes())
 
 bundle_sri = sha384(dist_dir / 'bundle.esm.min.js')
 pyodide_sri = sha384(dist_dir / 'pyodide.js')

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/rng.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/rng.js
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+export function lcg(seed) {
+  function rand() {
+    seed = Math.imul(1664525, seed) + 1013904223 >>> 0;
+    return seed / 2 ** 32;
+  }
+  rand.state = () => seed;
+  rand.set = (s) => { seed = s >>> 0; };
+  return rand;
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
@@ -1,16 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { loadPyodide } from '../lib/pyodide.js';
-
-// simple linear congruential generator
-function lcg(seed) {
-  function rand() {
-    seed = Math.imul(1664525, seed) + 1013904223 >>> 0;
-    return seed / 2 ** 32;
-  }
-  rand.state = () => seed;
-  rand.set = (s) => { seed = s >>> 0; };
-  return rand;
-}
+import { lcg } from '../utils/rng.js';
 
 let pyodideReady;
 async function initPy() {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
@@ -1,16 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { mutate } from '../src/evolve/mutate.js';
 import { paretoFront } from '../src/utils/pareto.js';
-
-function lcg(seed) {
-  function rand() {
-    seed = Math.imul(1664525, seed) + 1013904223 >>> 0;
-    return seed / 2 ** 32;
-  }
-  rand.state = () => seed;
-  rand.set = (s) => { seed = s >>> 0; };
-  return rand;
-}
+import { lcg } from '../src/utils/rng.js';
 
 function shuffle(arr, rand) {
   for (let i = arr.length - 1; i > 0; i--) {


### PR DESCRIPTION
## Summary
- add linear congruential generator utility
- reference rng utility from index.html and worker modules
- copy worker and rng utilities in build scripts

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683c9ce625e8833383fceebef22f385c