### PR TITLE
[alpha_factory] Improve manual build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -49,11 +49,14 @@ python manual_build.py
 ```
 
 The script requires Python ≥3.11 and writes the bundled output to `dist/`.
-`dist/index.html` loads `dist/app.js`, `bundle.esm.min.js` and
-`pyodide.js` with integrity hashes. Any `wasm/` or `wasm_llm/` directories
-are copied as-is so the demo can run fully offline.
-Run `python ../../../scripts/fetch_assets.py` beforehand to download the
-Pyodide runtime and GPT‑2 WASM model when building without internet access.
+`dist/index.html` includes SHA‑384 integrity hashes for `app.js`, `style.css`,
+`bundle.esm.min.js` and `pyodide.js`. It also embeds
+`window.PINNER_TOKEN`, `window.OPENAI_API_KEY` and `window.OTEL_ENDPOINT`
+from the environment just like `npm run build`.
+Any `wasm/` or `wasm_llm/` directories are copied as-is so the demo can
+run fully offline. Run `python ../../../scripts/fetch_assets.py` beforehand
+to download the Pyodide runtime and GPT‑2 WASM model when building
+without internet access.
 Serve the folder with `npm start` or open `dist/index.html` directly.
 
 ## Toolbar & Controls


### PR DESCRIPTION
## Summary
- inject PINNER_TOKEN etc. during manual browser build
- use SHA-384 SRI for `app.js` and `style.css`
- document the updated manual build procedure

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683ce14b833c8333babc37e375599dd4