### PR TITLE
[alpha_factory] Add self containment test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_dist_self_contained.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_dist_self_contained.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure built demo contains no relative paths."""
+
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_dist_self_contained() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        attrs = page.eval_on_selector_all(
+            "script[src], link[href]",
+            "els => els.map(e => e.getAttribute('src') || e.getAttribute('href'))",
+        )
+        assert all(".." not in a for a in attrs)
+        browser.close()


### PR DESCRIPTION
## Summary
- add a playwright test checking the built Insight bundle has no relative paths

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_dist_self_contained.py` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ca9cd02a48333a17607b5c10ea7ed