### PR TITLE
[alpha_factory] add build:dist script with zip test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -10,6 +10,7 @@
     "preinstall": "node -e \"const m=parseInt(process.versions.node); if(m<20){console.error('Node.js 20+ is required. Current version: '+process.versions.node); process.exit(1);} \"",
     "lint": "eslint --config .eslintrc.cjs src --ext .js,.ts",
     "build": "node build.js",
+    "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js manifest.json style.css assets insight_browser_quickstart.pdf && rm service-worker.js",
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",

--- a/tests/test_distribution_zip.py
+++ b/tests/test_distribution_zip.py
@@ -1,0 +1,45 @@
+import subprocess
+import shutil
+import zipfile
+from pathlib import Path
+
+import pytest
+
+BROWSER_DIR = Path("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1")
+
+@pytest.mark.skipif(not shutil.which("npm"), reason="npm not available")
+def test_distribution_zip(tmp_path: Path) -> None:
+    zip_path = BROWSER_DIR / "insight_browser.zip"
+    if zip_path.exists():
+        zip_path.unlink()
+    result = subprocess.run([
+        "npm",
+        "run",
+        "build:dist",
+    ], cwd=BROWSER_DIR, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert zip_path.exists(), "insight_browser.zip missing"
+    assert zip_path.stat().st_size <= 3 * 1024 * 1024, "zip size exceeds 3 MiB"
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    expected = {
+        "index.html",
+        "insight.bundle.js",
+        "service-worker.js",
+        "manifest.json",
+        "style.css",
+        "insight_browser_quickstart.pdf",
+    }
+    # ensure expected files exist
+    for name in expected:
+        assert name in names, f"{name} missing from zip"
+    # ensure assets directory exists and contains files
+    assert any(n.startswith("assets/") for n in names), "assets directory missing"
+    # ensure no unexpected files
+    allowed_prefixes = {"assets/"}
+    for name in names:
+        if name in expected:
+            continue
+        if any(name.startswith(p) for p in allowed_prefixes):
+            continue
+        pytest.fail(f"Unexpected file {name} in zip")


### PR DESCRIPTION
## Summary
- add `build:dist` npm script for Insight Browser distribution
- verify Insight Browser zip contents and size in `test_distribution_zip`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f2b0626308333bbd03e98b1e6d902