### PR TITLE
[alpha_factory] add missing spdx headers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/style/theme.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/style/theme.css
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 :root {
   --color-bg: #111;
   --color-bg-alt: #181818;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 #controls{position:fixed;top:10px;right:10px;background:rgba(0,0,0,.7);padding:8px;color:#fff;font:14px sans-serif}
 #controls label{display:block;margin-bottom:4px}
 #controls button{margin-right:4px;margin-top:4px}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/entropy.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/entropy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export interface Point { logic: number; feasible: number; }
 
 export function paretoEntropy(points: Point[], bins = 10): number {


### PR DESCRIPTION
## Summary
- add SPDX license headers to Insight Browser source files

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/entropy.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/style/theme.css alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/controls.css` *(fails: unable to access 'https://github.com/psf/black/')*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 1 error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683d174f377883338d8ec36daa54c1d6