### PR TITLE
[alpha_factory] enhance serializer validation

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/state/serializer.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/state/serializer.js
@@ -14,14 +14,46 @@ export function save(pop, rngState) {
 }
 
 export function load(json) {
-  const data = JSON.parse(json);
+  let data;
+  try {
+    data = JSON.parse(json);
+  } catch (err) {
+    throw new Error(`Malformed JSON: ${err.message}`);
+  }
+
+  if (data === null || typeof data !== 'object') {
+    throw new Error('Invalid data');
+  }
+
+  const allowedRoot = new Set(['gen', 'pop', 'rngState']);
+  for (const key of Object.keys(data)) {
+    if (!allowedRoot.has(key)) {
+      throw new Error(`Unexpected key: ${key}`);
+    }
+  }
+
   if (!Array.isArray(data.pop)) throw new Error('Invalid population');
-  const pop = data.pop.map((d) => ({
-    logic: d.logic,
-    feasible: d.feasible,
-    front: d.front,
-    strategy: d.strategy,
-  }));
-  pop.gen = data.gen ?? 0;
-  return { pop, rngState: data.rngState, gen: data.gen ?? 0 };
+
+  const allowedItem = new Set(['logic', 'feasible', 'front', 'strategy']);
+  const pop = data.pop.map((d) => {
+    if (d === null || typeof d !== 'object') {
+      throw new Error('Invalid population item');
+    }
+    for (const key of Object.keys(d)) {
+      if (!allowedItem.has(key)) {
+        throw new Error(`Invalid key in population item: ${key}`);
+      }
+    }
+    if (typeof d.logic !== 'number' || typeof d.feasible !== 'number') {
+      throw new Error('Population items require numeric logic and feasible');
+    }
+    return {
+      logic: d.logic,
+      feasible: d.feasible,
+      front: d.front,
+      strategy: d.strategy,
+    };
+  });
+  pop.gen = typeof data.gen === 'number' ? data.gen : 0;
+  return { pop, rngState: data.rngState, gen: pop.gen };
 }

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -27,8 +27,8 @@ def test_js_serializer_roundtrip(tmp_path: Path) -> None:
 
     sample = {
         "pop": [
-            {"logic": "a", "feasible": True, "front": 0, "strategy": "s"},
-            {"logic": "b", "feasible": False, "front": 1, "strategy": "t"},
+            {"logic": 1.1, "feasible": 0.2, "front": 0, "strategy": "s"},
+            {"logic": 2.3, "feasible": 0.4, "front": 1, "strategy": "t"},
         ],
         "gen": 5,
         "rngState": [1, 2, 3, 4],
@@ -40,3 +40,47 @@ def test_js_serializer_roundtrip(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     loaded = json.loads(result.stdout)
     assert loaded == sample
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"pop": [{"logic": "a", "feasible": 1}]},
+        {"pop": [{"logic": 1, "feasible": "b"}]},
+        {"pop": [{"logic": 1, "feasible": 2, "extra": True}]},
+        {"pop": [], "extra": 1},
+    ],
+)
+def test_js_serializer_rejects_invalid(tmp_path: Path, payload: dict) -> None:
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"import {{load}} from '{SERIALIZER.resolve().as_posix()}';\n"
+        "try {\n"
+        "  const out = load(process.argv[2]);\n"
+        "  console.log(JSON.stringify(out));\n"
+        "} catch (err) {\n"
+        "  console.error(err.message);\n"
+        "  process.exit(1);\n"
+        "}\n"
+    )
+    result = subprocess.run(
+        ["node", script, json.dumps(payload)], capture_output=True, text=True
+    )
+    assert result.returncode == 1
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+def test_js_serializer_malformed_json(tmp_path: Path) -> None:
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"import {{load}} from '{SERIALIZER.resolve().as_posix()}';\n"
+        "try {\n"
+        "  load(process.argv[2]);\n"
+        "} catch (err) {\n"
+        "  console.error(err.message);\n"
+        "  process.exit(1);\n"
+        "}\n"
+    )
+    result = subprocess.run(["node", script, "{invalid"], capture_output=True, text=True)
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary
- add strict checks in serializer `load()` to reject malformed data
- test numeric validation, unknown keys and malformed JSON

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/state/serializer.js tests/test_serializer.py` *(failed: couldn't fetch remote hooks)*
- `pytest tests/test_serializer.py -q`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683cb7c437148333973f84ac39d041c9