### PR TITLE
[alpha_factory] disable archive without storage access

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -254,6 +254,9 @@ window.addEventListener('DOMContentLoaded',async()=>{
   await initI18n();
   telemetry = initTelemetry();
   archive = new Archive();
+  if (typeof document.hasStorageAccess === 'function') {
+    try { await document.hasStorageAccess(); } catch {}
+  }
   await archive.open();
   evolutionPanel = initEvolutionPanel(archive);
   powerPanel = initPowerPanel();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -32,10 +32,26 @@ export class Archive {
   async open(): Promise<void> {
     await this.runStore.dbp;
     await this.evalStore.dbp;
-    if (!this.disabled && (this.runStore.memory || this.evalStore.memory)) {
-      this.disabled = true;
-      if (typeof (window as any).toast === 'function') {
-        (window as any).toast('Archive disabled (no storage access)');
+    if (!this.disabled) {
+      if (typeof document !== 'undefined' &&
+          typeof (document as any).hasStorageAccess === 'function') {
+        try {
+          const access = await (document as any).hasStorageAccess();
+          if (!access) {
+            this.runStore.memory = new Map();
+            this.evalStore.memory = new Map();
+          }
+        } catch {
+          this.runStore.memory = new Map();
+          this.evalStore.memory = new Map();
+        }
+      }
+
+      if (this.runStore.memory || this.evalStore.memory) {
+        this.disabled = true;
+        if (typeof (window as any).toast === 'function') {
+          (window as any).toast('Archive disabled (no storage access)');
+        }
       }
     }
   }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_storage_access_toast.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_storage_access_toast.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_storage_access_toast() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(storage_state=None)
+        context.add_init_script("document.hasStorageAccess = () => Promise.resolve(false)")
+        page = context.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        page.wait_for_function(
+            "document.getElementById('toast').textContent.includes('no storage access')"
+        )
+        browser.close()


### PR DESCRIPTION
## Summary
- check for `document.hasStorageAccess()` when initializing the archive
- fall back to in-memory archive if storage access is denied and show a toast
- call `document.hasStorageAccess()` from `app.js` before opening the archive
- add Playwright test ensuring the toast appears when storage is blocked

## Testing
- `python alpha_factory_v1/scripts/preflight.py` *(fails: docker missing)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 1 error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683fb60904288333b04df1edb990db82