### PR TITLE
[alpha_factory] enable webgpu backend

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -24,6 +24,8 @@ Copy [`.env.sample`](.env.sample) to `.env` then review the variables:
 - `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs.
 - `OTEL_ENDPOINT` – OTLP/HTTP endpoint for anonymous telemetry (leave blank to disable).
 - `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
+- Browsers with WebGPU can accelerate the local model using the ONNX runtime.
+  Use the GPU toggle in the power panel to switch between WebGPU and WASM.
 
 See [`.env.sample`](.env.sample) for the full list of supported variables.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -194,7 +194,13 @@ async function bundle() {
   let pyCode = await fs.readFile(path.join('lib', 'pyodide.js'), 'utf8');
   pyCode = pyCode.replace(/export\s+/g, '');
   pyCode += '\nwindow.loadPyodide=loadPyodide;';
-  bundleText = `${d3Code}\n${web3Code}\n${pyCode}\nwindow.PYODIDE_WASM_BASE64='${wasmBase64}';window.GPT2_MODEL_BASE64='${gpt2Base64}';\n` + bundleText;
+  let ortCode = '';
+  const ortPath = path.join('node_modules', 'onnxruntime-web', 'dist', 'ort.all.min.js');
+  if (fsSync.existsSync(ortPath)) {
+    ortCode = await fs.readFile(ortPath, 'utf8');
+    ortCode += '\nwindow.ort=ort;';
+  }
+  bundleText = `${d3Code}\n${web3Code}\n${pyCode}\n${ortCode}\nwindow.PYODIDE_WASM_BASE64='${wasmBase64}';window.GPT2_MODEL_BASE64='${gpt2Base64}';\n` + bundleText;
   await fs.writeFile(bundlePath, bundleText);
   outHtml = outHtml
     .replace(/<script[\s\S]*?d3\.v7\.min\.js[\s\S]*?<\/script>\s*/g, '')

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -14,7 +14,7 @@
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py ../../../../tests/test_evolution_panel_reload.py"
+    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js tests/onnx_gpu_backend.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py ../../../../tests/test_evolution_panel_reload.py"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",
@@ -32,6 +32,7 @@
     "daisyui": "^4.0.7",
     "workbox-build": "^6.5.4",
     "dotenv": "^16.4.5",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "onnxruntime-web": "^1.18.0"
   }
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+import { setUseGpu } from '../utils/llm.js';
+
 export function initPowerPanel() {
   const panel = document.createElement('div');
   panel.id = 'power-panel';
@@ -29,11 +31,10 @@ export function initPowerPanel() {
     gpuToggle.checked = true;
   }
   window.USE_GPU = gpuToggle.checked && !!navigator.gpu;
+  setUseGpu(window.USE_GPU);
   gpuToggle.addEventListener('change', () => {
     window.USE_GPU = gpuToggle.checked && !!navigator.gpu;
-    try {
-      localStorage.setItem('USE_GPU', gpuToggle.checked ? '1' : '0');
-    } catch {}
+    setUseGpu(window.USE_GPU);
   });
   document.body.appendChild(panel);
   function update(e) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/onnx_gpu_backend.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/onnx_gpu_backend.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Stub global objects
+global.window = {};
+global.navigator = { gpu: {} };
+window.ort = {};
+
+const { gpuBackend } = await import('../src/utils/llm.js');
+
+test('gpuBackend uses webgpu when navigator.gpu and ort present', async () => {
+  const backend = await gpuBackend();
+  assert.equal(backend, 'webgpu');
+});


### PR DESCRIPTION
## Summary
- add `onnxruntime-web` dependency
- support WebGPU toggle and ONNX runtime backend
- inline ONNX runtime into build output
- document GPU acceleration
- test gpu backend selection

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/onnx_gpu_backend.test.js`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683fa19b8860833387de10ea38d23507