### PR TITLE
[alpha_factory] share asset manifest

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -1,0 +1,43 @@
+{
+  "files": [
+    "d3.v7.min.js",
+    "lib/bundle.esm.min.js",
+    "lib/pyodide.js",
+    "lib/workbox-sw.js",
+    "src/utils/rng.js",
+    "sw.js",
+    "manifest.json",
+    "favicon.svg"
+  ],
+  "dirs": {
+    "translations": "src/i18n",
+    "critics": "data/critics",
+    "wasm": "wasm",
+    "wasm_llm": "wasm_llm"
+  },
+  "precache": [
+    "index.html",
+    "insight.bundle.js",
+    "d3.v7.min.js",
+    "pyodide.*",
+    "wasm_llm/*",
+    "wasm/*",
+    "data/critics/*",
+    "src/i18n/*.json"
+  ],
+  "assets": [
+    "wasm/pyodide.js",
+    "wasm/pyodide.asm.wasm",
+    "wasm/pyodide_py.tar",
+    "wasm/packages.json",
+    "wasm_llm/wasm-gpt2.tar",
+    "lib/bundle.esm.min.js",
+    "lib/workbox-sw.js"
+  ],
+  "checksums": {
+    "lib/bundle.esm.min.js": "sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax",
+    "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",
+    "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo"
+  },
+  "quickstart_pdf": "../../../../docs/insight_browser_quickstart.pdf"
+}


### PR DESCRIPTION
## Summary
- centralize Insight browser build assets in `build_assets.json`
- load manifest in `build.js` and `manual_build.py`
- copy/precaching driven by shared list

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json` *(fails: Could not fetch black)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683e4d62ef508333b2b1e89544a669ec