### PR TITLE
[alpha_factory] remove sourcemap hints

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -228,6 +228,7 @@ async function bundle() {
     ortCode += '\nwindow.ort=ort;';
   }
   bundleText = `${d3Code}\n${web3Code}\n${pyCode}\n${ortCode}\nwindow.PYODIDE_WASM_BASE64='${wasmBase64}';window.GPT2_MODEL_BASE64='${gpt2Base64}';\n` + bundleText;
+  bundleText = bundleText.replace(/\/\/#[ \t]*sourceMappingURL=.*(?:\r?\n)?/g, '');
   await fs.writeFile(bundlePath, bundleText);
   outHtml = outHtml
     .replace(/<script[\s\S]*?d3\.v7\.min\.js[\s\S]*?<\/script>\s*/g, '')

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -303,6 +303,12 @@ bundle = (
     + entry_code
     + "\n})();\n"
 )
+bundle = re.sub(
+    r"^//#\\s*sourceMappingURL=.*(?:\r?\n)?",
+    "",
+    bundle,
+    flags=re.MULTILINE,
+)
 
 dist_dir.mkdir(exist_ok=True)
 (dist_dir / "insight.bundle.js").write_text(bundle)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import Request, sync_playwright  # noqa: E402
 
 
 def test_single_network_request() -> None:
@@ -15,14 +15,19 @@ def test_single_network_request() -> None:
     with sync_playwright() as p:
         browser = p.chromium.launch()
         page = browser.new_page()
-        requests: list[str] = []
-        page.on(
-            "request",
-            lambda req: requests.append(req.url)
-            if req.url.endswith(".js") and not req.url.endswith("sw.js")
-            else None,
-        )
+        js_requests: list[str] = []
+        map_requests: list[str] = []
+
+        def handle_request(req: Request) -> None:
+            if req.url.endswith(".js") and not req.url.endswith("sw.js"):
+                js_requests.append(req.url)
+            elif req.url.endswith(".map"):
+                map_requests.append(req.url)
+
+        page.on("request", handle_request)
         page.goto(url)
         page.wait_for_selector("#controls")
-        assert requests == [page.url.replace("index.html", "insight.bundle.js")]
+        expected = page.url.replace("index.html", "insight.bundle.js")
+        assert js_requests == [expected]
+        assert map_requests == []
         browser.close()


### PR DESCRIPTION
## Summary
- strip `sourceMappingURL` comments in `build.js`
- strip sourcemap hints in `manual_build.py`
- expand playwright network test to assert no map fetches

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py`
- `pytest -k test_single_network_request -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6841185b5ec08333812a2c53ffb5b562