### PR TITLE
[alpha_factory] add cid equality test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -13,7 +13,7 @@
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --loader ts-node/register --test tests/entropy.test.js"
+    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replay_cid.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replay_cid.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ReplayDB } from '../src/replay.ts';
+
+const framesA = [
+  { id: 1, parent: null, delta: { step: 0 }, timestamp: 0 },
+  { id: 2, parent: 1, delta: { step: 1 }, timestamp: 1 },
+];
+
+const framesB = [
+  { id: 1, parent: null, delta: { step: 0 }, timestamp: 0 },
+  { id: 2, parent: 1, delta: { step: 1 }, timestamp: 1 },
+];
+
+test('cidForFrames returns the same hash for identical frames', async () => {
+  const cidA = await ReplayDB.cidForFrames(framesA);
+  const cidB = await ReplayDB.cidForFrames(framesB);
+  assert.equal(cidA, cidB);
+});


### PR DESCRIPTION
## Summary
- add a test verifying that cidForFrames is deterministic
- run it via npm

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError in tests/test_llm_cache.py)*

------
https://chatgpt.com/codex/tasks/task_e_683e62770bd88333928650b5236fc4ed