### PR TITLE
[alpha_factory] Localize EvolutionPanel labels

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
@@ -25,4 +25,8 @@
   "summary.debate": "Debate",
   "label.rank": "Rank",
   "label.score": "Score"
+  ,"score": "Score"
+  ,"novelty": "Novelty"
+  ,"time": "Time"
+  ,"respawn": "Re-spawn"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json
@@ -25,4 +25,8 @@
   "summary.debate": "Debate",
   "label.rank": "Rango",
   "label.score": "Puntuación"
+  ,"score": "Puntuación"
+  ,"novelty": "Novedad"
+  ,"time": "Tiempo"
+  ,"respawn": "Reaparecer"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
@@ -25,4 +25,8 @@
   "summary.debate": "Débat",
   "label.rank": "Rang",
   "label.score": "Score"
+  ,"score": "Score"
+  ,"novelty": "Nouveauté"
+  ,"time": "Temps"
+  ,"respawn": "Relancer"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { loadTaxonomy, saveTaxonomy, proposeSectorNodes } from '@insight-src/taxonomy.ts';
 import { loadMemes } from '@insight-src/memeplex.ts';
+import { t } from './i18n.js';
 import type { HyperGraph } from '@insight-src/taxonomy.ts';
 import type { Archive, InsightRun } from '../archive.ts';
 
@@ -34,10 +35,10 @@ export function initEvolutionPanel(archive: Archive): EvolutionPanel {
   const table = document.createElement('table');
   const header = document.createElement('tr');
   header.innerHTML =
-    '<th data-k="seed">Seed</th>' +
-    '<th data-k="score">Score</th>' +
-    '<th data-k="novelty">Novelty</th>' +
-    '<th data-k="timestamp">Time</th>' +
+    `<th data-k="seed">${t('seed')}</th>` +
+    `<th data-k="score">${t('score')}</th>` +
+    `<th data-k="novelty">${t('novelty')}</th>` +
+    `<th data-k="timestamp">${t('time')}</th>` +
     '<th></th>';
   table.appendChild(header);
   const memeDiv = document.createElement('div');
@@ -160,7 +161,7 @@ export function initEvolutionPanel(archive: Archive): EvolutionPanel {
       tr.innerHTML = `<td>${r.seed}</td><td>${r.score.toFixed(2)}</td><td>${r.novelty.toFixed(2)}</td><td>${time}</td>`;
       const td = document.createElement('td');
       const btn = document.createElement('button');
-      btn.textContent = 'Re-spawn';
+      btn.textContent = t('respawn');
       btn.onclick = () => respawn(r.seed);
       td.appendChild(btn);
       tr.appendChild(td);


### PR DESCRIPTION
## Summary
- use `t()` for EvolutionPanel header labels and respawn button
- add translations for new i18n keys

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ede379883338159fd3c25d577c8