### PR TITLE
[alpha_factory] Add debate arena worker

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -64,6 +64,7 @@ async function bundle() {
   await fs.copyFile('lib/pyodide.js', `${OUT_DIR}/pyodide.js`);
   await fs.mkdir(`${OUT_DIR}/worker`, { recursive: true });
   await fs.copyFile('worker/evolver.js', `${OUT_DIR}/worker/evolver.js`);
+  await fs.copyFile('worker/arenaWorker.js', `${OUT_DIR}/worker/arenaWorker.js`);
   await fs.mkdir(`${OUT_DIR}/src/utils`, { recursive: true });
   await fs.copyFile('src/utils/rng.js', `${OUT_DIR}/src/utils/rng.js`);
   await fs.copyFile('sw.js', `${OUT_DIR}/sw.js`).catch(() => {});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/worker/arenaWorker.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/worker/arenaWorker.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Simple debate arena executed in a Web Worker. The worker receives a
+ * hypothesis string and runs a fixed exchange between four roles:
+ * Proposer, Skeptic, Regulator and Investor. The outcome score is
+ * returned to the caller along with the threaded messages.
+ */
+self.onmessage = (ev) => {
+  const { hypothesis } = ev.data || {};
+  if (!hypothesis) return;
+
+  const messages = [
+    { role: 'Proposer', text: `I propose that ${hypothesis}.` },
+    { role: 'Skeptic', text: `I doubt that ${hypothesis} holds under scrutiny.` },
+    { role: 'Regulator', text: `Any implementation of ${hypothesis} must be safe.` },
+  ];
+
+  const approved = Math.random() > 0.5;
+  messages.push({
+    role: 'Investor',
+    text: approved
+      ? `Funding approved for: ${hypothesis}.`
+      : `Funding denied for: ${hypothesis}.`,
+  });
+
+  const score = approved ? 1 : 0;
+  self.postMessage({ messages, score });
+};

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -104,6 +104,7 @@ for src, dest in [
     ("lib/bundle.esm.min.js", "bundle.esm.min.js"),
     ("lib/pyodide.js", "pyodide.js"),
     ("worker/evolver.js", "worker/evolver.js"),
+    ("worker/arenaWorker.js", "worker/arenaWorker.js"),
     ("src/utils/rng.js", "src/utils/rng.js"),
     ("sw.js", "sw.js"),
     ("manifest.json", "manifest.json"),

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+export function initArenaPanel(onDebate) {
+  const root = document.createElement('details');
+  root.id = 'arena-panel';
+  Object.assign(root.style, {
+    position: 'fixed',
+    bottom: '10px',
+    right: '220px',
+    background: 'rgba(0,0,0,0.7)',
+    color: '#fff',
+    padding: '8px',
+    fontSize: '12px',
+    zIndex: 1000,
+    maxHeight: '40vh',
+    overflowY: 'auto',
+  });
+  const summary = document.createElement('summary');
+  summary.textContent = 'Debate Arena';
+  const ranking = document.createElement('ul');
+  ranking.id = 'ranking';
+  const panel = document.createElement('div');
+  panel.id = 'debate-panel';
+  const msgs = document.createElement('ul');
+  panel.appendChild(msgs);
+  root.appendChild(summary);
+  root.appendChild(ranking);
+  root.appendChild(panel);
+  document.body.appendChild(root);
+
+  let currentFront = [];
+
+  function render(front) {
+    currentFront = front;
+    ranking.innerHTML = '';
+    const sorted = [...front].sort((a, b) => (b.rank ?? 0) - (a.rank ?? 0));
+    sorted.forEach((p) => {
+      const li = document.createElement('li');
+      li.textContent = `Rank ${(p.rank ?? 0).toFixed(1)} `;
+      const btn = document.createElement('button');
+      btn.textContent = 'Debate';
+      btn.addEventListener('click', () => onDebate?.(p));
+      li.appendChild(btn);
+      ranking.appendChild(li);
+    });
+  }
+
+  function show(messages, score) {
+    msgs.innerHTML = messages
+      .map((m) => `<li><strong>${m.role}:</strong> ${m.text}</li>`)
+      .join('');
+    const li = document.createElement('li');
+    li.textContent = `Score: ${score}`;
+    msgs.appendChild(li);
+    root.open = true;
+  }
+
+  return { render, show };
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_debate_arena.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_debate_arena.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_debate_arena() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#arena-panel")
+        page.wait_for_selector("#arena-panel button")
+        page.click("#arena-panel button")
+        page.wait_for_selector("#debate-panel li")
+        page.wait_for_selector("#ranking li")
+        browser.close()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/arenaWorker.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/arenaWorker.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Simple debate arena executed in a Web Worker. The worker receives a
+ * hypothesis string and runs a fixed exchange between four roles:
+ * Proposer, Skeptic, Regulator and Investor. The outcome score is
+ * returned to the caller along with the threaded messages.
+ */
+self.onmessage = (ev) => {
+  const { hypothesis } = ev.data || {};
+  if (!hypothesis) return;
+
+  const messages = [
+    { role: 'Proposer', text: `I propose that ${hypothesis}.` },
+    { role: 'Skeptic', text: `I doubt that ${hypothesis} holds under scrutiny.` },
+    { role: 'Regulator', text: `Any implementation of ${hypothesis} must be safe.` },
+  ];
+
+  const approved = Math.random() > 0.5;
+  messages.push({
+    role: 'Investor',
+    text: approved
+      ? `Funding approved for: ${hypothesis}.`
+      : `Funding denied for: ${hypothesis}.`,
+  });
+
+  const score = approved ? 1 : 0;
+  self.postMessage({ messages, score });
+};


### PR DESCRIPTION
## Summary
- support a debate arena worker for insight browser
- render debate panel with score
- allow debating Pareto points via app.js
- copy new worker during build
- test debate arena with Playwright

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683d0f47bd4c833390c44c1d83374f10