### PR TITLE
[alpha_factory] add service worker cache version test

### DIFF
--- a/tests/service_worker_cache.spec.ts
+++ b/tests/service_worker_cache.spec.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const browserDir = path.resolve(__dirname, '../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1');
+
+function buildBrowser() {
+  const res = spawnSync('npm', ['run', 'build'], { cwd: browserDir, stdio: 'inherit' });
+  if (res.status !== 0) {
+    throw new Error('build failed');
+  }
+}
+
+test('service-worker.js cache name uses package version', async () => {
+  buildBrowser();
+  const pkg = JSON.parse(fs.readFileSync(path.join(browserDir, 'package.json'), 'utf8'));
+  const swPath = path.join(browserDir, 'dist', 'service-worker.js');
+  const sw = fs.readFileSync(swPath, 'utf8');
+  expect(sw).not.toContain('__CACHE_VERSION__');
+  expect(sw).toContain(pkg.version);
+});


### PR DESCRIPTION
## Summary
- add Playwright test to ensure service-worker.js cache name reflects package version

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_684106312a6883339887aaac30651d9b