### PR TITLE
[alpha_factory] add non-root user to muzero demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,9 @@ RUN pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_cli
     && pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
     && rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
 
+# run as non-root user for demos
+RUN useradd --uid 1001 --create-home appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 CMD ["uvicorn", "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml
+++ b/alpha_factory_v1/demos/muzero_planning/docker-compose.muzero.yml
@@ -6,6 +6,7 @@ services:
       context: ../..                # alpha_factory_v1 root
       dockerfile: ./Dockerfile      # uses existing image recipe
     image: alpha_factory_orchestrator:muzero
+    user: "1001:1001"
     env_file: ./config.env
     command: >-
       sh -c "pip install --no-cache-dir -r /app/demo/requirements.txt && \


### PR DESCRIPTION
## Summary
- add `user: "1001:1001"` to the MuZero compose file
- create UID 1001 in the demo Dockerfile

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_68411c55923c8333b2e01874a3ea3968