### PR TITLE
[alpha_factory] add telemetry consent translations

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
@@ -19,5 +19,6 @@
   "link_copied": "permalink copied",
   "state_loaded": "state loaded",
   "invalid_file": "invalid file",
-  "simulation_restarted": "simulation restarted"
+  "simulation_restarted": "simulation restarted",
+  "telemetry_consent": "Allow anonymous telemetry?"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
@@ -19,5 +19,6 @@
   "link_copied": "lien copié",
   "state_loaded": "état chargé",
   "invalid_file": "fichier invalide",
-  "simulation_restarted": "simulation redémarrée"
+  "simulation_restarted": "simulation redémarrée",
+  "telemetry_consent": "Autoriser la télémétrie anonyme\u00a0?"
 }


### PR DESCRIPTION
## Summary
- translate telemetry consent prompt in insight browser
- update French translation

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json` *(fails: unable to fetch psf/black)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `node build.js` *(fails: Cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_683d9c4851e8833384877900e61f4db1