### PR TITLE
[alpha_factory] Document Safari fallback

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -107,3 +107,10 @@ basic usage metrics are sent to the OTLP endpoint. Clearing browser storage
 resets the identifier.
 
 See **Environment Setup** above for the list of supported variables.
+
+## Safari/iOS Support
+Pyodide is disabled on Safari and iOS devices because the runtime fails to load
+reliably. The demo automatically falls back to the JavaScript engine instead of
+executing Python code in the browser. Expect noticeably slower performance for
+LLM tasks and the absence of features that rely on the Python bridge, such as
+the local GPT‑2 critic.


### PR DESCRIPTION
## Summary
- document Safari/iOS fallback to JS engine in insight demo

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files insight_browser_v1/README.md` *(fails: could not fetch psf/black due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_683dc45211e08333b007772eb51b4291