### PR TITLE
[alpha_factory] ensure service worker output

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -47,6 +47,8 @@ npm run build    # compile to dist/ and embed env vars
 The build script reads `.env` automatically and injects the values into
 `dist/index.html` as `window.PINNER_TOKEN`, `window.OPENAI_API_KEY`,
 `window.IPFS_GATEWAY` and `window.OTEL_ENDPOINT`.
+It also copies `dist/sw.js` to `dist/service-worker.js` which `index.html`
+registers for offline support.
 The unbuilt `index.html` falls back to `'self'` for the IPFS and telemetry
 origins, but running `npm run build` (or `python manual_build.py`) replaces
 these defaults with the real values from `.env`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -200,6 +200,10 @@ async function bundle() {
   await fs.writeFile(`${OUT_DIR}/index.html`, outHtml);
   const pkg = JSON.parse(fsSync.readFileSync('package.json', 'utf8'));
   await generateServiceWorker(OUT_DIR, manifest, pkg.version);
+  await fs.copyFile(
+    path.join(OUT_DIR, 'sw.js'),
+    path.join(OUT_DIR, 'service-worker.js')
+  );
   await checkGzipSize(`${OUT_DIR}/insight.bundle.js`);
   if (process.env.WEB3_STORAGE_TOKEN) {
     const client = new Web3Storage({ token: process.env.WEB3_STORAGE_TOKEN });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -305,5 +305,6 @@ else:
 
 # generate service worker
 generate_service_worker(ROOT, dist_dir, manifest)
+(dist_dir / "service-worker.js").write_bytes((dist_dir / "sw.js").read_bytes())
 check_gzip_size(dist_dir / "insight.bundle.js")
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_service_worker_present.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_service_worker_present.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure the built demo includes service-worker.js."""
+from pathlib import Path
+
+def test_service_worker_exists() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist"
+    assert (dist / "service-worker.js").is_file()


### PR DESCRIPTION
## Summary
- copy `dist/sw.js` to `dist/service-worker.js` in build scripts
- document service-worker copy step
- test service-worker.js presence in `dist`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_service_worker_present.py` *(fails: Interrupted (^C) during environment init)*
- `pytest -q` *(fails: 1 error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68403f71a2348333bcc649966f173408