### PR TITLE
[alpha_factory] simulator worker updates

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
@@ -19,48 +19,72 @@ export function initSimulatorPanel(archive) {
   });
 
   panel.innerHTML = `
+    <label>Seeds <input id="sim-seeds" value="1"></label>
     <label>Pop <input id="sim-pop" type="number" min="1" value="50"></label>
     <label>Gen <input id="sim-gen" type="number" min="1" value="10"></label>
+    <label>Rate <input id="sim-rate" type="number" step="0.01" value="1"></label>
+    <label>Heuristic <select id="sim-heur"><option value="none">none</option><option value="llm">llm</option></select></label>
     <button id="sim-start">Start</button>
     <button id="sim-cancel">Cancel</button>
     <progress id="sim-progress" value="0" max="1" style="width:100%"></progress>
+    <div id="sim-status"></div>
   `;
   document.body.appendChild(panel);
 
+  const seedsInput = panel.querySelector('#sim-seeds');
   const popInput = panel.querySelector('#sim-pop');
   const genInput = panel.querySelector('#sim-gen');
+  const rateInput = panel.querySelector('#sim-rate');
+  const heurSel = panel.querySelector('#sim-heur');
   const startBtn = panel.querySelector('#sim-start');
   const cancelBtn = panel.querySelector('#sim-cancel');
   const progress = panel.querySelector('#sim-progress');
+  const status = panel.querySelector('#sim-status');
 
   let sim = null;
 
   startBtn.addEventListener('click', async () => {
-    if (sim) sim.cancel();
-    sim = new Simulator({
+    if (sim && typeof sim.return === 'function') await sim.return();
+    const seeds = seedsInput.value.split(',').map((s) => Number(s.trim())).filter(Boolean);
+    sim = Simulator.run({
       popSize: Number(popInput.value),
       generations: Number(genInput.value),
+      mutations: ['gaussian'],
+      seeds,
       workerUrl: './worker/evolver.js',
+      critic: heurSel.value,
     });
     let lastPop = [];
     let count = 0;
-    for await (const g of sim.run()) {
-      lastPop = g.pop;
+    for await (const g of sim) {
+      lastPop = g.population;
       count = g.gen;
-      progress.value = count / sim.opts.generations;
-      const front = paretoFront(g.pop);
-      await archive.add(sim.opts.seed ?? 1, { popSize: sim.opts.popSize }, front).catch(() => {});
+      progress.value = count / Number(genInput.value);
+      status.textContent = `gen ${count} front ${g.fronts.length}`;
+      await archive.add(seeds[0] ?? 1, { popSize: Number(popInput.value) }, g.fronts).catch(() => {});
     }
-    if (!sim.cancelled) {
-      const json = save(lastPop, 0);
-      const file = new File([json], 'replay.json', { type: 'application/json' });
-      await pinFiles([file]);
-    }
+    const json = save(lastPop, 0);
+    const file = new File([json], 'replay.json', { type: 'application/json' });
+    const out = await pinFiles([file]);
+    if (out) status.textContent = `CID: ${out.cid}`;
   });
 
   cancelBtn.addEventListener('click', () => {
-    if (sim) sim.cancel();
+    if (sim && typeof sim.return === 'function') sim.return();
   });
+
+  const q = new URLSearchParams(window.location.hash.replace(/^#\/?/, ''));
+  const cid = q.get('cid');
+  if (cid) {
+    fetch(`https://ipfs.io/ipfs/${cid}`)
+      .then((r) => r.text())
+      .then((txt) => {
+        status.textContent = 'replaying...';
+        const data = JSON.parse(txt);
+        console.log('Replay', data);
+      })
+      .catch(() => {});
+  }
 
   return panel;
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
@@ -3,18 +3,22 @@ const { Simulator } = require('../src/simulator.ts');
 jest.setTimeout(10000);
 
 test('500-generation run', async () => {
-  const sim = new Simulator({ popSize: 5, generations: 500 });
+  const sim = Simulator.run({ popSize: 5, generations: 500 });
   let count = 0;
-  for await (const g of sim.run()) {
+  for await (const g of sim) {
     count = g.gen;
+    for (const d of g.population) {
+      expect(Number.isNaN(d.logic)).toBe(false);
+      expect(Number.isNaN(d.feasible)).toBe(false);
+    }
   }
   expect(count).toBe(500);
 });
 
 test('memory usage stable', async () => {
   const start = process.memoryUsage().heapUsed;
-  const sim = new Simulator({ popSize: 5, generations: 100 });
-  for await (const _ of sim.run()) {}
+  const sim = Simulator.run({ popSize: 5, generations: 100 });
+  for await (const _ of sim) {}
   const end = process.memoryUsage().heapUsed;
   expect(end - start).toBeLessThan(10 * 1024 * 1024);
 });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
@@ -2,6 +2,18 @@
 import { mutate } from '../src/evolve/mutate.js';
 import { paretoFront } from '../src/utils/pareto.js';
 import { lcg } from '../src/utils/rng.js';
+let pyReady;
+async function loadPy() {
+  if (!pyReady) {
+    try {
+      const mod = await import('../src/wasm/bridge.js');
+      pyReady = mod.initPy ? mod.initPy() : null;
+    } catch {
+      pyReady = null;
+    }
+  }
+  return pyReady;
+}
 
 function shuffle(arr, rand) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -10,14 +22,22 @@ function shuffle(arr, rand) {
   }
 }
 
-self.onmessage = (ev) => {
-  const { pop, rngState, mutations, popSize } = ev.data;
+self.onmessage = async (ev) => {
+  const { pop, rngState, mutations, popSize, critic } = ev.data;
   const rand = lcg(0);
   rand.set(rngState);
   let next = mutate(pop, rand, mutations);
   const front = paretoFront(next);
   next.forEach((d) => (d.front = front.includes(d)));
+  if (critic === 'llm') {
+    await loadPy();
+  }
   shuffle(next, rand);
   next = front.concat(next.slice(0, popSize - 10));
-  self.postMessage({ pop: next, rngState: rand.state() });
+  const metrics = {
+    avgLogic: next.reduce((s, d) => s + (d.logic ?? 0), 0) / next.length,
+    avgFeasible: next.reduce((s, d) => s + (d.feasible ?? 0), 0) / next.length,
+    frontSize: front.length,
+  };
+  self.postMessage({ pop: next, rngState: rand.state(), front, metrics });
 };


### PR DESCRIPTION
## Summary
- refactor browser simulator to yield fronts and metrics
- compute metrics in evolver worker and lazily load pyodide
- extend SimulatorPanel with advanced options, status and IPFS replay
- adjust simulator unit tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683cc268e20483338a065392bea6f6bb