### PR TITLE
[alpha_factory] enforce gzip bundle limit

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validate manual_build.py bundles enforce the gzip size limit."""
+
+from pathlib import Path
+import re
+
+
+def test_check_gzip_call_present() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    text = (browser_dir / "manual_build.py").read_text()
+    assert "def check_gzip_size" in text
+    pattern = r"write_text\(bundle\).*\n\s*check_gzip_size\(dist_dir / \"insight.bundle.js\"\)"
+    assert re.search(pattern, text)
+


### PR DESCRIPTION
## Summary
- enforce gzip size limit in `manual_build.py`
- add static unit test for manual build size enforcement

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py` *(fails: could not fetch psf/black)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f0d3f5c688333bb5a1042be3da7ee