### PR TITLE
[alpha_factory] update size script

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --config .eslintrc.cjs src --ext .js,.ts",
     "build": "node build.js",
     "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js manifest.json style.css assets insight_browser_quickstart.pdf && rm service-worker.js",
-    "size": "gzip-size-cli dist/app.js --bytes",
+    "size": "gzip-size-cli dist/insight.bundle.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",
     "test": "node tests/run.mjs"


### PR DESCRIPTION
## Summary
- update the Insight browser demo size script to check insight.bundle.js

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: KeyboardInterrupt)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json` *(fails: semgrep environment init hung)*
- `npm run build` *(fails: missing esbuild)
- `npm run size` *(fails: gzip-size-cli not found)

------
https://chatgpt.com/codex/tasks/task_e_68405d1b581083339dc8bfd6b45bc028