### PR TITLE
[alpha_factory] add window typings

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/global.d.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/global.d.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+declare global {
+  interface Window {
+    toast?: (msg: string) => void;
+    llmChat?: (prompt: string) => Promise<string> | string;
+    PINNER_TOKEN?: string;
+    OPENAI_API_KEY?: string;
+    OTEL_ENDPOINT?: string;
+    IPFS_GATEWAY?: string;
+  }
+}
+
+export {};

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -12,5 +12,5 @@
     "allowJs": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "worker/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.js", "src/global.d.ts", "worker/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- declare global browser variables for the insight demo
- include new declaration file in tsconfig

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `npm run build` *(fails: Cannot find package 'esbuild')*


------
https://chatgpt.com/codex/tasks/task_e_684055a70b148333b52c477e1e6948a5