### PR TITLE
[alpha_factory] Add browser build alias

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -14,7 +14,7 @@ import {initGestures} from './src/ui/gestures.js';
 import {initFpsMeter} from './src/ui/fpsMeter.js';
 import {initI18n,t} from './src/ui/i18n.js';
 import {chat as llmChat} from './src/utils/llm.js';
-import { initTelemetry } from '../../../../src/telemetry.js';
+import { initTelemetry } from '@insight-src/telemetry.js';
 import { lcg } from './src/utils/rng.js';
 import { paretoFront } from './src/utils/pareto.js';
 import { paretoEntropy } from './src/utils/entropy.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -4,12 +4,25 @@ import { build } from 'esbuild';
 import { promises as fs } from 'fs';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import gzipSize from 'gzip-size';
 import { Web3Storage, File } from 'web3.storage';
 import { injectManifest } from 'workbox-build';
 import dotenv from 'dotenv';
 
 dotenv.config();
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const aliasRoot = path.join(__dirname, '../../../..', 'src');
+const aliasPlugin = {
+  name: 'alias',
+  setup(build) {
+    build.onResolve({ filter: /^@insight-src\// }, args => ({
+      path: path.join(aliasRoot, args.path.slice('@insight-src/'.length)),
+    }));
+  },
+};
 
 const OUT_DIR = 'dist';
 
@@ -28,6 +41,7 @@ async function bundle() {
     minify: true,
     format: 'esm',
     outfile: `${OUT_DIR}/app.js`,
+    plugins: [aliasPlugin],
   });
   execSync(
     `npx tailwindcss -i style.css -o ${OUT_DIR}/style.css --minify`,

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-import { loadTaxonomy } from '../../../../../src/taxonomy.ts';
-import { loadMemes } from '../../../../../src/memeplex.ts';
+import { loadTaxonomy } from '@insight-src/taxonomy.ts';
+import { loadMemes } from '@insight-src/memeplex.ts';
 
 export function initEvolutionPanel(archive) {
   const panel = document.createElement('div');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Simulator } from '../simulator.ts';
 import { save, load } from '../state/serializer.js';
-import { ReplayDB } from '../../../../../src/replay.ts';
-import { mineMemes, saveMemes } from '../../../../../src/memeplex.ts';
+import { ReplayDB } from '@insight-src/replay.ts';
+import { mineMemes, saveMemes } from '@insight-src/memeplex.ts';
 import { mutateEvaluator } from '../evaluator_genome.ts';
 import { pinFiles } from '../ipfs/pinner.js';
 import { renderFrontier } from '../render/frontier.js';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
@@ -1,5 +1,5 @@
 const { Simulator } = require('../src/simulator.ts');
-const { mineMemes, saveMemes, loadMemes } = require('../../../../src/memeplex.ts');
+const { mineMemes, saveMemes, loadMemes } = require('@insight-src/memeplex.ts');
 
 beforeEach(() => {
   indexedDB.deleteDatabase('memeplex');


### PR DESCRIPTION
## Summary
- add `@insight-src` alias to esbuild and manual build
- update imports in browser UI code to use the alias

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js`
- `pytest -q`
- `npm run build` *(fails: Cannot find package 'esbuild')*
- `python manual_build.py` *(fails: Cannot find module 'workbox-build')*

------
https://chatgpt.com/codex/tasks/task_e_683d1b1ad7ac8333aa5a2636bb4a8b05