### PR TITLE
[alpha_factory] add license headers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """alpha_agi_business_v1 demo package."""
 
 __all__ = [

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/alpha_agi_business_v1.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Alpha‑AGI Business v1 demo.
 
 Bootstraps a minimal Alpha‑Factory orchestrator with two stub agents.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/find_best_alpha.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/find_best_alpha.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from pathlib import Path
 import sys

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/examples/openai_agent_client.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/examples/openai_agent_client.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Minimal OpenAI Agents client for the business demo.
 
 This helper queries the ``business_helper`` agent exposed by

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/gradio_dashboard.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Simple Gradio dashboard for the Alpha‑AGI Business demo."""
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """OpenAI Agents SDK bridge for the alpha_agi_business_v1 demo.
 
 This utility registers a small helper agent that interacts with the

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_demo.sh
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 # ────────────────────────────────────────────────────────────────
 # Alpha‑AGI Business v1 – quick launcher
 # Options : --pull  use the signed image from GHCR (skip local build)

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Local launcher for the Alpha‑AGI Business v1 demo.
 
 Runs the orchestrator directly without Docker and optionally starts the

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/scripts/post_alpha_job.sh
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/scripts/post_alpha_job.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 # scripts/post_alpha_job.sh - queue a demo job via the orchestrator REST API
 # Usage: ./scripts/post_alpha_job.sh examples/job_copper_spread.json
 # Requirements: curl, jq

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """One-click launcher for the Alpha‑AGI Business v1 demo.
 
 This helper checks dependencies, starts the local orchestrator with the


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX headers to demo scripts in `alpha_agi_business_v1`

## Testing
- `python check_env.py --auto-install`
- ❌ `pre-commit` *(failed: command not found)*
- ❌ `pytest -q` *(failed: duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6841104bf6008333a0b597f4c86ecaba