### PR TITLE
[alpha_factory] copy additional assets

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -66,6 +66,14 @@ async function bundle() {
   await fs.copyFile('worker/evolver.js', `${OUT_DIR}/worker/evolver.js`);
   await fs.mkdir(`${OUT_DIR}/src/utils`, { recursive: true });
   await fs.copyFile('src/utils/rng.js', `${OUT_DIR}/src/utils/rng.js`);
+  await fs.copyFile('sw.js', `${OUT_DIR}/sw.js`).catch(() => {});
+  await fs.copyFile('manifest.json', `${OUT_DIR}/manifest.json`).catch(() => {});
+  await fs.copyFile('favicon.svg', `${OUT_DIR}/favicon.svg`).catch(() => {});
+  await fs.mkdir(`${OUT_DIR}/data/critics`, { recursive: true });
+  await fs
+    .copyFile('../../../../data/critics/innovations.txt',
+      `${OUT_DIR}/data/critics/innovations.txt`)
+    .catch(() => {});
   const bundleSri = await sha384('bundle.esm.min.js');
   const pyodideSri = await sha384('pyodide.js');
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -104,8 +104,12 @@ for src, dest in [
     ("lib/pyodide.js", "pyodide.js"),
     ("worker/evolver.js", "worker/evolver.js"),
     ("src/utils/rng.js", "src/utils/rng.js"),
+    ("sw.js", "sw.js"),
+    ("manifest.json", "manifest.json"),
+    ("favicon.svg", "favicon.svg"),
+    (ROOT.parents[3] / "data" / "critics" / "innovations.txt", "data/critics/innovations.txt"),
 ]:
-    src_path = ROOT / src
+    src_path = ROOT / src if isinstance(src, str) else src
     if src_path.exists():
         target = dist_dir / dest
         target.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure browser build includes `manifest.json`, `favicon.svg`, `sw.js` and critics data

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py` *(fails to fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683cf2806944833387d2538af6d3779a