### PR TITLE
[alpha_factory] add env-driven CSP origins

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,3 +29,6 @@ API_TOKEN=REPLACE_ME_TOKEN
 # Web3.Storage token for pinning Insight demo exports
 PINNER_TOKEN=
 
+# IPFS gateway base URL
+IPFS_GATEWAY=https://ipfs.io/ipfs
+

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample
@@ -6,6 +6,9 @@
 # Web3.Storage token to enable result pinning
 PINNER_TOKEN=
 
+# IPFS gateway base URL
+IPFS_GATEWAY=https://ipfs.io/ipfs
+
 # Optional OpenAI credential
 OPENAI_API_KEY=
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -11,10 +11,11 @@ A zero-backend Pareto explorer lives in
 npm ci           # deterministic install
 npm run build    # compile to dist/ and embed env vars
 ```
-Copy `.env.sample` to `.env` and fill in variables like `PINNER_TOKEN` and
-`OTEL_ENDPOINT` before building or running.
+Copy `.env.sample` to `.env` and fill in variables like `PINNER_TOKEN`,
+`IPFS_GATEWAY` and `OTEL_ENDPOINT` before building or running.
 The build script reads `.env` automatically and writes `window.PINNER_TOKEN`,
-`window.OPENAI_API_KEY` and `window.OTEL_ENDPOINT` to `dist/index.html`.
+`window.OPENAI_API_KEY`, `window.IPFS_GATEWAY` and `window.OTEL_ENDPOINT` to
+`dist/index.html`.
 Place the Pyodide 0.25 files in `wasm/` before building. The script copies them
 to `dist/wasm` so the demo can run offline. When preparing the environment
 offline run:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#0d0e2e" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval'"
+      content="default-src 'self'; connect-src 'self' https://api.openai.com __IPFS__ __OTEL__; script-src 'self' 'wasm-unsafe-eval'"
     />
     <title>α-AGI Insight – in-browser Pareto explorer</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.js
@@ -6,7 +6,8 @@ export async function pinFiles(files) {
   try {
     const client = new Web3Storage({ token: window.PINNER_TOKEN });
     const cid = await client.put(files);
-    const url = `https://ipfs.io/ipfs/${cid}`;
+    const gateway = (window.IPFS_GATEWAY || 'https://ipfs.io/ipfs').replace(/\/$/, '');
+    const url = `${gateway}/${cid}`;
     if (navigator.clipboard) {
       try {
         await navigator.clipboard.writeText(url);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
@@ -105,7 +105,8 @@ export function initSimulatorPanel(archive, power) {
   const q = new URLSearchParams(window.location.hash.replace(/^#\/?/, ''));
   const cid = q.get('cid');
   if (cid) {
-    fetch(`https://ipfs.io/ipfs/${cid}`)
+    const gateway = (window.IPFS_GATEWAY || 'https://ipfs.io/ipfs').replace(/\/$/, '');
+    fetch(`${gateway}/${cid}`)
       .then((r) => r.text())
       .then((txt) => {
         status.textContent = 'replaying...';


### PR DESCRIPTION
## Summary
- add IPFS gateway var in env templates
- allow customizing connect-src via build scripts
- expose IPFS_GATEWAY on window
- update docs

## Testing
- `pre-commit run --files .env.sample alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js` (failed to install hooks)
- `python check_env.py --auto-install`
- `pytest -q` (failed: ValueError: Duplicated timeseries in CollectorRegistry)


------
https://chatgpt.com/codex/tasks/task_e_683cf0672a0c8333b8983cb77ae8c382