### PR TITLE
[alpha_factory] Add aria-live region to toast container

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -9,7 +9,7 @@
 <!-- styles injected by insight.bundle.js -->
 
 <div id="controls"></div>
-<div id="toast"></div>
+<div id="toast" aria-live="polite"></div>
 <div id="toolbar"></div>
 <div id="legend"></div>
 <script src="d3.v7.min.js" integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8" crossorigin="anonymous"></script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -33,7 +33,7 @@
       <main id="canvas" class="flex-1 relative overflow-hidden"></main>
       <aside id="log" class="w-80 bg-base-100/70 backdrop-blur-md p-4 overflow-y-auto" aria-label="Log"></aside>
     </div>
-    <div id="toast"></div>
+    <div id="toast" aria-live="polite"></div>
     <div id="toolbar"></div>
     <div id="legend"></div>
     <div id="depth-legend"></div>


### PR DESCRIPTION
## Summary
- add `aria-live="polite"` to the toast placeholder in the demo
- update the built `dist/index.html`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html` *(fails: couldn't fetch psf/black)*

------
https://chatgpt.com/codex/tasks/task_e_683e5dac2d70833389b696017687f991