### PR TITLE
[alpha_factory] extract shared build functions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared build helpers for the Insight browser."""
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import json
+import subprocess
+import sys
+import re
+from pathlib import Path
+
+
+def sha384(path: Path) -> str:
+    """Return the SHA-384 digest of ``path`` in SRI format."""
+    digest = hashlib.sha384(path.read_bytes()).digest()
+    return "sha384-" + base64.b64encode(digest).decode()
+
+
+def check_gzip_size(path: Path, max_bytes: int = 2 * 1024 * 1024) -> None:
+    """Exit if gzip-compressed ``path`` exceeds ``max_bytes``."""
+    compressed = gzip.compress(path.read_bytes())
+    if len(compressed) > max_bytes:
+        sys.exit(f"gzip size {len(compressed)} bytes exceeds limit")
+
+
+def generate_service_worker(root: Path, dist_dir: Path, manifest: dict) -> None:
+    """Create ``sw.js`` using workbox and inject it into ``index.html``."""
+    sw_src = root / "sw.js"
+    sw_dest = dist_dir / "sw.js"
+    version = json.loads((root / "package.json").read_text())["version"]
+    temp_sw = dist_dir / "sw.build.js"
+    temp_sw.write_text(sw_src.read_text().replace("__CACHE_VERSION__", version))
+    node_script = f"""
+const {{injectManifest}} = require('workbox-build');
+injectManifest({{
+  swSrc: {json.dumps(str(temp_sw))},
+  swDest: {json.dumps(str(sw_dest))},
+  globDirectory: {json.dumps(str(dist_dir))},
+  importWorkboxFrom: 'disabled',
+  globPatterns: {json.dumps(manifest['precache'])},
+  injectionPoint: 'self.__WB_MANIFEST',
+}}).catch(err => {{console.error(err); process.exit(1);}});
+"""
+    try:
+        subprocess.run(["node", "-e", node_script], check=True)
+    except FileNotFoundError:
+        print(
+            "[manual_build] node not found; skipping service worker generation",
+            file=sys.stderr,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"[manual_build] workbox build failed: {exc}; offline features disabled",
+            file=sys.stderr,
+        )
+    finally:
+        temp_sw.unlink(missing_ok=True)
+    sw_hash = sha384(sw_dest)
+    index_path = dist_dir / "index.html"
+    text = index_path.read_text()
+    text = text.replace(".register('sw.js')", ".register('service-worker.js')")
+    text = text.replace(
+        "</body>",
+        f'<script src="service-worker.js" integrity="{sw_hash}" crossorigin="anonymous"></script>\n</body>',
+    )
+    text = re.sub(r"(script-src 'self' 'wasm-unsafe-eval')", rf"\1 '{sw_hash}'", text)
+    index_path.write_text(text)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py
@@ -8,7 +8,7 @@ import re
 def test_check_gzip_call_present() -> None:
     browser_dir = Path(__file__).resolve().parents[1]
     text = (browser_dir / "manual_build.py").read_text()
-    assert "def check_gzip_size" in text
+    assert "from build.common import check_gzip_size" in text
     pattern = r"write_text\(bundle\).*\n\s*check_gzip_size\(dist_dir / \"insight.bundle.js\"\)"
     assert re.search(pattern, text)
 


### PR DESCRIPTION
## Summary
- add build/common.py with gzip and service-worker helpers
- reuse build/common.js for gzip/service worker
- import common helpers in manual_build.py and build.js
- update gzip size test for new import

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6840377965288333a7233d51314eccb8