### PR TITLE
[alpha_factory] handle GPU messages in evolver worker

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -111,6 +111,9 @@ When building without internet access:
 - **Share** – copy a permalink to the clipboard. When `PINNER_TOKEN` is set,
   exported JSON is pinned to Web3.Storage and the CID appears in a toast.
 - **Theme** – toggle between light and dark mode.
+- **GPU** – enable or disable WebGPU acceleration. The app sends a
+  `{type:'gpu', available:<flag>}` message to the evolver worker which
+  forwards the flag to mutation functions.
 
 Drag a previously exported JSON state onto the drop zone to restore a
 simulation.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-export function mutate(pop, rand, strategies, gen = 0, adaptive = false, scale = 1) {
+export function mutate(pop, rand, strategies, gen = 0, adaptive = false, scale = 1, gpu = false) {
   const clamp = (v) => Math.min(1, Math.max(0, v));
   const mutants = [];
   function converged() {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
@@ -1,0 +1,26 @@
+const path = require('path');
+
+jest.mock('../src/evolve/mutate.js', () => ({
+  mutate: jest.fn(() => [])
+}));
+
+const { mutate } = require('../src/evolve/mutate.js');
+
+function makeMsg(gen) {
+  return { pop: [], rngState: 1, mutations: [], popSize: 1, critic: 'none', gen };
+}
+
+test('worker updates gpu flag before mutate calls', async () => {
+  const selfObj = { navigator: {}, postMessage: jest.fn() };
+  global.self = selfObj;
+  await import('../worker/evolver.js');
+  const handler = selfObj.onmessage;
+
+  handler({ data: { type: 'gpu', available: true } });
+  await handler({ data: makeMsg(1) });
+  expect(mutate.mock.calls[0][6]).toBe(true);
+
+  handler({ data: { type: 'gpu', available: false } });
+  await handler({ data: makeMsg(2) });
+  expect(mutate.mock.calls[1][6]).toBe(false);
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js
@@ -9,6 +9,7 @@ const isIOS = /(iPad|iPhone|iPod)/.test(ua);
 let pyReady;
 let warned = false;
 let pySupported = !(isSafari || isIOS);
+let gpuAvailable = false;
 
 async function loadPy() {
   if (!pySupported) {
@@ -42,10 +43,14 @@ function shuffle(arr, rand) {
 }
 
 self.onmessage = async (ev) => {
+  if (ev.data?.type === 'gpu') {
+    gpuAvailable = !!ev.data.available;
+    return;
+  }
   const { pop, rngState, mutations, popSize, critic, gen, adaptive, sigmaScale = 1 } = ev.data;
   const rand = lcg(0);
   rand.set(rngState);
-  let next = mutate(pop, rand, mutations, gen, adaptive, sigmaScale);
+  let next = mutate(pop, rand, mutations, gen, adaptive, sigmaScale, gpuAvailable);
   const front = paretoFront(next);
   next.forEach((d) => (d.front = front.includes(d)));
   if (critic === 'llm') {


### PR DESCRIPTION
## Summary
- update evolver.js worker to store GPU availability and pass it to `mutate`
- extend `mutate` signature with a GPU flag
- test worker GPU flag handling
- document GPU toggle in the browser README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(failed to fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683e66b0847c8333a44f1c95b964cba5