### PR TITLE
[alpha_factory] Add license header

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os, re, sys, hashlib, base64
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- add Apache-2.0 license header to manual_build.py

## Testing
- `pre-commit run --files manual_build.py` *(fails: unable to fetch black)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 1 error, 13 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683ca1fdc4288333b67d0b53f3a8be39