### PR TITLE
[alpha_factory] enhance asset fetch retry

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -66,6 +66,9 @@ It also retrieves `lib/bundle.esm.min.js` from the mirror. The build and
 `"placeholder"` and abort when any file still contains that marker.
 `scripts/fetch_assets.py` also downloads `lib/workbox-sw.js` from
 Workbox 6.5.4 so the service worker can operate offline.
+Each file is retried up to three times. If a download fails the script exits
+with an error suggesting you check connectivity or the `IPFS_GATEWAY`
+setting.
 Run `scripts/fetch_assets.py` if you encounter this error.
 ```bash
 PINNER_TOKEN=<token> npm start

--- a/tests/test_fetch_assets.py
+++ b/tests/test_fetch_assets.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import scripts.fetch_assets as fa
+
+
+def test_fetch_assets_failure(monkeypatch, capsys):
+    monkeypatch.setattr(fa, "ASSETS", {"dummy.txt": "cid"})
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(fa, "download_with_retry", boom)
+
+    with pytest.raises(SystemExit) as exc:
+        fa.main()
+
+    out = capsys.readouterr().out
+    assert "Download failed for dummy.txt" in out
+    assert "ERROR: Unable to retrieve dummy.txt" in out
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- improve retry behavior in `fetch_assets.py`
- record failures and exit with clear connectivity instructions
- test failed download handling
- document fetch script retry logic in the browser demo README

## Testing
- `pre-commit run black --files scripts/fetch_assets.py tests/test_fetch_assets.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md`
- `pre-commit run ruff --files scripts/fetch_assets.py tests/test_fetch_assets.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md`
- `pre-commit run ruff-format --files scripts/fetch_assets.py tests/test_fetch_assets.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6840f2d7ed648333b749f26686d25b50