### PR TITLE
[alpha_factory] add ts tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -14,7 +14,7 @@
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js && pytest ../../../../tests/test_quickstart_offline.py"
+    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",

--- a/tests/memeplex.test.ts
+++ b/tests/memeplex.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mineMemes, saveMemes, loadMemes } from '../src/memeplex.ts';
+
+const DB_NAME = 'memeplex';
+
+function resetDB() {
+  indexedDB.deleteDatabase(DB_NAME);
+}
+
+resetDB();
+
+test('mineMemes counts edges and persists', async () => {
+  resetDB();
+  const runs = [
+    { edges: [{ from: 'A', to: 'B' }, { from: 'B', to: 'C' }] },
+    { edges: [{ from: 'A', to: 'B' }] },
+    { edges: [{ from: 'A', to: 'B' }] },
+  ];
+  const memes = mineMemes(runs, 2);
+  assert.equal(memes.length, 1);
+  assert.equal(memes[0].count, 3);
+  await saveMemes(memes);
+  const loaded = await loadMemes();
+  assert.deepEqual(loaded, memes);
+});

--- a/tests/taxonomy.test.ts
+++ b/tests/taxonomy.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mineTaxonomy, pruneTaxonomy, proposeSectorNodes, loadTaxonomy } from '.../src/taxonomy.ts';
+
+// Clean database before each run
+const DB_NAME = 'sectorTaxonomy';
+
+function resetDB() {
+  indexedDB.deleteDatabase(DB_NAME);
+}
+
+resetDB();
+
+test('mineTaxonomy and pruneTaxonomy', () => {
+  const g = mineTaxonomy([
+    { params: { sector: 'A' } },
+    { params: { sector: 'B' } },
+    { params: { sector: 'A' } },
+  ]);
+  assert.deepEqual(Object.keys(g.nodes).sort(), ['A', 'B']);
+  const pruned = pruneTaxonomy(g, new Set(['A']));
+  assert.deepEqual(Object.keys(pruned.nodes), ['A']);
+});
+
+test('proposeSectorNodes clusters keywords and saves', async () => {
+  resetDB();
+  const origFetch = global.fetch;
+  (global as any).fetch = async () => ({
+    json: async () => ({ choices: [{ message: { content: 'Yes' } }] })
+  }) as any;
+
+  const runs = [
+    { keywords: ['solar', 'energy'] },
+    { keywords: ['wind', 'energy'] },
+  ];
+  let g = { nodes: {} as any };
+  g = await proposeSectorNodes(runs, g);
+  assert.ok(Object.keys(g.nodes).length > 0);
+  const loaded = await loadTaxonomy();
+  assert.deepEqual(Object.keys(loaded.nodes), Object.keys(g.nodes));
+
+  (global as any).fetch = origFetch;
+});


### PR DESCRIPTION
## Summary
- add new TypeScript tests for taxonomy and memeplex modules
- call new tests from npm test script

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `npm test` *(fails: cannot find module 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_683f84d5e5188333ac1c28c4b0e0f4c7