### PR TITLE
[alpha_factory] enforce noImplicitAny for insight browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
         run: pnpm --dir src/interface/web_client install
       - name: Audit web dependencies
         run: npm --prefix src/interface/web_client audit --production --audit-level=high
+      - name: Type check insight browser
+        run: pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
       - name: Cypress E2E tests with Percy
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.ts
@@ -43,7 +43,7 @@ export function initArenaPanel(onDebate?: DebateHandler): ArenaPanel {
 
   let currentFront = [];
 
-  function render(front) {
+  function render(front: Individual[]): void {
     currentFront = front;
     ranking.innerHTML = '';
     const sorted = [...front].sort((a, b) => (b.rank ?? 0) - (a.rank ?? 0));
@@ -58,9 +58,9 @@ export function initArenaPanel(onDebate?: DebateHandler): ArenaPanel {
     });
   }
 
-  function show(messages, score) {
+  function show(messages: DebateMessage[], score: number): void {
     msgs.innerHTML = messages
-      .map((m) => `<li><strong>${m.role}:</strong> ${m.text}</li>`)
+      .map((m: DebateMessage) => `<li><strong>${m.role}:</strong> ${m.text}</li>`)
       .join('');
     const li = document.createElement('li');
     li.textContent = `${t('label.score')}: ${score}`;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.ts
@@ -48,7 +48,8 @@ export function initEvolutionPanel(archive: Archive): EvolutionPanel {
   panel.appendChild(memeDiv);
   document.body.appendChild(panel);
 
-  let sortKey = 'timestamp';
+  type RunSortKey = 'seed' | 'score' | 'novelty' | 'timestamp';
+  let sortKey: RunSortKey = 'timestamp';
   let desc = true;
   let taxonomy: HyperGraph | null = null;
   let selectedNode: string | null = null;
@@ -57,7 +58,7 @@ export function initEvolutionPanel(archive: Archive): EvolutionPanel {
     .forEach((th) => {
       th.style.cursor = 'pointer';
       th.onclick = () => {
-        const k = th.dataset.k ?? '';
+        const k = (th.dataset.k ?? 'timestamp') as RunSortKey;
         if (sortKey === k) desc = !desc;
         else {
           sortKey = k;
@@ -147,7 +148,11 @@ export function initEvolutionPanel(archive: Archive): EvolutionPanel {
         return parts.every((p) => kws.includes(p));
       });
     }
-    runs.sort((a, b) => (desc ? b[sortKey] - a[sortKey] : a[sortKey] - b[sortKey]));
+    runs.sort((a, b) =>
+      desc
+        ? (b[sortKey] as number) - (a[sortKey] as number)
+        : (a[sortKey] as number) - (b[sortKey] as number),
+    );
     table.querySelectorAll('tr').forEach((tr, i) => { if (i) tr.remove(); });
     runs.forEach((r) => {
       const tr = document.createElement('tr');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
@@ -95,7 +95,7 @@ export async function initSimulatorPanel(
     prompt: 'score idea',
   };
 
-  function showFrame(i) {
+  function showFrame(i: number): void {
     const f = frames[i];
     if (!f) return;
     pop = f;
@@ -112,7 +112,10 @@ export async function initSimulatorPanel(
 
   startBtn.addEventListener('click', async () => {
     if (sim && typeof sim.return === 'function') await sim.return(undefined);
-    const seeds = seedsInput.value.split(',').map((s) => Number(s.trim())).filter(Boolean);
+    const seeds = seedsInput.value
+      .split(',')
+      .map((s: string) => Number(s.trim()))
+      .filter(Boolean);
     memeRuns = [];
     sim = Simulator.run({
       popSize: Number(popInput.value),
@@ -134,7 +137,10 @@ export async function initSimulatorPanel(
         await new Promise((r) => setTimeout(r, 100));
       }
       lastPop = g.population;
-      const edges = g.population.map((p) => ({ from: p.strategy || 'x', to: p.strategy || 'x' }));
+      const edges = g.population.map((p: Individual) => ({
+        from: p.strategy || 'x',
+        to: p.strategy || 'x',
+      }));
       memeRuns.push({ edges });
       await saveMemes(mineMemes(memeRuns));
       frames.push(clone(g.population));
@@ -146,7 +152,7 @@ export async function initSimulatorPanel(
       count = g.gen;
       window.pop = g.population;
       if (g.population[0] && g.population[0].umap) {
-        const pts = g.population.map((p) => p.umap);
+        const pts = g.population.map((p: Individual) => p.umap);
         window.coldZone = detectColdZone(pts);
       }
       progress.value = count / Number(genInput.value);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "esnext",
     "strict": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "moduleResolution": "node",
     "baseUrl": "./",
     "paths": {

--- a/src/taxonomy.ts
+++ b/src/taxonomy.ts
@@ -131,11 +131,11 @@ export function clusterKeywords(
   runs: Array<{ keywords: string[] }>,
   thresh = 0.6,
 ): string[][] {
-  const kwRuns: Record<string, Set<number>> = {};
+  const kwRuns: Record<string, Set<string>> = {};
   runs.forEach((r, i) => {
     for (const k of r.keywords || []) {
       kwRuns[k] = kwRuns[k] || new Set();
-      kwRuns[k].add(i);
+      kwRuns[k].add(String(i));
     }
   });
   const keys = Object.keys(kwRuns);
@@ -161,7 +161,9 @@ export function clusterKeywords(
 
 export async function validateLabel(name: string): Promise<boolean> {
   try {
-    const { chat } = await import('./utils/llm.js');
+    const { chat } = await import(
+      '../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js'
+    );
     const resp = await chat(`Does '${name}' denote a distinct economic activity?`);
     return /^yes/i.test(String(resp).trim());
   } catch {


### PR DESCRIPTION
## Summary
- turn on `noImplicitAny` in insight browser tsconfig
- fix typings in taxonomy and UI panels
- check browser types in CI

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: duplicated timeseries in CollectorRegistry)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683f6088855c833387906d9247ff8058