### PR TITLE
[alpha_factory] add debate arena worker

### DIFF
--- a/src/arenaWorker.js
+++ b/src/arenaWorker.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Simple debate arena executed in a Web Worker. The worker receives a
+ * hypothesis string and runs a fixed exchange between four roles:
+ * Proposer, Skeptic, Regulator and Investor. The outcome score is
+ * returned to the caller along with the threaded messages.
+ */
+self.onmessage = (ev) => {
+  const { hypothesis } = ev.data || {};
+  if (!hypothesis) return;
+
+  const messages = [
+    { role: 'Proposer', text: `I propose that ${hypothesis}.` },
+    { role: 'Skeptic', text: `I doubt that ${hypothesis} holds under scrutiny.` },
+    { role: 'Regulator', text: `Any implementation of ${hypothesis} must be safe.` },
+  ];
+
+  const approved = Math.random() > 0.5;
+  messages.push({
+    role: 'Investor',
+    text: approved
+      ? `Funding approved for: ${hypothesis}.`
+      : `Funding denied for: ${hypothesis}.`,
+  });
+
+  const score = approved ? 1 : 0;
+  self.postMessage({ messages, score });
+};

--- a/src/interface/web_client/cypress/e2e/debate.cy.ts
+++ b/src/interface/web_client/cypress/e2e/debate.cy.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+describe('debate arena', () => {
+  it('runs debate and updates ranking', () => {
+    cy.visit('/');
+    cy.get('#start-debate').click();
+    cy.get('#debate-panel li').should('have.length.at.least', 4);
+    cy.get('#ranking li').should('have.length.at.least', 1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `arenaWorker.js` for running short debates
- expose debate results in Dashboard via a collapsible panel
- update ranking when debate completes
- add Cypress test to verify debate workflow

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/arenaWorker.js src/interface/web_client/src/pages/Dashboard.tsx src/interface/web_client/cypress/e2e/debate.cy.ts` *(failed: unable to fetch hook dependencies)*
- `pytest -q` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*
- `npx cypress run` *(failed: could not reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_683d0718f3788333bb1c4513cb614d45