### PR TITLE
[alpha_factory] drop unused lcg import

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 import { loadPyodide } from '../lib/pyodide.js';
-import { lcg } from '../utils/rng.js';
 
 let pyodideReady;
 async function initPy() {


### PR DESCRIPTION
## Summary
- drop unused `lcg` import from insight WASM bridge

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js` *(fails: unable to access github.com)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `npm run build` *(fails: cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_683ca2e85c8c8333a32e5a8307008a84