### PR TITLE
[alpha_factory] clamp sim controls

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -209,7 +209,11 @@ function loadState(text){
   }catch{toast(t('invalid_file'))}
 }
 
-function apply(p){location.hash=toHash(p)}
+function apply(p, info = {}){
+  if(info.popClamped) toast('max population is 500');
+  if(info.genClamped) toast('max generations is 500');
+  location.hash=toHash(p);
+}
 
 window.addEventListener('DOMContentLoaded',async()=>{
   telemetry = initTelemetry();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
@@ -58,11 +58,12 @@ function t(key){
 }
 
 // SPDX-License-Identifier: Apache-2.0
+const MAX_VAL=500;
 function initControls(params,onChange){
   const root=document.getElementById('controls');
   root.innerHTML=`<label>${t('seed')} <input id="seed" type="number" min="0" aria-label="${t('seed')}" tabindex="1"></label>
-<label>${t('population')} <input id="pop" type="number" min="1" aria-label="${t('population')}" tabindex="2"></label>
-<label>${t('generations')} <input id="gen" type="number" min="1" aria-label="${t('generations')}" tabindex="3"></label>
+<label>${t('population')} <input id="pop" type="number" min="1" max="${MAX_VAL}" aria-label="${t('population')}" tabindex="2"></label>
+<label>${t('generations')} <input id="gen" type="number" min="1" max="${MAX_VAL}" aria-label="${t('generations')}" tabindex="3"></label>
 <label><input id="gaussian" type="checkbox" aria-label="${t('gaussian')}" tabindex="4"> ${t('gaussian')}</label>
 <label><input id="swap" type="checkbox" aria-label="${t('swap')}" tabindex="5"> ${t('swap')}</label>
 <label><input id="jump" type="checkbox" aria-label="${t('jump')}" tabindex="6"> ${t('jump')}</label>
@@ -83,8 +84,8 @@ function initControls(params,onChange){
         scramble=root.querySelector('#scramble');
   function update(p){
     seed.value=p.seed;
-    pop.value=p.pop;
-    gen.value=p.gen;
+    pop.value=Math.min(p.pop,MAX_VAL);
+    gen.value=Math.min(p.gen,MAX_VAL);
     const set=new Set(p.mutations||[]);
     gauss.checked=set.has('gaussian');
     swap.checked=set.has('swap');
@@ -94,9 +95,14 @@ function initControls(params,onChange){
   update(params);
   function emit(){
     const muts=[gauss,swap,jump,scramble].filter(c=>c.checked).map(c=>c.id);
-    const p={seed:+seed.value,pop:+pop.value,gen:+gen.value,mutations:muts};
+    let popVal=Math.min(+pop.value,MAX_VAL);
+    let genVal=Math.min(+gen.value,MAX_VAL);
+    const info={popClamped:popVal!==+pop.value,genClamped:genVal!==+gen.value};
+    pop.value=popVal;
+    gen.value=genVal;
+    const p={seed:+seed.value,pop:popVal,gen:genVal,mutations:muts};
     try{localStorage.setItem('insightParams',JSON.stringify(p));}catch{}
-    onChange(p);
+    onChange(p,info);
   }
   seed.addEventListener('change',emit);
   pop.addEventListener('change',emit);
@@ -1436,7 +1442,7 @@ function loadState(text){
   }catch{toast(t('invalid_file'))}
 }
 
-function apply(p){location.hash=toHash(p)}
+function apply(p,info={}){if(info.popClamped)toast('max population is 500');if(info.genClamped)toast('max generations is 500');location.hash=toHash(p)}
 
 window.addEventListener('DOMContentLoaded',async()=>{
   telemetry = initTelemetry();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import {t,setLanguage,currentLanguage} from './i18n.js';
+const MAX_VAL = 500;
 export function initControls(params,onChange){
   const root=document.getElementById('controls');
   root.innerHTML=`<label>${t('seed')} <input id="seed" type="number" min="0" aria-label="${t('seed')}" tabindex="1"></label>
-<label>${t('population')} <input id="pop" type="number" min="1" aria-label="${t('population')}" tabindex="2"></label>
-<label>${t('generations')} <input id="gen" type="number" min="1" aria-label="${t('generations')}" tabindex="3"></label>
+<label>${t('population')} <input id="pop" type="number" min="1" max="${MAX_VAL}" aria-label="${t('population')}" tabindex="2"></label>
+<label>${t('generations')} <input id="gen" type="number" min="1" max="${MAX_VAL}" aria-label="${t('generations')}" tabindex="3"></label>
 <label><input id="gaussian" type="checkbox" aria-label="${t('gaussian')}" tabindex="4"> ${t('gaussian')}</label>
 <label><input id="swap" type="checkbox" aria-label="${t('swap')}" tabindex="5"> ${t('swap')}</label>
 <label><input id="jump" type="checkbox" aria-label="${t('jump')}" tabindex="6"> ${t('jump')}</label>
@@ -27,8 +28,8 @@ export function initControls(params,onChange){
         adaptive=root.querySelector('#adaptive');
   function update(p){
     seed.value=p.seed;
-    pop.value=p.pop;
-    gen.value=p.gen;
+    pop.value=Math.min(p.pop,MAX_VAL);
+    gen.value=Math.min(p.gen,MAX_VAL);
     const set=new Set(p.mutations||[]);
     gauss.checked=set.has('gaussian');
     swap.checked=set.has('swap');
@@ -39,9 +40,14 @@ export function initControls(params,onChange){
   update(params);
   function emit(){
     const muts=[gauss,swap,jump,scramble].filter(c=>c.checked).map(c=>c.id);
-    const p={seed:+seed.value,pop:+pop.value,gen:+gen.value,mutations:muts,adaptive:adaptive.checked};
+    let popVal=Math.min(+pop.value,MAX_VAL);
+    let genVal=Math.min(+gen.value,MAX_VAL);
+    const info={popClamped:popVal!==+pop.value,genClamped:genVal!==+gen.value};
+    pop.value=popVal;
+    gen.value=genVal;
+    const p={seed:+seed.value,pop:popVal,gen:genVal,mutations:muts,adaptive:adaptive.checked};
     try{localStorage.setItem('insightParams',JSON.stringify(p));}catch{}
-    onChange(p);
+    onChange(p,info);
   }
   seed.addEventListener('change',emit);
   pop.addEventListener('change',emit);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/limits.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/limits.test.js
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+const { initControls } = require('../src/ui/ControlsPanel.js');
+
+test('values above max are clamped', () => {
+  document.body.innerHTML = '<div id="controls"></div>';
+  let params = null;
+  function onChange(p) { params = p; }
+  initControls({ seed: 1, pop: 1, gen: 1, mutations: [], adaptive: false }, onChange);
+  const popInput = document.querySelector('#pop');
+  const genInput = document.querySelector('#gen');
+  popInput.value = '600';
+  popInput.dispatchEvent(new Event('change'));
+  genInput.value = '700';
+  genInput.dispatchEvent(new Event('change'));
+  expect(popInput.value).toBe('500');
+  expect(genInput.value).toBe('500');
+  expect(params.pop).toBe(500);
+  expect(params.gen).toBe(500);
+});


### PR DESCRIPTION
## Summary
- add max limits for population and generations inputs
- clamp values in ControlsPanel and surface warnings in app
- show validation toast messages when limits exceeded
- test clamping logic

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/limits.test.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dabfb02148333b37c9aaad7c90803