### PR TITLE
[alpha_factory] add eslint config

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/eslint.config.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/eslint.config.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: 'module',
+      ecmaVersion: 'latest'
+    },
+    plugins: { '@typescript-eslint': tsPlugin },
+    rules: { ...tsPlugin.configs.recommended.rules }
+  }
+];

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "lint": "eslint src --ext .js",
+    "lint": "eslint --config .eslintrc.cjs src --ext .js,.ts",
     "build": "node build.js",
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
@@ -14,6 +14,9 @@
   "devDependencies": {
     "esbuild": "^0.20.0",
     "eslint": "^8.57.0",
+    "@eslint/js": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "gzip-size-cli": "^5.1.1",
     "serve": "^14.2.0",
     "web3.storage": "^5.1.0",


### PR DESCRIPTION
## Summary
- add ESLint flat config
- lint `.ts` files

## Testing
- `python check_env.py --auto-install`
- `pytest -q`
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ddfca1278833390de0fc0b10b320f