### PR TITLE
[alpha_factory] gpu-aware llm backend

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -104,6 +104,9 @@ function start(p){
   updateLegend(p.mutations)
   if(worker) worker.terminate()
   worker=new Worker('./worker/evolver.js',{type:'module'})
+  if(navigator.gpu){
+    worker.postMessage({type:'gpu', available: window.USE_GPU !== false})
+  }
   worker.onmessage=ev=>{
     if(ev.data.toast){toast(ev.data.toast);return}
     pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)
@@ -200,6 +203,9 @@ function loadState(text){
     updateLegend(current.mutations)
     if(worker) worker.terminate()
     worker=new Worker('./worker/evolver.js',{type:'module'})
+    if(navigator.gpu){
+      worker.postMessage({type:'gpu', available: window.USE_GPU !== false})
+    }
     worker.onmessage=ev=>{
       if(ev.data.toast){toast(ev.data.toast);return}
       pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)
@@ -221,6 +227,7 @@ window.addEventListener('DOMContentLoaded',async()=>{
   await archive.open();
   evolutionPanel = initEvolutionPanel(archive);
   powerPanel = initPowerPanel();
+  powerPanel.update({ gpu: !!navigator.gpu, use: window.USE_GPU });
   await initSimulatorPanel(archive, powerPanel);
   analyticsPanel = initAnalyticsPanel();
   arenaPanel = initArenaPanel((pt) => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js
@@ -14,10 +14,30 @@ export function initPowerPanel() {
     whiteSpace: 'pre',
   });
   const pre = document.createElement('pre');
+  const gpuLabel = document.createElement('label');
+  const gpuToggle = document.createElement('input');
+  gpuToggle.type = 'checkbox';
+  gpuToggle.id = 'gpu-toggle';
+  gpuLabel.appendChild(gpuToggle);
+  gpuLabel.append(' GPU');
+  panel.appendChild(gpuLabel);
   panel.appendChild(pre);
+  try {
+    const saved = localStorage.getItem('USE_GPU');
+    gpuToggle.checked = saved !== '0';
+  } catch {
+    gpuToggle.checked = true;
+  }
+  window.USE_GPU = gpuToggle.checked && !!navigator.gpu;
+  gpuToggle.addEventListener('change', () => {
+    window.USE_GPU = gpuToggle.checked && !!navigator.gpu;
+    try {
+      localStorage.setItem('USE_GPU', gpuToggle.checked ? '1' : '0');
+    } catch {}
+  });
   document.body.appendChild(panel);
   function update(e) {
     pre.textContent = JSON.stringify(e, null, 2);
   }
-  return { update };
+  return { update, gpuToggle };
 }

--- a/tests/test_gpu_detection.py
+++ b/tests/test_gpu_detection.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+LLM = Path(
+    "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js"
+)
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+def test_llm_gpu_backend(tmp_path: Path) -> None:
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"globalThis.navigator = {{ gpu: {{}} }};\n"
+        f"globalThis.localStorage = {{ getItem: () => null }};\n"
+        f"const m = await import('{LLM.resolve().as_posix()}');\n"
+        "console.log(m.gpuBackend());\n"
+    )
+    res = subprocess.run(["node", script], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == "webgpu"
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+def test_llm_no_gpu_backend(tmp_path: Path) -> None:
+    script = tmp_path / "run.mjs"
+    script.write_text(
+        f"globalThis.navigator = {{}};\n"
+        f"globalThis.localStorage = {{ getItem: () => null }};\n"
+        f"const m = await import('{LLM.resolve().as_posix()}');\n"
+        "console.log(m.gpuBackend());\n"
+    )
+    res = subprocess.run(["node", script], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == "wasm-simd"


### PR DESCRIPTION
## Summary
- detect navigator.gpu when loading local LLM model
- add GPU toggle in PowerPanel
- inform workers if GPU is available
- tests for GPU backend selection

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683e2bcc419c8333b7524f4e264a9645