### PR TITLE
[alpha_factory] cache runtime assets

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -154,6 +154,7 @@ async function bundle() {
     globDirectory: OUT_DIR,
     importWorkboxFrom: 'disabled',
     globPatterns: [...manifest.precache, 'insight_browser_quickstart.pdf'],
+    injectionPoint: 'self.__WB_MANIFEST',
   });
   const size = await gzipSize.file(`${OUT_DIR}/insight.bundle.js`);
   const MAX_GZIP_SIZE = 2 * 1024 * 1024; // 2 MiB

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -261,6 +261,7 @@ injectManifest({{
   globDirectory: {json.dumps(str(dist_dir))},
   importWorkboxFrom: 'disabled',
   globPatterns: {json.dumps(manifest["precache"] + ["insight_browser_quickstart.pdf"])},
+  injectionPoint: 'self.__WB_MANIFEST',
 }}).catch(err => {{console.error(err); process.exit(1);}});
 """
 try:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
@@ -2,9 +2,21 @@
 /* eslint-env serviceworker */
 importScripts('workbox-sw.js');
 import {precacheAndRoute} from 'workbox-precaching';
+import {registerRoute} from 'workbox-routing';
+import {CacheFirst} from 'workbox-strategies';
 
 // include translation JSON files in the precache
 precacheAndRoute(self.__WB_MANIFEST);
+
+registerRoute(
+  ({request, url}) =>
+    request.destination === 'script' ||
+    request.destination === 'worker' ||
+    request.destination === 'font' ||
+    url.pathname.endsWith('.wasm') ||
+    (url.pathname.includes('/ipfs/') && url.pathname.endsWith('.json')),
+  new CacheFirst({cacheName: 'insight-v1'})
+);
 
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING') {


### PR DESCRIPTION
## Summary
- cache fonts and IPFS JSON using Workbox runtime caching
- keep runtime caching when building service workers
- verify cached fonts and IPFS JSON load when offline

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683e6b96d6b08333bbf63ad0cd9435d1