### PR TITLE
[alpha_factory] add verbose flag to build script

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Build
-        run: npm run build
+        run: npm run build -- --verbose
         env:
           WEB3_STORAGE_TOKEN: ${{ secrets.WEB3_STORAGE_TOKEN }}
       - name: Check gzip size

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -22,6 +22,8 @@ const { injectManifest } = await import('workbox-build');
 const dotenv = (await import('dotenv')).default;
 dotenv.config();
 
+const verbose = process.argv.includes('--verbose');
+
 try {
   execSync('tsc --noEmit', { stdio: 'inherit' });
 } catch (err) {
@@ -231,7 +233,9 @@ async function bundle() {
     ].map(async f => new File([await fs.readFile(`${OUT_DIR}/${f}`)], f)));
     const cid = await client.put(files, { wrapWithDirectory: false });
     await fs.writeFile(`${OUT_DIR}/CID.txt`, cid);
-    console.log('Pinned CID:', cid);
+    if (verbose) {
+      console.log('Pinned CID:', cid);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add optional `--verbose` flag to `build.js`
- gate CID log behind the verbose option
- run web client build step with the flag in CI

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml` *(fails: could not fetch 'black' due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_683dcc71335c8333a781f9cfe78092d2