### PR TITLE
[alpha_factory] document offline npm cache

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -127,6 +127,23 @@ Failing to replace placeholders will break offline mode.
 
 Failing to run the fetch script leaves offline mode disabled.
 
+### Offline npm install
+
+Create a cache on a connected machine:
+
+```bash
+npm ci --cache /path/to/npm-cache
+```
+
+Copy the cache to the target machine then run:
+
+```bash
+npm ci --offline --cache /path/to/npm-cache
+```
+
+This installs dependencies without network access.
+
+
 ### Fetching Assets Offline
 
 Set `WEB3_STORAGE_TOKEN` before running the helper script:


### PR DESCRIPTION
## Summary
- add Offline npm install section to the browser demo README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1a796a08333bfa4391ec60abbb2