### PR TITLE
[alpha_factory] add i18n fetch fallback

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
@@ -1,19 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
-let strings={};
-export let currentLanguage='en';
-export async function initI18n(){
-  const saved=localStorage.getItem('lang');
-  const lang=(saved||navigator.language||'en').slice(0,2);
-  currentLanguage=lang.startsWith('fr')?'fr':lang.startsWith('es')?'es':'en';
-  const res=await fetch(`src/i18n/${currentLanguage}.json`);
-  strings=await res.json();
+import enStrings from '../i18n/en.json';
+
+let strings = enStrings;
+export let currentLanguage = 'en';
+
+export async function initI18n() {
+  const saved = localStorage.getItem('lang');
+  const lang = (saved || navigator.language || 'en').slice(0, 2);
+  currentLanguage = lang.startsWith('fr') ? 'fr' : lang.startsWith('es') ? 'es' : 'en';
+  try {
+    const res = await fetch(`src/i18n/${currentLanguage}.json`);
+    strings = await res.json();
+  } catch {
+    strings = enStrings;
+    currentLanguage = 'en';
+  }
 }
-export async function setLanguage(lang){
-  currentLanguage=lang;
-  localStorage.setItem('lang',lang);
-  const res=await fetch(`src/i18n/${lang}.json`);
-  strings=await res.json();
+
+export async function setLanguage(lang) {
+  currentLanguage = lang;
+  localStorage.setItem('lang', lang);
+  try {
+    const res = await fetch(`src/i18n/${lang}.json`);
+    strings = await res.json();
+  } catch {
+    strings = enStrings;
+    currentLanguage = 'en';
+  }
 }
-export function t(key){
-  return strings[key]||key;
+
+export function t(key) {
+  return strings[key] || key;
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/i18n_fallback.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/i18n_fallback.test.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+const { initI18n, t } = require('../src/ui/i18n.js');
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
+});
+
+test('fallback to english on fetch failure', async () => {
+  await initI18n();
+  expect(t('seed')).toBe('Seed');
+});


### PR DESCRIPTION
## Summary
- wrap `fetch` calls in `src/ui/i18n.js`
- fall back to bundled English strings on error
- add Jest test for the fallback logic

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/i18n_fallback.test.js` *(failed: unable to fetch remote hooks)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683e0e7286948333873e97d07c8d3a37