### PR TITLE
[alpha_factory] enforce strict ts types

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
@@ -30,6 +30,13 @@ interface Individual {
   horizonYears: number;
   front: boolean;
 }
+
+interface EvolverResult {
+  pop: Individual[];
+  rngState: number;
+  front: Individual[];
+  metrics: { avgLogic: number; avgFeasible: number; frontSize: number };
+}
 export class Simulator {
   static async *run(opts: SimulatorConfig): AsyncGenerator<Generation> {
     const options = { mutations: ['gaussian'], seeds: [1], critic: 'none', ...opts };
@@ -50,9 +57,9 @@ export class Simulator {
       let metrics = { avgLogic: 0, avgFeasible: 0, frontSize: 0 };
       if (options.workerUrl && typeof Worker !== 'undefined') {
         if (!worker) worker = new Worker(options.workerUrl, { type: 'module' });
-        const result: any = await new Promise((resolve) => {
+        const result: EvolverResult = await new Promise((resolve) => {
           if (!worker) return resolve({ pop, rngState: rand.state(), front: [], metrics });
-          worker.onmessage = (ev) => resolve(ev.data);
+          worker.onmessage = (ev) => resolve(ev.data as EvolverResult);
           worker.postMessage({
             pop,
             rngState: rand.state(),

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/umapWorker.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/umapWorker.ts
@@ -3,8 +3,13 @@ import { loadPyodide } from '../lib/pyodide.js';
 import type { Individual } from '../src/state/serializer.ts';
 import { t } from '../src/ui/i18n.js';
 
-let pyReady: any;
-async function initPy(): Promise<any> {
+interface Pyodide {
+  globals: { set(key: string, value: unknown): void; get(key: string): string };
+  runPythonAsync(code: string): Promise<unknown>;
+}
+
+let pyReady: Pyodide | null = null;
+async function initPy(): Promise<Pyodide | null> {
   if (!pyReady) {
     pyReady = await loadPyodide({ indexURL: './wasm/' }).catch(() => null);
     if (!pyReady) self.postMessage({ toast: t('pyodide_failed') });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",

--- a/src/interface/web_client/tsconfig.json
+++ b/src/interface/web_client/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",


### PR DESCRIPTION
## Summary
- enable `noImplicitAny` in web client configs
- define interfaces for archive params and worker results
- replace any casts in browser simulator and workers

## Testing
- `npm run typecheck`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_683fbd7f4dc48333abe60563c973eaa3