### PR TITLE
[alpha_factory] ensure unique archive ids

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -4,19 +4,19 @@ import type { EvaluatorGenome } from './evaluator_genome.ts';
 import { detectColdZone } from './utils/cluster.js';
 
 export interface InsightRun {
-  id: number;
+  id: string;
   seed: number;
   params: any;
   paretoFront: any[];
-  parents: number[];
-  evalId: number;
+  parents: string[];
+  evalId: string;
   score: number;
   novelty: number;
   timestamp: number;
 }
 
 export interface EvaluatorRecord {
-  id: number;
+  id: string;
   genome: EvaluatorGenome;
 }
 
@@ -57,14 +57,16 @@ export class Archive {
     seed: number,
     params: any,
     paretoFront: any[],
-    parents: number[] = [],
-    evalId: number = 0
-  ): Promise<number> {
+    parents: string[] = [],
+    evalId: string = ''
+  ): Promise<string> {
     await this.open();
     const vec = this._vector(paretoFront);
     const score = (vec[0] + vec[1]) / 2;
     const novelty = await this._novelty(vec);
-    const id = Date.now();
+    const id = typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : String(Date.now());
     const run: InsightRun = {
       id,
       seed,
@@ -100,9 +102,11 @@ export class Archive {
     return runs;
   }
 
-  async addEvaluator(genome: EvaluatorGenome): Promise<number> {
+  async addEvaluator(genome: EvaluatorGenome): Promise<string> {
     await this.open();
-    const id = Date.now() + Math.floor(Math.random() * 1000);
+    const id = typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : String(Date.now());
     const rec: EvaluatorRecord = { id, genome };
     await set(id, rec, this.evalStore);
     return id;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -54,3 +54,13 @@ test('prune removes unused evaluators', async () => {
   const evals = await a.listEvaluators();
   expect(evals.length).toBe(0);
 });
+
+test('add generates unique ids', async () => {
+  const a = new Archive('jest');
+  await a.open();
+  const id1 = await a.add(1, {}, []);
+  const id2 = await a.add(2, {}, []);
+  expect(id1).not.toBe(id2);
+  const runs = await a.list();
+  expect(runs.length).toBe(2);
+});


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID` to create archive and evaluator IDs with a timestamp fallback
- adjust types in browser archive
- test that IDs are unique

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js` *(fails: unable to fetch black)*
- `pytest -q` *(fails: duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683e0b07b0748333bc67a06a0baeb577