### PR TITLE
[alpha_factory] Improve browser telemetry

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -31,6 +31,7 @@ let current,rand,pop,gen,svg,view,info,running=true
 let worker
 let telemetry
 let fpsStarted=false;
+let workerStart=0;
 let archive,evolutionPanel,powerPanel,analyticsPanel;
 let arenaPanel,debateWorker,debateTarget;
 function toast(msg) {
@@ -109,6 +110,7 @@ function start(p){
   }
   worker.onmessage=ev=>{
     if(ev.data.toast){toast(ev.data.toast);return}
+    if(analyticsPanel) analyticsPanel.recordWorkerTime(performance.now()-workerStart)
     pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)
   }
   step()
@@ -148,6 +150,7 @@ function step(){
     scale=0.5
   }
   telemetry.recordRun(1)
+  workerStart=performance.now()
   worker.postMessage({pop,rngState:rand.state(),mutations:current.mutations,popSize:current.pop,gen,adaptive:current.adaptive,sigmaScale:scale})
 }
 
@@ -208,6 +211,7 @@ function loadState(text){
     }
     worker.onmessage=ev=>{
       if(ev.data.toast){toast(ev.data.toast);return}
+      if(analyticsPanel) analyticsPanel.recordWorkerTime(performance.now()-workerStart)
       pop=ev.data.pop;rand.set(ev.data.rngState);requestAnimationFrame(step)
     }
     step()

--- a/tests/test_browser_ui.py
+++ b/tests/test_browser_ui.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from pathlib import Path
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_metrics_update_during_sim() -> None:
+    dist = Path(__file__).resolve().parents[1] / (
+        "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html"
+    )
+    url = dist.as_uri()
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            page.wait_for_selector("#simulator-panel")
+            page.evaluate("document.querySelector('#simulator-panel #sim-gen').value=2")
+            page.evaluate("document.querySelector('#simulator-panel #sim-pop').value=3")
+            page.click("#simulator-panel #sim-start")
+            page.wait_for_function("document.querySelector('#worker-time').textContent.includes('ms')")
+            page.wait_for_function("document.querySelector('#heap').textContent !== ''")
+            page.wait_for_function("document.querySelector('#fps-value').textContent.includes('fps')")
+            page.click('#simulator-panel #sim-cancel')
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- show JS heap, worker timing, and FPS in `AnalyticsPanel`
- add telemetry toggle controls and log viewer
- record worker response time from app
- test analytics metrics in the browser demo

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/AnalyticsPanel.js tests/test_browser_ui.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683e2dad9a78833397c019dffefe8c42