### PR TITLE
[alpha_factory] clarify browser build requirements

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -11,6 +11,7 @@ This demo is a conceptual research prototype. Mentions of "AGI" or "superintelli
 - **Python ≥3.11** is required when using `manual_build.py`.
 - `package-lock.json` must remain checked in so `npm ci` installs the exact
   versions specified.
+- Run `npm ci` before executing any lint or build script.
 
 Verify your Node.js version before running the build script:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -6,6 +6,7 @@ import { execSync, spawnSync } from 'child_process';
 import path from 'path';
 import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { copyAssets, injectEnv, checkGzipSize, generateServiceWorker } from './build/common.js';
 import { requireNode20 } from './build/version_check.js';
 
@@ -14,6 +15,27 @@ const manifest = JSON.parse(
 );
 
 requireNode20();
+
+function ensureDevPackages() {
+  const require = createRequire(import.meta.url);
+  const packages = [
+    'esbuild',
+    'tailwindcss',
+    'workbox-build',
+    'web3.storage',
+    'dotenv',
+  ];
+  for (const pkg of packages) {
+    try {
+      require.resolve(pkg);
+    } catch {
+      console.error(`Missing dependency "${pkg}". Run 'npm ci' before building.`);
+      process.exit(1);
+    }
+  }
+}
+
+ensureDevPackages();
 
 const { build } = await import('esbuild');
 const { Web3Storage, File } = await import('web3.storage');


### PR DESCRIPTION
## Summary
- mention running `npm ci` before lint or build
- check for missing packages in `build.js`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*

------
https://chatgpt.com/codex/tasks/task_e_684121c0ff0c8333915234c292ea0537