### PR TITLE
[alpha_factory] add env validation

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -20,6 +20,32 @@ const { Web3Storage, File } = await import('web3.storage');
 const dotenv = (await import('dotenv')).default;
 dotenv.config();
 
+function validateEnv() {
+  for (const key of ['PINNER_TOKEN', 'OPENAI_API_KEY', 'WEB3_STORAGE_TOKEN']) {
+    const val = process.env[key];
+    if (val !== undefined && !val.trim()) {
+      throw new Error(`${key} may not be empty`);
+    }
+  }
+  for (const key of ['IPFS_GATEWAY', 'OTEL_ENDPOINT']) {
+    const val = process.env[key];
+    if (val) {
+      try {
+        new URL(val);
+      } catch {
+        throw new Error(`Invalid URL in ${key}`);
+      }
+    }
+  }
+}
+
+try {
+  validateEnv();
+} catch (err) {
+  console.error(err.message || err);
+  process.exit(1);
+}
+
 const verbose = process.argv.includes('--verbose');
 
 try {


### PR DESCRIPTION
## Summary
- validate environment variables in `build.js` and `manual_build.py`
- ensure build scripts exit when tokens are empty or URLs are invalid

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_684109020dec833384411b92d2a706e9