### PR TITLE
[alpha_factory] Warn about demo-token usage

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -8,7 +8,7 @@ This guide summarises the minimal steps required to run the **Alpha‑AGI Busine
    - Optionally enable the Google ADK gateway by setting `ALPHA_FACTORY_ENABLE_ADK=true`.
    - Set `MCP_ENDPOINT` to push logs to a Model Context Protocol server (optional).
    - Set `MCP_TIMEOUT_SEC` to adjust the timeout for MCP requests (default: 30 seconds).
-   - `API_TOKEN` defaults to `"demo-token"`; change it to a strong secret in production.
+   - `API_TOKEN` defaults to `"demo-token"` *(for demonstrations only)*; always set a strong secret before deploying.
    - For API protection set either `AUTH_BEARER_TOKEN` or `JWT_PUBLIC_KEY`/`JWT_ISSUER`.
    - Validate that all Python packages are available. From the project root run:
      ```bash

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -184,6 +184,8 @@ cp config.env.sample config.env
 #   - WHEELHOUSE=/path/to/wheels for offline package installs
 # The launcher automatically picks up these settings.
 
+> **Security Note:** `API_TOKEN` defaults to `demo-token` for quick demos. Replace it with a strong, unique value before any production deployment.
+
 By default this launcher restricts `ALPHA_ENABLED_AGENTS` to the five
 lightweight demo stubs so the orchestrator runs even on minimal setups.
 Set the variable yourself to customise the agent list.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/config.env.sample
@@ -42,6 +42,7 @@ AUTH_BEARER_TOKEN = ""  # static REST auth token
 JWT_PUBLIC_KEY = ""  # PEM for JWT verification
 JWT_ISSUER = "alpha-business.local"  # expected issuer claim
 # Bearer token required by the REST API
+# See README.md for the security note on setting a strong value
 API_TOKEN = "demo-token"
 # Set to '1' to let check_env.py auto-install missing deps
 AUTO_INSTALL_MISSING = 0


### PR DESCRIPTION
## Summary
- warn that `demo-token` is for demonstration only
- remind users in the business demo README to set a strong `API_TOKEN`
- reference the new note from `config.env.sample`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in Collector...)*

------
https://chatgpt.com/codex/tasks/task_e_684190db4dfc83338b6d2babcbc558c1