### PR TITLE
[alpha_factory] use spawnSync for python

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { promises as fs } from 'fs';
 import fsSync from 'fs';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { createHash } from 'crypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -67,8 +67,16 @@ for node in tree.body:
             if getattr(t, 'id', None) == 'ASSETS':
                 assets = ast.literal_eval(node.value)
 print(json.dumps(list(assets.keys())))`;
-  const out = execSync('python', ['-'], { input: py, cwd: repoRoot, encoding: 'utf8' });
-  return JSON.parse(out.trim());
+  const proc = spawnSync('python', ['-'], {
+    input: py,
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (proc.error) throw proc.error;
+  if (proc.status !== 0) {
+    throw new Error(proc.stderr);
+  }
+  return JSON.parse(proc.stdout.trim());
 }
 
 function expectedChecksums() {
@@ -82,8 +90,16 @@ for node in tree.body:
             if getattr(t, 'id', None) == 'CHECKSUMS':
                 checks = ast.literal_eval(node.value)
 print(json.dumps(checks))`;
-  const out = execSync('python', ['-'], { input: py, cwd: repoRoot, encoding: 'utf8' });
-  return JSON.parse(out.trim());
+  const proc = spawnSync('python', ['-'], {
+    input: py,
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (proc.error) throw proc.error;
+  if (proc.status !== 0) {
+    throw new Error(proc.stderr);
+  }
+  return JSON.parse(proc.stdout.trim());
 }
 
 function ensureAssets() {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_build_python.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_build_python.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test that build.js can execute Python snippets when Python is available."""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_python_available() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    repo_root = browser_dir.parents[3]
+    py_snippet = """import ast, json, pathlib
+txt = pathlib.Path('scripts/fetch_assets.py').read_text()
+tree = ast.parse(txt)
+assets = {}
+for node in tree.body:
+    if isinstance(node, ast.Assign):
+        for t in node.targets:
+            if getattr(t, 'id', None) == 'ASSETS':
+                assets = ast.literal_eval(node.value)
+print(json.dumps(list(assets.keys())))"""
+    node_code = f"""
+import {{ spawnSync }} from 'child_process';
+const out = spawnSync('python', ['-'], {{
+  input: `{py_snippet}`,
+  cwd: {json.dumps(str(repo_root))},
+  encoding: 'utf8',
+}});
+if (out.error) {{ throw out.error; }}
+process.exit(out.status);
+"""
+    res = subprocess.run([
+        "node",
+        "-e",
+        node_code,
+    ], cwd=browser_dir, capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr


### PR DESCRIPTION
## Summary
- use `spawnSync` instead of `execSync` to invoke python in `build.js`
- add a test covering python availability for the insight build script

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683dd9960c6483339428f4a1c03562fd