### PR TITLE
[alpha_factory] clean manual build script

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -25,7 +25,6 @@ ALIAS_TARGET = repo_root / "src"
 index_html = ROOT / "index.html"
 dist_dir = ROOT / "dist"
 lib_dir = ROOT / "lib"
-src_dir = ROOT / "src"
 
 bundle_path = lib_dir / "bundle.esm.min.js"
 try:


### PR DESCRIPTION
## Summary
- remove unused `src_dir` variable
- ensure only one `import json` in `manual_build.py`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py` *(fails: Failed to connect to proxy)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*


------
https://chatgpt.com/codex/tasks/task_e_683dc299341c8333adf7694172952909