### PR TITLE
[alpha_factory] update fetch_assets instructions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -59,6 +59,8 @@ This downloads the Pyodide runtime and `wasm-gpt2` model from IPFS into
 It also retrieves `lib/bundle.esm.min.js` from the mirror. The build and
 `manual_build.py` scripts scan every downloaded asset for the word
 `"placeholder"` and abort when any file still contains that marker.
+`scripts/fetch_assets.py` also downloads `lib/workbox-sw.js` from
+Workbox 6.5.4 so the service worker can operate offline.
 Run `scripts/fetch_assets.py` if you encounter this error.
 ```bash
 PINNER_TOKEN=<token> npm start

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -36,7 +36,7 @@
   ],
   "checksums": {
     "lib/bundle.esm.min.js": "sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax",
-    "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",
+    "lib/workbox-sw.js": "sha384-REPLACE_WITH_REAL_DIGEST",
     "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo"
   },
   "quickstart_pdf": "../../../../docs/insight_browser_quickstart.pdf"

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -23,12 +23,13 @@ ASSETS = {
     # Web3.Storage bundle
     "lib/bundle.esm.min.js": "bafybeibundlecidreplace",
     # Workbox runtime
-    "lib/workbox-sw.js": "bafybeiwbxplaceholder",
+    "lib/workbox-sw.js": "https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js",
 }
 
 CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax",
-    "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",
+    # TODO: replace with actual SHA-384 digest of Workbox 6.5.4
+    "lib/workbox-sw.js": "sha384-REPLACE_WITH_REAL_DIGEST",
     "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
 }
 
@@ -43,7 +44,7 @@ def _session() -> requests.Session:
 
 
 def download(cid: str, path: Path, fallback: str | None = None) -> None:
-    url = f"{GATEWAY}/{cid}"
+    url = cid if cid.startswith("http") else f"{GATEWAY}/{cid}"
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with _session().get(url, timeout=60) as resp:

--- a/tests/test_assets_replaced.py
+++ b/tests/test_assets_replaced.py
@@ -1,0 +1,7 @@
+import pathlib
+
+
+def test_workbox_replaced():
+    path = pathlib.Path("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/lib/workbox-sw.js")
+    data = path.read_text(errors="ignore")
+    assert "Placeholder" not in data


### PR DESCRIPTION
## Summary
- update asset list in fetch_assets to pull workbox directly from CDN
- note missing digest in CHECKSUMS
- mention Workbox asset in the insight browser README
- add regression test ensuring workbox-sw.js placeholder is replaced

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_assets_replaced.py` *(fails: Placeholder still present)*


------
https://chatgpt.com/codex/tasks/task_e_683e6def4f04833393235bc92476eb7f