### PR TITLE
[alpha_factory] add gzip size test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_bundle_size.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_bundle_size.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure the gzipped bundle stays under 6 MiB."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import gzip
+
+
+def test_bundle_size_under_limit() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    app_js = browser_dir / "dist" / "app.js"
+    data = app_js.read_bytes()
+    compressed = gzip.compress(data)
+    assert len(compressed) <= 6 * 1024 * 1024


### PR DESCRIPTION
## Summary
- check gzip size of `dist/app.js` in the Insight browser demo

## Testing
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_bundle_size.py`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683df5435f008333932fe0ecb6f1d9f8