### PR TITLE
[alpha_factory] polyfill structuredClone

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js
@@ -3,6 +3,7 @@
    The actual file should be downloaded from:
    https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js
 */
+function clonePolyfill(o){if(o===null||typeof o!=='object')return o;if(o instanceof Date)return new Date(o.getTime());if(Array.isArray(o))return o.map(i=>clonePolyfill(i));const r={};for(const k of Object.keys(o))r[k]=clonePolyfill(o[k]);return r;}const clone=globalThis.structuredClone?((v)=>globalThis.structuredClone(v)):clonePolyfill;
 function Web3Storage(){ throw new Error('web3.storage not bundled'); }
 
 // SPDX-License-Identifier: Apache-2.0
@@ -1202,7 +1203,7 @@ function initSimulatorPanel(archive) {
     frames = [];
     for await (const g of sim) {
       lastPop = g.population;
-      frames.push(structuredClone(g.population));
+      frames.push(clone(g.population));
       count = g.gen;
       progress.value = count / Number(genInput.value);
       status.textContent = `gen ${count} front ${g.fronts.length}`;
@@ -1231,7 +1232,7 @@ function initSimulatorPanel(archive) {
         frames = [];
         try {
           const s = load(txt);
-          frames.push(structuredClone(s.pop));
+          frames.push(clone(s.pop));
           frameInput.max = '0';
           frameInput.value = '0';
           loadState(txt);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js
@@ -7,6 +7,7 @@ import { mutateEvaluator } from '../evaluator_genome.ts';
 import { pinFiles } from '../ipfs/pinner.ts';
 import { renderFrontier } from '../render/frontier.js';
 import { detectColdZone } from '../utils/cluster.js';
+import clone from '../../../../../../src/utils/clone.js';
 
 export async function initSimulatorPanel(archive, power) {
   const panel = document.createElement('div');
@@ -104,7 +105,7 @@ export async function initSimulatorPanel(archive, power) {
       const edges = g.population.map((p) => ({ from: p.strategy || 'x', to: p.strategy || 'x' }));
       memeRuns.push({ edges });
       await saveMemes(mineMemes(memeRuns));
-      frames.push(structuredClone(g.population));
+      frames.push(clone(g.population));
       const fid = await replay.addFrame(frameIds[frameIds.length - 1] || null, { population: g.population, gen: g.gen });
       frameIds.push(fid);
       count = g.gen;

--- a/src/utils/clone.js
+++ b/src/utils/clone.js
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Lightweight structuredClone polyfill.
+ * Falls back to a lodash-style deep clone when structuredClone
+ * is not available.
+ */
+export default function clone(value) {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(value);
+  }
+  return deepClone(value);
+}
+
+function deepClone(obj) {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+  if (obj instanceof Date) {
+    return new Date(obj.getTime());
+  }
+  if (Array.isArray(obj)) {
+    return obj.map((item) => deepClone(item));
+  }
+  const result = {};
+  for (const key of Object.keys(obj)) {
+    result[key] = deepClone(obj[key]);
+  }
+  return result;
+}

--- a/tests/test_clone_polyfill.py
+++ b/tests/test_clone_polyfill.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests the structuredClone polyfill."""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CLONE_JS = Path("src/utils/clone.js")
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+def test_clone_polyfill(tmp_path: Path) -> None:
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"globalThis.structuredClone = undefined;\n"
+        f"import clone from '{CLONE_JS.resolve().as_posix()}';\n"
+        "const src = {a:1,b:{c:2}};\n"
+        "const out = clone(src);\n"
+        "out.b.c = 3;\n"
+        "console.log(src.b.c === 2 && out.b.c === 3);\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(["node", script], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "true"


### PR DESCRIPTION
## Summary
- add a clone utility that polyfills `structuredClone`
- use the new clone helper in SimulatorPanel.js and the bundled dist
- test polyfill behavior when `structuredClone` is undefined

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_clone_polyfill.py`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.js src/utils/clone.js tests/test_clone_polyfill.py` *(fails: Could not fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683e12e7b9f883339c0bc46d1aad14a2