### PR TITLE
[alpha_factory] update archive pruning

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -98,7 +98,7 @@ export class Archive {
         throw err;
       }
     }
-    await this.prune(500);
+    await this.prune(50);
     return id;
   }
 
@@ -125,10 +125,10 @@ export class Archive {
     return evals;
   }
 
-  async prune(max = 500): Promise<void> {
+  async prune(max = 50): Promise<void> {
     const runs = await this.list();
     if (runs.length <= max) return;
-    runs.sort((a, b) => a.score + a.novelty - (b.score + b.novelty));
+    runs.sort((a, b) => a.timestamp - b.timestamp);
     const remove = runs.slice(0, runs.length - max);
     await Promise.all(remove.map((r) => del(r.id, this.runStore)));
     const keepIds = new Set(runs.slice(runs.length - max).map((r) => r.evalId));

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -77,3 +77,14 @@ test('in-memory fallback triggers toast', async () => {
   expect(runs.length).toBe(1);
   global.indexedDB = orig;
 });
+
+test('auto prune retains latest 50 runs', async () => {
+  const a = new Archive('jest');
+  await a.open();
+  for (let i = 0; i < 55; i++) {
+    await a.add(i, {}, [{ logic: 0, feasible: 0 }]);
+  }
+  const runs = await a.list();
+  expect(runs.length).toBe(50);
+  expect(runs[0].seed).toBe(5);
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_archive_quota.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_archive_quota.py
@@ -29,7 +29,10 @@ def test_archive_quota_toast() -> None:
             };
             """
         )
-        page.evaluate("window.archive.add(1, {}, [{logic:1,feasible:1}])")
+        page.evaluate(
+            "(async () => { for (let i = 0; i < 55; i++) await window.archive.add(i, {}, [{logic:1,feasible:1}]); })()"
+        )
         page.wait_for_selector("#toast.show")
         assert "Archive full" in page.inner_text("#toast")
+        page.wait_for_function("window.archive.list().then(r => r.length === 50)")
         browser.close()


### PR DESCRIPTION
## Summary
- limit insight browser archive to 50 entries
- delete oldest entries first
- update browser unit tests with new limit

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d38544083338ad2985123115d30