### PR TITLE
[alpha_factory] add offline test flag

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -122,6 +122,8 @@ Failing to replace placeholders will break offline mode.
 2. Confirm no placeholder text remains in `lib/` or `wasm*/`.
 3. Execute `npm run build` or `python manual_build.py`.
 
+4. Run `npm test --offline` to execute the suite with pre‑installed browsers.
+
 Failing to run the fetch script leaves offline mode disabled.
 
 ### Fetching Assets Offline

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -14,7 +14,7 @@
     "size": "gzip-size-cli dist/app.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
-    "test": "npm run build && node --loader ts-node/register --test tests/entropy.test.js tests/replay_cid.test.js tests/iframe_worker_cleanup.test.js tests/onnx_gpu_backend.test.js ../../../../tests/taxonomy.test.ts ../../../../tests/memeplex.test.ts && pytest ../../../../tests/test_quickstart_offline.py ../../../../tests/test_evolution_panel_reload.py"
+    "test": "node tests/run.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import {spawnSync} from 'child_process';
+import {dirname, resolve} from 'path';
+import {fileURLToPath} from 'url';
+
+const args = process.argv.slice(2);
+const offlineIndex = args.indexOf('--offline');
+const offline = offlineIndex !== -1;
+if (offline) {
+  args.splice(offlineIndex, 1);
+  process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = '1';
+  if (!process.env.PLAYWRIGHT_BROWSERS_PATH) {
+    process.env.PLAYWRIGHT_BROWSERS_PATH = resolve(process.cwd(), 'browsers');
+  }
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function run(cmd, options = {}) {
+  const res = spawnSync(cmd[0], cmd.slice(1), {stdio: 'inherit', cwd: root, ...options});
+  if (res.status) process.exit(res.status);
+}
+
+run(['npm', 'run', 'build']);
+run(['node', '--loader', 'ts-node/register', '--test',
+  'tests/entropy.test.js',
+  'tests/replay_cid.test.js',
+  'tests/iframe_worker_cleanup.test.js',
+  'tests/onnx_gpu_backend.test.js',
+  '../../../../tests/taxonomy.test.ts',
+  '../../../../tests/memeplex.test.ts'
+]);
+run(['pytest', '../../../../tests/test_quickstart_offline.py', '../../../../tests/test_evolution_panel_reload.py']);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_entropy_js.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_entropy_js.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Run the browser entropy test via npm."""
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -9,6 +10,13 @@ import pytest
 
 BROWSER_DIR = Path(__file__).resolve().parents[1]
 
-@pytest.mark.skipif(shutil.which("npm") is None, reason="npm not installed")
+
+@pytest.mark.skipif(
+    shutil.which("npm") is None,
+    reason="npm not installed",
+)  # type: ignore[misc]
 def test_entropy_js() -> None:
-    subprocess.check_call(["npm", "test"], cwd=BROWSER_DIR)
+    cmd = ["npm", "test"]
+    if os.environ.get("PLAYWRIGHT_BROWSERS_PATH"):
+        cmd.append("--offline")
+    subprocess.check_call(cmd, cwd=BROWSER_DIR)


### PR DESCRIPTION
## Summary
- document how to run browser tests offline
- add Node test runner that respects `--offline`
- support offline Playwright usage in entropy test
- add `--offline` option to `run_tests.py`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_entropy_js.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs alpha_factory_v1/scripts/run_tests.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_6840424a9a908333abdde8afa0bc49dc