### PR TITLE
[alpha_factory] enforce wasm asset integrity

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -27,6 +27,14 @@ Copy [`.env.sample`](.env.sample) to `.env` then review the variables:
 See [`.env.sample`](.env.sample) for the full list of supported variables.
 
 ## Build & Run
+Before running the build script you **must** replace the placeholder
+WebAssembly artifacts. Fetch the real assets with:
+
+```bash
+python ../../../scripts/fetch_assets.py
+```
+
+Once the wasm files are in place run:
 ```bash
 npm ci           # deterministic install
 npm run build    # compile to dist/ and embed env vars

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify wasm assets are real."""
+from __future__ import annotations
+
+from pathlib import Path
+
+BROWSER = Path(__file__).resolve().parents[1] / "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+
+
+def asset_files() -> list[Path]:
+    paths = []
+    for sub in ("wasm", "wasm_llm"):
+        root = BROWSER / sub
+        if root.exists():
+            for p in root.rglob("*"):
+                if p.is_file():
+                    paths.append(p)
+    return paths
+
+
+def test_no_placeholder() -> None:
+    files = asset_files()
+    assert files, "no wasm assets found"
+    for path in files:
+        data = path.read_bytes()
+        assert b"placeholder" not in data.lower(), f"placeholder found in {path}"


### PR DESCRIPTION
## Summary
- document that `fetch_assets.py` must run before building the Insight browser demo
- verify WASM artifacts do not contain the placeholder text

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683ddb7874fc83338ba3b5371ed02bf9