### PR TITLE
[alpha_factory] add simulator panel and worker

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -102,6 +102,7 @@ async function bundle() {
       'pyodide.*',
       'wasm_llm/*',
       'wasm/*',
+      'worker/*',
     ],
   });
   const size = await gzipSize.file(`${OUT_DIR}/app.js`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -72,6 +72,7 @@ import { initTelemetry } from '../../../../src/telemetry.js';
 import { lcg } from './src/utils/rng.js';
 import { Archive } from './src/archive.ts';
 import { initEvolutionPanel } from './src/ui/EvolutionPanel.js';
+import { initSimulatorPanel } from './src/ui/SimulatorPanel.js';
 
 let panel,pauseBtn,exportBtn,dropZone
 let criticPanel,logicCritic,feasCritic
@@ -235,6 +236,7 @@ window.addEventListener('DOMContentLoaded',async()=>{
   archive = new Archive();
   await archive.open();
   evolutionPanel = initEvolutionPanel(archive);
+  initSimulatorPanel(archive);
   await evolutionPanel.render();
   window.archive = archive;
   await initI18n()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+import { lcg } from './utils/rng.js';
+import { mutate } from './evolve/mutate.js';
+import { paretoFront } from './utils/pareto.js';
+
+export interface SimulatorOptions {
+  popSize: number;
+  generations: number;
+  mutations?: string[];
+  seed?: number;
+  workerUrl?: string;
+}
+
+export interface Generation {
+  gen: number;
+  pop: any[];
+}
+
+export class Simulator {
+  public readonly opts: SimulatorOptions;
+  private rand: ReturnType<typeof lcg>;
+  private worker: Worker | null = null;
+  private _cancelled = false;
+
+  constructor(opts: SimulatorOptions) {
+    this.opts = { mutations: ['gaussian'], seed: 1, ...opts };
+    this.rand = lcg(this.opts.seed ?? 1);
+  }
+
+  get cancelled(): boolean {
+    return this._cancelled;
+  }
+
+  cancel() {
+    this._cancelled = true;
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+  }
+
+  async *run(): AsyncGenerator<Generation> {
+    let pop = Array.from({ length: this.opts.popSize }, () => ({
+      logic: this.rand(),
+      feasible: this.rand(),
+      strategy: 'base',
+    }));
+    for (let gen = 0; gen < this.opts.generations && !this._cancelled; gen++) {
+      if (this.opts.workerUrl && typeof Worker !== 'undefined') {
+        if (!this.worker) {
+          this.worker = new Worker(this.opts.workerUrl, { type: 'module' });
+        }
+        const result: any = await new Promise((resolve) => {
+          if (!this.worker) return resolve({ pop, rngState: this.rand.state() });
+          this.worker.onmessage = (ev) => resolve(ev.data);
+          this.worker.postMessage({
+            pop,
+            rngState: this.rand.state(),
+            mutations: this.opts.mutations,
+            popSize: this.opts.popSize,
+          });
+        });
+        pop = result.pop;
+        this.rand.set(result.rngState);
+      } else {
+        pop = mutate(pop, this.rand, this.opts.mutations ?? ['gaussian']);
+        const front = paretoFront(pop);
+        pop.forEach((d) => (d.front = front.includes(d)));
+        pop = front.concat(pop.slice(0, this.opts.popSize - 10));
+      }
+      yield { gen: gen + 1, pop };
+    }
+    this.cancel();
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Simulator } from '../simulator.ts';
+import { save } from '../state/serializer.js';
+import { pinFiles } from '../ipfs/pinner.js';
+
+export function initSimulatorPanel(archive) {
+  const panel = document.createElement('div');
+  panel.id = 'simulator-panel';
+  Object.assign(panel.style, {
+    position: 'fixed',
+    bottom: '10px',
+    right: '10px',
+    background: 'rgba(0,0,0,0.7)',
+    color: '#fff',
+    padding: '8px',
+    fontSize: '12px',
+    zIndex: 1000,
+  });
+
+  panel.innerHTML = `
+    <label>Pop <input id="sim-pop" type="number" min="1" value="50"></label>
+    <label>Gen <input id="sim-gen" type="number" min="1" value="10"></label>
+    <button id="sim-start">Start</button>
+    <button id="sim-cancel">Cancel</button>
+    <progress id="sim-progress" value="0" max="1" style="width:100%"></progress>
+  `;
+  document.body.appendChild(panel);
+
+  const popInput = panel.querySelector('#sim-pop');
+  const genInput = panel.querySelector('#sim-gen');
+  const startBtn = panel.querySelector('#sim-start');
+  const cancelBtn = panel.querySelector('#sim-cancel');
+  const progress = panel.querySelector('#sim-progress');
+
+  let sim = null;
+
+  startBtn.addEventListener('click', async () => {
+    if (sim) sim.cancel();
+    sim = new Simulator({
+      popSize: Number(popInput.value),
+      generations: Number(genInput.value),
+      workerUrl: './worker/evolver.js',
+    });
+    let lastPop = [];
+    let count = 0;
+    for await (const g of sim.run()) {
+      lastPop = g.pop;
+      count = g.gen;
+      progress.value = count / sim.opts.generations;
+      await archive.add(g.gen, { popSize: sim.opts.popSize }, g.pop).catch(() => {});
+    }
+    if (!sim.cancelled) {
+      const json = save(lastPop, 0);
+      const file = new File([json], 'replay.json', { type: 'application/json' });
+      await pinFiles([file]);
+    }
+  });
+
+  cancelBtn.addEventListener('click', () => {
+    if (sim) sim.cancel();
+  });
+
+  return panel;
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
@@ -1,0 +1,20 @@
+const { Simulator } = require('../src/simulator.ts');
+
+jest.setTimeout(10000);
+
+test('500-generation run', async () => {
+  const sim = new Simulator({ popSize: 5, generations: 500 });
+  let count = 0;
+  for await (const g of sim.run()) {
+    count = g.gen;
+  }
+  expect(count).toBe(500);
+});
+
+test('memory usage stable', async () => {
+  const start = process.memoryUsage().heapUsed;
+  const sim = new Simulator({ popSize: 5, generations: 100 });
+  for await (const _ of sim.run()) {}
+  const end = process.memoryUsage().heapUsed;
+  expect(end - start).toBeLessThan(10 * 1024 * 1024);
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_cancel_persists.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_cancel_persists.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_cancel_persists_generations() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        page.wait_for_function("window.archive !== undefined")
+
+        page.evaluate("document.querySelector('#simulator-panel #sim-gen').value = 5")
+        page.click("#simulator-panel #sim-start")
+        page.wait_for_timeout(200)
+        page.click("#simulator-panel #sim-cancel")
+        page.wait_for_timeout(200)
+        count = page.evaluate("window.archive.list().then(r=>r.length)")
+        assert count > 0
+        browser.close()


### PR DESCRIPTION
## Summary
- implement `Simulator.run()` with worker support
- add `SimulatorPanel` UI and IPFS pinning
- cache worker in service worker
- test long simulations and cancellation

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_cancel_persists.py` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683cb3ac87c883338f5bc22aabadc174