### PR TITLE
[alpha_factory] add TypeScript checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ PY
           node-version: '20'
       - name: Install pnpm
         run: npm install -g pnpm
+      - name: Type check insight browser
+        run: pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
       - name: Build web client
         run: |
           make build_web
@@ -187,6 +189,8 @@ PY
           cache: 'pnpm'
       - name: Install pnpm
         run: npm install -g pnpm
+      - name: Type check insight browser
+        run: pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
       - name: Build web client
         run: make build_web
       - name: Pack release assets

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -14,6 +14,12 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+try {
+  execSync('tsc --noEmit', { stdio: 'inherit' });
+} catch (err) {
+  process.exit(1);
+}
+
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), '..', '..', '..', '..');
 const aliasRoot = path.join(repoRoot, 'src');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -57,6 +57,8 @@ for rel in _asset_paths():
     if p.exists() and 'placeholder' in p.read_text(errors='ignore').lower():
         sys.exit(f"{rel} contains placeholder text. Run scripts/fetch_assets.py to download assets.")
 
+subprocess.run(["tsc", "--noEmit"], check=True)
+
 html = index_html.read_text()
 entry = (ROOT / "app.js").read_text()
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint src --ext .js",
     "build": "node build.js",
     "size": "gzip-size-cli dist/app.js --bytes",
-    "start": "npx serve dist"
+    "start": "npx serve dist",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `tsconfig.json` for the Insight Browser demo
- typecheck in `build.js` and `manual_build.py`
- add `typecheck` npm script
- run TypeScript check in CI before building

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in Collector)*
- `pre-commit run --files .github/workflows/ci.yml alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json` *(fails: could not fetch hook due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683dbe9120588333ad88b02cbfb0ccba