### PR TITLE
[alpha_factory] add sha384 helper

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -2,6 +2,11 @@
 import os, re, sys, hashlib, base64
 from pathlib import Path
 
+
+def sha384(path: Path) -> str:
+    digest = hashlib.sha384(path.read_bytes()).digest()
+    return "sha384-" + base64.b64encode(digest).decode()
+
 ROOT = Path(__file__).resolve().parent
 index_html = ROOT / 'index.html'
 dist_dir = ROOT / 'dist'


### PR DESCRIPTION
## Summary
- add a `sha384` helper in manual_build.py

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py` *(fails: couldn't connect to server)*
- `pytest alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_dist_self_contained.py` *(fails: BrowserType.launch executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_683cafbfc5788333bc7e1089029b1638