### PR TITLE
[alpha_factory] extend browser globals

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/global.d.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/global.d.ts
@@ -8,6 +8,10 @@ declare global {
     OPENAI_API_KEY?: string;
     OTEL_ENDPOINT?: string;
     IPFS_GATEWAY?: string;
+    USE_GPU?: boolean;
+    pop?: unknown;
+    coldZone?: unknown;
+    recordedPrompts?: string[];
   }
 }
 


### PR DESCRIPTION
## Summary
- add USE_GPU, pop, coldZone, and recordedPrompts to web globals
- run `tsc --noEmit` to validate types

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68418acd9da08333812c9874709c3ac6