### PR TITLE
[alpha_factory] handle service worker registration errors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -16,4 +16,13 @@
 <script src="d3.v7.min.js" integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8" crossorigin="anonymous"></script>
 <script src="bundle.esm.min.js" integrity="sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax" crossorigin="anonymous"></script>
 <script src="pyodide.js" integrity="sha384-4lQJt6JNK5sYso6mEO1s2l1EnmbkIm958N+CAuWcYFBPuizBJ5nENroO7dtV8upW" crossorigin="anonymous"></script>
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker
+        .register('sw.js')
+        .catch(() => toast('Service worker registration failed; offline mode disabled.'));
+    });
+  }
+</script>
 <script src="app.js" integrity="sha384-o32o6wnQtXErSidJSWvLAjgPd7w1gZIYBPHpkuqdYWsdX9zppcbPOBqVbi34Bvl0" crossorigin="anonymous"></script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -49,7 +49,9 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('sw.js');
+          navigator.serviceWorker
+            .register('sw.js')
+            .catch(() => toast('Service worker registration failed; offline mode disabled.'));
         });
       }
     </script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
@@ -68,3 +68,21 @@ def test_offline_pwa_and_share() -> None:
         page.wait_for_function("window.pop && window.pop.length > 0")
         browser.close()
 
+
+def test_service_worker_registration_failure_toast() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.add_init_script(
+            "navigator.serviceWorker.register = () => Promise.reject('fail')"
+        )
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        page.wait_for_function(
+            "document.getElementById('toast').textContent.includes('offline mode disabled')"
+        )
+        browser.close()
+


### PR DESCRIPTION
## Summary
- warn when service worker registration fails
- test toast on registration failure

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py`
- `python check_env.py --auto-install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e191a64288333a818b7b8c41fa668