### PR TITLE
[alpha_factory] fix closing tags for insight browser

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -1,27 +1,33 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="theme-color" content="#0d0e2e" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval'" />
-<title>α-AGI Insight – in-browser Pareto explorer</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml" />
-<link rel="manifest" href="manifest.json" />
-<!-- styles injected by insight.bundle.js -->
-
-<div id="controls"></div>
-<div id="toast" aria-live="polite"></div>
-<div id="toolbar"><button id="install-btn" hidden>Install</button></div>
-<div id="legend"></div>
-<script src="d3.v7.min.js" integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8" crossorigin="anonymous"></script>
-<script src="bundle.esm.min.js" integrity="sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax" crossorigin="anonymous"></script>
-<script src="pyodide.js" integrity="sha384-4lQJt6JNK5sYso6mEO1s2l1EnmbkIm958N+CAuWcYFBPuizBJ5nENroO7dtV8upW" crossorigin="anonymous"></script>
-<script>
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
-      navigator.serviceWorker
-        .register('sw.js')
-        .catch(() => toast('Service worker registration failed; offline mode disabled.'));
-    });
-  }
-</script>
-<script src="insight.bundle.js" integrity="sha384-fytBrbzLowDzZ22VyNAPLq8E8xGIlgLXM8JfVX+8ecZ+5YAj2RY+4FuIy1vI8ENI" crossorigin="anonymous"></script>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0d0e2e" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval'" />
+    <title>α-AGI Insight – in-browser Pareto explorer</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+    <link rel="manifest" href="manifest.json" />
+    <!-- styles injected by insight.bundle.js -->
+  </head>
+  <body>
+    <div id="controls"></div>
+    <div id="toast" aria-live="polite"></div>
+    <div id="toolbar"><button id="install-btn" hidden>Install</button></div>
+    <div id="legend"></div>
+    <script src="d3.v7.min.js" integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8" crossorigin="anonymous"></script>
+    <script src="bundle.esm.min.js" integrity="sha384-HCq3AUAghBODOAg7+u+o8u2pKjENSb3YGAjRfL6TZgAY49LXzq1SaOwNtQmWsIax" crossorigin="anonymous"></script>
+    <script src="pyodide.js" integrity="sha384-4lQJt6JNK5sYso6mEO1s2l1EnmbkIm958N+CAuWcYFBPuizBJ5nENroO7dtV8upW" crossorigin="anonymous"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker
+            .register('sw.js')
+            .catch(() => toast('Service worker registration failed; offline mode disabled.'));
+        });
+      }
+    </script>
+    <script src="insight.bundle.js" integrity="sha384-fytBrbzLowDzZ22VyNAPLq8E8xGIlgLXM8JfVX+8ecZ+5YAj2RY+4FuIy1vI8ENI" crossorigin="anonymous"></script>
+    <script>window.PINNER_TOKEN="";window.OPENAI_API_KEY="";window.OTEL_ENDPOINT="";window.IPFS_GATEWAY="";</script>
+  </body>
+</html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_closing_tags.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_closing_tags.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for closing tags in the built HTML."""
+from pathlib import Path
+
+
+def test_index_html_has_closing_tags() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    html = (browser_dir / "dist" / "index.html").read_text().splitlines()
+    assert html[-2].strip() == "</body>"
+    assert html[-1].strip() == "</html>"
+    joined = "\n".join(html)
+    assert "window.PINNER_TOKEN" in joined


### PR DESCRIPTION
## Summary
- rebuild `dist/index.html` with closing tags and env vars
- add regression test for closing tags

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries error)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e57725c83339c894db4cdca257d