### PR TITLE
[alpha_factory] inline WASM assets

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/lib/pyodide.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/lib/pyodide.js
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 export async function loadPyodide(opts) {
   if (typeof window.loadPyodide === 'function') {
+    if (window.PYODIDE_WASM_BASE64) {
+      const bytes = Uint8Array.from(atob(window.PYODIDE_WASM_BASE64), c => c.charCodeAt(0));
+      const blob = new Blob([bytes], { type: 'application/wasm' });
+      const url = URL.createObjectURL(blob);
+      return window.loadPyodide({ ...opts, indexURL: url });
+    }
     return window.loadPyodide(opts);
   }
   throw new Error('pyodide.js not bundled');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js
@@ -5,7 +5,14 @@ async function loadLocal() {
   if (!localModel) {
     try {
       const { pipeline } = await import('../lib/bundle.esm.min.js');
-      localModel = await pipeline('text-generation', './wasm_llm/');
+      if (window.GPT2_MODEL_BASE64) {
+        const bytes = Uint8Array.from(atob(window.GPT2_MODEL_BASE64), c => c.charCodeAt(0));
+        const blob = new Blob([bytes]);
+        const url = URL.createObjectURL(blob);
+        localModel = await pipeline('text-generation', url);
+      } else {
+        localModel = await pipeline('text-generation', './wasm_llm/');
+      }
     } catch (err) {
       localModel = async (p) => `[offline] ${p}`;
     }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator_perf.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator_perf.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Simulator } from '../src/simulator.ts';
+
+test('run initializes within 70ms', async () => {
+  const start = performance.now();
+  const sim = Simulator.run({ popSize: 1, generations: 1 });
+  await sim.next();
+  const elapsed = performance.now() - start;
+  assert.ok(elapsed < 70, `init took ${elapsed}ms`);
+});

--- a/tests/test_simulator_init.py
+++ b/tests/test_simulator_init.py
@@ -1,0 +1,34 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SIM_TS = Path("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts")
+
+@pytest.mark.skipif(not shutil.which("tsc") or not shutil.which("node"), reason="tsc/node not available")
+def test_simulator_init_fast(tmp_path: Path) -> None:
+    js_out = tmp_path / "sim.js"
+    subprocess.run([
+        "tsc",
+        "--target",
+        "es2020",
+        "--module",
+        "es2020",
+        SIM_TS,
+        "--outFile",
+        js_out,
+    ], check=True)
+
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"import {{ Simulator }} from '{js_out.resolve().as_posix()}';\n"
+        "const start = performance.now();\n"
+        "const it = Simulator.run({popSize:1,generations:1});\n"
+        "await it.next();\n"
+        "console.log(performance.now()-start);\n",
+        encoding="utf-8",
+    )
+    res = subprocess.run(["node", script], capture_output=True, text=True, check=True)
+    elapsed = float(res.stdout.strip())
+    assert elapsed < 70


### PR DESCRIPTION
## Summary
- inline pyodide asm and wasm-gpt2 placeholders in the Insight build
- expose helper to load Pyodide from a base64 blob
- allow the LLM loader to read a base64 model
- verify Simulator initializes quickly

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/lib/pyodide.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator_perf.test.js tests/test_simulator_init.py`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683e2480c83c8333a86bdeb7f1e6bc17