### PR TITLE
[alpha_factory] add Spanish i18n option

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ControlsPanel.js
@@ -18,6 +18,7 @@ export function initControls(params,onChange){
     <select id="lang" tabindex="11">
       <option value="en">English</option>
       <option value="fr">Français</option>
+      <option value="es">Español</option>
     </select>`;
   const seed=root.querySelector('#seed'),
         pop=root.querySelector('#pop'),


### PR DESCRIPTION
## Summary
- add `es` to the language selector

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --all-files` *(fails: couldn't access GitHub for black)*
- `pytest -q` *(fails: duplicated timeseries ValueError)*

------
https://chatgpt.com/codex/tasks/task_e_683f11029edc8333b68669467ae4f357