### PR TITLE
[alpha_factory] copy quickstart PDF during build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -118,6 +118,10 @@ async function bundle() {
     `<meta http-equiv="Content-Security-Policy" content="${csp}" />`
   );
   await copyAssets(manifest, repoRoot, OUT_DIR);
+  const pdf = path.join(repoRoot, 'docs/insight_browser_quickstart.pdf');
+  if (fsSync.existsSync(pdf)) {
+    await fs.copyFile(pdf, path.join(OUT_DIR, 'insight_browser_quickstart.pdf'));
+  }
   const bundleSri = await sha384('bundle.esm.min.js');
   const pyodideSri = await sha384('pyodide.js');
   const envScript = injectEnv(process.env);
@@ -153,7 +157,7 @@ async function bundle() {
     swDest: `${OUT_DIR}/sw.js`,
     globDirectory: OUT_DIR,
     importWorkboxFrom: 'disabled',
-    globPatterns: [...manifest.precache, 'insight_browser_quickstart.pdf'],
+    globPatterns: manifest.precache,
     injectionPoint: 'self.__WB_MANIFEST',
   });
   const size = await gzipSize.file(`${OUT_DIR}/insight.bundle.js`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -9,10 +9,6 @@ export async function copyAssets(manifest, repoRoot, outDir) {
     await fs.mkdir(path.dirname(dest), { recursive: true });
     await fs.copyFile(rel, dest).catch(() => {});
   }
-  const pdfSrc = path.join(repoRoot, manifest.quickstart_pdf);
-  if (fsSync.existsSync(pdfSrc)) {
-    await fs.copyFile(pdfSrc, path.join(outDir, path.basename(pdfSrc)));
-  }
   const i18nDir = manifest.dirs.translations;
   if (fsSync.existsSync(i18nDir)) {
     await fs.mkdir(path.join(outDir, i18nDir), { recursive: true });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -23,7 +23,8 @@
     "wasm_llm/*",
     "wasm/*",
     "data/critics/*",
-    "src/i18n/*.json"
+    "src/i18n/*.json",
+    "insight_browser_quickstart.pdf"
   ],
   "assets": [
     "wasm/pyodide.js",
@@ -39,5 +40,5 @@
     "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",
     "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo"
   },
-  "quickstart_pdf": "../../../../docs/insight_browser_quickstart.pdf"
+  "quickstart_pdf": "docs/insight_browser_quickstart.pdf"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -65,9 +65,6 @@ def copy_assets(manifest: dict, repo_root: Path, dist_dir: Path) -> None:
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(src_path.read_bytes())
 
-    quickstart_pdf = repo_root / manifest["quickstart_pdf"]
-    if quickstart_pdf.exists():
-        (dist_dir / quickstart_pdf.name).write_bytes(quickstart_pdf.read_bytes())
 
     translations = ROOT / manifest["dirs"]["translations"]
     if translations.exists():
@@ -225,6 +222,9 @@ out_html = re.sub(
 )
 
 copy_assets(manifest, repo_root, dist_dir)
+pdf_src = repo_root / "docs/insight_browser_quickstart.pdf"
+if pdf_src.exists():
+    (dist_dir / pdf_src.name).write_bytes(pdf_src.read_bytes())
 
 app_sri = sha384(dist_dir / "insight.bundle.js")
 bundle_sri = sha384(dist_dir / "bundle.esm.min.js")
@@ -268,7 +268,7 @@ injectManifest({{
   swDest: {json.dumps(str(sw_dest))},
   globDirectory: {json.dumps(str(dist_dir))},
   importWorkboxFrom: 'disabled',
-  globPatterns: {json.dumps(manifest["precache"] + ["insight_browser_quickstart.pdf"])},
+  globPatterns: {json.dumps(manifest["precache"])},
   injectionPoint: 'self.__WB_MANIFEST',
 }}).catch(err => {{console.error(err); process.exit(1);}});
 """

--- a/tests/test_build_quickstart_pdf.py
+++ b/tests/test_build_quickstart_pdf.py
@@ -1,0 +1,22 @@
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+BROWSER_DIR = Path("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1")
+
+@pytest.mark.skipif(not shutil.which("npm"), reason="npm not available")
+def test_pdf_copied_after_build(tmp_path: Path) -> None:
+    dist = BROWSER_DIR / "dist"
+    pdf = dist / "insight_browser_quickstart.pdf"
+    if pdf.exists():
+        pdf.unlink()
+    result = subprocess.run([
+        "npm",
+        "run",
+        "build",
+    ], cwd=BROWSER_DIR, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert pdf.exists(), "insight_browser_quickstart.pdf missing in dist"
+


### PR DESCRIPTION
## Summary
- include insight_browser_quickstart.pdf in build assets
- copy the PDF from docs into `dist/` in both build scripts
- precache the PDF for offline use
- test that `npm run build` places the quickstart PDF in `dist/`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py tests/test_build_quickstart_pdf.py` *(failed: Could not fetch pre-commit hooks)*
- `pytest -q` *(failed: 1 error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683f1841c2e883338dc2a716dfed5ce4