### PR TITLE
[alpha_factory] Add Development section to browser README

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -224,3 +224,9 @@ launches Playwright to exercise `dist/index.html` and then runs the Python
 checks. Offline setups can point Playwright at pre‑downloaded browsers by
 exporting `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` or skip the download step
 with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`.
+
+## Development
+
+- Run `pre-commit run --all-files` to format and lint the code.
+- `npm test` builds the bundle then launches Playwright and Python tests.
+- See [../../../../AGENTS.md](../../../../AGENTS.md) for full contributor guidelines.


### PR DESCRIPTION
## Summary
- document pre-commit and npm test workflow in `insight_browser_v1` README
- reference repository root AGENTS.md for full guidelines

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: proto-verify)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries)*

------
https://chatgpt.com/codex/tasks/task_e_68407b054fc48333a10dcb68e94d72ed