### PR TITLE
[alpha_factory] enable linting for muzero demo

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,27 @@
+[flake8]
+max-line-length = 120
+exclude = \
+    alpha_factory_v1/demos/aiga_meta_evolution/*,\
+    alpha_factory_v1/demos/alpha_agi_business_2_v1/*,\
+    alpha_factory_v1/demos/alpha_agi_business_3_v1/*,\
+    alpha_factory_v1/demos/alpha_agi_business_v1/*,\
+    alpha_factory_v1/demos/alpha_agi_insight_v0/*,\
+    alpha_factory_v1/demos/alpha_agi_insight_v1/*,\
+    alpha_factory_v1/demos/alpha_agi_marketplace_v1/*,\
+    alpha_factory_v1/demos/alpha_asi_world_model/*,\
+    alpha_factory_v1/demos/cross_industry_alpha_factory/*,\
+    alpha_factory_v1/demos/era_of_experience/*,\
+    alpha_factory_v1/demos/finance_alpha/*,\
+    alpha_factory_v1/demos/macro_sentinel/*,\
+    alpha_factory_v1/demos/meta_agentic_agi/*,\
+    alpha_factory_v1/demos/meta_agentic_agi_v2/*,\
+    alpha_factory_v1/demos/meta_agentic_agi_v3/*,\
+    alpha_factory_v1/demos/meta_agentic_tree_search_v0/*,\
+    alpha_factory_v1/demos/muzeromctsllmagent_v0/*,\
+    alpha_factory_v1/demos/omni_factory_demo/*,\
+    alpha_factory_v1/demos/self_healing_repo/*,\
+    alpha_factory_v1/demos/self_healing_repo.py,\
+    alpha_factory_v1/demos/solving_agi_governance/*,\
+    alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/*,\
+    alpha_factory_v1/tests/*,\
+    *.ipynb

--- a/alpha_factory_v1/demos/muzero_planning/__init__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__init__.py
@@ -3,12 +3,10 @@
 try:
     from .agent_muzero_entrypoint import launch_dashboard
 except ImportError:  # pragma: no cover - optional deps may be missing
+
     def launch_dashboard() -> None:  # type: ignore[return-type]
         """Placeholder when optional dependencies are absent."""
-        raise RuntimeError(
-            "gradio and other optional packages are required for the MuZero demo"
-        )
+        raise RuntimeError("gradio and other optional packages are required for the MuZero demo")
+
 
 __all__ = ["launch_dashboard"]
-
-

--- a/alpha_factory_v1/demos/muzero_planning/minimuzero.py
+++ b/alpha_factory_v1/demos/muzero_planning/minimuzero.py
@@ -12,25 +12,33 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 try:
     import gymnasium as gym
 except ModuleNotFoundError:  # pragma: no cover - lightweight stub
+
     class _StubEnv:
         observation_space = type("obs", (), {"shape": (4,)})
         action_space = type("act", (), {"n": 2})
+
         def reset(self, *, seed=None):
-            return [0.0]*4, {}
+            return [0.0] * 4, {}
+
         def step(self, action):
-            return [0.0]*4, 0.0, True, False, {}
+            return [0.0] * 4, 0.0, True, False, {}
+
         def render(self):
             return []
+
         def close(self):
             pass
+
     def make(env_id, render_mode=None):
         return _StubEnv()
+
     gym = type("gym", (), {"make": make, "Env": _StubEnv})
 
 try:
     import torch
     import torch.nn as nn
     import torch.nn.functional as F
+
     _TORCH = True
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     _TORCH = False
@@ -39,6 +47,7 @@ from typing import Dict, List, Tuple
 
 
 if _TORCH:
+
     class MiniMuNet(nn.Module):
         """Lightweight world model with representation, dynamics and prediction."""
 
@@ -70,6 +79,7 @@ if _TORCH:
             return next_state.detach(), reward, value, policy
 
 else:  # pragma: no cover - torch missing
+
     class MiniMuNet:  # type: ignore[misc]
         def __init__(self, *a, **kw) -> None:
             self.action_dim = kw.get("action_dim", 2)
@@ -117,10 +127,13 @@ def mcts_policy(net: MiniMuNet, env: gym.Env, obs, num_simulations: int = 64):
         n = env.action_space.n
         if np is not None:
             return np.full(n, 1 / n)
+
         class _P(list):
             def sum(self):  # minimal numpy-like API
                 from builtins import sum as _sum
+
                 return _sum(self)
+
         return _P([1 / n] * n)
 
     state, value, policy_logits = net.initial(obs)
@@ -196,4 +209,3 @@ def play_episode(agent: MiniMu, render: bool = True, max_steps: int = 500) -> Tu
         frames.append(agent.env.render())
     agent.env.close()
     return frames, total_reward
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,29 @@ line-length = 120
 line-length = 120
 target-version = "py311"
 exclude = [
-    "alpha_factory_v1/demos/*",
+    # exclude all demo directories except MuZero planning
+    "alpha_factory_v1/demos/aiga_meta_evolution/*",
+    "alpha_factory_v1/demos/alpha_agi_business_2_v1/*",
+    "alpha_factory_v1/demos/alpha_agi_business_3_v1/*",
+    "alpha_factory_v1/demos/alpha_agi_business_v1/*",
+    "alpha_factory_v1/demos/alpha_agi_insight_v0/*",
+    "alpha_factory_v1/demos/alpha_agi_insight_v1/*",
+    "alpha_factory_v1/demos/alpha_agi_marketplace_v1/*",
+    "alpha_factory_v1/demos/alpha_asi_world_model/*",
+    "alpha_factory_v1/demos/cross_industry_alpha_factory/*",
+    "alpha_factory_v1/demos/era_of_experience/*",
+    "alpha_factory_v1/demos/finance_alpha/*",
+    "alpha_factory_v1/demos/macro_sentinel/*",
+    "alpha_factory_v1/demos/meta_agentic_agi/*",
+    "alpha_factory_v1/demos/meta_agentic_agi_v2/*",
+    "alpha_factory_v1/demos/meta_agentic_agi_v3/*",
+    "alpha_factory_v1/demos/meta_agentic_tree_search_v0/*",
+    "alpha_factory_v1/demos/muzeromctsllmagent_v0/*",
+    "alpha_factory_v1/demos/omni_factory_demo/*",
+    "alpha_factory_v1/demos/self_healing_repo/*",
+    "alpha_factory_v1/demos/self_healing_repo.py",
+    "alpha_factory_v1/demos/solving_agi_governance/*",
+    "alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/*",
     "alpha_factory_v1/tests/*",
     "*.ipynb",
 ]


### PR DESCRIPTION
## Summary
- configure ruff and flake8 to lint muzero planning demo
- add dedicated `.flake8` file with demo excludes

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `SKIP="proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,mypy,semgrep" pre-commit run --files alpha_factory_v1/demos/muzero_planning/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841144ddc388333805b2ec3e21ca58b