### PR TITLE
[alpha_factory] add localized disclaimer footer

### DIFF
--- a/src/interface/web_client/arenaWorker.js
+++ b/src/interface/web_client/arenaWorker.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Simple debate arena executed in a Web Worker. The worker receives a
+ * hypothesis string and runs a fixed exchange between four roles:
+ * Proposer, Skeptic, Regulator and Investor. The outcome score is
+ * returned to the caller along with the threaded messages.
+ */
+self.onmessage = (ev) => {
+  const { hypothesis } = ev.data || {};
+  if (!hypothesis) return;
+
+  const messages = [
+    { role: 'Proposer', text: `I propose that ${hypothesis}.` },
+    { role: 'Skeptic', text: `I doubt that ${hypothesis} holds under scrutiny.` },
+    { role: 'Regulator', text: `Any implementation of ${hypothesis} must be safe.` },
+  ];
+
+  const approved = Math.random() > 0.5;
+  messages.push({
+    role: 'Investor',
+    text: approved
+      ? `Funding approved for: ${hypothesis}.`
+      : `Funding denied for: ${hypothesis}.`,
+  });
+
+  const score = approved ? 1 : 0;
+  self.postMessage({ messages, score });
+};

--- a/src/interface/web_client/dist/index.html
+++ b/src/interface/web_client/dist/index.html
@@ -3,11 +3,19 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0d0e2e" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <title>AGI Dashboard</title>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://cdn.plot.ly/plotly-2.24.2.min.js"></script>
-    <script src="app.js" defer></script>
+    <script type="module" crossorigin src="/assets/index-64bb4409.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align: center;">
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+    </footer>
+    
+    
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
@@ -15,8 +23,5 @@
         });
       }
     </script>
-  </head>
-  <body>
-    <div id="root"></div>
   </body>
 </html>

--- a/src/interface/web_client/i18n/en.json
+++ b/src/interface/web_client/i18n/en.json
@@ -28,5 +28,6 @@
   "summary.debateArena": "Debate Arena",
   "label.rank": "Rank",
   "label.score": "Score",
-  "alert.urlCopied": "URL copied to clipboard"
+  "alert.urlCopied": "URL copied to clipboard",
+  "disclaimer": "This repository is a conceptual research prototype. References to \"AGI\" and \"superintelligence\" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk."
 }

--- a/src/interface/web_client/i18n/es.json
+++ b/src/interface/web_client/i18n/es.json
@@ -28,5 +28,6 @@
   "summary.debateArena": "Arena de debate",
   "label.rank": "Rango",
   "label.score": "Puntuación",
-  "alert.urlCopied": "URL copiada al portapapeles"
+  "alert.urlCopied": "URL copiada al portapapeles",
+  "disclaimer": "Este repositorio es un prototipo de investigación conceptual. Las referencias a \"AGI\" y \"superinteligencia\" describen metas aspiracionales y no indican la presencia de una inteligencia general real. Úselo bajo su propio riesgo."
 }

--- a/src/interface/web_client/i18n/fr.json
+++ b/src/interface/web_client/i18n/fr.json
@@ -28,5 +28,6 @@
   "summary.debateArena": "Arène de débat",
   "label.rank": "Rang",
   "label.score": "Score",
-  "alert.urlCopied": "URL copiée dans le presse-papiers"
+  "alert.urlCopied": "URL copiée dans le presse-papiers",
+  "disclaimer": "Ce dépôt est un prototype de recherche conceptuel. Les références à \"AGI\" et à la \"superintelligence\" décrivent des objectifs aspirants et n'indiquent pas la présence d'une véritable intelligence générale. Utilisez-le à vos risques et périls."
 }

--- a/src/interface/web_client/index.html
+++ b/src/interface/web_client/index.html
@@ -10,7 +10,21 @@
   </head>
   <body>
     <div id="root"></div>
+    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align: center;">
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+    </footer>
     <script type="module" src="/src/main.tsx"></script>
+    <script type="module">
+      import en from './i18n/en.json';
+      import fr from './i18n/fr.json';
+      import es from './i18n/es.json';
+      const dict = { en, fr, es };
+      const lower = navigator.language.toLowerCase();
+      const lang = lower.startsWith('fr') ? 'fr' : lower.startsWith('es') ? 'es' : 'en';
+      const msg = (dict[lang] || dict.en)["disclaimer"];
+      const el = document.getElementById('disclaimer');
+      if (el) el.textContent = msg;
+    </script>
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- embed disclaimer footer in web client
- localize the text in i18n files
- include a JS snippet to swap the text based on language
- copy `arenaWorker.js` so Vite build succeeds

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `npm run build` in `src/interface/web_client` *(fails to run workbox but Vite build succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_6840ff35694883339d50b153cc863367