### PR TITLE
[alpha_factory] Add critic consilience scoring

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_mutated_critic.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_mutated_critic.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_critic_prompt_mutates() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        page.evaluate("window.recordedPrompts = []")
+        page.evaluate(
+            "scoreGenome('foo', [new LogicCritic([], 'a'), new FeasibilityCritic([], 'b')], new JudgmentDB('jest'), 0.9)"
+        )
+        page.wait_for_function("window.recordedPrompts.length > 0")
+        assert page.evaluate("window.recordedPrompts.length") > 0
+        browser.close()

--- a/tests/test_consilience.py
+++ b/tests/test_consilience.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the consilience calculation."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+CRITICS = Path(
+    "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.js"
+)
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+def test_consilience_values(tmp_path: Path) -> None:
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"import {{ consilience }} from '{CRITICS.resolve().as_posix()}';\n"
+        "const r1 = consilience({a:0.5,b:0.5,c:0.5});\n"
+        "const r2 = consilience({a:0,b:1});\n"
+        "console.log(JSON.stringify({r1,r2}));\n"
+    )
+    result = subprocess.run(["node", script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout)
+    assert data["r1"] > 0.99
+    assert data["r2"] < data["r1"]


### PR DESCRIPTION
## Summary
- store critic judgments locally
- compute consilience across critics and mutate prompts when agreement falls
- export helper functions to window
- unit test for consilience
- e2e test for critic prompt mutation

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js tests/test_consilience.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_mutated_critic.py` *(fails: Failed to connect to proxy port 8080)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683d02330a5c833382c4158d5d961fdf