### PR TITLE
[alpha_factory] inline wasm assets

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -198,6 +198,14 @@ web3_code += "\nwindow.Web3Storage=Web3Storage;"
 py_code = (lib_dir / "pyodide.js").read_text()
 py_code = re.sub(r"^\s*export\s+", "", py_code, flags=re.MULTILINE)
 py_code += "\nwindow.loadPyodide=loadPyodide;"
+wasm_b64 = ""
+wasm_file = ROOT / "wasm" / "pyodide.asm.wasm"
+if wasm_file.exists():
+    wasm_b64 = base64.b64encode(wasm_file.read_bytes()).decode()
+gpt2_b64 = ""
+gpt2_file = ROOT / "wasm_llm" / "wasm-gpt2.tar"
+if gpt2_file.exists():
+    gpt2_b64 = base64.b64encode(gpt2_file.read_bytes()).decode()
 evolver = (ROOT / "worker" / "evolver.js").read_text()
 arena = (ROOT / "worker" / "arenaWorker.js").read_text()
 bundle = (
@@ -206,7 +214,8 @@ bundle = (
     + web3_code
     + "\n"
     + py_code
-    + "\n(function() {\nconst style="
+    + f"\nwindow.PYODIDE_WASM_BASE64='{wasm_b64}';window.GPT2_MODEL_BASE64='{gpt2_b64}';\n"
+    + "(function() {\nconst style="
     + repr(css)
     + ";\nconst s=document.createElement('style');s.textContent=style;document.head.appendChild(s);\nconst EVOLVER_URL=URL.createObjectURL(new Blob(["
     + repr(evolver)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.js
@@ -5,7 +5,17 @@ let pyodideReady;
 async function initPy() {
   if (!pyodideReady) {
     try {
-      pyodideReady = await loadPyodide({ indexURL: './wasm/' });
+      let opts = { indexURL: './wasm/' };
+      if (window.PYODIDE_WASM_BASE64) {
+        const bytes = Uint8Array.from(
+          atob(window.PYODIDE_WASM_BASE64),
+          c => c.charCodeAt(0)
+        );
+        const blob = new Blob([bytes], { type: 'application/wasm' });
+        const url = URL.createObjectURL(blob);
+        opts.indexURL = url;
+      }
+      pyodideReady = await loadPyodide(opts);
     } catch (err) {
       toast('Pyodide failed to load');
       return Promise.reject(err);

--- a/tests/test_wasm_base64.py
+++ b/tests/test_wasm_base64.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_pyodide_base64_global() -> None:
+    dist = Path(__file__).resolve().parents[1] / (
+        "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html"
+    )
+    url = dist.as_uri()
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            val = page.evaluate("window.PYODIDE_WASM_BASE64")
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")
+    assert val, "PYODIDE_WASM_BASE64 not set"


### PR DESCRIPTION
## Summary
- inline `pyodide.asm.wasm` and `wasm-gpt2.tar` during manual build
- decode embedded WASM in runtime loader
- test that `window.PYODIDE_WASM_BASE64` exists in the built UI

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pytest tests/test_wasm_base64.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f210c617c8333933deaf6d9902bf9