### PR TITLE
[alpha_factory] abort build if assets missing

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -37,6 +37,9 @@ python ../../../scripts/fetch_assets.py
 
 This downloads the Pyodide runtime and `wasm-gpt2` model from IPFS into
 `wasm/` and `wasm_llm/`.
+It also retrieves `lib/bundle.esm.min.js` from the mirror. The build scripts
+abort when this file still contains the placeholder comment, so run
+`scripts/fetch_assets.py` if you encounter that error.
 ```bash
 PINNER_TOKEN=<token> npm start
 ```

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -25,10 +25,25 @@ const aliasPlugin = {
   },
 };
 
+async function ensureWeb3Bundle() {
+  const bundlePath = path.join('lib', 'bundle.esm.min.js');
+  const data = await fs.readFile(bundlePath, 'utf8').catch(() => {
+    throw new Error(
+      'lib/bundle.esm.min.js missing. Run scripts/fetch_assets.py to download assets.'
+    );
+  });
+  if (data.includes('Placeholder for web3.storage bundle.esm.min.js')) {
+    throw new Error(
+      'lib/bundle.esm.min.js is a placeholder. Run scripts/fetch_assets.py to download assets.'
+    );
+  }
+}
+
 const OUT_DIR = 'dist';
 
 async function bundle() {
   const html = await fs.readFile('index.html', 'utf8');
+  await ensureWeb3Bundle();
   const ipfsOrigin = process.env.IPFS_GATEWAY
     ? new URL(process.env.IPFS_GATEWAY).origin
     : '';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -26,6 +26,18 @@ dist_dir = ROOT / "dist"
 lib_dir = ROOT / "lib"
 src_dir = ROOT / "src"
 
+bundle_path = lib_dir / "bundle.esm.min.js"
+try:
+    data = bundle_path.read_text()
+except FileNotFoundError:
+    sys.exit(
+        "lib/bundle.esm.min.js missing. Run scripts/fetch_assets.py to download assets."
+    )
+if "Placeholder for web3.storage bundle.esm.min.js" in data:
+    sys.exit(
+        "lib/bundle.esm.min.js is a placeholder. Run scripts/fetch_assets.py to download assets."
+    )
+
 html = index_html.read_text()
 entry = (ROOT / "app.js").read_text()
 


### PR DESCRIPTION
## Summary
- stop `build.js` and `manual_build.py` when `lib/bundle.esm.min.js` still holds the placeholder
- instruct how to fix in insight browser README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files insight_browser_v1/*` *(fails: can't fetch hooks due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683da0dea3fc8333839bbd53074b27af