### PR TITLE
[alpha_factory] runtime key setup for browser demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -26,7 +26,9 @@ via the `engines` field.
 Copy [`.env.sample`](.env.sample) to `.env` then review the variables:
 
 - `PINNER_TOKEN` – Web3.Storage token used to pin results.
-- `OPENAI_API_KEY` – optional OpenAI key for chat prompts.
+- `OPENAI_API_KEY` – optional OpenAI key for chat prompts. **For security, do not
+  embed the key in the built HTML.** Store it in `localStorage` or enter it at
+  runtime instead.
 - `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs.
 - `OTEL_ENDPOINT` – OTLP/HTTP endpoint for anonymous telemetry (leave blank to disable).
 - `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
@@ -45,8 +47,9 @@ npm ci            # installs dependencies from package-lock.json
 npm run build     # or `python manual_build.py` to compile to dist/
 ```
 The build script reads `.env` automatically and injects the values into
-`dist/index.html` as `window.PINNER_TOKEN`, `window.OPENAI_API_KEY`,
-`window.IPFS_GATEWAY` and `window.OTEL_ENDPOINT`.
+`dist/index.html` as `window.PINNER_TOKEN`, `window.IPFS_GATEWAY` and
+`window.OTEL_ENDPOINT`. `OPENAI_API_KEY` is **not** embedded by default.
+Set it in `localStorage` or provide it at runtime when prompted.
 It also copies `dist/sw.js` to `dist/service-worker.js` which `index.html`
 registers for offline support.
 The unbuilt `index.html` falls back to `'self'` for the IPFS and telemetry
@@ -78,8 +81,8 @@ PINNER_TOKEN=<token> npm start
 Set `PINNER_TOKEN` to your [Web3.Storage](https://web3.storage/) token so
 exported JSON results can be pinned.
 
-If `OPENAI_API_KEY` is saved in `localStorage`, the demo uses the OpenAI API for
-chat prompts. When the key is absent a lightweight GPT‑2 model under
+If `OPENAI_API_KEY` is stored in `localStorage`, the demo uses the OpenAI API for
+chat prompts. When no key is present a lightweight GPT‑2 model under
 `wasm_llm/` runs locally.
 
 Open `index.html` directly or pin the built `dist/` directory to IPFS

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -43,7 +43,7 @@ const dotenv = (await import('dotenv')).default;
 dotenv.config();
 
 function validateEnv() {
-  for (const key of ['PINNER_TOKEN', 'OPENAI_API_KEY', 'WEB3_STORAGE_TOKEN']) {
+  for (const key of ['PINNER_TOKEN', 'WEB3_STORAGE_TOKEN']) {
     const val = process.env[key];
     if (val !== undefined && !val.trim()) {
       throw new Error(`${key} may not be empty`);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -38,10 +38,9 @@ export async function copyAssets(manifest, repoRoot, outDir) {
 export function injectEnv(env) {
   const enc = (v) => Buffer.from(String(v ?? ''), 'utf8').toString('base64');
   const b64Pinner = enc(env.PINNER_TOKEN);
-  const b64Openai = enc(env.OPENAI_API_KEY);
   const b64Otel = enc(env.OTEL_ENDPOINT);
   const b64Ipfs = enc(env.IPFS_GATEWAY);
-  const script = `<script>window.PINNER_TOKEN=atob('${b64Pinner}');window.OPENAI_API_KEY=atob('${b64Openai}');window.OTEL_ENDPOINT=atob('${b64Otel}');window.IPFS_GATEWAY=atob('${b64Ipfs}');</script>`;
+  const script = `<script>window.PINNER_TOKEN=atob('${b64Pinner}');window.OTEL_ENDPOINT=atob('${b64Otel}');window.IPFS_GATEWAY=atob('${b64Ipfs}');</script>`; 
   return script;
 }
 export async function checkGzipSize(file, maxBytes = 2 * 1024 * 1024) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -48,7 +48,7 @@
       }
     </script>
     <script type="module" src="insight.bundle.js" integrity="sha384-xvBtRNt3wDxbGvoB3SGnTkR049k6Z27KPqtC6P5m68+XNbPLFR9y2bC++HNGc7vJ" crossorigin="anonymous"></script>
-  <script>window.PINNER_TOKEN=atob('');window.OPENAI_API_KEY=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('aHR0cHM6Ly9pcGZzLmlvL2lwZnM=');</script>
+  <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('aHR0cHM6Ly9pcGZzLmlvL2lwZnM=');</script>
 <script src="service-worker.js" integrity="sha384-o4otzwjbNKzpYYcqiTHOYyd9asjheSu1P8UVzmVl3HU8cvmE86GWhOgWUjkJ6gXT" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -56,7 +56,7 @@ except Exception as exc:  # pragma: no cover - optional dep
 
 def _validate_env() -> None:
     """Validate tokens and URLs in the environment."""
-    for key in ("PINNER_TOKEN", "OPENAI_API_KEY", "WEB3_STORAGE_TOKEN"):
+    for key in ("PINNER_TOKEN", "WEB3_STORAGE_TOKEN"):
         val = os.getenv(key)
         if val is not None and not val.strip():
             sys.exit(f"{key} may not be empty")
@@ -116,7 +116,6 @@ def inject_env() -> str:
     return (
         "<script>"
         f"window.PINNER_TOKEN=atob('{_enc(os.getenv('PINNER_TOKEN'))}');"
-        f"window.OPENAI_API_KEY=atob('{_enc(os.getenv('OPENAI_API_KEY'))}');"
         f"window.OTEL_ENDPOINT=atob('{_enc(os.getenv('OTEL_ENDPOINT'))}');"
         f"window.IPFS_GATEWAY=atob('{_enc(os.getenv('IPFS_GATEWAY'))}');"
         "</script>"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
@@ -67,14 +67,14 @@ def test_llm_offline() -> None:
         page.wait_for_selector("#controls")
 
         out = page.evaluate("window.llmChat('hi')")
-        assert out.startswith('[offline]')
+        assert out.startswith("[offline]")
         browser.close()
 
 
 @pytest.mark.skipif(
     not (Path(__file__).resolve().parents[1] / "wasm_llm" / "wasm-gpt2.tar").exists(),
     reason="wasm model missing",
-)
+)  # type: ignore[misc]
 def test_llm_offline_pipeline() -> None:
     dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
     url = dist.as_uri()
@@ -86,7 +86,7 @@ def test_llm_offline_pipeline() -> None:
         page.wait_for_selector("#controls")
 
         out = page.evaluate("window.llmChat('hello')")
-        assert not out.startswith('[offline]')
+        assert not out.startswith("[offline]")
         browser.close()
 
 
@@ -109,11 +109,11 @@ def test_llm_openai_path() -> None:
         page.evaluate("localStorage.setItem('OPENAI_API_KEY','sk')")
 
         out = page.evaluate("window.llmChat('hi')")
-        assert out == 'pong'
+        assert out == "pong"
         browser.close()
 
 
-@pytest.mark.skipif(shutil.which("npm") is None, reason="npm not installed")
+@pytest.mark.skipif(shutil.which("npm") is None, reason="npm not installed")  # type: ignore[misc]
 def test_env_value_injected(tmp_path: Path) -> None:
     browser_dir = Path(__file__).resolve().parents[1]
     target = tmp_path / "browser"
@@ -128,6 +128,7 @@ def test_env_value_injected(tmp_path: Path) -> None:
         page.goto(url)
         page.wait_for_selector("#controls")
         assert page.evaluate("window.PINNER_TOKEN") == "test123"
+        assert page.evaluate("typeof window.OPENAI_API_KEY === 'undefined' || !window.OPENAI_API_KEY")
         browser.close()
 
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_closing_tags.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_closing_tags.py
@@ -10,3 +10,4 @@ def test_index_html_has_closing_tags() -> None:
     assert html[-1].strip() == "</html>"
     joined = "\n".join(html)
     assert "window.PINNER_TOKEN" in joined
+    assert "window.OPENAI_API_KEY" not in joined

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_escaping.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_escaping.py
@@ -28,6 +28,7 @@ def test_env_value_escaped(tmp_path: Path) -> None:
     html_text = (target / "dist" / "index.html").read_text()
     assert token not in html_text
     assert "window.PINNER_TOKEN=atob(" in html_text
+    assert "window.OPENAI_API_KEY" not in html_text
 
     url = (target / "dist" / "index.html").as_uri()
     with sync_playwright() as p:


### PR DESCRIPTION
## Summary
- disable OPENAI_API_KEY injection in build scripts
- read key from localStorage at runtime instead
- document security risk in the browser demo README
- update tests for the missing key

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files README.md build.js build/common.js dist/index.html manual_build.py tests/test_browser_ui.py tests/test_closing_tags.py tests/test_env_escaping.py` *(skipped proto & lockfile hooks)*
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_closing_tags.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_escaping.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py` *(fails: Missing browsers/Node dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841281ec4dc8333afc91fcfadf10510