### PR TITLE
[alpha_factory] add offline service worker test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -31,4 +31,9 @@ run(['node', '--loader', 'ts-node/register', '--test',
   '../../../../tests/taxonomy.test.ts',
   '../../../../tests/memeplex.test.ts'
 ]);
-run(['pytest', '../../../../tests/test_quickstart_offline.py', '../../../../tests/test_evolution_panel_reload.py']);
+run([
+  'pytest',
+  '../../../../tests/test_quickstart_offline.py',
+  '../../../../tests/test_evolution_panel_reload.py',
+  '../../../../tests/test_sw_offline_reload.py'
+]);

--- a/tests/test_sw_offline_reload.py
+++ b/tests/test_sw_offline_reload.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+import http.server
+import threading
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def _start_server(directory: Path):
+    handler = partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    server = http.server.ThreadingHTTPServer(("localhost", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_offline_reload_no_errors() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    dist = repo / "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist"
+
+    server, thread = _start_server(dist)
+    host, port = server.server_address
+    url = f"http://{host}:{port}/index.html"
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            page = context.new_page()
+            errors: list[str] = []
+            page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+            page.on("pageerror", lambda err: errors.append(str(err)))
+
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            page.wait_for_function("navigator.serviceWorker.ready")
+
+            context.set_offline(True)
+            page.reload()
+            page.wait_for_selector("#controls")
+            context.set_offline(False)
+
+            assert not errors, f"Console errors: {errors}"
+            assert page.evaluate("navigator.serviceWorker.controller !== null")
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- extend tests run script to run new offline reload test
- add a Playwright test that verifies service worker after offline reload

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_llm_cache.py - ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6840b08aef188333b0460748a2883ebc