### PR TITLE
[alpha_factory] add license headers to insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "name": "α-AGI Insight",
   "short_name": "Insight",


### PR DESCRIPTION
## Summary
- add Apache 2.0 header to insight demo index.html
- add Apache 2.0 header to manifest.json

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manifest.json` *(fails: Makefile:26: *** missing separator.  Stop.)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_684050402c648333a56bc08e182bf564