### PR TITLE
[alpha_factory] enable strict tsconfig

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
@@ -17,9 +17,18 @@ export interface SimulatorConfig {
 
 export interface Generation {
   gen: number;
-  population: any[];
-  fronts: any[];
+  population: Individual[];
+  fronts: Individual[];
   metrics: { avgLogic: number; avgFeasible: number; frontSize: number };
+}
+
+interface Individual {
+  logic: number;
+  feasible: number;
+  strategy: string;
+  depth: number;
+  horizonYears: number;
+  front: boolean;
 }
 export class Simulator {
   static async *run(opts: SimulatorConfig): AsyncGenerator<Generation> {
@@ -28,15 +37,16 @@ export class Simulator {
     let worker: Worker | null = null;
     let umapWorker: Worker | null = null;
     const horizon = options.horizonYears ?? options.generations;
-    let pop = Array.from({ length: options.popSize }, () => ({
+    let pop: Individual[] = Array.from({ length: options.popSize }, () => ({
       logic: rand(),
       feasible: rand(),
       strategy: 'base',
       depth: 0,
       horizonYears: horizon,
+      front: false,
     }));
     for (let gen = 0; gen < options.generations; gen++) {
-      let front: any[] = [];
+      let front: Individual[] = [];
       let metrics = { avgLogic: 0, avgFeasible: 0, frontSize: 0 };
       if (options.workerUrl && typeof Worker !== 'undefined') {
         if (!worker) worker = new Worker(options.workerUrl, { type: 'module' });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "esnext"
+    "module": "esnext",
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "@insight-src/*": ["src/*"]
+    },
+    "allowJs": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- enable `strict` mode for the Insight browser demo
- configure Node-style module resolution and alias path
- allow TypeScript to compile JS sources
- annotate simulator population items

## Testing
- `npm run typecheck`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts` *(fails: Could not fetch psf/black)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683dea943f308333999a121cfe01e00d