### PR TITLE
[alpha_factory] Add browser error logging

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -24,6 +24,7 @@ import { initSimulatorPanel } from './src/ui/SimulatorPanel.ts';
 import { initPowerPanel } from './src/ui/PowerPanel.js';
 import { initAnalyticsPanel } from './src/ui/AnalyticsPanel.js';
 import { initArenaPanel } from './src/ui/ArenaPanel.ts';
+import { initErrorBoundary } from './src/utils/errorBoundary.js';
 
 let panel,pauseBtn,exportBtn,dropZone
 let criticPanel,logicCritic,feasCritic
@@ -234,6 +235,7 @@ function apply(p, info = {}){
 }
 
 window.addEventListener('DOMContentLoaded',async()=>{
+  initErrorBoundary();
   telemetry = initTelemetry();
   archive = new Archive();
   await archive.open();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/AnalyticsPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/AnalyticsPanel.js
@@ -34,11 +34,14 @@ export function initAnalyticsPanel() {
   disableBtn.textContent = 'Disable telemetry';
   const logBtn = document.createElement('button');
   logBtn.textContent = 'Show logs';
+  const downloadBtn = document.createElement('button');
+  downloadBtn.textContent = 'Download log';
   const logPre = document.createElement('pre');
   logPre.style.display = 'none';
   telControls.appendChild(enableBtn);
   telControls.appendChild(disableBtn);
   telControls.appendChild(logBtn);
+  telControls.appendChild(downloadBtn);
   telControls.appendChild(logPre);
   panel.appendChild(telControls);
   const canvas = document.createElement('canvas');
@@ -63,6 +66,15 @@ export function initAnalyticsPanel() {
     const logs = localStorage.getItem('telemetryQueue') || '[]';
     logPre.textContent = logs;
     logPre.style.display = logPre.style.display === 'none' ? 'block' : 'none';
+  });
+  downloadBtn.addEventListener('click', () => {
+    const logs = localStorage.getItem('errorLog') || '[]';
+    const blob = new Blob([logs], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'error-log.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
   });
 
   function update(pop, gen, entropy) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+let log = [];
+
+export function initErrorBoundary() {
+  try {
+    log = JSON.parse(localStorage.getItem('errorLog') || '[]');
+  } catch {
+    log = [];
+  }
+  function record(entry) {
+    log.push(entry);
+    try {
+      localStorage.setItem('errorLog', JSON.stringify(log));
+    } catch {}
+    if (window.toast) {
+      window.toast(entry.message || String(entry));
+    }
+  }
+  window.onerror = (msg, url, line, col, err) => {
+    record({
+      type: 'error',
+      message: String(msg),
+      url: url || '',
+      line: line || 0,
+      column: col || 0,
+      stack: err && err.stack,
+      ts: Date.now(),
+    });
+  };
+  window.onunhandledrejection = (ev) => {
+    const reason = ev.reason || {};
+    record({
+      type: 'unhandledrejection',
+      message: reason.message ? String(reason.message) : String(reason),
+      stack: reason.stack,
+      ts: Date.now(),
+    });
+  };
+}
+
+export function getErrorLog() {
+  return log.slice();
+}
+
+export function clearErrorLog() {
+  log = [];
+  try {
+    localStorage.removeItem('errorLog');
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- add `initErrorBoundary` to track window errors
- surface a **Download log** button in the Analytics panel
- wire error boundary into `app.js`

## Testing
- `pre-commit run --all-files` *(fails: unable to access github.com)*
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f125e49988333b0941db76797ecfc