### PR TITLE
[alpha_factory] cache quickstart PDF offline

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -196,7 +196,7 @@ async function bundle() {
     swDest: `${OUT_DIR}/sw.js`,
     globDirectory: OUT_DIR,
     importWorkboxFrom: 'disabled',
-    globPatterns: manifest.precache,
+    globPatterns: [...manifest.precache, 'insight_browser_quickstart.pdf'],
   });
   const size = await gzipSize.file(`${OUT_DIR}/insight.bundle.js`);
   const MAX_GZIP_SIZE = 2 * 1024 * 1024; // 2 MiB

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -247,14 +247,14 @@ if wasm_llm_dir.exists():
 # generate service worker
 sw_src = ROOT / "sw.js"
 sw_dest = dist_dir / "sw.js"
-node_script = f"""
+  node_script = f"""
 const {{injectManifest}} = require('workbox-build');
 injectManifest({{
   swSrc: {json.dumps(str(sw_src))},
   swDest: {json.dumps(str(sw_dest))},
   globDirectory: {json.dumps(str(dist_dir))},
   importWorkboxFrom: 'disabled',
-  globPatterns: {json.dumps(manifest["precache"])},
+  globPatterns: {json.dumps(manifest["precache"] + ["insight_browser_quickstart.pdf"])},
 }}).catch(err => {{console.error(err); process.exit(1);}});
 """
 try:

--- a/tests/test_pwa_offline.py
+++ b/tests/test_pwa_offline.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+import http.server
+import threading
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def _start_server(directory: Path):
+    handler = partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    server = http.server.ThreadingHTTPServer(("localhost", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_quickstart_pdf_offline() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    dist = repo / "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist"
+    pdf_src = repo / "docs/insight_browser_quickstart.pdf"
+    pdf_dest = dist / "insight_browser_quickstart.pdf"
+    if not pdf_dest.exists() and pdf_src.exists():
+        pdf_dest.write_bytes(pdf_src.read_bytes())
+
+    server, thread = _start_server(dist)
+    host, port = server.server_address
+    url = f"http://{host}:{port}"
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            page = context.new_page()
+            page.goto(url + "/index.html")
+            page.wait_for_selector("#controls")
+            page.wait_for_function("navigator.serviceWorker.ready")
+            page.reload()
+            page.wait_for_function("navigator.serviceWorker.controller !== null")
+            context.set_offline(True)
+            resp = page.goto(url + "/insight_browser_quickstart.pdf")
+            assert resp and resp.ok, "PDF not served offline"
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- precache quickstart PDF in PWA build
- test that PDF loads while offline

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py tests/test_pwa_offline.py` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_683e5030a09c8333b28c73abbe8abec3