### PR TITLE
[alpha_factory] fix simulator init order

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -216,8 +216,8 @@ window.addEventListener('DOMContentLoaded',async()=>{
   archive = new Archive();
   await archive.open();
   evolutionPanel = initEvolutionPanel(archive);
-  await initSimulatorPanel(archive, powerPanel);
   powerPanel = initPowerPanel();
+  await initSimulatorPanel(archive, powerPanel);
   analyticsPanel = initAnalyticsPanel();
   arenaPanel = initArenaPanel((pt) => {
     debateTarget = pt;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/power_panel_update.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/power_panel_update.test.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+const simulator = require('../src/simulator.ts');
+const { initSimulatorPanel } = require('../src/ui/SimulatorPanel.js');
+
+jest.mock('@insight-src/replay.ts', () => ({
+  ReplayDB: class {
+    async open() {}
+    async addFrame() { return 1; }
+    async share() { return { data: '{}', cid: '1' }; }
+  }
+}));
+
+jest.mock('@insight-src/memeplex.ts', () => ({
+  mineMemes: () => [],
+  saveMemes: async () => {},
+}));
+
+jest.mock('../src/ipfs/pinner.js', () => ({
+  pinFiles: async () => null,
+}));
+
+jest.mock('../src/render/frontier.js', () => ({
+  renderFrontier: () => {},
+}));
+
+jest.mock('../src/utils/cluster.js', () => ({
+  detectColdZone: () => ({ x: 0, y: 0 }),
+}));
+
+jest.mock('../src/evaluator_genome.ts', () => ({
+  mutateEvaluator: (e) => e,
+}));
+
+
+test('simulator.start updates power panel', async () => {
+  const archive = {
+    addEvaluator: jest.fn().mockResolvedValue(1),
+    add: jest.fn().mockResolvedValue(null),
+  };
+  const updates = [];
+  const power = { update: (e) => updates.push(e) };
+
+  simulator.Simulator.run = function () {
+    return (async function* () {
+      yield { population: [], fronts: [], gen: 1 };
+    })();
+  };
+
+  document.body.innerHTML = '';
+  await initSimulatorPanel(archive, power);
+
+  const startBtn = document.querySelector('#simulator-panel #sim-start');
+  startBtn.click();
+  await new Promise((r) => setTimeout(r, 0));
+
+  expect(updates.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- initialize power panel before simulator panel so updates work
- add regression test for simulator power panel updates

## Testing
- `python check_env.py --auto-install`
- `python -m alpha_factory_v1.scripts.run_tests`
- `npx jest alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/power_panel_update.test.js` *(fails: npm can't reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_683d9e13a0f483339559c4a586f6058f