### PR TITLE
[alpha_factory] enforce python 3.11 in manual build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -12,6 +12,12 @@ from urllib.parse import urlparse
 import gzip
 
 
+def _require_python_311() -> None:
+    major, minor = sys.version_info[:2]
+    if (major, minor) < (3, 11):
+        sys.exit(f"Python ≥3.11 required. Current version: {sys.version}")
+
+
 def _require_node_20() -> None:
     """Exit when Node.js is missing or too old."""
     if not shutil.which("node"):
@@ -28,6 +34,7 @@ def _require_node_20() -> None:
         sys.exit(f"Node.js 20+ is required. Current version: {version}")
 
 
+_require_python_311()
 _require_node_20()
 
 # load environment variables

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import subprocess
 from pathlib import Path
+import runpy
+import sys
+from unittest import mock
+import pytest
 
 
 def test_requires_node_20() -> None:
@@ -18,4 +22,12 @@ def test_requires_node_20() -> None:
     )
     assert res.returncode == 1
     assert "Node.js 20+ is required. Current version: 19.0.0" in res.stderr
+
+
+def test_requires_python_311() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    script = browser_dir / "manual_build.py"
+    with mock.patch.object(sys, "version_info", (3, 10)):
+        with pytest.raises(SystemExit):
+            runpy.run_path(script, run_name="__main__")
 


### PR DESCRIPTION
## Summary
- ensure `manual_build.py` requires Python >=3.11
- check Python version before Node version
- expand node version tests with Python version assertion

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f575fe5508333920a538a3a7c7d7e