### PR TITLE
[alpha_factory] add safari offline test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_safari_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_safari_offline.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify offline reload on Safari."""
+
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_safari_offline_reload() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    try:
+        with sync_playwright() as p:
+            browser = p.webkit.launch()
+            context = browser.new_context(
+                user_agent=(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Safari/605.1.15"
+                )
+            )
+            page = context.new_page()
+            errors: list[str] = []
+            page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+            page.on("pageerror", lambda err: errors.append(str(err)))
+
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            page.wait_for_function("navigator.serviceWorker.ready")
+
+            context.set_offline(True)
+            page.reload()
+            page.wait_for_selector("#controls")
+            context.set_offline(False)
+
+            assert not errors, f"Console errors: {errors}"
+            assert page.evaluate("navigator.serviceWorker.controller !== null")
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- add Safari offline reload regression test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683e535e596c83339d7483f7531a68c9