### PR TITLE
[alpha_factory] track memes during evolution

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { loadTaxonomy } from '../../../../../src/taxonomy.ts';
+import { loadMemes } from '../../../../../src/memeplex.ts';
 
 export function initEvolutionPanel(archive) {
   const panel = document.createElement('div');
@@ -26,9 +27,12 @@ export function initEvolutionPanel(archive) {
   header.innerHTML =
     '<th data-k="seed">Seed</th><th data-k="score">Score</th><th data-k="novelty">Novelty</th><th data-k="timestamp">Time</th><th></th>';
   table.appendChild(header);
+  const memeDiv = document.createElement('div');
+  memeDiv.id = 'meme-cloud';
   panel.appendChild(tree);
   panel.appendChild(svg);
   panel.appendChild(table);
+  panel.appendChild(memeDiv);
   document.body.appendChild(panel);
 
   let sortKey = 'timestamp';
@@ -132,6 +136,11 @@ export function initEvolutionPanel(archive) {
       table.appendChild(tr);
     });
     drawTree(runs);
+    const memes = await loadMemes();
+    memeDiv.innerHTML = memes
+      .sort((a, b) => b.count - a.count)
+      .map((m) => `<span style="font-size:${10 + m.count * 2}px;margin-right:4px;">${m.edges[0].from}->${m.edges[0].to} (${m.count})</span>`)
+      .join(' ');
   }
 
   renderTaxonomy();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
@@ -1,0 +1,18 @@
+const { Simulator } = require('../src/simulator.ts');
+const { mineMemes, saveMemes, loadMemes } = require('../../../../src/memeplex.ts');
+
+beforeEach(() => {
+  indexedDB.deleteDatabase('memeplex');
+});
+
+test('meme counts increase during run', async () => {
+  const runs = [];
+  const sim = Simulator.run({ popSize: 3, generations: 3 });
+  for await (const g of sim) {
+    const edges = g.population.map(p => ({ from: p.strategy || 'x', to: p.strategy || 'x' }));
+    runs.push({ edges });
+    await saveMemes(mineMemes(runs, 1));
+  }
+  const memes = await loadMemes();
+  expect(memes.some(m => m.count > 1)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- import memeplex utilities into SimulatorPanel and EvolutionPanel
- track strategy edges each generation and persist meme counts
- render meme counts in Evolution panel
- add Jest test ensuring meme counts increase

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js` *(fails: could not fetch hooks due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683d1175725c83339377a17541daf9c5