### PR TITLE
[alpha_factory] visualize generation depth

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -38,6 +38,7 @@
     <div id="toast"></div>
     <div id="toolbar"></div>
     <div id="legend"></div>
+    <div id="depth-legend"></div>
     <script
       src="d3.v7.min.js"
       integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8"
@@ -134,10 +135,18 @@ function updateLegend(strats){
   }
 }
 
+function updateDepthLegend(max){
+  const dl=document.getElementById('depth-legend');
+  dl.innerHTML='depth';
+  const bar=document.createElement('div');
+  bar.className='bar';
+  dl.appendChild(bar);
+}
+
 function start(p){
   current=p
   rand=lcg(p.seed)
-  pop=Array.from({length:p.pop},()=>({logic:rand(),feasible:rand(),strategy:'base'}))
+  pop=Array.from({length:p.pop},()=>({logic:rand(),feasible:rand(),strategy:'base',depth:0}))
   gen=0
   running=true
   setupView()
@@ -166,11 +175,13 @@ function step(){
   info.text(`gen ${gen}`)
   const front = paretoFront(pop)
   renderFrontier(view.node ? view.node() : view,pop,selectPoint)
+  const md = Math.max(...pop.map(d=>d.depth||0))
+  updateDepthLegend(md)
   archive.add(current.seed, current, front).then(()=>evolutionPanel.render()).catch(()=>{})
   if(!running)return
   if(gen++>=current.gen){worker.terminate();return}
   telemetry.recordRun(1)
-  worker.postMessage({pop,rngState:rand.state(),mutations:current.mutations,popSize:current.pop})
+  worker.postMessage({pop,rngState:rand.state(),mutations:current.mutations,popSize:current.pop,gen})
 }
 
 function togglePause(){

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-export function mutate(pop, rand, strategies) {
+export function mutate(pop, rand, strategies, gen = 0) {
   const clamp = (v) => Math.min(1, Math.max(0, v));
   const mutants = [];
   for (const d of pop) {
@@ -10,19 +10,20 @@ export function mutate(pop, rand, strategies) {
             logic: clamp(d.logic + (rand() - 0.5) * 0.12),
             feasible: clamp(d.feasible + (rand() - 0.5) * 0.12),
             strategy: s,
+            depth: gen,
           });
           break;
         case 'swap': {
           const other = pop[Math.floor(rand() * pop.length)];
-          mutants.push({ logic: other.logic, feasible: d.feasible, strategy: s });
+          mutants.push({ logic: other.logic, feasible: d.feasible, strategy: s, depth: gen });
           break;
         }
         case 'jump':
-          mutants.push({ logic: rand(), feasible: rand(), strategy: s });
+          mutants.push({ logic: rand(), feasible: rand(), strategy: s, depth: gen });
           break;
         case 'scramble': {
           const other = pop[Math.floor(rand() * pop.length)];
-          mutants.push({ logic: d.logic, feasible: other.feasible, strategy: s });
+          mutants.push({ logic: d.logic, feasible: other.feasible, strategy: s, depth: gen });
           break;
         }
       }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js
@@ -13,3 +13,9 @@ export function credibilityColor(v) {
   const hue = 120 * clamped; // red -> green
   return `hsl(${hue},70%,50%)`;
 }
+
+export function depthColor(depth, maxDepth) {
+  const md = Math.max(1, maxDepth ?? depth ?? 1);
+  const ratio = 1 - Math.min(depth ?? 0, md) / md;
+  return `rgba(0,175,255,${ratio})`;
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js
@@ -2,16 +2,17 @@
 import * as Plot from '@observablehq/plot';
 import { plotCanvas } from '@observablehq/plot-canvas';
 import { paretoFront } from '../utils/pareto.js';
-import { credibilityColor } from './colors.js';
+import { depthColor } from './colors.js';
 
 export function renderFrontier(container, pop, onSelect) {
   const front = paretoFront(pop).sort((a, b) => a.logic - b.logic);
 
+  const maxDepth = pop.reduce((m, d) => Math.max(m, d.depth ?? 0), 0);
   const dotOptions = {
     x: 'logic',
     y: 'feasible',
     r: 3,
-    fill: (d) => credibilityColor(d.insightCredibility ?? 0),
+    fill: (d) => depthColor(d.depth ?? 0, maxDepth),
     title: (d) => `${d.summary ?? ''}\n${d.critic ?? ''}`,
   };
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
@@ -27,6 +27,7 @@ export class Simulator {
       logic: rand(),
       feasible: rand(),
       strategy: 'base',
+      depth: 0,
     }));
     for (let gen = 0; gen < options.generations; gen++) {
       let front: any[] = [];
@@ -42,6 +43,7 @@ export class Simulator {
             mutations: options.mutations,
             popSize: options.popSize,
             critic: options.critic,
+            gen: gen + 1,
           });
         });
         pop = result.pop;
@@ -49,7 +51,7 @@ export class Simulator {
         front = result.front;
         metrics = result.metrics;
       } else {
-        pop = mutate(pop, rand, options.mutations ?? ['gaussian']);
+        pop = mutate(pop, rand, options.mutations ?? ['gaussian'], gen + 1);
         front = paretoFront(pop);
         pop.forEach((d) => (d.front = front.includes(d)));
         pop = front.concat(pop.slice(0, options.popSize - 10));

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css
@@ -11,6 +11,13 @@ svg {
 #legend {
   @apply text-base-content fixed bottom-4 right-4 text-sm;
 }
+#depth-legend {
+  @apply text-base-content fixed bottom-12 right-4 text-sm flex items-center;
+}
+#depth-legend .bar {
+  @apply ml-2 h-2 w-16 rounded;
+  background: linear-gradient(to right, rgba(0,175,255,1), rgba(0,175,255,0));
+}
 #tooltip {
   @apply absolute hidden pointer-events-none bg-black/70 text-white px-1 py-0.5 rounded text-sm;
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
@@ -23,10 +23,10 @@ function shuffle(arr, rand) {
 }
 
 self.onmessage = async (ev) => {
-  const { pop, rngState, mutations, popSize, critic } = ev.data;
+  const { pop, rngState, mutations, popSize, critic, gen } = ev.data;
   const rand = lcg(0);
   rand.set(rngState);
-  let next = mutate(pop, rand, mutations);
+  let next = mutate(pop, rand, mutations, gen);
   const front = paretoFront(next);
   next.forEach((d) => (d.front = front.includes(d)));
   if (critic === 'llm') {


### PR DESCRIPTION
## Summary
- color datapoints by generation depth
- store `depth` in evolver and simulator
- seed initial populations with depth 0
- show depth legend in the browser

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/colors.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/style.css alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js` *(fails: could not fetch black)*

------
https://chatgpt.com/codex/tasks/task_e_683cd8ec407c8333a8ee5747cb17c952