### PR TITLE
[alpha_factory] add IndexedDB archive for insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -70,6 +70,8 @@ import {initI18n,t} from './src/ui/i18n.js';
 import {chat as llmChat} from './src/utils/llm.js';
 import { initTelemetry } from '../../../../src/telemetry.js';
 import { lcg } from './src/utils/rng.js';
+import { Archive } from './src/archive.ts';
+import { initEvolutionPanel } from './src/ui/EvolutionPanel.js';
 
 let panel,pauseBtn,exportBtn,dropZone
 let criticPanel,logicCritic,feasCritic
@@ -77,6 +79,7 @@ let current,rand,pop,gen,svg,view,info,running=true
 let worker
 let telemetry
 let fpsStarted=false;
+let archive,evolutionPanel;
 function toast(msg) {
   const t = document.getElementById('toast');
   t.textContent = msg;
@@ -160,6 +163,7 @@ function selectPoint(d, elem){
 function step(){
   info.text(`gen ${gen}`)
   renderFrontier(view.node ? view.node() : view,pop,selectPoint)
+  archive.add(gen,current,pop).then(()=>evolutionPanel.render()).catch(()=>{})
   if(!running)return
   if(gen++>=current.gen){worker.terminate();return}
   telemetry.recordRun(1)
@@ -228,6 +232,11 @@ function apply(p){location.hash=toHash(p)}
 
 window.addEventListener('DOMContentLoaded',async()=>{
   telemetry = initTelemetry();
+  archive = new Archive();
+  await archive.open();
+  evolutionPanel = initEvolutionPanel(archive);
+  await evolutionPanel.render();
+  window.archive = archive;
   await initI18n()
   loadTheme()
   const ex=await loadCriticExamples()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+export interface RunEntry {
+  id?: number;
+  gen: number;
+  params: any;
+  pop: any[];
+  ts: number;
+}
+
+export class Archive {
+  private db: IDBDatabase | null = null;
+  constructor(private name = 'insight-archive') {}
+
+  async open(): Promise<IDBDatabase> {
+    if (this.db) return this.db;
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(this.name, 1);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore('runs', { keyPath: 'id', autoIncrement: true });
+      };
+      req.onsuccess = () => {
+        this.db = req.result;
+        resolve(this.db);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private store(mode: IDBTransactionMode) {
+    if (!this.db) throw new Error('DB not opened');
+    return this.db.transaction('runs', mode).objectStore('runs');
+  }
+
+  async add(gen: number, params: any, pop: any[]): Promise<number> {
+    await this.open();
+    return new Promise((resolve, reject) => {
+      const req = this.store('readwrite').add({ gen, params, pop, ts: Date.now() });
+      req.onsuccess = () => resolve(req.result as number);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async list(): Promise<RunEntry[]> {
+    await this.open();
+    return new Promise((resolve, reject) => {
+      const req = this.store('readonly').getAll();
+      req.onsuccess = () => {
+        const runs = req.result as RunEntry[];
+        runs.sort((a, b) => a.ts - b.ts);
+        resolve(runs);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async prune(max: number): Promise<void> {
+    const runs = await this.list();
+    if (runs.length <= max) return;
+    const toRemove = runs.slice(0, runs.length - max);
+    await new Promise<void>((resolve, reject) => {
+      const tx = this.db!.transaction('runs', 'readwrite');
+      const store = tx.objectStore('runs');
+      for (const r of toRemove) store.delete(r.id!);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async selectParents(count: number): Promise<RunEntry[]> {
+    const runs = await this.list();
+    const result: RunEntry[] = [];
+    for (let i = 0; i < Math.min(count, runs.length); i++) {
+      const idx = Math.floor(Math.random() * runs.length);
+      result.push(runs[idx]);
+    }
+    return result;
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initEvolutionPanel(archive) {
+  const panel = document.createElement('div');
+  panel.id = 'evolution-panel';
+  Object.assign(panel.style, {
+    position: 'fixed',
+    bottom: '10px',
+    left: '10px',
+    background: 'rgba(0,0,0,0.7)',
+    color: '#fff',
+    padding: '8px',
+    fontSize: '12px',
+    zIndex: 1000,
+    maxHeight: '40vh',
+    overflowY: 'auto',
+  });
+  const list = document.createElement('ul');
+  const table = document.createElement('table');
+  panel.appendChild(list);
+  panel.appendChild(table);
+  document.body.appendChild(panel);
+
+  async function render() {
+    const runs = await archive.list();
+    list.innerHTML = '';
+    runs.forEach((r, idx) => {
+      const li = document.createElement('li');
+      li.textContent = `run ${idx + 1} gen ${r.gen}`;
+      li.style.cursor = 'pointer';
+      li.onclick = () => show(r);
+      list.appendChild(li);
+    });
+  }
+
+  function show(run) {
+    table.innerHTML = '<tr><th>logic</th><th>feasible</th><th>strategy</th></tr>';
+    for (const d of run.pop) {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${d.logic}</td><td>${d.feasible}</td><td>${d.strategy}</td>`;
+      table.appendChild(tr);
+    }
+  }
+
+  return { render, show };
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -1,0 +1,34 @@
+const { Archive } = require('../src/archive.ts');
+
+beforeEach(async () => {
+  indexedDB.deleteDatabase('jest');
+});
+
+test('add and list', async () => {
+  const a = new Archive('jest');
+  await a.open();
+  await a.add(1, {seed:1}, [{logic:1,feasible:1,strategy:'s'}]);
+  const runs = await a.list();
+  expect(runs.length).toBe(1);
+  expect(runs[0].gen).toBe(1);
+});
+
+test('prune keeps max entries', async () => {
+  const a = new Archive('jest');
+  await a.open();
+  await a.add(1, {}, []);
+  await a.add(2, {}, []);
+  await a.prune(1);
+  const runs = await a.list();
+  expect(runs.length).toBe(1);
+  expect(runs[0].gen).toBe(2);
+});
+
+test('selectParents returns entries', async () => {
+  const a = new Archive('jest');
+  await a.open();
+  await a.add(1, {}, []);
+  await a.add(2, {}, []);
+  const parents = await a.selectParents(2);
+  expect(parents.length).toBe(2);
+});


### PR DESCRIPTION
## Summary
- implement IndexedDB archive with add/list/prune/selectParents
- show archive contents via new EvolutionPanel
- load archive from UI and update each generation
- add Jest test skeleton
- ensure runs persist after reload in browser UI

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js` *(failed: Could not fetch pre-commit hooks)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: Duplicated timeseries in CollectorRegistry)*


------
https://chatgpt.com/codex/tasks/task_e_683cb0a49c548333965a7f4771c3294b