### PR TITLE
[alpha_factory] audit environment checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,7 @@ pip install -r requirements-dev.txt
 Install the project in editable mode so tests resolve imports:
 ```bash
 pip install -e .
+python check_env.py --auto-install
 ```
 
 The suite includes `tests/test_api_rate_limit.py` which spins up

--- a/alpha_factory_v1/requirements.lock
+++ b/alpha_factory_v1/requirements.lock
@@ -5,6 +5,7 @@ anthropic==0.52.1
 anyio==4.9.0
 certifi==2025.4.26
 cffi==1.17.1
+cachetools==5.5.2
 charset-normalizer==3.4.2
 click==8.2.1
 colorama==0.4.6

--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -24,6 +24,7 @@ better-profanity~=0.7
 httpx~=0.28
 aiohttp~=3.9
 backoff~=2.2
+cachetools~=5.3
 PyYAML>=6.0
 rich>=13           # CLI output only (backend omits to stay lean)
 
@@ -46,6 +47,7 @@ litellm>=1.31           # local gateway / fallback router
 tiktoken>=0.5
 grpcio~=1.71
 grpcio-tools
+protobuf>=5
 
 # Google ADK – optional Agent-to-Agent federation (A2A protocol)
 google-adk>=0.3.0        # https://pypi.org/project/google-adk/

--- a/check_env.py
+++ b/check_env.py
@@ -31,6 +31,9 @@ REQUIRED = [
     "grpc",
     "cryptography",
     "numpy",
+    "google.protobuf",
+    "cachetools",
+    "yaml",
     "click",
     "requests",
     "pandas",
@@ -54,6 +57,9 @@ PIP_NAMES = {
     "pytest_benchmark": "pytest-benchmark",
     "playwright.sync_api": "playwright",
     "websockets": "websockets",
+    "google.protobuf": "protobuf",
+    "cachetools": "cachetools",
+    "yaml": "PyYAML",
 }
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,8 @@
 
 These integration tests expect the `alpha_factory_v1` package to be importable. When running from the repository root without installation, set `PYTHONPATH` so Python can locate the source tree:
 
+Run `python check_env.py --auto-install` first to confirm all dependencies are available.
+
 ```bash
 export PYTHONPATH=$(pwd)
 python -m pytest -q tests


### PR DESCRIPTION
## Summary
- verify cachetools and protobuf are installed in check_env
- ensure check_env is run before tests
- document check_env usage
- pin cachetools and protobuf in requirements

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files check_env.py alpha_factory_v1/requirements.txt alpha_factory_v1/requirements.lock README.md tests/README.md` *(fails: proto-verify)*
- `pytest -q` *(fails: 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_684188091eb0833381980362ae8eb36c