### PR TITLE
[alpha_factory] Add install prompt button

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -284,6 +284,24 @@ window.addEventListener('DOMContentLoaded',async()=>{
   tb.appendChild(pngBtn);
   tb.appendChild(shareBtn);
   tb.appendChild(themeBtn);
+  const installBtn=document.getElementById("install-btn");
+  let deferredPrompt=null;
+  window.addEventListener("beforeinstallprompt",(e)=>{
+    e.preventDefault();
+    deferredPrompt=e;
+    installBtn.hidden=false;
+  });
+  installBtn.addEventListener("click",async()=>{
+    if(!deferredPrompt)return;
+    installBtn.hidden=true;
+    deferredPrompt.prompt();
+    try{await deferredPrompt.userChoice;}catch{}
+    deferredPrompt=null;
+  });
+  window.addEventListener("appinstalled",()=>{
+    installBtn.hidden=true;
+    deferredPrompt=null;
+  });
   csvBtn.addEventListener("click",()=>exportCSV(pop));
   pngBtn.addEventListener("click",exportPNG);
   shareBtn.addEventListener("click", async () => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -10,7 +10,7 @@
 
 <div id="controls"></div>
 <div id="toast" aria-live="polite"></div>
-<div id="toolbar"></div>
+<div id="toolbar"><button id="install-btn" hidden>Install</button></div>
 <div id="legend"></div>
 <script src="d3.v7.min.js" integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8" crossorigin="anonymous"></script>
 <script src="bundle.esm.min.js" integrity="sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax" crossorigin="anonymous"></script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/insight.bundle.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/insight.bundle.js
@@ -1484,6 +1484,11 @@ window.addEventListener('DOMContentLoaded',async()=>{
   tb.appendChild(pngBtn);
   tb.appendChild(shareBtn);
   tb.appendChild(themeBtn);
+  const installBtn=document.getElementById("install-btn");
+  let deferredPrompt=null;
+  window.addEventListener("beforeinstallprompt",e=>{e.preventDefault();deferredPrompt=e;installBtn.hidden=false;});
+  installBtn.addEventListener("click",async()=>{if(!deferredPrompt)return;installBtn.hidden=true;deferredPrompt.prompt();try{await deferredPrompt.userChoice;}catch{}deferredPrompt=null;});
+  window.addEventListener("appinstalled",()=>{installBtn.hidden=true;deferredPrompt=null;});
   csvBtn.addEventListener("click",()=>exportCSV(pop));
   pngBtn.addEventListener("click",exportPNG);
   shareBtn.addEventListener("click", async () => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -34,7 +34,9 @@
       <aside id="log" class="w-80 bg-base-100/70 backdrop-blur-md p-4 overflow-y-auto" aria-label="Log"></aside>
     </div>
     <div id="toast" aria-live="polite"></div>
-    <div id="toolbar"></div>
+    <div id="toolbar">
+      <button id="install-btn" hidden>Install</button>
+    </div>
     <div id="legend"></div>
     <div id="depth-legend"></div>
     <script

--- a/tests/test_install_button.py
+++ b/tests/test_install_button.py
@@ -1,0 +1,26 @@
+import pytest
+from pathlib import Path
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_install_button_shows_on_event() -> None:
+    dist = Path(__file__).resolve().parents[1] / (
+        "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html"
+    )
+    url = dist.as_uri()
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            assert page.is_hidden("#install-btn")
+            page.evaluate("window.dispatchEvent(new Event('beforeinstallprompt'))")
+            page.wait_for_selector("#install-btn", state="visible")
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")
+


### PR DESCRIPTION
## Summary
- add hidden install button in the insight browser toolbar
- handle `beforeinstallprompt` event in app.js
- embed install prompt logic in built JS
- test install button visibility with Playwright

## Testing
- `pre-commit run --all-files` *(failed: could not access network)*
- `pytest -q` *(failed: ValueError in tests/test_llm_cache.py)*

------
https://chatgpt.com/codex/tasks/task_e_683f1482036483339b6d65ba15b73b88