### PR TITLE
[alpha_factory] add Node version check module

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -10,11 +10,11 @@ A zero-backend Pareto explorer lives in
 Verify your Node.js version before running the build script:
 
 ```bash
-node --version
+node build/version_check.js
 ```
-The output must start with `v20` or higher. Only run `manual_build.py` when this
-requirement is met. The `package.json` also enforces Node.js 20 or newer via the
-`engines` field.
+The output should be empty for a valid setup. Only run `manual_build.py` when
+this requirement is met. The `package.json` also enforces Node.js 20 or newer
+via the `engines` field.
 
 ## Environment Setup
 Copy [`.env.sample`](.env.sample) to `.env` then review the variables:
@@ -92,8 +92,8 @@ Use `manual_build.py` for air‑gapped environments:
 2. `python ../../../scripts/fetch_assets.py` to fetch Pyodide and the GPT‑2 model.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.
-3. Confirm `node --version` reports **v20** or newer. `manual_build.py` exits if
-   Node.js is missing or too old.
+3. Run `node build/version_check.js` to ensure Node.js **v20** or newer is
+   installed. `manual_build.py` exits if this check fails.
 4. `python manual_build.py` – bundles the app, generates `dist/sw.js` and embeds
    your `.env` settings.
 5. `npm start` or open `dist/index.html` directly to run the demo.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -7,18 +7,13 @@ import { createHash } from 'crypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { copyAssets, injectEnv } from './build/common.js';
+import { requireNode20 } from './build/version_check.js';
 
 const manifest = JSON.parse(
   fsSync.readFileSync(new URL('./build_assets.json', import.meta.url), 'utf8')
 );
 
-const [major] = process.versions.node.split('.').map(Number);
-if (major < 20) {
-  console.error(
-    `Node.js 20+ is required. Current version: ${process.versions.node}`
-  );
-  process.exit(1);
-}
+requireNode20();
 
 const { build } = await import('esbuild');
 const gzipSize = (await import('gzip-size')).default;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
@@ -1,0 +1,15 @@
+import { pathToFileURL } from 'url';
+
+export function requireNode20() {
+  const [major] = process.versions.node.split('.').map(Number);
+  if (major < 20) {
+    console.error(
+      `Node.js 20+ is required. Current version: ${process.versions.node}`
+    );
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  requireNode20();
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -6,7 +6,6 @@ import base64
 import json
 import subprocess
 import sys
-import shutil
 from pathlib import Path
 from urllib.parse import urlparse
 import gzip
@@ -18,24 +17,18 @@ def _require_python_311() -> None:
         sys.exit(f"Python ≥3.11 required. Current version: {sys.version}")
 
 
-def _require_node_20() -> None:
-    """Exit when Node.js is missing or too old."""
-    if not shutil.which("node"):
-        sys.exit(
-            "Node.js 20+ is required. Install Node.js and ensure 'node' is in your PATH."
-        )
-    try:
-        out = subprocess.check_output(["node", "--version"], text=True).strip()
-    except subprocess.CalledProcessError:
-        sys.exit("Failed to execute 'node --version'. Is Node.js installed correctly?")
-    version = out.lstrip("v")
-    major = int(version.split(".")[0])
-    if major < 20:
-        sys.exit(f"Node.js 20+ is required. Current version: {version}")
-
-
 _require_python_311()
-_require_node_20()
+
+ROOT = Path(__file__).resolve().parent
+try:
+    subprocess.run([
+        "node",
+        "build/version_check.js",
+    ], cwd=ROOT, check=True)
+except FileNotFoundError:
+    sys.exit("Node.js 20+ is required. Install Node.js and ensure 'node' is in your PATH.")
+except subprocess.CalledProcessError as exc:
+    sys.exit(exc.returncode)
 
 # load environment variables
 env_file = Path(__file__).resolve().parent / ".env"


### PR DESCRIPTION
## Summary
- add `version_check.js` for shared Node.js validation
- call `requireNode20` in build.js
- invoke Node version check from `manual_build.py`
- document Node version checker in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(failed: proto-verify; mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fb051715c8333874b15997f963884