### PR TITLE
[alpha_factory] add offline critics examples

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -70,10 +70,14 @@ async function bundle() {
   await fs.copyFile('manifest.json', `${OUT_DIR}/manifest.json`).catch(() => {});
   await fs.copyFile('favicon.svg', `${OUT_DIR}/favicon.svg`).catch(() => {});
   await fs.mkdir(`${OUT_DIR}/data/critics`, { recursive: true });
-  await fs
-    .copyFile('../../../../data/critics/innovations.txt',
-      `${OUT_DIR}/data/critics/innovations.txt`)
-    .catch(() => {});
+  try {
+    for (const f of await fs.readdir('../../../../data/critics')) {
+      await fs.copyFile(
+        `../../../../data/critics/${f}`,
+        `${OUT_DIR}/data/critics/${f}`
+      );
+    }
+  } catch {}
   const bundleSri = await sha384('bundle.esm.min.js');
   const pyodideSri = await sha384('pyodide.js');
 
@@ -115,6 +119,7 @@ async function bundle() {
       'wasm_llm/*',
       'wasm/*',
       'worker/*',
+      'data/critics/*',
     ],
   });
   const size = await gzipSize.file(`${OUT_DIR}/app.js`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -107,13 +107,20 @@ for src, dest in [
     ("sw.js", "sw.js"),
     ("manifest.json", "manifest.json"),
     ("favicon.svg", "favicon.svg"),
-    (ROOT.parents[3] / "data" / "critics" / "innovations.txt", "data/critics/innovations.txt"),
 ]:
     src_path = ROOT / src if isinstance(src, str) else src
     if src_path.exists():
         target = dist_dir / dest
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(src_path.read_bytes())
+
+# copy critic examples
+critics_src = ROOT.parents[3] / "data" / "critics"
+critics_dst = dist_dir / "data" / "critics"
+if critics_src.exists():
+    critics_dst.mkdir(parents=True, exist_ok=True)
+    for f in critics_src.iterdir():
+        (critics_dst / f.name).write_bytes(f.read_bytes())
 
 app_sri = sha384(dist_dir / "app.js")
 style_sri = sha384(dist_dir / "style.css")
@@ -170,6 +177,7 @@ injectManifest({{
     'wasm_llm/*',
     'wasm/*',
     'worker/*',
+    'data/critics/*',
   ],
 }}).catch(err => {{console.error(err); process.exit(1);}});
 """

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-export async function loadExamples(url = '../data/critics/innovations.txt') {
+export async function loadExamples(url = './data/critics/innovations.txt') {
   try {
     const res = await fetch(url);
     if (!res.ok) return [];

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
@@ -39,6 +39,10 @@ def test_offline_pwa_and_share() -> None:
         assert page.evaluate("typeof d3 !== 'undefined'")
         assert page.evaluate('document.querySelector("link[href=\'style.css\']").sheet !== null')
 
+        # critic examples should be available offline
+        text = page.evaluate("async () => await (await fetch('./data/critics/innovations.txt')).text()")
+        assert 'Wheel' in text
+
         # Stub Web3Storage to avoid network
         page.evaluate(
             f"window.PINNER_TOKEN='tok'; window.Web3Storage = class {{ async put() {{ return '{CID}'; }} }}"


### PR DESCRIPTION
## Summary
- default to `./data/critics/innovations.txt` in `loadExamples`
- package critic examples into build output
- precache critic data in service worker
- verify offline critics examples

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py` *(fails: could not fetch black)*

------
https://chatgpt.com/codex/tasks/task_e_683cf52985008333ad04b83103687cbe