### PR TITLE
[alpha_factory] Add offline browser build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,21 +97,27 @@ Follow these steps when working without internet access.
    export LLAMA_MODEL_PATH=~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf
    ```
 
-4. **Fetch browser assets** with ``scripts/fetch_assets.py`` (verifies
-   checksums and replaces the placeholder Web3.Storage bundle):
+4. **Fetch and build the browser assets** to run the Insight demo fully offline:
    ```bash
-   python scripts/fetch_assets.py
+   cd alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+   python ../../../scripts/fetch_assets.py
+   npm ci
+   npm run build
+   ```
+5. **Skip browser downloads** when running the web demo tests offline:
+   ```bash
+   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test
    ```
 
-5. **Enable offline inference** by setting ``AGI_INSIGHT_OFFLINE=1`` in
+6. **Enable offline inference** by setting ``AGI_INSIGHT_OFFLINE=1`` in
    ``.env`` or the environment.
 
-6. **Disable broadcasting** to avoid network calls:
+7. **Disable broadcasting** to avoid network calls:
    ```bash
    export AGI_INSIGHT_BROADCAST=0
    ```
 
-7. **Seed the lineage database** from existing DGM logs using ``--import-dgm``.
+8. **Seed the lineage database** from existing DGM logs using ``--import-dgm``.
    ```bash
    python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli \
      simulate --import-dgm path/to/dgm/logs

--- a/docs/insight_browser_quickstart.pdf
+++ b/docs/insight_browser_quickstart.pdf
@@ -1,48 +1,71 @@
-%PDF-1.4
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
-<< /Type /Catalog /Pages 2 0 R >>
+<<
+/F1 2 0 R
+>>
 endobj
 2 0 obj
-<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
 endobj
 3 0 obj
-<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
 endobj
 4 0 obj
-<< /Length 481 >>
-stream
-BT
-/F1 12 Tf
-72 720 Td
-(Insight Browser Quickstart) Tj
-72 700 Td
-(1. Open dist/index.html in your browser.) Tj
-72 680 Td
-(2. Set PINNER_TOKEN to pin runs to IPFS.) Tj
-72 660 Td
-(3. Run python ../../../scripts/fetch_assets.py before npm run build or manual_build.py.) Tj
-72 640 Td
-(4. This downloads the Pyodide runtime and wasm-gpt2 model.) Tj
-72 620 Td
-(5. Click Share to copy the CID or permalink.) Tj
-72 600 Td
-(6. Use the Analytics panel to enable or disable telemetry.) Tj
-ET
-endstream
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
 endobj
 5 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+<<
+/Author (anonymous) /CreationDate (D:20250604203556+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250604203556+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Length 523
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+BT 1 0 0 1 72 720 Tm (Insight Browser Quickstart) Tj T* 0 -20 Td (1. Run python ../../../scripts/fetch_assets.py.) Tj T* 0 -20 Td (2. Execute npm ci.) Tj T* 0 -20 Td (3. Run npm run build.) Tj T* 0 -20 Td (4. Open dist/index.html in your browser.) Tj T* 0 -20 Td (5. Set PINNER_TOKEN to pin runs to IPFS.) Tj T* 0 -20 Td (6. Set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 for offline npm test.) Tj T* 0 -20 Td (7. Use the Analytics panel to enable or disable telemetry.) Tj T* 0 -20 Td ET
+ 
+endstream
 endobj
 xref
-0 6
+0 8
 0000000000 65535 f 
-0000000009 00000 n 
-0000000058 00000 n 
-0000000115 00000 n 
-0000000241 00000 n 
-0000000772 00000 n 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
 trailer
-<< /Root 1 0 R /Size 6 >>
+<<
+/ID 
+[<a143a2e006a3c72b59acf4cb5a1e8f1f><a143a2e006a3c72b59acf4cb5a1e8f1f>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
 startxref
-842
+1400
 %%EOF


### PR DESCRIPTION
## Summary
- show how to fetch and build the Insight browser assets offline
- mention skipping Playwright browser download for offline `npm test`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `pre-commit run --files README.md docs/insight_browser_quickstart.pdf` *(fails to finish due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad27a29c8333b4788418deb42892