### PR TITLE
[alpha_factory] Notify on Pyodide load failure

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
@@ -4,7 +4,12 @@ import { loadPyodide } from '../lib/pyodide.js';
 let pyodideReady;
 async function initPy() {
   if (!pyodideReady) {
-    pyodideReady = loadPyodide({ indexURL: './wasm/' });
+    try {
+      pyodideReady = await loadPyodide({ indexURL: './wasm/' });
+    } catch (err) {
+      toast('Pyodide failed to load');
+      return Promise.reject(err);
+    }
   }
   return pyodideReady;
 }

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test WASM bridge error handling."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BRIDGE = Path(
+    "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js"
+)
+LIB = Path(
+    "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/lib/pyodide.js"
+)
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+def test_pyodide_load_failure(tmp_path: Path) -> None:
+    bridge_copy = tmp_path / "bridge.mjs"
+    text = BRIDGE.read_text().replace(
+        "../lib/pyodide.js", LIB.resolve().as_posix()
+    )
+    bridge_copy.write_text(text)
+
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        "globalThis.window = {\n"
+        "  toast: (m) => console.log(m),\n"
+        "  loadPyodide: () => { throw new Error('boom'); }\n"
+        "};\n"
+        "globalThis.toast = globalThis.window.toast;\n"
+        f"const m = await import('{bridge_copy.as_posix()}');\n"
+        "try { await m.run(); } catch (e) {}\n"
+    )
+    result = subprocess.run(["node", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "Pyodide failed to load" in result.stdout


### PR DESCRIPTION
## Summary
- catch `loadPyodide` errors in the Insight demo and show a toast
- add a regression test for the error message

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pytest -q tests/test_wasm_bridge.py`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js tests/test_wasm_bridge.py` *(fails: could not fetch psf/black)*

------
https://chatgpt.com/codex/tasks/task_e_683cac3606248333ba6c4d68e3368d07