### PR TITLE
[alpha_factory] add SRI hashing and tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -6,7 +6,7 @@
 <title>α-AGI Insight – in-browser Pareto explorer</title>
 <link rel="icon" href="favicon.svg" type="image/svg+xml" />
 <link rel="manifest" href="manifest.json" />
-<link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" integrity="sha384-igG1oTISvMs/ujtCT7PqbuPP1PgCg/+AYv9ZKHlUe8PDLcY8ylHPnMVT6tDil3sz" crossorigin="anonymous" />
 <link rel="stylesheet" href="controls.css" />
 
 <div id="controls"></div>
@@ -16,7 +16,7 @@
 <script src="d3.v7.min.js" integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8" crossorigin="anonymous"></script>
 <script src="bundle.esm.min.js" integrity="sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax" crossorigin="anonymous"></script>
 <script src="pyodide.js" integrity="sha384-4lQJt6JNK5sYso6mEO1s2l1EnmbkIm958N+CAuWcYFBPuizBJ5nENroO7dtV8upW" crossorigin="anonymous"></script>
-<script src="app.js"></script>
+<script src="app.js" integrity="sha384-o32o6wnQtXErSidJSWvLAjgPd7w1gZIYBPHpkuqdYWsdX9zppcbPOBqVbi34Bvl0" crossorigin="anonymous"></script>
 <script type="module">
 import { initTelemetry } from '../../../../../src/telemetry.js';
 window.telemetry = initTelemetry();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_integrity.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_integrity.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Check SRI attributes in the built Insight demo."""
+
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_sri_attributes() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        app_integrity = page.get_attribute("script[src='app.js']", "integrity")
+        style_integrity = page.get_attribute("link[href='style.css']", "integrity")
+        assert app_integrity and app_integrity.startswith("sha384-")
+        assert style_integrity and style_integrity.startswith("sha384-")
+        browser.close()


### PR DESCRIPTION
## Summary
- compute SHA-384 integrity hashes for `app.js` and `style.css`
- embed `integrity` attributes in the generated HTML
- update built `dist/index.html`
- test that the built demo contains the expected SRI attributes

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683c9f00de488333b564d661e8019ca0