### PR TITLE
[alpha_factory] add ReplayDB share/import test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+const { ReplayDB } = require('../src/replay.ts');
+
+beforeEach(() => {
+  indexedDB.deleteDatabase('jest');
+  indexedDB.deleteDatabase('jest2');
+});
+
+test('share and import frames maintain order and cid', async () => {
+  const db1 = new ReplayDB('jest');
+  await db1.open();
+  let parent = null;
+  for (let i = 0; i < 3; i++) {
+    parent = await db1.addFrame(parent, { step: i });
+  }
+  const finalId = parent;
+
+  const { cid, data } = await db1.share(finalId);
+
+  const db2 = new ReplayDB('jest2');
+  await db2.open();
+  const importedId = await db2.importFrames(data);
+
+  const thread1 = await db1.exportThread(finalId);
+  const thread2 = await db2.exportThread(importedId);
+
+  expect(thread2).toEqual(thread1);
+
+  const cid1 = await db1.computeCid(finalId);
+  const cid2 = await db2.computeCid(importedId);
+  expect(cid1).toBe(cid);
+  expect(cid2).toBe(cid);
+});


### PR DESCRIPTION
## Summary
- test round-trip share/import behaviour for ReplayDB

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js` *(fails: could not fetch hooks due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_683da91c20dc8333bd886dfdb9e25b0c