### PR TITLE
[alpha_factory] add chinese locale support

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -143,6 +143,11 @@ required. New users can review
 [dist/insight_browser_quickstart.pdf](dist/insight_browser_quickstart.pdf) after
 extraction for a brief walkthrough.
 
+## Locale Support
+The interface automatically loads French, Spanish or Chinese translations based
+on your browser preferences. Set `localStorage.lang` to override the detected
+language.
+
 ## Toolbar & Controls
 - **CSV** – export the current population as `population.csv`.
 - **PNG** – download a `frontier.png` screenshot of the chart.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -24,6 +24,7 @@
     "wasm/*",
     "data/critics/*",
     "src/i18n/*.json",
+    "src/i18n/zh.json",
     "insight_browser_quickstart.pdf"
   ],
   "assets": [

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/zh.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/zh.json
@@ -1,0 +1,38 @@
+{
+  "seed": "种子",
+  "population": "种群",
+  "generations": "世代",
+  "gaussian": "高斯",
+  "swap": "交换",
+  "jump": "跳跃",
+  "scramble": "打乱",
+  "adaptive": "自适应",
+  "pause": "暂停",
+  "resume": "继续",
+  "export": "导出",
+  "drop": "拖放 JSON 到此处",
+  "csv": "CSV",
+  "png": "PNG",
+  "share": "分享",
+  "theme": "主题",
+  "iframe_copied": "iframe 片段已复制",
+  "link_copied": "永久链接已复制",
+  "state_loaded": "状态已加载",
+  "invalid_file": "文件无效",
+  "simulation_restarted": "模拟已重启",
+  "telemetry_consent": "允许匿名遥测吗？",
+  "summary.debateArena": "辩论竞技场",
+  "summary.debate": "辩论",
+  "label.rank": "排名",
+  "label.score": "分数"
+  ,"score": "分数"
+  ,"novelty": "新颖度"
+  ,"time": "时间"
+  ,"respawn": "重新生成"
+  ,"pyodide_unavailable": "Pyodide 不可用；仅使用 JS"
+  ,"pyodide_failed": "Pyodide 加载失败；仅使用 JS"
+  ,"archive_disabled": "存档已禁用（无存储访问）"
+  ,"archive_full": "存档已满；已删除最旧的运行"
+  ,"pin_failed": "固定失败"
+  ,"error_unknown": "未知错误"
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js
@@ -6,8 +6,19 @@ export let currentLanguage = 'en';
 
 export async function initI18n() {
   const saved = localStorage.getItem('lang');
-  const lang = (saved || navigator.language || 'en').slice(0, 2);
-  currentLanguage = lang.startsWith('fr') ? 'fr' : lang.startsWith('es') ? 'es' : 'en';
+  const langs = navigator.languages || [navigator.language || 'en'];
+  let lang = (saved || langs[0] || 'en').slice(0, 2);
+  if (!saved) {
+    if (langs.some(l => l.startsWith('zh'))) {
+      lang = 'zh';
+    } else if (langs.some(l => l.startsWith('fr'))) {
+      lang = 'fr';
+    } else if (langs.some(l => l.startsWith('es'))) {
+      lang = 'es';
+    }
+  }
+  currentLanguage =
+    lang.startsWith('fr') ? 'fr' : lang.startsWith('es') ? 'es' : lang.startsWith('zh') ? 'zh' : 'en';
   try {
     const res = await fetch(`src/i18n/${currentLanguage}.json`);
     strings = { ...enStrings, ...(await res.json()) };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_chinese_locale.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_chinese_locale.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_chinese_labels() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(locale="zh-CN")
+        page = context.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        label_text = page.locator("#controls label").first.inner_text()
+        assert "种子" in label_text
+        browser.close()
+


### PR DESCRIPTION
## Summary
- add zh.json translations
- detect zh in locale list in ui
- precache zh.json via build_assets.json
- add Chinese locale test
- document locale support in insight_browser_v1 README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/zh.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_chinese_locale.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: could not fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683fa40465ec8333a0a8f3e1f526b660