### PR TITLE
[alpha_factory] extend taxonomy functions

### DIFF
--- a/src/taxonomy.ts
+++ b/src/taxonomy.ts
@@ -93,3 +93,110 @@ export async function loadTaxonomy(): Promise<HyperGraph> {
   }
   return out;
 }
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t);
+}
+
+function toVector(tokens: string[]): Record<string, number> {
+  const vec: Record<string, number> = {};
+  for (const t of tokens) vec[t] = (vec[t] || 0) + 1;
+  return vec;
+}
+
+function cosine(a: Record<string, number>, b: Record<string, number>): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (const k in a) {
+    dot += (a[k] || 0) * (b[k] || 0);
+    na += a[k] * a[k];
+  }
+  for (const k in b) nb += b[k] * b[k];
+  if (!na || !nb) return 0;
+  return dot / Math.sqrt(na * nb);
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  const inter = new Set([...a].filter((x) => b.has(x))).size;
+  const union = new Set([...a, ...b]).size;
+  if (!union) return 0;
+  return inter / union;
+}
+
+export function clusterKeywords(
+  runs: Array<{ keywords: string[] }>,
+  thresh = 0.6,
+): string[][] {
+  const kwRuns: Record<string, Set<number>> = {};
+  runs.forEach((r, i) => {
+    for (const k of r.keywords || []) {
+      kwRuns[k] = kwRuns[k] || new Set();
+      kwRuns[k].add(i);
+    }
+  });
+  const keys = Object.keys(kwRuns);
+  const clusters: string[][] = [];
+  const used = new Set<string>();
+  for (let i = 0; i < keys.length; i++) {
+    const a = keys[i];
+    if (used.has(a)) continue;
+    const group = [a];
+    used.add(a);
+    for (let j = i + 1; j < keys.length; j++) {
+      const b = keys[j];
+      if (used.has(b)) continue;
+      if (jaccard(kwRuns[a], kwRuns[b]) >= thresh) {
+        group.push(b);
+        used.add(b);
+      }
+    }
+    clusters.push(group);
+  }
+  return clusters;
+}
+
+export async function validateLabel(name: string): Promise<boolean> {
+  try {
+    const { chat } = await import('./utils/llm.js');
+    const resp = await chat(`Does '${name}' denote a distinct economic activity?`);
+    return /^yes/i.test(String(resp).trim());
+  } catch {
+    return false;
+  }
+}
+
+function bestParent(label: string, graph: HyperGraph): [string | null, number] {
+  const vec = toVector(tokenize(label));
+  let best: string | null = null;
+  let score = 0;
+  for (const n of Object.values(graph.nodes)) {
+    if (!n.id) continue;
+    const sim = cosine(vec, toVector(tokenize(n.id)));
+    if (sim > score) {
+      score = sim;
+      best = n.id;
+    }
+  }
+  return [best, score];
+}
+
+export async function proposeSectorNodes(
+  runs: Array<{ keywords: string[] }>,
+  graph: HyperGraph,
+): Promise<HyperGraph> {
+  const clusters = clusterKeywords(runs, 0.6);
+  for (const c of clusters) {
+    const name = c.join(' ');
+    if (graph.nodes[name]) continue;
+    if (!(await validateLabel(name))) continue;
+    const [parent, sim] = bestParent(name, graph);
+    if (parent && sim > 0.9) continue;
+    graph.nodes[name] = { id: name, parent: sim > 0.3 ? parent : null };
+  }
+  await saveTaxonomy(graph);
+  return graph;
+}


### PR DESCRIPTION
## Summary
- expand taxonomy module with keyword clustering and LLM validation
- update browser evolution panel to build tree from proposed sectors
- test taxonomy persistence and keyword clusters

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f51c5f9988333978987b90e70261f