### PR TITLE
[alpha_factory] add typescript dev dependency

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -22,6 +22,7 @@
     "@eslint/js": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
+    "typescript": "^5.3.0",
     "gzip-size-cli": "^5.1.1",
     "serve": "^14.2.0",
     "web3.storage": "^5.1.0",


### PR DESCRIPTION
## Summary
- add TypeScript to demo browser's dev deps

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json` *(fails: could not fetch black)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f49a48f788333bc76f020a34d14f4