### PR TITLE
[alpha_factory] enforce node >=20 in build scripts

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -1,17 +1,25 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
-import { build } from 'esbuild';
 import { promises as fs } from 'fs';
 import fsSync from 'fs';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import gzipSize from 'gzip-size';
-import { Web3Storage, File } from 'web3.storage';
-import { injectManifest } from 'workbox-build';
-import dotenv from 'dotenv';
 
+const [major] = process.versions.node.split('.').map(Number);
+if (major < 20) {
+  console.error(
+    `Node.js 20+ is required. Current version: ${process.versions.node}`
+  );
+  process.exit(1);
+}
+
+const { build } = await import('esbuild');
+const gzipSize = (await import('gzip-size')).default;
+const { Web3Storage, File } = await import('web3.storage');
+const { injectManifest } = await import('workbox-build');
+const dotenv = (await import('dotenv')).default;
 dotenv.config();
 
 try {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -11,6 +11,22 @@ from urllib.parse import urlparse
 import ast
 
 
+def _require_node_20() -> None:
+    try:
+        out = subprocess.check_output(
+            ["node", "-e", "console.log(process.versions.node)"],
+            text=True,
+        ).strip()
+    except FileNotFoundError:
+        sys.exit("Node.js 20+ is required. 'node' not found.")
+    major = int(out.split(".")[0])
+    if major < 20:
+        sys.exit(f"Node.js 20+ is required. Current version: {out}")
+
+
+_require_node_20()
+
+
 def sha384(path: Path) -> str:
     digest = hashlib.sha384(path.read_bytes()).digest()
     return "sha384-" + base64.b64encode(digest).decode()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
@@ -1,0 +1,20 @@
+import subprocess
+from pathlib import Path
+
+
+def test_requires_node_20() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    script = browser_dir / "build.js"
+    node_code = (
+        "Object.defineProperty(process.versions,'node',{value:'19.0.0'});"
+        f" import('./{script.name}')"
+    )
+    res = subprocess.run(
+        ["node", "-e", node_code],
+        cwd=browser_dir,
+        text=True,
+        capture_output=True,
+    )
+    assert res.returncode == 1
+    assert "Node.js 20+ is required. Current version: 19.0.0" in res.stderr
+


### PR DESCRIPTION
## Summary
- check Node.js version at the start of the browser build scripts
- exit early when Node.js is older than v20
- cover the check with a new unit test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pytest alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683dc8caa434833390899a0bd5eb434e