### PR TITLE
[alpha_factory] document pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,19 @@ of a real general intelligence. Use at your own risk.
 ## Contributing
 See [AGENTS.md](AGENTS.md) for the full contributor guide.
 
+### Pre‑commit Hooks
+After running `./codex/setup.sh`, install the hooks and run a full check:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files   # verify hooks after setup
+pre-commit run --files <paths>   # before each commit
+```
+Run `pre-commit run --all-files` once after the setup script to confirm
+everything is formatted correctly. These commands mirror the steps in
+[AGENTS.md](AGENTS.md) and keep commits consistent.
+
 ## 📜 Table of Contents
 0. [Design Philosophy](#0-design-philosophy)  
 1. [System Topology 🗺️](#1-system-topology)  


### PR DESCRIPTION
## Summary
- document pre-commit setup under Contributing

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries & missing AgentRuntime)*
- `pre-commit run --files README.md --hook-stage manual` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_684194024d588333b457285b2008ddc0