### PR TITLE
[alpha_factory] add low consilience prompt test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/consilience.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/consilience.test.js
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+const { consilience, scoreGenome, LogicCritic, FeasibilityCritic, JudgmentDB } = require('../src/wasm/critics.js');
+
+beforeEach(() => {
+  indexedDB.deleteDatabase('jest');
+  window.recordedPrompts = [];
+});
+
+test('scoreGenome mutates prompts when consilience is low', async () => {
+  const logic = new LogicCritic([], 'logic');
+  const feas = new FeasibilityCritic([], 'feasible');
+  logic.score = () => 0;
+  feas.score = () => 1;
+
+  const db = new JudgmentDB('jest');
+  const result = await scoreGenome('foo', [logic, feas], db, 0.6);
+  const expected = consilience({ LogicCritic: 0, FeasibilityCritic: 1 });
+
+  expect(result.cons).toBeCloseTo(expected);
+  expect(result.cons).toBeLessThan(0.6);
+  expect(logic.prompt).not.toBe('logic');
+  expect(feas.prompt).not.toBe('feasible');
+  expect(window.recordedPrompts).toEqual([logic.prompt, feas.prompt]);
+});


### PR DESCRIPTION
## Summary
- add `consilience.test.js` to check critic prompt mutation when consilience is low

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError in tests/test_llm_cache.py)*

------
https://chatgpt.com/codex/tasks/task_e_683da7cf6bb08333985998767cfb5e81