### PR TITLE
[alpha_factory] replace fixed panel sizes

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
@@ -32,10 +32,10 @@ export async function initSimulatorPanel(archive, power) {
     <button id="sim-pause">Pause</button>
     <button id="sim-fork">Fork</button>
     <button id="sim-cancel">Cancel</button>
-    <progress id="sim-progress" value="0" max="1" style="width:100%"></progress>
-    <input id="sim-frame" type="range" min="0" value="0" step="1" style="width:100%">
+    <progress id="sim-progress" value="0" max="1" class="w-full"></progress>
+    <input id="sim-frame" type="range" min="0" value="0" step="1" class="w-full">
     <div id="sim-status"></div>
-    <pre id="sim-inspect" style="max-height:100px;overflow:auto"></pre>
+    <pre id="sim-inspect" class="max-h-[40vh] overflow-auto"></pre>
   `;
   document.body.appendChild(panel);
 

--- a/src/interface/web_client/src/App.tsx
+++ b/src/interface/web_client/src/App.tsx
@@ -174,9 +174,9 @@ export default function App() {
         <button type="submit">{t('button.run')}</button>
       </form>
       <button type="button" onClick={refreshRuns}>{t('label.refresh')}</button>
-      <div id="sectors" role="img" aria-label="sectors" style={{ width: '100%', height: 300 }} />
-      <div id="capability" role="img" aria-label="capability" style={{ width: '100%', height: 300 }} />
-      <div id="pareto" role="img" aria-label="pareto" style={{ width: '100%', height: 400 }} />
+      <div id="sectors" role="img" aria-label="sectors" className="w-full h-[300px]" />
+      <div id="capability" role="img" aria-label="capability" className="w-full h-[300px]" />
+      <div id="pareto" role="img" aria-label="pareto" className="w-full h-[400px]" />
       <h2>{t('heading.lastRuns')}</h2>
       <ul>
         {runs.map((r) => (

--- a/src/interface/web_client/src/LineageTimeline.tsx
+++ b/src/interface/web_client/src/LineageTimeline.tsx
@@ -77,5 +77,5 @@ export default function LineageTimeline({ data }: Props) {
     });
   }, [data]);
 
-  return <div id="lineage-timeline" style={{ width: '100%', height: 400 }} />;
+  return <div id="lineage-timeline" className="w-full h-[400px]" />;
 }

--- a/src/interface/web_client/src/LineageTree.tsx
+++ b/src/interface/web_client/src/LineageTree.tsx
@@ -46,5 +46,5 @@ export default function LineageTree({ data }: Props) {
     );
   }, [data]);
 
-  return <div id="lineage-tree" style={{ width: '100%', height: 400 }} />;
+  return <div id="lineage-tree" className="w-full h-[400px]" />;
 }

--- a/src/interface/web_client/src/Pareto3D.tsx
+++ b/src/interface/web_client/src/Pareto3D.tsx
@@ -40,5 +40,5 @@ export default function Pareto3D({ data }: Props) {
     );
   }, [data]);
 
-  return <div id="pareto3d" style={{ width: '100%', height: 400 }} />;
+  return <div id="pareto3d" className="w-full h-[400px]" />;
 }

--- a/src/interface/web_client/src/RationaleModal.tsx
+++ b/src/interface/web_client/src/RationaleModal.tsx
@@ -10,13 +10,9 @@ interface Props {
 export default function RationaleModal({ open, onClose, docUrl }: Props) {
   if (!open) return null;
   return (
-    <div
-      className="modal-overlay"
-      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)' }}
-    >
+    <div className="modal-overlay fixed inset-0 bg-black/50 flex justify-center pt-[10%]">
       <div
-        className="modal-content"
-        style={{ background: '#fff', margin: '10% auto', padding: 20, maxWidth: 400 }}
+        className="modal-content bg-white dark:bg-neutral-900 p-5 max-w-[400px] w-80 sm:w-64 max-h-[40vh] overflow-y-auto"
       >
         <p>
           See <a href={docUrl} target="_blank" rel="noopener noreferrer">documentation</a>{' '}

--- a/src/interface/web_client/src/pages/Dashboard.tsx
+++ b/src/interface/web_client/src/pages/Dashboard.tsx
@@ -287,11 +287,11 @@ export default function Dashboard() {
         aria-label={t('aria.progress')}
         value={progress}
         max={1}
-        style={{ width: '100%' }}
+        className="w-full"
       />
-      <div id="sectors" role="img" aria-label="sectors" style={{ width: '100%', height: 300 }} />
-      <div id="capability" role="img" aria-label="capability" style={{ width: '100%', height: 300 }} />
-      <div id="pareto" role="img" aria-label="pareto" style={{ width: '100%', height: 400 }} />
+      <div id="sectors" role="img" aria-label="sectors" className="w-full h-[300px]" />
+      <div id="capability" role="img" aria-label="capability" className="w-full h-[300px]" />
+      <div id="pareto" role="img" aria-label="pareto" className="w-full h-[400px]" />
       <Pareto3D data={population} />
       <ul id="ranking">
         {population.map((p, i) => (

--- a/src/interface/web_client/tests/dashboard.spec.ts
+++ b/src/interface/web_client/tests/dashboard.spec.ts
@@ -6,3 +6,12 @@ test('renders pareto front and timeline', async ({ page }) => {
   await expect(page.locator('#pareto3d')).toBeVisible();
   await expect(page.locator('#lineage-timeline')).toBeVisible();
 });
+
+test('rationale panel fits mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/');
+  await page.click('text=Show details');
+  await page.click('text=Learn more');
+  const box = await page.locator('.modal-content').boundingBox();
+  expect(box?.width).toBeLessThanOrEqual(375);
+});


### PR DESCRIPTION
## Summary
- apply Tailwind utilities in RationaleModal
- use responsive classes in simulator panel
- convert inline sizes to Tailwind in dashboard UI
- check modal width in Playwright

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683d1d3d937c8333a2443613eba7fe0e