### PR TITLE
[alpha_factory] Add salted session hashing for telemetry

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -85,4 +85,10 @@ the run finishes. Keep this CID handy to share or reload the simulation later.
 Append `#/cid=&lt;CID&gt;` to the URL (or use the **Share** permalink) to replay a
 previous run. The simulator fetches the JSON from IPFS and populates the chart.
 
+## Privacy
+Anonymous telemetry is optional. On first use a random ID is generated and
+hashed with SHA-256 using the static salt `"insight"`. Only this salted hash and
+basic usage metrics are sent to the OTLP endpoint. Clearing browser storage
+resets the identifier.
+
 Environment variables can be configured in `.env` (see `.env.sample`).


### PR DESCRIPTION
## Summary
- salt session IDs and persist to localStorage
- include hashed ID in OTLP payload
- document telemetry privacy behaviour
- test deterministic session hashing

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683ce73799648333bd2f397d5d35c654