### PR TITLE
[alpha_factory] toast message on pin failure

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.js
@@ -21,6 +21,9 @@ export async function pinFiles(files) {
     return { cid, url };
   } catch (err) {
     console.error('pinFiles failed', err);
+    if (typeof window.toast === 'function') {
+      window.toast('pin failed');
+    }
     return null;
   }
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pin_failure_toast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pin_failure_toast.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_pin_failure_toast() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context()
+        page = context.new_page()
+
+        page.goto(url)
+        page.wait_for_selector("#controls")
+
+        page.evaluate("window.PINNER_TOKEN='tok'")
+        context.route("https://api.web3.storage/**", lambda route: route.abort())
+        page.click("text=Share")
+        page.wait_for_function(
+            "document.getElementById('toast').textContent.includes('pin failed')"
+        )
+        browser.close()


### PR DESCRIPTION
## Summary
- show a toast when pinFiles fails
- test pinFiles failure scenario

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pin_failure_toast.py`
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pin_failure_toast.py`


------
https://chatgpt.com/codex/tasks/task_e_683df38569f08333bc89eb6091967a03