### PR TITLE
[alpha_factory] Add replay support

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -203,7 +203,7 @@ window.addEventListener('DOMContentLoaded',async()=>{
   archive = new Archive();
   await archive.open();
   evolutionPanel = initEvolutionPanel(archive);
-  initSimulatorPanel(archive, powerPanel);
+  await initSimulatorPanel(archive, powerPanel);
   powerPanel = initPowerPanel();
   analyticsPanel = initAnalyticsPanel();
   await evolutionPanel.render();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Simulator } from '../simulator.ts';
 import { save, load } from '../state/serializer.js';
+import { ReplayDB } from '../../../../../src/replay.ts';
 import { mutateEvaluator } from '../evaluator_genome.ts';
 import { pinFiles } from '../ipfs/pinner.js';
 import { renderFrontier } from '../render/frontier.js';
 import { detectColdZone } from '../utils/cluster.js';
 
-export function initSimulatorPanel(archive, power) {
+export async function initSimulatorPanel(archive, power) {
   const panel = document.createElement('div');
   panel.id = 'simulator-panel';
   Object.assign(panel.style, {
@@ -27,10 +28,13 @@ export function initSimulatorPanel(archive, power) {
     <label>Rate <input id="sim-rate" type="number" step="0.01" value="1"></label>
     <label>Heuristic <select id="sim-heur"><option value="none">none</option><option value="llm">llm</option></select></label>
     <button id="sim-start">Start</button>
+    <button id="sim-pause">Pause</button>
+    <button id="sim-fork">Fork</button>
     <button id="sim-cancel">Cancel</button>
     <progress id="sim-progress" value="0" max="1" style="width:100%"></progress>
     <input id="sim-frame" type="range" min="0" value="0" step="1" style="width:100%">
     <div id="sim-status"></div>
+    <pre id="sim-inspect" style="max-height:100px;overflow:auto"></pre>
   `;
   document.body.appendChild(panel);
 
@@ -40,13 +44,20 @@ export function initSimulatorPanel(archive, power) {
   const rateInput = panel.querySelector('#sim-rate');
   const heurSel = panel.querySelector('#sim-heur');
   const startBtn = panel.querySelector('#sim-start');
+  const pauseBtn = panel.querySelector('#sim-pause');
+  const forkBtn = panel.querySelector('#sim-fork');
   const cancelBtn = panel.querySelector('#sim-cancel');
   const progress = panel.querySelector('#sim-progress');
   const frameInput = panel.querySelector('#sim-frame');
   const status = panel.querySelector('#sim-status');
+  const inspectPre = panel.querySelector('#sim-inspect');
 
   let sim = null;
   let frames = [];
+  let frameIds = [];
+  let paused = false;
+  const replay = new ReplayDB('sim-replay');
+  await replay.open();
   let evaluator = { weights: { logic: 0.5, feasible: 0.5 }, prompt: 'score idea' };
 
   function showFrame(i) {
@@ -57,6 +68,7 @@ export function initSimulatorPanel(archive, power) {
     window.pop = pop;
     renderFrontier(view.node ? view.node() : view, pop, selectPoint);
     info.textContent = `gen ${i}`;
+    if (inspectPre) inspectPre.textContent = JSON.stringify(f, null, 2);
   }
 
   frameInput.addEventListener('input', () => {
@@ -78,10 +90,17 @@ export function initSimulatorPanel(archive, power) {
     let lastPop = [];
     let count = 0;
     frames = [];
+    frameIds = [];
+    paused = false;
     let evalId = await archive.addEvaluator(evaluator);
     for await (const g of sim) {
+      while (paused) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
       lastPop = g.population;
       frames.push(structuredClone(g.population));
+      const fid = await replay.addFrame(frameIds[frameIds.length - 1] || null, { population: g.population, gen: g.gen });
+      frameIds.push(fid);
       count = g.gen;
       window.pop = g.population;
       if (g.population[0] && g.population[0].umap) {
@@ -100,14 +119,27 @@ export function initSimulatorPanel(archive, power) {
     frameInput.max = Math.max(0, frames.length - 1);
     frameInput.value = String(frames.length - 1);
     showFrame(frames.length - 1);
-    const json = save(lastPop, 0);
-    const file = new File([json], 'replay.json', { type: 'application/json' });
+    const share = await replay.share(frameIds[frameIds.length - 1]);
+    const file = new File([share.data], 'replay.json', { type: 'application/json' });
     const out = await pinFiles([file]);
-    if (out) status.textContent = `CID: ${out.cid}`;
+    if (out) status.textContent = `CID: ${share.cid}`;
   });
 
   cancelBtn.addEventListener('click', () => {
     if (sim && typeof sim.return === 'function') sim.return();
+  });
+
+  pauseBtn.addEventListener('click', () => {
+    paused = !paused;
+    pauseBtn.textContent = paused ? 'Resume' : 'Pause';
+  });
+
+  forkBtn.addEventListener('click', async () => {
+    const idx = Number(frameInput.value);
+    const fid = frameIds[idx];
+    if (!fid) return;
+    const share = await replay.share(fid);
+    window.open(`#cid=${share.cid}`, '_blank');
   });
 
   const q = new URLSearchParams(window.location.hash.replace(/^#\/?/, ''));
@@ -116,15 +148,18 @@ export function initSimulatorPanel(archive, power) {
     const gateway = (window.IPFS_GATEWAY || 'https://ipfs.io/ipfs').replace(/\/$/, '');
     fetch(`${gateway}/${cid}`)
       .then((r) => r.text())
-      .then((txt) => {
+      .then(async (txt) => {
         status.textContent = 'replaying...';
         frames = [];
+        frameIds = [];
         try {
-          const s = load(txt);
-          frames.push(structuredClone(s.pop));
-          frameInput.max = '0';
+          const last = await replay.importFrames(txt);
+          const thread = await replay.exportThread(last);
+          frames = thread.map((f) => f.delta.population);
+          frameIds = thread.map((f) => f.id);
+          frameInput.max = String(Math.max(0, frames.length - 1));
           frameInput.value = '0';
-          loadState(txt);
+          showFrame(0);
         } catch {
           /* ignore */
         }

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+export interface ReplayDelta {
+  [key: string]: any;
+}
+
+export interface ReplayFrame {
+  id: number;
+  parent: number | null;
+  delta: ReplayDelta;
+  timestamp: number;
+}
+
+const DB_NAME = 'replay';
+const FRAME_STORE = 'frames';
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(FRAME_STORE)) db.createObjectStore(FRAME_STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function withStore<T>(mode: IDBTransactionMode, fn: (s: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+  return openDB().then(
+    db => new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(FRAME_STORE, mode);
+      const st = tx.objectStore(FRAME_STORE);
+      const req = fn(st);
+      tx.oncomplete = () => resolve(req.result as T);
+      tx.onerror = () => reject(tx.error);
+    })
+  );
+}
+
+export class ReplayDB {
+  constructor(private name = DB_NAME) {}
+
+  async open(): Promise<void> {
+    await openDB();
+  }
+
+  async addFrame(parent: number | null, delta: ReplayDelta): Promise<number> {
+    const id = Date.now() + Math.floor(Math.random() * 1000);
+    const frame: ReplayFrame = { id, parent, delta, timestamp: Date.now() };
+    await withStore('readwrite', (s) => s.put(frame, id));
+    return id;
+  }
+
+  async getFrame(id: number): Promise<ReplayFrame | undefined> {
+    return withStore('readonly', (s) => s.get(id));
+  }
+
+  async exportThread(id: number): Promise<ReplayFrame[]> {
+    const out: ReplayFrame[] = [];
+    let cur: number | null = id;
+    while (cur) {
+      const f = await this.getFrame(cur);
+      if (!f) break;
+      out.unshift(f);
+      cur = f.parent;
+    }
+    return out;
+  }
+
+  static async cidForFrames(frames: ReplayFrame[]): Promise<string> {
+    const deltas = frames.map((f) => f.delta);
+    const buf = new TextEncoder().encode(JSON.stringify(deltas));
+    const hash = await crypto.subtle.digest('SHA-256', buf);
+    return Array.from(new Uint8Array(hash))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
+  async computeCid(id: number): Promise<string> {
+    const frames = await this.exportThread(id);
+    return ReplayDB.cidForFrames(frames);
+  }
+
+  async share(id: number): Promise<{ cid: string; data: string }> {
+    const frames = await this.exportThread(id);
+    const cid = await ReplayDB.cidForFrames(frames);
+    const data = JSON.stringify(frames.map((f) => ({ parent: f.parent, delta: f.delta })));
+    return { cid, data };
+  }
+
+  async importFrames(json: string): Promise<number> {
+    const records: Array<{ parent: number | null; delta: ReplayDelta }> = JSON.parse(json);
+    let parent: number | null = null;
+    let last = 0;
+    for (const r of records) {
+      last = await this.addFrame(parent, r.delta);
+      parent = last;
+    }
+    return last;
+  }
+}
+

--- a/tests/test_replay_ts.py
+++ b/tests/test_replay_ts.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the replay TypeScript module."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPLAY_TS = Path("src/replay.ts")
+
+@pytest.mark.skipif(not shutil.which("tsc") or not shutil.which("node"), reason="tsc/node not available")
+def test_branching_and_cid(tmp_path: Path) -> None:
+    js_out = tmp_path / "replay.js"
+    subprocess.run([
+        "tsc",
+        "--target",
+        "es2020",
+        "--module",
+        "es2020",
+        REPLAY_TS,
+        "--outFile",
+        js_out,
+    ], check=True)
+
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"import {{ ReplayDB }} from '{js_out.resolve().as_posix()}';\n"
+        "const db = new ReplayDB('jest');\n"
+        "await db.open();\n"
+        "const root = await db.addFrame(null,{msg:'root'});\n"
+        "const a = await db.addFrame(root,{msg:'a'});\n"
+        "const b = await db.addFrame(root,{msg:'b'});\n"
+        "const cid1 = await db.computeCid(b);\n"
+        "const thread = await db.exportThread(b);\n"
+        "const cid2 = await ReplayDB.cidForFrames(thread);\n"
+        "console.log(thread.length,cid1===cid2);\n",
+        encoding="utf-8",
+    )
+    res = subprocess.run(["node", script], capture_output=True, text=True, check=True)
+    parts = res.stdout.strip().split()
+    assert int(parts[0]) == 2
+    assert parts[1] == "true"


### PR DESCRIPTION
## Summary
- serialize full conversations in `src/replay.ts`
- extend `SimulatorPanel` with pause, inspect and fork
- hook replay controls in `app.js`
- add regression test for replay TypeScript module

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683d0472c21c8333b54d728f01b3e553