### PR TITLE
[alpha_factory] bundle browser assets from ipfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,21 @@ Follow these steps when working without internet access.
    export LLAMA_MODEL_PATH=~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf
    ```
 
-4. **Enable offline inference** by setting ``AGI_INSIGHT_OFFLINE=1`` in
+4. **Fetch browser assets** with ``scripts/fetch_assets.py`` (verifies
+   checksums and replaces the placeholder Web3.Storage bundle):
+   ```bash
+   python scripts/fetch_assets.py
+   ```
+
+5. **Enable offline inference** by setting ``AGI_INSIGHT_OFFLINE=1`` in
    ``.env`` or the environment.
 
-5. **Disable broadcasting** to avoid network calls:
+6. **Disable broadcasting** to avoid network calls:
    ```bash
    export AGI_INSIGHT_BROADCAST=0
    ```
 
-6. **Seed the lineage database** from existing DGM logs using ``--import-dgm``.
+7. **Seed the lineage database** from existing DGM logs using ``--import-dgm``.
    ```bash
    python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli \
      simulate --import-dgm path/to/dgm/logs

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
@@ -70,6 +70,25 @@ def test_llm_offline() -> None:
         browser.close()
 
 
+@pytest.mark.skipif(
+    not (Path(__file__).resolve().parents[1] / "wasm_llm" / "wasm-gpt2.tar").exists(),
+    reason="wasm model missing",
+)
+def test_llm_offline_pipeline() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+
+        out = page.evaluate("window.llmChat('hello')")
+        assert not out.startswith('[offline]')
+        browser.close()
+
+
 def test_llm_openai_path() -> None:
     dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
     url = dist.as_uri()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
@@ -43,10 +43,17 @@ def test_offline_pwa_and_share() -> None:
         text = page.evaluate("async () => await (await fetch('./data/critics/innovations.txt')).text()")
         assert 'Wheel' in text
 
-        # Stub Web3Storage to avoid network
-        page.evaluate(
-            f"window.PINNER_TOKEN='tok'; window.Web3Storage = class {{ async put() {{ return '{CID}'; }} }}"
+        # Provide PINNER_TOKEN and intercept Web3Storage API
+        page.evaluate("window.PINNER_TOKEN='tok'")
+        context.route(
+            "https://api.web3.storage/**",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='{\"cid\":\"%s\"}' % CID,
+            ),
         )
+        assert page.evaluate("typeof Web3Storage === 'function'")
 
         page.click("text=Share")
         page.wait_for_selector("#toast.show")

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -162,3 +162,9 @@ $PYTHON check_env.py --auto-install "${check_env_opts[@]}"
 # Verify all dependencies are satisfied and abort on issues
 $PYTHON -m pip check
 
+# Fetch browser demo assets
+if [[ "${FETCH_BROWSER_ASSETS:-1}" != "0" ]]; then
+  echo "Fetching Insight browser assets..."
+  $PYTHON scripts/fetch_assets.py
+fi
+


### PR DESCRIPTION
## Summary
- fetch `bundle.esm.min.js` from IPFS with checksum verification
- copy assets during setup
- document new fetch step in offline guide
- adjust browser demo tests for Web3Storage pinning
- add optional offline pipeline test

## Testing
- `python check_env.py --auto-install`
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py` *(fails: BrowserType.launch: Executable doesn't exist)*
- `pre-commit run --files scripts/fetch_assets.py codex/setup.sh README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py` *(fails to install hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683cf92c95f083339ec45ec2450b0762