### PR TITLE
[alpha_factory] add asset placeholder check

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_assets_replaced.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_assets_replaced.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify Insight demo assets were downloaded."""
+from pathlib import Path
+
+
+def test_assets_replaced() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    for sub in ("wasm", "wasm_llm", "lib"):
+        for p in (browser_dir / sub).rglob("*"):
+            if not p.is_file():
+                continue
+            if "placeholder" in p.read_text(errors="ignore").lower():
+                rel = p.relative_to(browser_dir)
+                raise AssertionError(f"{rel} contains placeholder text")


### PR DESCRIPTION
## Summary
- ensure Insight browser assets have placeholder content removed

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_assets_replaced.py` *(fails: Couldn't connect to server)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 1 error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683dec070ab08333b83289a17cc80c8a