### PR TITLE
[alpha_factory] enforce Node.js 20+

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -13,7 +13,8 @@ Verify your Node.js version before running the build script:
 node --version
 ```
 The output must start with `v20` or higher. Only run `manual_build.py` when this
-requirement is met.
+requirement is met. The `package.json` also enforces Node.js 20 or newer via the
+`engines` field.
 
 ## Environment Setup
 Copy [`.env.sample`](.env.sample) to `.env` then review the variables:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
+    "preinstall": "node -e \"const m=parseInt(process.versions.node); if(m<20){console.error('Node.js 20+ is required. Current version: '+process.versions.node); process.exit(1);} \"",
     "lint": "eslint --config .eslintrc.cjs src --ext .js,.ts",
     "build": "node build.js",
     "size": "gzip-size-cli dist/app.js --bytes",


### PR DESCRIPTION
## Summary
- enforce Node.js >=20 in `package.json`
- mention engines requirement in the insight browser README

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: unable to access 'https://github.com/psf/black/')*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683de93e63308333affc9cf07d807a09