### PR TITLE
[alpha_factory] evolve evaluator genome

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -20,6 +20,7 @@ import { paretoFront } from './src/utils/pareto.js';
 import { Archive } from './src/archive.ts';
 import { initEvolutionPanel } from './src/ui/EvolutionPanel.js';
 import { initSimulatorPanel } from './src/ui/SimulatorPanel.js';
+import { initPowerPanel } from './src/ui/PowerPanel.js';
 
 let panel,pauseBtn,exportBtn,dropZone
 let criticPanel,logicCritic,feasCritic
@@ -27,7 +28,7 @@ let current,rand,pop,gen,svg,view,info,running=true
 let worker
 let telemetry
 let fpsStarted=false;
-let archive,evolutionPanel;
+let archive,evolutionPanel,powerPanel;
 function toast(msg) {
   const t = document.getElementById('toast');
   t.textContent = msg;
@@ -125,7 +126,7 @@ function step(){
   renderFrontier(view.node ? view.node() : view,pop,selectPoint)
   const md = Math.max(...pop.map(d=>d.depth||0))
   updateDepthLegend(md)
-  archive.add(current.seed, current, front).then(()=>evolutionPanel.render()).catch(()=>{})
+  archive.add(current.seed, current, front, [], 0).then(()=>evolutionPanel.render()).catch(()=>{})
   if(!running)return
   if(gen++>=current.gen){worker.terminate();return}
   telemetry.recordRun(1)
@@ -200,7 +201,8 @@ window.addEventListener('DOMContentLoaded',async()=>{
   archive = new Archive();
   await archive.open();
   evolutionPanel = initEvolutionPanel(archive);
-  initSimulatorPanel(archive);
+  initSimulatorPanel(archive, powerPanel);
+  powerPanel = initPowerPanel();
   await evolutionPanel.render();
   window.archive = archive;
   await initI18n()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evaluator_genome.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evaluator_genome.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+export interface EvaluatorGenome {
+  weights: { logic: number; feasible: number };
+  prompt: string;
+}
+
+function clamp(v: number): number {
+  return Math.min(1, Math.max(0, v));
+}
+
+export function mutateEvaluator(
+  base: EvaluatorGenome,
+  rand: () => number = Math.random
+): EvaluatorGenome {
+  let l = clamp(base.weights.logic + (rand() - 0.5) * 0.1);
+  let f = clamp(base.weights.feasible + (rand() - 0.5) * 0.1);
+  const sum = l + f || 1;
+  l /= sum;
+  f /= sum;
+  const words = ['innovative', 'efficient', 'robust', 'scalable'];
+  let tokens = base.prompt.split(/\s+/);
+  if (rand() < 0.5 && tokens.length > 1) {
+    tokens.splice(Math.floor(rand() * tokens.length), 1);
+  } else {
+    const w = words[Math.floor(rand() * words.length)];
+    tokens.splice(Math.floor(rand() * (tokens.length + 1)), 0, w);
+  }
+  const prompt = tokens.join(' ');
+  return { weights: { logic: l, feasible: f }, prompt };
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initPowerPanel() {
+  const panel = document.createElement('div');
+  panel.id = 'power-panel';
+  Object.assign(panel.style, {
+    position: 'fixed',
+    top: '10px',
+    left: '10px',
+    background: 'rgba(0,0,0,0.7)',
+    color: '#fff',
+    padding: '8px',
+    fontSize: '12px',
+    zIndex: 1000,
+    whiteSpace: 'pre',
+  });
+  const pre = document.createElement('pre');
+  panel.appendChild(pre);
+  document.body.appendChild(panel);
+  function update(e) {
+    pre.textContent = JSON.stringify(e, null, 2);
+  }
+  return { update };
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -43,3 +43,13 @@ test('parents saved and retrieved', async () => {
   const run = runs.find((r) => r.id === id);
   expect(run.parents).toEqual([1, 2]);
 });
+
+test('prune removes unused evaluators', async () => {
+  const a = new Archive('jest');
+  await a.open();
+  const evalId = await a.addEvaluator({ weights: { logic: 0.5, feasible: 0.5 }, prompt: 'x' });
+  await a.add(1, {}, [{logic:0.1,feasible:0.1}], [], evalId);
+  await a.prune(0);
+  const evals = await a.listEvaluators();
+  expect(evals.length).toBe(0);
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js
@@ -1,0 +1,11 @@
+const { mutateEvaluator } = require('../src/evaluator_genome.ts');
+const { lcg } = require('../src/utils/rng.js');
+
+test('mutateEvaluator changes weights and prompt', () => {
+  const rand = lcg(1);
+  const base = { weights: { logic: 0.7, feasible: 0.3 }, prompt: 'judge idea' };
+  const m = mutateEvaluator(base, rand);
+  expect(m.weights.logic + m.weights.feasible).toBeCloseTo(1, 5);
+  expect(m.weights.logic).not.toBeCloseTo(base.weights.logic);
+  expect(m.prompt).not.toBe(base.prompt);
+});


### PR DESCRIPTION
## Summary
- support evaluator genome in archive
- mutate evaluator every generation and show details in power panel
- expose new power user panel
- add tests for evaluator mutation and pruning

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evaluator_genome.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js` *(fails: CalledProcessError: git fetch)*

------
https://chatgpt.com/codex/tasks/task_e_683cec985b108333aebcf1c4c2b26ab1