### PR TITLE
[alpha_factory] add pyodide fallback

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -99,7 +99,10 @@ function start(p){
   updateLegend(p.mutations)
   if(worker) worker.terminate()
   worker=new Worker('./worker/evolver.js',{type:'module'})
-  worker.onmessage=ev=>{pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)}
+  worker.onmessage=ev=>{
+    if(ev.data.toast){toast(ev.data.toast);return}
+    pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)
+  }
   step()
 }
 
@@ -181,7 +184,10 @@ function loadState(text){
     updateLegend(current.mutations)
     if(worker) worker.terminate()
     worker=new Worker('./worker/evolver.js',{type:'module'})
-    worker.onmessage=ev=>{pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)}
+    worker.onmessage=ev=>{
+      if(ev.data.toast){toast(ev.data.toast);return}
+      pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)
+    }
     step()
     toast(t('state_loaded'))
   }catch{toast(t('invalid_file'))}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pyodide_fallback.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pyodide_fallback.py
@@ -1,0 +1,21 @@
+import pytest
+from pathlib import Path
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_pyodide_fallback() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.route("**/pyodide.js", lambda route: route.abort())
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        page.wait_for_selector("#toast.show")
+        assert "Pyodide" in page.inner_text("#toast")
+        browser.close()
+


### PR DESCRIPTION
## Summary
- detect Safari/iOS or Pyodide load failure in worker
- warn once via toast and continue with JS logic
- expose worker toast messages in app
- test fallback logic with Playwright

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pyodide_fallback.py` *(fails: Could not fetch black)*

------
https://chatgpt.com/codex/tasks/task_e_683ceae902008333b8f5ebc14bff0b9b