### PR TITLE
[alpha_factory] add missing SPDX headers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const path = require('path');
 
 jest.mock('../src/evolve/mutate.js', () => ({

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/iframe_worker_cleanup.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/iframe_worker_cleanup.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replay_cid.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replay_cid.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ReplayDB } from '../src/replay.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator_perf.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator_perf.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Simulator } from '../src/simulator.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- add SPDX headers to Insight browser tests

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replay_cid.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/iframe_worker_cleanup.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator_perf.test.js` *(fails: CONNECT tunnel failed)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_683f4ce6f2d88333bbcdb82a8328bee3