### PR TITLE
[alpha_factory] Add Safari fallback test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           PERCY_TOKEN_E2E: ${{ secrets.PERCY_TOKEN }}
         run: pnpm --dir src/interface/web_client run percy:cypress
       - name: Install Playwright browsers
-        run: playwright install chromium
+        run: playwright install chromium webkit
       - name: Install proto compiler
         run: pip install grpcio-tools
       - name: Verify protobuf

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_safari_pyodide.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_safari_pyodide.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify Pyodide fallback on Safari."""
+
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_safari_pyodide_fallback() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    try:
+        with sync_playwright() as p:
+            browser = p.webkit.launch()
+            context = browser.new_context(
+                user_agent=(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Safari/605.1.15"
+                )
+            )
+            page = context.new_page()
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            page.wait_for_selector("#toast.show")
+            assert "Pyodide unavailable; using JS only" in page.inner_text("#toast")
+            assert page.evaluate("typeof d3 !== 'undefined'")
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- add Safari Playwright test to verify Pyodide fallback message and rendering
- install WebKit in CI for headless Safari tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_safari_pyodide.py` *(skipped: Playwright browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683dd4e90a708333a3aa09124b872c49