### PR TITLE
[alpha_factory] add memory fallback for archive

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -119,7 +119,9 @@ Drag a previously exported JSON state onto the drop zone to restore a
 simulation.
 
 ## Darwin-Archive
-Every completed run is stored locally using IndexedDB. The **Evolution** panel
+Every completed run is stored locally using IndexedDB. When storage access is
+unavailable, the archive falls back to an in-memory store and data is lost on
+refresh. The **Evolution** panel
 lists archived runs with their score and novelty. Click **Re-spawn** next to a
 row to restart the simulation using that seed.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -23,6 +23,7 @@ export interface EvaluatorRecord {
 export class Archive {
   private runStore;
   private evalStore;
+  private disabled = false;
   constructor(private name = 'insight-archive') {
     this.runStore = createStore(this.name, 'runs');
     this.evalStore = createStore(this.name, 'evals');
@@ -31,6 +32,12 @@ export class Archive {
   async open(): Promise<void> {
     await this.runStore.dbp;
     await this.evalStore.dbp;
+    if (!this.disabled && (this.runStore.memory || this.evalStore.memory)) {
+      this.disabled = true;
+      if (typeof (window as any).toast === 'function') {
+        (window as any).toast('Archive disabled (no storage access)');
+      }
+    }
   }
 
   private _vector(front: any[]): [number, number] {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/keyval.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/keyval.js
@@ -1,16 +1,42 @@
 // SPDX-License-Identifier: Apache-2.0
 export function createStore(dbName, storeName) {
-  const dbp = new Promise((resolve, reject) => {
-    const req = indexedDB.open(dbName, 1);
-    req.onupgradeneeded = () => req.result.createObjectStore(storeName);
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
+  const store = { dbp: null, storeName, memory: null };
+
+  if (typeof indexedDB === 'undefined') {
+    store.dbp = Promise.resolve(null);
+    store.memory = new Map();
+    return store;
+  }
+
+  store.dbp = new Promise((resolve) => {
+    try {
+      const req = indexedDB.open(dbName, 1);
+      req.onupgradeneeded = () => req.result.createObjectStore(storeName);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => {
+        store.memory = new Map();
+        resolve(null);
+      };
+    } catch (err) {
+      store.memory = new Map();
+      resolve(null);
+    }
   });
-  return { dbp, storeName };
+
+  return store;
 }
 
 async function withStore(type, store, fn) {
+  if (store.memory) {
+    return Promise.resolve(fn(store.memory));
+  }
+
   const db = await store.dbp;
+  if (!db) {
+    store.memory = new Map();
+    return Promise.resolve(fn(store.memory));
+  }
+
   return new Promise((resolve, reject) => {
     const tx = db.transaction(store.storeName, type);
     const st = tx.objectStore(store.storeName);
@@ -21,17 +47,17 @@ async function withStore(type, store, fn) {
 }
 
 export function get(key, store) {
-  return withStore('readonly', store, (s) => s.get(key));
+  return withStore('readonly', store, (s) => (s instanceof Map ? s.get(key) : s.get(key)));
 }
 export function set(key, val, store) {
-  return withStore('readwrite', store, (s) => s.put(val, key));
+  return withStore('readwrite', store, (s) => (s instanceof Map ? s.set(key, val) : s.put(val, key)));
 }
 export function del(key, store) {
-  return withStore('readwrite', store, (s) => s.delete(key));
+  return withStore('readwrite', store, (s) => (s instanceof Map ? s.delete(key) : s.delete(key)));
 }
 export function keys(store) {
-  return withStore('readonly', store, (s) => s.getAllKeys());
+  return withStore('readonly', store, (s) => (s instanceof Map ? Array.from(s.keys()) : s.getAllKeys()));
 }
 export function values(store) {
-  return withStore('readonly', store, (s) => s.getAll());
+  return withStore('readonly', store, (s) => (s instanceof Map ? Array.from(s.values()) : s.getAll()));
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -64,3 +64,16 @@ test('add generates unique ids', async () => {
   const runs = await a.list();
   expect(runs.length).toBe(2);
 });
+
+test('in-memory fallback triggers toast', async () => {
+  const orig = global.indexedDB;
+  delete global.indexedDB;
+  window.toast = jest.fn();
+  const a = new Archive('jest');
+  await a.open();
+  expect(window.toast).toHaveBeenCalledWith('Archive disabled (no storage access)');
+  await a.add(3, {}, []);
+  const runs = await a.list();
+  expect(runs.length).toBe(1);
+  global.indexedDB = orig;
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/keyval.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/keyval.test.js
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+const { createStore, set, get } = require('../src/utils/keyval.js');
+
+beforeEach(() => {
+  indexedDB.deleteDatabase('jest');
+});
+
+test('createStore uses indexedDB when available', async () => {
+  const store = createStore('jest', 'runs');
+  await store.dbp;
+  expect(store.memory).toBeNull();
+  await set('a', 1, store);
+  const v = await get('a', store);
+  expect(v).toBe(1);
+});
+
+test('fallback to memory when indexedDB unavailable', async () => {
+  const orig = global.indexedDB;
+  delete global.indexedDB;
+  const store = createStore('jest', 'runs');
+  await store.dbp;
+  expect(store.memory).toBeInstanceOf(Map);
+  await set('b', 2, store);
+  const v = await get('b', store);
+  expect(v).toBe(2);
+  global.indexedDB = orig;
+});


### PR DESCRIPTION
## Summary
- detect IndexedDB failure and fallback to memory
- toast when archive disabled and update README docs
- test memory fallback path for archive

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683e688562a48333b5e76319d531ddf8