### PR TITLE
[alpha_factory] Document Insight browser quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,8 +650,15 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py --loglevel info
 ```
 
-See `docs/insight_browser_quickstart.pdf` for a brief guide on opening
-`dist/index.html` and sharing pinned runs from the browser demo.
+
+### Insight Browser Demo
+
+A browser-only Pareto explorer lives under
+`alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1`.
+Build the PWA and open `dist/index.html` to run the demo locally.
+The quick-start guide `docs/insight_browser_quickstart.pdf` is copied to
+`dist/insight_browser_quickstart.pdf` during the build so it is available
+alongside the compiled assets.
 
 For evolutionary experiments you can run the optional
 [evolution worker](docs/DESIGN.md#evolution-worker) container and POST a tarball

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -75,6 +75,10 @@ Open `index.html` directly in your browser or pin the folder to IPFS
 (`ipfs add -r insight_browser_v1`) and share the CID.
 The URL fragment encodes parameters such as `#/s=42&p=120&g=80`.
 
+See `docs/insight_browser_quickstart.pdf` for a short walkthrough. The
+build script copies this file to `dist/insight_browser_quickstart.pdf` so
+the guide is available alongside `dist/index.html`.
+
 ## Manual Build
 Use `manual_build.py` for air‑gapped environments:
 


### PR DESCRIPTION
## Summary
- highlight browser demo quick-start in the main README
- link to the Quick-Start PDF from the insight browser README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails to fetch hooks due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_683e47a784f08333801784d6220aca7e