### PR TITLE
[alpha_factory] Add entropy test for browser

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -8,7 +8,8 @@
     "build": "node build.js",
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test tests/entropy.test.js"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/entropy.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/entropy.test.js
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { paretoEntropy } from '../src/utils/entropy.ts';
+
+const uniform = [];
+for (let y = 0; y < 10; y++) {
+  for (let x = 0; x < 10; x++) {
+    uniform.push({ logic: (x + 0.5) / 10, feasible: (y + 0.5) / 10 });
+  }
+}
+
+const clustered = Array.from({ length: 100 }, () => ({ logic: 0.5, feasible: 0.5 }));
+
+// Entropy of a uniform 10x10 grid should be close to log2(100)
+const UNIFORM_EXPECTED = Math.log2(100);
+
+test('uniform distribution entropy', () => {
+  const h = paretoEntropy(uniform, 10);
+  assert.ok(Math.abs(h - UNIFORM_EXPECTED) < 0.01);
+});
+
+test('clustered distribution entropy', () => {
+  const h = paretoEntropy(clustered, 10);
+  assert.equal(h, 0);
+});
+
+test('uniform entropy greater than clustered entropy', () => {
+  const hUniform = paretoEntropy(uniform, 10);
+  const hCluster = paretoEntropy(clustered, 10);
+  assert.ok(hUniform > hCluster);
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_entropy_js.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_entropy_js.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run the browser entropy test via npm."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BROWSER_DIR = Path(__file__).resolve().parents[1]
+
+@pytest.mark.skipif(shutil.which("npm") is None, reason="npm not installed")
+def test_entropy_js() -> None:
+    subprocess.check_call(["npm", "test"], cwd=BROWSER_DIR)


### PR DESCRIPTION
## Summary
- add uniform vs clustered entropy tests for the browser
- expose npm test runner for the new test
- integrate npm test with pytest

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector...)*

------
https://chatgpt.com/codex/tasks/task_e_683dc551958c8333a51b1bbe8b3bf7e8