### PR TITLE
[alpha_factory] add SPDX headers for insight browser tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const { Archive } = require('../src/archive.ts');
 
 beforeEach(async () => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/cluster.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/cluster.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const { detectColdZone } = require('../src/utils/cluster.js');
 
 test('detect coldest cell', () => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const { mutateEvaluator } = require('../src/evaluator_genome.ts');
 const { lcg } = require('../src/utils/rng.js');
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const { Simulator } = require('../src/simulator.ts');
 const { mineMemes, saveMemes, loadMemes } = require('@insight-src/memeplex.ts');
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/mutate_scaling.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/mutate_scaling.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const { mutate } = require('../src/evolve/mutate.js');
 
 function fixed(v) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const { Simulator } = require('../src/simulator.ts');
 
 jest.setTimeout(10000);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import time
 from pathlib import Path
 import shutil

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import time
 from pathlib import Path
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pyodide_fallback.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pyodide_fallback.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from pathlib import Path
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX headers to Insight browser tests that were missing a license notice

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/cluster.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/mutate_scaling.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_plot_perf.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pyodide_fallback.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py` *(failed: couldn't access network)*
- `pytest -q` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*


------
https://chatgpt.com/codex/tasks/task_e_683d1feb3ac48333b26f1160be1ad122