### PR TITLE
[alpha_factory] add i18n precache

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -173,6 +173,10 @@ async function bundle() {
   await fs.copyFile('worker/arenaWorker.js', `${OUT_DIR}/worker/arenaWorker.js`);
   await fs.mkdir(`${OUT_DIR}/src/utils`, { recursive: true });
   await fs.copyFile('src/utils/rng.js', `${OUT_DIR}/src/utils/rng.js`);
+  await fs.mkdir(`${OUT_DIR}/src/i18n`, { recursive: true });
+  for (const f of await fs.readdir('src/i18n')) {
+    await fs.copyFile(`src/i18n/${f}`, `${OUT_DIR}/src/i18n/${f}`);
+  }
   await fs.copyFile('sw.js', `${OUT_DIR}/sw.js`).catch(() => {});
   await fs.copyFile('manifest.json', `${OUT_DIR}/manifest.json`).catch(() => {});
   await fs.copyFile('favicon.svg', `${OUT_DIR}/favicon.svg`).catch(() => {});
@@ -235,6 +239,7 @@ async function bundle() {
       'wasm/*',
       'worker/*',
       'data/critics/*',
+      'src/i18n/*.json',
     ],
   });
   const size = await gzipSize.file(`${OUT_DIR}/app.js`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/sw.js
@@ -1,0 +1,9 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -205,6 +205,15 @@ for src, dest in [
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(src_path.read_bytes())
 
+# copy translations
+translations = ROOT / "src" / "i18n"
+if translations.exists():
+    for f in translations.iterdir():
+        if f.is_file():
+            target = dist_dir / "src" / "i18n" / f.name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(f.read_bytes())
+
 # copy critic examples
 critics_src = ROOT.parents[3] / "data" / "critics"
 critics_dst = dist_dir / "data" / "critics"
@@ -280,6 +289,7 @@ injectManifest({{
     'wasm/*',
     'worker/*',
     'data/critics/*',
+    'src/i18n/*.json',
   ],
 }}).catch(err => {{console.error(err); process.exit(1);}});
 """

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
@@ -2,4 +2,11 @@
 /* eslint-env serviceworker */
 import {precacheAndRoute} from 'workbox-precaching';
 
+// include translation JSON files in the precache
 precacheAndRoute(self.__WB_MANIFEST);
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
@@ -39,6 +39,9 @@ def test_offline_pwa_and_share() -> None:
         assert page.evaluate("typeof d3 !== 'undefined'")
         assert page.evaluate('document.querySelector("link[href=\'style.css\']").sheet !== null')
 
+        # i18n files should be served from cache
+        assert page.evaluate("(await fetch('src/i18n/en.json')).ok")
+
         # critic examples should be available offline
         text = page.evaluate("async () => await (await fetch('./data/critics/innovations.txt')).text()")
         assert 'Wheel' in text


### PR DESCRIPTION
## Summary
- cache locale JSON files in the Insight demo service worker
- update build scripts and offline test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py` *(fails: could not fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683e14e79714833394fa05218bb4a081