### PR TITLE
[alpha_factory] document telemetry queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,24 @@ docker run -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
 Set ``OTEL_ENDPOINT`` to enable anonymous dashboard telemetry. Users are
 prompted for consent before any metrics are sent.
 
+### Telemetry Queue
+Anonymous usage metrics are buffered in the browser under the
+`telemetryQueue` key in `localStorage`. Each record includes:
+
+- `ts` – the timestamp when the entry was recorded.
+- `session` – a deterministic SHA‑256 hash identifying the session.
+- `generations` – how many runs were executed.
+- `shares` – how many times results were shared.
+
+When the browser is online the queue is flushed to ``OTEL_ENDPOINT`` using
+`navigator.sendBeacon` with a `fetch` fallback. The queue holds at most 100
+entries and is persisted across page loads until sent. No personal data or IP
+addresses are stored.
+
+Telemetry can be disabled from the Analytics panel by clicking **Disable
+telemetry**. Clearing the `telemetryConsent` and `telemetryQueue` entries in
+browser storage also stops all transmissions.
+
 ---
 
 <a name="10-safety--security"></a>


### PR DESCRIPTION
## Summary
- document what data `telemetryQueue` stores and how it's sent
- explain how to disable telemetry and note no personal data is kept

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pre-commit run --files README.md` *(fails: could not fetch black due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_683e5229f2408333b39fa414ed2d53c1