### PR TITLE
[alpha_factory] npm test triggers Insight demo build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -206,14 +206,14 @@ the local GPT‑2 critic.
 ## Running Browser Tests
 
 The demo includes a small Playwright and Pytest suite. **Node.js ≥20** is
-required. After fetching the WebAssembly assets and compiling the bundle with
-`npm run build` (or `python manual_build.py`), execute:
+required. After fetching the WebAssembly assets simply run:
 
 ```bash
 npm test
 ```
 
-This command launches Playwright to exercise `dist/index.html` and then runs the
-Python checks. Offline setups can point Playwright at pre‑downloaded browsers by
+This command now builds the bundle automatically before running the tests. It
+launches Playwright to exercise `dist/index.html` and then runs the Python
+checks. Offline setups can point Playwright at pre‑downloaded browsers by
 exporting `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` or skip the download step
 with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -14,7 +14,7 @@
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js tests/onnx_gpu_backend.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py ../../../../tests/test_evolution_panel_reload.py"
+    "test": "npm run build && node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js tests/onnx_gpu_backend.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py ../../../../tests/test_evolution_panel_reload.py"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",


### PR DESCRIPTION
## Summary
- ensure `npm test` for the Insight browser build runs `npm run build` first
- document automatic build step in the Insight browser README

## Testing
- `npm test` *(fails: Cannot find package 'esbuild')*
- `pytest -q` *(fails: tests/test_llm_cache.py - ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_68403d054620833380fb81b640153598