### PR TITLE
[alpha_factory] bundle telemetry in build output

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -13,8 +13,9 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const aliasRoot = path.join(__dirname, '../../../..', 'src');
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), '..', '..', '..', '..');
+const aliasRoot = path.join(repoRoot, 'src');
 const aliasPlugin = {
   name: 'alias',
   setup(build) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -17,7 +17,3 @@
 <script src="bundle.esm.min.js" integrity="sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax" crossorigin="anonymous"></script>
 <script src="pyodide.js" integrity="sha384-4lQJt6JNK5sYso6mEO1s2l1EnmbkIm958N+CAuWcYFBPuizBJ5nENroO7dtV8upW" crossorigin="anonymous"></script>
 <script src="app.js" integrity="sha384-o32o6wnQtXErSidJSWvLAjgPd7w1gZIYBPHpkuqdYWsdX9zppcbPOBqVbi34Bvl0" crossorigin="anonymous"></script>
-<script type="module">
-import { initTelemetry } from '../../../../../src/telemetry.js';
-window.telemetry = initTelemetry();
-</script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -17,7 +17,10 @@ def sha384(path: Path) -> str:
 
 ROOT = Path(__file__).resolve().parent
 ALIAS_PREFIX = "@insight-src/"
-ALIAS_TARGET = ROOT.parents[3] / "src"
+repo_root = Path(__file__).resolve()
+for _ in range(4):
+    repo_root = repo_root.parent
+ALIAS_TARGET = repo_root / "src"
 index_html = ROOT / "index.html"
 dist_dir = ROOT / "dist"
 lib_dir = ROOT / "lib"


### PR DESCRIPTION
## Summary
- keep telemetry init inside `app.js`
- compute repo root using `fileURLToPath` and `path.resolve`
- update manual build to locate repo root dynamically
- remove module telemetry script from built index

## Testing
- `pre-commit run --files build.js manual_build.py dist/index.html` *(fails: could not fetch psf/black)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683d998bac80833387cf4349dc23d87e