### PR TITLE
[alpha_factory] Speed up Pareto front

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.js
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 export function paretoFront(pop) {
+  if (pop.length === 0) return [];
+
+  // Sort by logic (desc) then feasible (desc) and scan once.
+  const sorted = [...pop].sort(
+    (a, b) => b.logic - a.logic || b.feasible - a.feasible,
+  );
+
   const front = [];
-  for (const a of pop) {
-    let dominated = false;
-    for (const b of pop) {
-      if (a === b) continue;
-      if (
-        b.logic >= a.logic &&
-        b.feasible >= a.feasible &&
-        (b.logic > a.logic || b.feasible > a.feasible)
-      ) {
-        dominated = true;
-        break;
-      }
+  let bestFeasible = -Infinity;
+  for (const p of sorted) {
+    if (p.feasible >= bestFeasible) {
+      front.push(p);
+      bestFeasible = p.feasible;
     }
-    if (!dominated) front.push(a);
   }
+
   return front;
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py
@@ -9,7 +9,7 @@ from playwright.sync_api import sync_playwright
 
 def test_frontier_60fps() -> None:
     dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
-    url = dist.as_uri() + "#seed=1&pop=5000&gen=1"
+    url = dist.as_uri() + "#seed=1&pop=12000&gen=1"
 
     with sync_playwright() as p:
         browser = p.chromium.launch()


### PR DESCRIPTION
## Summary
- speed up Pareto front computation with a single scan
- increase performance test population size

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: `tests/test_llm_cache.py` ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py` *(failed to fetch hooks due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_683caafc60688333b384bf4cebb229ef