### PR TITLE
[alpha_factory] migrate web workers to TypeScript

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -61,6 +61,21 @@ async function ensureWeb3Bundle() {
   }
 }
 
+async function compileWorkers() {
+  const workers = ['evolver', 'arenaWorker', 'umapWorker'];
+  await Promise.all(
+    workers.map((w) =>
+      build({
+        entryPoints: [`worker/${w}.ts`],
+        outfile: `worker/${w}.js`,
+        bundle: false,
+        format: 'esm',
+        target: 'es2020',
+      }),
+    ),
+  );
+}
+
 function collectFiles(dir) {
   let out = [];
   if (!fsSync.existsSync(dir)) return out;
@@ -108,6 +123,7 @@ async function bundle() {
   const html = await fs.readFile('index.html', 'utf8');
   await ensureWeb3Bundle();
   ensureAssets();
+  await compileWorkers();
   const ipfsOrigin = process.env.IPFS_GATEWAY
     ? new URL(process.env.IPFS_GATEWAY).origin
     : '';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -154,6 +154,16 @@ if placeholders:
 
 subprocess.run(["tsc", "--noEmit"], check=True)
 
+def _compile_worker(path: Path) -> str:
+    script = (
+        "const ts=require('typescript');"
+        "const fs=require('fs');"
+        "const src=fs.readFileSync(process.argv[1],'utf8');"
+        "const out=ts.transpileModule(src,{compilerOptions:{module:'ES2022',target:'ES2022'}});"
+        "process.stdout.write(out.outputText);"
+    )
+    return subprocess.check_output(["node", "-e", script, str(path)], text=True)
+
 html = index_html.read_text()
 entry = (ROOT / "app.js").read_text()
 
@@ -228,8 +238,8 @@ gpt2_b64 = ""
 gpt2_file = ROOT / "wasm_llm" / "wasm-gpt2.tar"
 if gpt2_file.exists():
     gpt2_b64 = base64.b64encode(gpt2_file.read_bytes()).decode()
-evolver = (ROOT / "worker" / "evolver.js").read_text()
-arena = (ROOT / "worker" / "arenaWorker.js").read_text()
+evolver = _compile_worker(ROOT / "worker" / "evolver.ts")
+arena = _compile_worker(ROOT / "worker" / "arenaWorker.ts")
 bundle = (
     d3_code
     + "\n"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
@@ -14,7 +14,7 @@ function makeMsg(gen) {
 test('worker updates gpu flag before mutate calls', async () => {
   const selfObj = { navigator: {}, postMessage: jest.fn() };
   global.self = selfObj;
-  await import('../worker/evolver.js');
+  await import('../worker/evolver.ts');
   const handler = selfObj.onmessage;
 
   handler({ data: { type: 'gpu', available: true } });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -12,5 +12,5 @@
     "allowJs": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["src/**/*.ts", "src/**/*.js"]
+  "include": ["src/**/*.ts", "src/**/*.js", "worker/**/*.ts"]
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/arenaWorker.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/arenaWorker.ts
@@ -5,7 +5,21 @@
  * Proposer, Skeptic, Regulator and Investor. The outcome score is
  * returned to the caller along with the threaded messages.
  */
-self.onmessage = (ev) => {
+interface ArenaRequest {
+  hypothesis?: string;
+}
+
+interface DebateMessage {
+  role: string;
+  text: string;
+}
+
+interface ArenaResult {
+  messages: DebateMessage[];
+  score: number;
+}
+
+self.onmessage = (ev: MessageEvent<ArenaRequest>) => {
   const { hypothesis } = ev.data || {};
   if (!hypothesis) return;
 
@@ -24,5 +38,6 @@ self.onmessage = (ev) => {
   });
 
   const score = approved ? 1 : 0;
-  self.postMessage({ messages, score });
+  const result: ArenaResult = { messages, score };
+  self.postMessage(result);
 };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts
@@ -2,6 +2,7 @@
 import { mutate } from '../src/evolve/mutate.js';
 import { paretoFront } from '../src/utils/pareto.js';
 import { lcg } from '../src/utils/rng.js';
+import type { Individual } from '../src/state/serializer.ts';
 
 const ua = self.navigator?.userAgent ?? '';
 const isSafari = /Safari/.test(ua) && !/Chrome|Chromium|Edge/.test(ua);
@@ -10,6 +11,29 @@ let pyReady;
 let warned = false;
 let pySupported = !(isSafari || isIOS);
 let gpuAvailable = false;
+
+interface GPUMessage {
+  type: 'gpu';
+  available: boolean;
+}
+
+interface EvolverRequest {
+  pop: Individual[];
+  rngState: number;
+  mutations: string[];
+  popSize: number;
+  critic: 'llm' | 'none';
+  gen: number;
+  adaptive?: boolean;
+  sigmaScale?: number;
+}
+
+interface EvolverResult {
+  pop: Individual[];
+  rngState: number;
+  front: Individual[];
+  metrics: { avgLogic: number; avgFeasible: number; frontSize: number };
+}
 
 async function loadPy() {
   if (!pySupported) {
@@ -35,22 +59,41 @@ async function loadPy() {
   return pyReady;
 }
 
-function shuffle(arr, rand) {
+function shuffle<T>(arr: T[], rand: () => number) {
   for (let i = arr.length - 1; i > 0; i--) {
     const j = Math.floor(rand() * (i + 1));
     [arr[i], arr[j]] = [arr[j], arr[i]];
   }
 }
 
-self.onmessage = async (ev) => {
-  if (ev.data?.type === 'gpu') {
-    gpuAvailable = !!ev.data.available;
+self.onmessage = async (
+  ev: MessageEvent<EvolverRequest | GPUMessage>,
+) => {
+  if ((ev.data as GPUMessage)?.type === 'gpu') {
+    gpuAvailable = !!(ev.data as GPUMessage).available;
     return;
   }
-  const { pop, rngState, mutations, popSize, critic, gen, adaptive, sigmaScale = 1 } = ev.data;
+  const {
+    pop,
+    rngState,
+    mutations,
+    popSize,
+    critic,
+    gen,
+    adaptive,
+    sigmaScale = 1,
+  } = ev.data as EvolverRequest;
   const rand = lcg(0);
   rand.set(rngState);
-  let next = mutate(pop, rand, mutations, gen, adaptive, sigmaScale, gpuAvailable);
+  let next = mutate(
+    pop,
+    rand,
+    mutations,
+    gen,
+    adaptive,
+    sigmaScale,
+    gpuAvailable,
+  );
   const front = paretoFront(next);
   next.forEach((d) => (d.front = front.includes(d)));
   if (critic === 'llm') {
@@ -63,5 +106,11 @@ self.onmessage = async (ev) => {
     avgFeasible: next.reduce((s, d) => s + (d.feasible ?? 0), 0) / next.length,
     frontSize: front.length,
   };
-  self.postMessage({ pop: next, rngState: rand.state(), front, metrics });
+  const result: EvolverResult = {
+    pop: next,
+    rngState: rand.state(),
+    front,
+    metrics,
+  };
+  self.postMessage(result);
 };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/umapWorker.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/umapWorker.ts
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { loadPyodide } from '../lib/pyodide.js';
+import type { Individual } from '../src/state/serializer.ts';
 
-let pyReady;
-async function initPy() {
+let pyReady: any;
+async function initPy(): Promise<any> {
   if (!pyReady) {
     pyReady = await loadPyodide({ indexURL: './wasm/' }).catch(() => null);
   }
   return pyReady;
 }
 
-async function embedTexts(texts) {
+async function embedTexts(texts: string[]): Promise<[number, number][]> {
   const py = await initPy();
   if (!py) return texts.map(() => [Math.random(), Math.random()]);
   try {
@@ -22,7 +23,11 @@ async function embedTexts(texts) {
   }
 }
 
-self.onmessage = async (ev) => {
+interface UmapRequest {
+  population: (Individual & { summary?: string })[];
+}
+
+self.onmessage = async (ev: MessageEvent<UmapRequest>) => {
   const { population } = ev.data;
   const texts = population.map((p) => p.summary || '');
   const coords = await embedTexts(texts);


### PR DESCRIPTION
## Summary
- convert Insight Browser workers to TypeScript
- generate JS worker output during build
- compile workers in manual build
- update tsconfig and GPU flag test

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/arenaWorker.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/umapWorker.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f8e6a1f6c8333926bda4bdd52b70c