### PR TITLE
[alpha_factory] sanitize env injection

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -36,7 +36,12 @@ export async function copyAssets(manifest, repoRoot, outDir) {
 }
 
 export function injectEnv(env) {
-  const script = `<script>window.PINNER_TOKEN=${JSON.stringify(env.PINNER_TOKEN || '')};window.OPENAI_API_KEY=${JSON.stringify(env.OPENAI_API_KEY || '')};window.OTEL_ENDPOINT=${JSON.stringify(env.OTEL_ENDPOINT || '')};window.IPFS_GATEWAY=${JSON.stringify(env.IPFS_GATEWAY || '')};</script>`;
+  const enc = (v) => Buffer.from(String(v ?? ''), 'utf8').toString('base64');
+  const b64Pinner = enc(env.PINNER_TOKEN);
+  const b64Openai = enc(env.OPENAI_API_KEY);
+  const b64Otel = enc(env.OTEL_ENDPOINT);
+  const b64Ipfs = enc(env.IPFS_GATEWAY);
+  const script = `<script>window.PINNER_TOKEN=atob('${b64Pinner}');window.OPENAI_API_KEY=atob('${b64Openai}');window.OTEL_ENDPOINT=atob('${b64Otel}');window.IPFS_GATEWAY=atob('${b64Ipfs}');</script>`;
   return script;
 }
 export async function checkGzipSize(file, maxBytes = 2 * 1024 * 1024) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_escaping.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_escaping.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure script tags in env values do not break the built HTML."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+@pytest.mark.skipif(
+    shutil.which("npm") is None,
+    reason="npm not installed",
+)  # type: ignore[misc]
+def test_env_value_escaped(tmp_path: Path) -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    target = tmp_path / "browser"
+    shutil.copytree(browser_dir, target)
+    token = "foo</script>bar"
+    (target / ".env").write_text(f"PINNER_TOKEN={token}\n")
+    subprocess.check_call(["npm", "run", "build"], cwd=target)
+
+    html_text = (target / "dist" / "index.html").read_text()
+    assert token not in html_text
+    assert "window.PINNER_TOKEN=atob(" in html_text
+
+    url = (target / "dist" / "index.html").as_uri()
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url)
+        page.wait_for_selector("#controls")
+        assert page.evaluate("window.PINNER_TOKEN") == token
+        browser.close()


### PR DESCRIPTION
## Summary
- encode environment variables in injectEnv
- decode env vars at runtime via `atob`
- escape env values during manual build
- test HTML injection resistance

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_escaping.py` *(fails: Makefile:26: *** missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68406509a9688333a92bbc7cd3481e34