### PR TITLE
[alpha_factory] Add taxonomy persistence

### DIFF
--- a/src/interface/web_client/cypress/e2e/taxonomy.cy.ts
+++ b/src/interface/web_client/cypress/e2e/taxonomy.cy.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+describe('taxonomy persistence', () => {
+  it('restores taxonomy tree after reload', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        const req = win.indexedDB.open('sectorTaxonomy', 1);
+        req.onupgradeneeded = () => {
+          req.result.createObjectStore('nodes');
+        };
+        req.onsuccess = () => {
+          const tx = req.result.transaction('nodes', 'readwrite');
+          tx.objectStore('nodes').put({ id: 'foo', parent: null }, 'foo');
+          tx.oncomplete = () => {};
+        };
+      },
+    });
+    cy.get('#taxonomy-tree button').contains('foo');
+    cy.reload();
+    cy.get('#taxonomy-tree button').contains('foo');
+  });
+});

--- a/src/taxonomy.ts
+++ b/src/taxonomy.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+export interface TaxonomyNode {
+  id: string;
+  parent: string | null;
+}
+
+export interface HyperGraph {
+  nodes: Record<string, TaxonomyNode>;
+}
+
+/**
+ * Mine a taxonomy from a list of insight runs. Each run may define
+ * `params.sector` which becomes a node in the taxonomy.
+ */
+export function mineTaxonomy(runs: Array<{ params?: { sector?: string } }>): HyperGraph {
+  const graph: HyperGraph = { nodes: {} };
+  for (const r of runs) {
+    const sec = r.params?.sector;
+    if (sec && !graph.nodes[sec]) {
+      graph.nodes[sec] = { id: sec, parent: null };
+    }
+  }
+  return graph;
+}
+
+/**
+ * Remove nodes not present in `valid`.
+ */
+export function pruneTaxonomy(graph: HyperGraph, valid: Set<string>): HyperGraph {
+  const out: HyperGraph = { nodes: {} };
+  for (const id of valid) {
+    const n = graph.nodes[id];
+    if (n) out.nodes[id] = n;
+  }
+  return out;
+}
+
+const DB_NAME = 'sectorTaxonomy';
+const NODE_STORE = 'nodes';
+const META_STORE = 'meta';
+const VERSION_KEY = 'version';
+const CURRENT_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(NODE_STORE)) db.createObjectStore(NODE_STORE);
+      if (!db.objectStoreNames.contains(META_STORE)) db.createObjectStore(META_STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function withStore<T>(mode: IDBTransactionMode, store: string, fn: (s: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+  return openDB().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const tx = db.transaction(store, mode);
+        const st = tx.objectStore(store);
+        const req = fn(st);
+        tx.oncomplete = () => resolve(req.result as T);
+        tx.onerror = () => reject(tx.error);
+      }),
+  );
+}
+
+export async function saveTaxonomy(graph: HyperGraph): Promise<void> {
+  await withStore('readwrite', NODE_STORE, (s) => {
+    s.clear();
+    for (const n of Object.values(graph.nodes)) s.put(n, n.id);
+    return s.put(0, '__dummy__');
+  });
+  await withStore('readwrite', META_STORE, (s) => s.put(CURRENT_VERSION, VERSION_KEY));
+}
+
+export async function loadTaxonomy(): Promise<HyperGraph> {
+  const version = await withStore<number>('readonly', META_STORE, (s) => s.get(VERSION_KEY));
+  if (version !== CURRENT_VERSION) {
+    await withStore('readwrite', NODE_STORE, (s) => {
+      s.clear();
+      return s.put(0, '__dummy__');
+    });
+    await withStore('readwrite', META_STORE, (s) => s.put(CURRENT_VERSION, VERSION_KEY));
+    return { nodes: {} };
+  }
+  const nodes = (await withStore< TaxonomyNode[] >('readonly', NODE_STORE, (s) => s.getAll())) || [];
+  const out: HyperGraph = { nodes: {} };
+  for (const n of nodes) {
+    if (n && n.id) out.nodes[n.id] = { id: n.id, parent: n.parent ?? null };
+  }
+  return out;
+}

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the taxonomy TypeScript module."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+TAXONOMY_TS = Path('src/taxonomy.ts')
+
+@pytest.mark.skipif(not shutil.which('tsc') or not shutil.which('node'), reason='tsc/node not available')
+def test_taxonomy_mine_and_prune(tmp_path: Path) -> None:
+    js_out = tmp_path / 'taxonomy.js'
+    subprocess.run([
+        'tsc', '--target', 'es2020', '--module', 'es2020', TAXONOMY_TS, '--outFile', js_out
+    ], check=True)
+
+    script = tmp_path / 'run.mjs'
+    script.write_text(
+        f"import {{ mineTaxonomy, pruneTaxonomy }} from '{js_out.resolve().as_posix()}';\n"
+        "const runs = [\n"
+        "  {params:{sector:'A'}},\n"
+        "  {params:{sector:'B'}},\n"
+        "  {params:{sector:'A'}}\n"
+        "];\n"
+        "let g = mineTaxonomy(runs);\n"
+        "g = pruneTaxonomy(g, new Set(['A']));\n"
+        "console.log(JSON.stringify(g));\n"
+    )
+    result = subprocess.run(['node', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout)
+    assert set(data['nodes'].keys()) == {'A'}


### PR DESCRIPTION
## Summary
- implement `src/taxonomy.ts` for sector taxonomy hypergraph
- extend legacy EvolutionPanel to render taxonomy tree and filter runs
- add unit test compiling TypeScript with `tsc`
- add Cypress test verifying IndexedDB persistence

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files src/taxonomy.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js tests/test_taxonomy.py src/interface/web_client/cypress/e2e/taxonomy.cy.ts` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_683cfb7913c483339e1bfdddd50ce97d