### PR TITLE
[alpha_factory] add playwright test for evolution panel

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -14,7 +14,7 @@
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py"
+    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py ../../../../tests/test_evolution_panel_reload.py"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",

--- a/tests/test_evolution_panel_reload.py
+++ b/tests/test_evolution_panel_reload.py
@@ -1,0 +1,26 @@
+import pytest
+from pathlib import Path
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_evolution_panel_persists_after_reload() -> None:
+    dist = Path(__file__).resolve().parents[1] / (
+        "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html"
+    )
+    url = dist.as_uri() + "#s=1&p=3&g=3"
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            page.wait_for_function("window.gen >= 3")
+            page.reload()
+            page.wait_for_selector("#controls")
+            page.wait_for_function("document.querySelectorAll('#evolution-panel table tr').length > 1")
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- add a Playwright test verifying archived runs persist after reload
- run test via npm by updating package.json

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `npm test --silent` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_683f8848a888833393351b947a820383