### PR TITLE
[alpha_factory] Add Insight browser quickstart PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,9 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py --loglevel info
 ```
 
+See `docs/insight_browser_quickstart.pdf` for a brief guide on opening
+`dist/index.html` and sharing pinned runs from the browser demo.
+
 For evolutionary experiments you can run the optional
 [evolution worker](docs/DESIGN.md#evolution-worker) container and POST a tarball
 of agent code to `/mutate`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -170,6 +170,10 @@ async function bundle() {
   await fs.copyFile('sw.js', `${OUT_DIR}/sw.js`).catch(() => {});
   await fs.copyFile('manifest.json', `${OUT_DIR}/manifest.json`).catch(() => {});
   await fs.copyFile('favicon.svg', `${OUT_DIR}/favicon.svg`).catch(() => {});
+  const pdfSrc = path.join(repoRoot, 'docs', 'insight_browser_quickstart.pdf');
+  if (fsSync.existsSync(pdfSrc)) {
+    await fs.copyFile(pdfSrc, `${OUT_DIR}/insight_browser_quickstart.pdf`);
+  }
   await fs.mkdir(`${OUT_DIR}/data/critics`, { recursive: true });
   try {
     for (const f of await fs.readdir('../../../../data/critics')) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -59,6 +59,7 @@ ALIAS_TARGET = repo_root / "src"
 index_html = ROOT / "index.html"
 dist_dir = ROOT / "dist"
 lib_dir = ROOT / "lib"
+quickstart_pdf = repo_root / "docs" / "insight_browser_quickstart.pdf"
 
 bundle_path = lib_dir / "bundle.esm.min.js"
 try:
@@ -207,6 +208,10 @@ for src, dest in [
         target = dist_dir / dest
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(src_path.read_bytes())
+
+# include quickstart PDF
+if quickstart_pdf.exists():
+    (dist_dir / quickstart_pdf.name).write_bytes(quickstart_pdf.read_bytes())
 
 # copy translations
 translations = ROOT / "src" / "i18n"

--- a/docs/insight_browser_quickstart.pdf
+++ b/docs/insight_browser_quickstart.pdf
@@ -1,0 +1,42 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 230 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(Insight Browser Quickstart) Tj
+72 700 Td
+(1. Open dist/index.html in your browser.) Tj
+72 680 Td
+(2. Set PINNER_TOKEN to pin runs to IPFS.) Tj
+72 660 Td
+(3. Click Share to copy the CID or permalink.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000521 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+591
+%%EOF


### PR DESCRIPTION
## Summary
- document offline browser instructions in a small PDF
- copy the quickstart PDF during the browser build
- mention the PDF in the README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683e26b0be788333b48781edf790f58f