### PR TITLE
[alpha_factory] add i18n strings and fallbacks

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -251,6 +251,7 @@ function apply(p, info = {}){
 
 window.addEventListener('DOMContentLoaded',async()=>{
   initErrorBoundary();
+  await initI18n();
   telemetry = initTelemetry();
   archive = new Archive();
   await archive.open();
@@ -276,7 +277,6 @@ window.addEventListener('DOMContentLoaded',async()=>{
   };
   await evolutionPanel.render();
   window.archive = archive;
-  await initI18n()
   loadTheme()
   const ex=await loadCriticExamples()
   logicCritic=new LogicCritic(ex)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
@@ -29,4 +29,10 @@
   ,"novelty": "Novelty"
   ,"time": "Time"
   ,"respawn": "Re-spawn"
+  ,"pyodide_unavailable": "Pyodide unavailable; using JS only"
+  ,"pyodide_failed": "Pyodide failed to load; using JS only"
+  ,"archive_disabled": "Archive disabled (no storage access)"
+  ,"archive_full": "Archive full; oldest runs pruned"
+  ,"pin_failed": "pin failed"
+  ,"error_unknown": "unknown error"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json
@@ -29,4 +29,10 @@
   ,"novelty": "Novedad"
   ,"time": "Tiempo"
   ,"respawn": "Reaparecer"
+  ,"pyodide_unavailable": "Pyodide no disponible; usando solo JS"
+  ,"pyodide_failed": "Pyodide no se carg\u00f3; usando solo JS"
+  ,"archive_disabled": "Archivo deshabilitado (sin acceso a almacenamiento)"
+  ,"archive_full": "Archivo lleno; ejecuciones antiguas eliminadas"
+  ,"pin_failed": "error al fijar"
+  ,"error_unknown": "error desconocido"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
@@ -29,4 +29,10 @@
   ,"novelty": "Nouveauté"
   ,"time": "Temps"
   ,"respawn": "Relancer"
+  ,"pyodide_unavailable": "Pyodide indisponible; JS uniquement"
+  ,"pyodide_failed": "\u00c9chec du chargement de Pyodide; JS uniquement"
+  ,"archive_disabled": "Archive d\u00e9sactiv\u00e9e (pas d'acc\u00e8s au stockage)"
+  ,"archive_full": "Archive pleine; anciennes ex\u00e9cutions supprim\u00e9es"
+  ,"pin_failed": "\u00e9chec de l'\u00e9pinglage"
+  ,"error_unknown": "erreur inconnue"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
@@ -10,7 +10,7 @@ export async function initI18n() {
   currentLanguage = lang.startsWith('fr') ? 'fr' : lang.startsWith('es') ? 'es' : 'en';
   try {
     const res = await fetch(`src/i18n/${currentLanguage}.json`);
-    strings = await res.json();
+    strings = { ...enStrings, ...(await res.json()) };
   } catch {
     strings = enStrings;
     currentLanguage = 'en';
@@ -22,7 +22,7 @@ export async function setLanguage(lang) {
   localStorage.setItem('lang', lang);
   try {
     const res = await fetch(`src/i18n/${lang}.json`);
-    strings = await res.json();
+    strings = { ...enStrings, ...(await res.json()) };
   } catch {
     strings = enStrings;
     currentLanguage = 'en';
@@ -30,5 +30,5 @@ export async function setLanguage(lang) {
 }
 
 export function t(key) {
-  return strings[key] || key;
+  return strings[key] || enStrings[key] || key;
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.js
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { t } from '../ui/i18n.js';
 let log = [];
 
 export function initErrorBoundary() {
@@ -13,7 +14,7 @@ export function initErrorBoundary() {
       localStorage.setItem('errorLog', JSON.stringify(log));
     } catch {}
     if (window.toast) {
-      window.toast(entry.message || String(entry));
+      window.toast(entry.message ? String(entry.message) : t('error_unknown'));
     }
   }
   window.onerror = (msg, url, line, col, err) => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/i18n_fallback.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/i18n_fallback.test.js
@@ -9,3 +9,10 @@ test('fallback to english on fetch failure', async () => {
   await initI18n();
   expect(t('seed')).toBe('Seed');
 });
+
+test('missing keys use default language', async () => {
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+  localStorage.setItem('lang', 'es');
+  await initI18n();
+  expect(t('pyodide_failed')).toBe('Pyodide failed to load; using JS only');
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts
@@ -2,6 +2,7 @@
 import { mutate } from '../src/evolve/mutate.js';
 import { paretoFront } from '../src/utils/pareto.js';
 import { lcg } from '../src/utils/rng.js';
+import { t } from '../src/ui/i18n.js';
 import type { Individual } from '../src/state/serializer.ts';
 
 const ua = self.navigator?.userAgent ?? '';
@@ -38,7 +39,7 @@ interface EvolverResult {
 async function loadPy() {
   if (!pySupported) {
     if (!warned) {
-      self.postMessage({ toast: 'Pyodide unavailable; using JS only' });
+      self.postMessage({ toast: t('pyodide_unavailable') });
       warned = true;
     }
     return null;
@@ -51,7 +52,7 @@ async function loadPy() {
       pyReady = null;
       pySupported = false;
       if (!warned) {
-        self.postMessage({ toast: 'Pyodide failed to load; using JS only' });
+        self.postMessage({ toast: t('pyodide_failed') });
         warned = true;
       }
     }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/umapWorker.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/umapWorker.ts
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { loadPyodide } from '../lib/pyodide.js';
 import type { Individual } from '../src/state/serializer.ts';
+import { t } from '../src/ui/i18n.js';
 
 let pyReady: any;
 async function initPy(): Promise<any> {
   if (!pyReady) {
     pyReady = await loadPyodide({ indexURL: './wasm/' }).catch(() => null);
+    if (!pyReady) self.postMessage({ toast: t('pyodide_failed') });
   }
   return pyReady;
 }


### PR DESCRIPTION
## Summary
- add additional phrases to English, Spanish and French translations
- preload translations earlier in the app and fall back to English when missing
- use `t()` for worker and error boundary messages
- test untranslated key fallback

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683f919a27c083338d235363a1eb0f37