### PR TITLE
[alpha_factory] remove ts-nocheck from browser src

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/canvasLayer.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/canvasLayer.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 
 export function ensureLayer(parent: any): CanvasRenderingContext2D {
@@ -22,10 +21,10 @@ export function ensureLayer(parent: any): CanvasRenderingContext2D {
     canvas.height = height;
     fo.appendChild(canvas);
     node.appendChild(fo);
-    return canvas.getContext('2d');
+    return canvas.getContext('2d')!;
   }
   const canvas = fo.querySelector('canvas');
-  return canvas.getContext('2d');
+  return canvas.getContext('2d')!;
 }
 
 export function drawPoints(

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/plotCanvas.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/plotCanvas.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 // Minimal stub for @observablehq/plot-canvas
 // This implementation simply returns the mark unchanged.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/svg2png.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/svg2png.ts
@@ -1,11 +1,10 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export async function svg2png(svg: SVGSVGElement): Promise<Blob | null> {
   const xml = new XMLSerializer().serializeToString(svg);
   const blob = new Blob([xml], { type: 'image/svg+xml' });
   const url = URL.createObjectURL(blob);
   const img = new Image();
-  const loaded = new Promise((resolve, reject) => {
+  const loaded = new Promise<void>((resolve, reject) => {
     img.onload = () => resolve();
     img.onerror = reject;
     img.src = url;
@@ -15,7 +14,7 @@ export async function svg2png(svg: SVGSVGElement): Promise<Blob | null> {
   const vb = svg.viewBox.baseVal;
   canvas.width = vb && vb.width ? vb.width : svg.clientWidth;
   canvas.height = vb && vb.height ? vb.height : svg.clientHeight;
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext('2d')!;
   ctx.drawImage(img, 0, 0);
   URL.revokeObjectURL(url);
   return new Promise((resolve) => canvas.toBlob((b) => resolve(b), 'image/png'));

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/Tooltip.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/Tooltip.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export function showTooltip(x: number, y: number, text: string): void {
   let tip = document.getElementById('tooltip');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/cluster.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/cluster.ts
@@ -1,7 +1,9 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
-export function detectColdZone(points: Array<[number, number]>, bins = 10) {
-  const hist = new Map();
+export function detectColdZone(
+  points: Array<[number, number]>,
+  bins = 10,
+): { x: number; y: number; count: number } {
+  const hist = new Map<string, number>();
   for (const [x, y] of points) {
     const cx = Math.max(0, Math.min(bins - 1, Math.floor(x * bins)));
     const cy = Math.max(0, Math.min(bins - 1, Math.floor(y * bins)));

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/csv.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/csv.ts
@@ -1,9 +1,8 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
-export function toCSV(rows: any[], headers?: string[]) {
+export function toCSV(rows: any[], headers?: string[]): string {
   if (!rows.length) return '';
   const keys = headers || Object.keys(rows[0]);
-  const escape = (v) => `"${String(v).replace(/"/g, '""')}"`;
+  const escape = (v: unknown): string => `"${String(v).replace(/"/g, '""')}"`;
   const lines = [keys.join(',')];
   for (const row of rows) {
     lines.push(keys.map((k) => escape(row[k])).join(','));


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` from a few browser TypeScript utilities
- add basic types

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `npx tsc --noEmit -p alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68411e6aa7e48333bfb620fa6ac65e99