### PR TITLE
[alpha_factory] tighten insight bundle size checks

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -131,6 +131,7 @@ async function bundle() {
     entryPoints: ['app.js'],
     bundle: true,
     minify: true,
+    treeShaking: true,
     format: 'esm',
     target: 'es2020',
     outfile: `${OUT_DIR}/insight.bundle.js`,
@@ -228,7 +229,7 @@ async function bundle() {
     ],
   });
   const size = await gzipSize.file(`${OUT_DIR}/insight.bundle.js`);
-  const MAX_GZIP_SIZE = 6 * 1024 * 1024; // 6 MiB
+  const MAX_GZIP_SIZE = 2 * 1024 * 1024; // 2 MiB
   if (size > MAX_GZIP_SIZE) {
     throw new Error(`gzip size ${size} bytes exceeds limit`);
   }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -10,6 +10,7 @@ import shutil
 from pathlib import Path
 from urllib.parse import urlparse
 import ast
+import gzip
 
 
 def _require_node_20() -> None:
@@ -303,3 +304,8 @@ except FileNotFoundError:
     print("[manual_build] node not found; skipping service worker generation", file=sys.stderr)
 except subprocess.CalledProcessError as exc:
     print(f"[manual_build] workbox build failed: {exc}; offline features disabled", file=sys.stderr)
+
+compressed = gzip.compress((dist_dir / "insight.bundle.js").read_bytes())
+MAX_GZIP_SIZE = 2 * 1024 * 1024  # 2 MiB
+if len(compressed) > MAX_GZIP_SIZE:
+    sys.exit(f"gzip size {len(compressed)} bytes exceeds limit")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_bundle_size.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_bundle_size.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Ensure the gzipped bundle stays under 6 MiB."""
+"""Ensure the gzipped bundle stays under 2 MiB."""
 
 from __future__ import annotations
 
@@ -12,4 +12,4 @@ def test_bundle_size_under_limit() -> None:
     app_js = browser_dir / "dist" / "insight.bundle.js"
     data = app_js.read_bytes()
     compressed = gzip.compress(data)
-    assert len(compressed) <= 6 * 1024 * 1024
+    assert len(compressed) <= 2 * 1024 * 1024


### PR DESCRIPTION
## Summary
- enable explicit treeShaking in `build.js`
- shrink gzip max size to 2 MiB in `build.js`
- enforce 2 MiB limit in `test_bundle_size.py`
- apply same 2 MiB gzip check in `manual_build.py`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_bundle_size.py` *(fails to fetch hooks due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_683e492a82a88333ac63e88d9db12e8b