### PR TITLE
[alpha_factory] handle archive quota errors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
@@ -755,7 +755,19 @@ class Archive {
       novelty,
       timestamp: Date.now(),
     };
-    await set(id, run, this.store);
+    try {
+      await set(id, run, this.store);
+    } catch (err) {
+      if ((err == null ? void 0 : err.name) === "QuotaExceededError") {
+        await this.prune();
+        if (typeof window.toast === "function") {
+          window.toast("Archive full; oldest runs pruned");
+        }
+        await set(id, run, this.store);
+      } else {
+        throw err;
+      }
+    }
     await this.prune(500);
     return id;
   }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -58,7 +58,19 @@ export class Archive {
       novelty,
       timestamp: Date.now(),
     };
-    await set(id, run, this.store);
+    try {
+      await set(id, run, this.store);
+    } catch (err: any) {
+      if (err?.name === 'QuotaExceededError') {
+        await this.prune();
+        if (typeof (window as any).toast === 'function') {
+          (window as any).toast('Archive full; oldest runs pruned');
+        }
+        await set(id, run, this.store);
+      } else {
+        throw err;
+      }
+    }
     await this.prune(500);
     return id;
   }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_archive_quota.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_archive_quota.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_archive_quota_toast() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        page.wait_for_function("window.archive !== undefined")
+        page.evaluate(
+            """
+            const orig = IDBObjectStore.prototype.put;
+            let thrown = false;
+            IDBObjectStore.prototype.put = function(...a) {
+                if (!thrown) {
+                    thrown = true;
+                    throw new DOMException('full','QuotaExceededError');
+                }
+                return orig.apply(this, a);
+            };
+            """
+        )
+        page.evaluate("window.archive.add(1, {}, [{logic:1,feasible:1}])")
+        page.wait_for_selector("#toast.show")
+        assert "Archive full" in page.inner_text("#toast")
+        browser.close()


### PR DESCRIPTION
## Summary
- handle QuotaExceededError when adding runs to local archive
- show toast when archive is full and retry after prune
- test quota error toast via Playwright

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683ce01cc4088333ad80886e531d265f