### PR TITLE
[alpha_factory] clarify manual browser build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -80,15 +80,15 @@ Use `manual_build.py` for air‑gapped environments:
 1. `cp .env.sample .env` and edit the values if you haven't already.
 2. `python ../../../scripts/fetch_assets.py` to fetch Pyodide and the GPT‑2 model.
    The build scripts verify these files no longer contain the word `"placeholder"`.
-3. Confirm `node --version` reports **v20** or newer.
-4. `python manual_build.py` – bundles the app and generates `dist/sw.js`.
+3. Confirm `node --version` reports **v20** or newer. `manual_build.py` exits if
+   Node.js is missing or too old.
+4. `python manual_build.py` – bundles the app, generates `dist/sw.js` and embeds
+   your `.env` settings.
 5. `npm start` or open `dist/index.html` directly to run the demo.
 
-The script requires Python ≥3.11 and uses **Node.js** to invoke Workbox. When
-`node` is missing, offline PWA features are skipped. `dist/index.html` contains
-SHA‑384 integrity hashes and embeds `window.PINNER_TOKEN`, `window.OPENAI_API_KEY`,
-`window.IPFS_GATEWAY` and `window.OTEL_ENDPOINT` from `.env` just like
-`npm run build`.
+The script requires Python ≥3.11. It loads `.env` automatically and injects
+`PINNER_TOKEN`, `OPENAI_API_KEY`, `IPFS_GATEWAY` and `OTEL_ENDPOINT` into
+`dist/index.html`, mirroring `npm run build`.
 
 ## Toolbar & Controls
 - **CSV** – export the current population as `population.csv`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -30,6 +30,20 @@ def _require_node_20() -> None:
 
 _require_node_20()
 
+# load environment variables
+env_file = Path(__file__).resolve().parent / ".env"
+if not env_file.is_file():
+    sys.exit(
+        ".env not found. Copy .env.sample to .env and populate the required values."
+    )
+try:
+    from alpha_factory_v1.utils.env import _load_env_file
+
+    for key, val in _load_env_file(env_file).items():
+        os.environ.setdefault(key, val)
+except Exception as exc:  # pragma: no cover - optional dep
+    print(f"[manual_build] failed to load .env: {exc}", file=sys.stderr)
+
 
 def sha384(path: Path) -> str:
     digest = hashlib.sha384(path.read_bytes()).digest()


### PR DESCRIPTION
## Summary
- mention Node version check and .env embedding in insight browser README
- load .env and fail loudly when missing in manual_build.py

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: Failed to connect to proxy port 8080)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683ddd4015408333b8c6140ecfef00e4