### PR TITLE
[alpha_factory] clamp parseHash params

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export const defaults={seed:42,pop:80,gen:60,mutations:['gaussian'],adaptive:false};
+const MAX_VAL=500;
 export function parseHash(h=window.location.hash){
   if(!h || h==='#'){
     try{
@@ -9,8 +10,8 @@ export function parseHash(h=window.location.hash){
         const p=JSON.parse(stored);
         return{
           seed:p.seed??defaults.seed,
-          pop:p.pop??defaults.pop,
-          gen:p.gen??defaults.gen,
+          pop:Math.min(p.pop??defaults.pop,MAX_VAL),
+          gen:Math.min(p.gen??defaults.gen,MAX_VAL),
           mutations:p.mutations??defaults.mutations,
           adaptive:p.adaptive??defaults.adaptive
         };
@@ -20,8 +21,8 @@ export function parseHash(h=window.location.hash){
   const q=new URLSearchParams(h.replace(/^#\/?/,''));
   return{
     seed:+q.get('s')||defaults.seed,
-    pop:+q.get('p')||defaults.pop,
-    gen:+q.get('g')||defaults.gen,
+    pop:Math.min(+q.get('p')||defaults.pop,MAX_VAL),
+    gen:Math.min(+q.get('g')||defaults.gen,MAX_VAL),
     mutations:(q.get('m')||defaults.mutations.join(',')).split(',').filter(Boolean),
     adaptive:q.get('a')==='1'||defaults.adaptive
   };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/limits.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/limits.test.js
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 const { initControls } = require('../src/ui/ControlsPanel.ts');
+const { parseHash } = require('../src/config/params.ts');
 
 test('values above max are clamped', () => {
   document.body.innerHTML = '<div id="controls"></div>';
@@ -14,6 +15,12 @@ test('values above max are clamped', () => {
   genInput.dispatchEvent(new Event('change'));
   expect(popInput.value).toBe('500');
   expect(genInput.value).toBe('500');
+  expect(params.pop).toBe(500);
+  expect(params.gen).toBe(500);
+});
+
+test('parseHash clamps values above max', () => {
+  const params = parseHash('#/p=9999&g=9999');
   expect(params.pop).toBe(500);
   expect(params.gen).toBe(500);
 });


### PR DESCRIPTION
## Summary
- enforce UI max for population and generation when parsing URL/hash
- test parseHash clamps values above 500

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_68411c411ce08333a29d98e5b82224e8