### PR TITLE
[alpha_factory] add pyodide wasm integrity

### DIFF
--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -26,6 +26,7 @@ ASSETS = {
 
 CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax",
+    "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
 }
 
 

--- a/tests/security/test_csp.py
+++ b/tests/security/test_csp.py
@@ -25,6 +25,9 @@ def test_csp_no_violations() -> None:
             page.on("pageerror", lambda err: violations.append(str(err)))
             page.goto(url)
             page.wait_for_selector("#controls")
+            link = page.query_selector("link[rel='preload'][href='wasm/pyodide.asm.wasm']")
+            assert link is not None
+            assert link.get_attribute("integrity")
             policy = page.get_attribute("meta[http-equiv='Content-Security-Policy']", "content")
             assert "https://api.openai.com" in policy
             assert not any("Content Security Policy" in v for v in violations)


### PR DESCRIPTION
## Summary
- compute SHA-384 for wasm/pyodide.asm.wasm during build
- embed preload tag with integrity
- abort build on checksum mismatch
- check preload link in CSP test

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py scripts/fetch_assets.py tests/security/test_csp.py` *(fails: Couldn't connect to server)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683dc0b77cf48333af8b368c2a37180d