### PR TITLE
[alpha_factory] enable typechecking for ui panels

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.ts
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-// @ts-nocheck
 import { t } from './i18n.js';
 import type { Individual } from '../state/serializer.ts';
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-// @ts-nocheck
 import { Simulator } from '../simulator.ts';
 import type { Individual } from '../state/serializer.ts';
 import { save, load } from '../state/serializer.ts';
@@ -106,7 +105,7 @@ export async function initSimulatorPanel(
   });
 
   startBtn.addEventListener('click', async () => {
-    if (sim && typeof sim.return === 'function') await sim.return();
+    if (sim && typeof sim.return === 'function') await sim.return(undefined);
     const seeds = seedsInput.value.split(',').map((s) => Number(s.trim())).filter(Boolean);
     memeRuns = [];
     sim = Simulator.run({
@@ -160,7 +159,7 @@ export async function initSimulatorPanel(
   });
 
   cancelBtn.addEventListener('click', () => {
-    if (sim && typeof sim.return === 'function') sim.return();
+    if (sim && typeof sim.return === 'function') void sim.return(undefined);
   });
 
   pauseBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` directives from the Insight Browser panels
- annotate DOM operations and internal data types so `npm run typecheck` passes

## Checks
- [ ] `pre-commit` *(fails: could not fetch black due to network)*
- [x] `python check_env.py --auto-install`
- [ ] `pytest -q` *(fails: duplicated timeseries in CollectorRegistry)*
- [x] `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683e5f063e308333b690bdfbf41412d5