### PR TITLE
[alpha_factory] add telemetry consent i18n

### DIFF
--- a/src/interface/web_client/i18n/en.json
+++ b/src/interface/web_client/i18n/en.json
@@ -19,5 +19,6 @@
   "aria.language": "Language selector",
   "aria.progress": "Simulation progress",
   "label.refresh": "Refresh summaries",
-  "heading.lastRuns": "Last 20 simulations"
+  "heading.lastRuns": "Last 20 simulations",
+  "telemetry_consent": "Allow anonymous telemetry?"
 }

--- a/src/interface/web_client/i18n/fr.json
+++ b/src/interface/web_client/i18n/fr.json
@@ -19,5 +19,6 @@
   "aria.language": "Sélecteur de langue",
   "aria.progress": "Progression de la simulation",
   "label.refresh": "Rafraîchir les résumés",
-  "heading.lastRuns": "20 dernières simulations"
+  "heading.lastRuns": "20 dernières simulations",
+  "telemetry_consent": "Autoriser la télémétrie anonyme ?"
 }

--- a/src/interface/web_client/src/App.tsx
+++ b/src/interface/web_client/src/App.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, FormEvent } from 'react';
 import Plotly from 'plotly.js-dist';
 import { useI18n } from './IntlContext';
+import telemetry from './Telemetry';
 
 interface SectorData {
   name: string;
@@ -41,6 +42,10 @@ export default function App() {
   const [runs, setRuns] = useState<string[]>([]);
   const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
   const TOKEN = import.meta.env.VITE_API_TOKEN ?? '';
+
+  useEffect(() => {
+    telemetry.requestConsent(t('telemetry_consent'));
+  }, [t]);
 
   useEffect(() => {
     refreshRuns();

--- a/src/interface/web_client/src/Telemetry.ts
+++ b/src/interface/web_client/src/Telemetry.ts
@@ -9,8 +9,8 @@ interface Recorder {
 class Telemetry {
   private rec: Recorder = { recordRun() {}, recordShare() {} };
 
-  requestConsent(): void {
-    this.rec = initTelemetry();
+  requestConsent(msg: string): void {
+    this.rec = initTelemetry(() => msg);
   }
 
   recordRun(generations: number): void {

--- a/src/interface/web_client/src/main.tsx
+++ b/src/interface/web_client/src/main.tsx
@@ -5,7 +5,6 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Archive from './pages/Archive';
 import { IntlProvider, useI18n } from './IntlContext';
-import telemetry from './Telemetry';
 
 function Nav() {
   const { lang, setLang, t } = useI18n();
@@ -43,7 +42,6 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   </IntlProvider>,
 );
 
-telemetry.requestConsent();
 
 window.addEventListener('beforeinstallprompt', (e) => {
   e.preventDefault();

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -14,7 +14,7 @@ export async function hashSession(id) {
     .join('');
 }
 
-export function initTelemetry() {
+export function initTelemetry(t) {
   const endpoint =
     (typeof process !== 'undefined' && process.env.OTEL_ENDPOINT) ||
     (typeof window !== 'undefined' && window.OTEL_ENDPOINT) ||
@@ -27,7 +27,8 @@ export function initTelemetry() {
   const consentKey = 'telemetryConsent';
   let consent = localStorage.getItem(consentKey);
   if (consent === null) {
-    const allow = window.confirm('Allow anonymous telemetry?');
+    const prompt = typeof t === 'function' ? t('telemetry_consent') : 'Allow anonymous telemetry?';
+    const allow = window.confirm(prompt);
     consent = allow ? 'true' : 'false';
     localStorage.setItem(consentKey, consent);
   }


### PR DESCRIPTION
## Summary
- localize telemetry consent message
- prompt user for consent with new i18n string
- trigger consent request after app start

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files src/interface/web_client/i18n/en.json src/interface/web_client/i18n/fr.json src/interface/web_client/src/App.tsx src/interface/web_client/src/Telemetry.ts src/interface/web_client/src/main.tsx src/telemetry.js` *(fails: Could not fetch https://github.com/psf/black/)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683d19ac47cc833385d4fc58b9089e96