### PR TITLE
[alpha_factory] embed libs in bundle

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -151,9 +151,9 @@ async function bundle() {
   bundleText = `${d3Code}\n${web3Code}\n${pyCode}\nwindow.PYODIDE_WASM_BASE64='${wasmBase64}';window.GPT2_MODEL_BASE64='${gpt2Base64}';\n` + bundleText;
   await fs.writeFile(bundlePath, bundleText);
   outHtml = outHtml
-    .replace(/<script[^>]*d3.v7.min.js[^>]*>\s*<\/script>\n?/,'')
-    .replace(/<script[^>]*bundle.esm.min.js[^>]*>\s*<\/script>\n?/,'')
-    .replace(/<script[^>]*pyodide.js[^>]*>\s*<\/script>\n?/,'')
+    .replace(/<script[\s\S]*?d3\.v7\.min\.js[\s\S]*?<\/script>\s*/g, '')
+    .replace(/<script[\s\S]*?bundle\.esm\.min\.js[\s\S]*?<\/script>\s*/g, '')
+    .replace(/<script[\s\S]*?pyodide\.js[\s\S]*?<\/script>\s*/g, '')
     .replace('</body>', `${envScript}\n</body>`);
   await fs.writeFile(`${OUT_DIR}/index.html`, outHtml);
   const pkg = JSON.parse(fsSync.readFileSync('package.json', 'utf8'));

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -266,9 +266,9 @@ out_html = out_html.replace(
     f'<script type="module" src="insight.bundle.js" integrity="{app_sri}" crossorigin="anonymous"></script>',
 )
 env_script = inject_env()
-out_html = re.sub(r'<script[^>]*d3.v7.min.js[^>]*>\s*</script>\n?', '', out_html)
-out_html = re.sub(r'<script[^>]*bundle.esm.min.js[^>]*>\s*</script>\n?', '', out_html)
-out_html = re.sub(r'<script[^>]*pyodide.js[^>]*>\s*</script>\n?', '', out_html)
+out_html = re.sub(r'<script[\s\S]*?d3\.v7\.min\.js[\s\S]*?</script>\s*', '', out_html)
+out_html = re.sub(r'<script[\s\S]*?bundle\.esm\.min\.js[\s\S]*?</script>\s*', '', out_html)
+out_html = re.sub(r'<script[\s\S]*?pyodide\.js[\s\S]*?</script>\s*', '', out_html)
 out_html = out_html.replace(
     "</body>",
     f"{env_script}\n</body>",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure only the bundled script is fetched when opening the demo."""
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_single_network_request() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        requests: list[str] = []
+        page.on(
+            "request",
+            lambda req: requests.append(req.url)
+            if req.url.endswith(".js") and not req.url.endswith("sw.js")
+            else None,
+        )
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        assert requests == [page.url.replace("index.html", "insight.bundle.js")]
+        browser.close()


### PR DESCRIPTION
## Summary
- embed library code and remove legacy script tags
- test that the built demo only makes one JS request

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py` *(fails: unable to access 'https://github.com/psf/black/' due to network)*
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py` *(fails: BrowserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_683f4fe33fbc833393ab683467939387