### PR TITLE
[alpha_factory] fix ts test loader

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -9,7 +9,7 @@
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --test tests/entropy.test.js"
+    "test": "node --loader ts-node/register --test tests/entropy.test.js"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",
@@ -25,6 +25,7 @@
     "tailwindcss": "^3.4.0",
     "daisyui": "^4.0.7",
     "workbox-build": "^6.5.4",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
## Summary
- update insight_browser_v1 test script to load TypeScript with ts-node
- add ts-node dev dependency

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `npm test` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_683de175e9208333866fe573298213f8