### PR TITLE
[alpha_factory] add browser size workflow

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,0 +1,26 @@
+name: "📦 Browser Size"
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+      - name: Build distribution zip
+        run: npm run build:dist --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+      - name: Check archive size
+        run: |
+          size=$(stat -c%s alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/insight_browser.zip)
+          echo "insight_browser.zip size: $size bytes"
+          if [ "$size" -gt $((3 * 1024 * 1024)) ]; then
+            echo "Archive exceeds 3 MiB" >&2
+            exit 1
+          fi

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -172,6 +172,11 @@ required. New users can review
 [dist/insight_browser_quickstart.pdf](dist/insight_browser_quickstart.pdf) after
 extraction for a brief walkthrough.
 
+A dedicated GitHub Actions workflow
+[`size-check.yml`](../../../../.github/workflows/size-check.yml) rebuilds the
+archive on each pull request and fails if `insight_browser.zip` grows beyond
+**3&nbsp;MiB**.
+
 ## Locale Support
 The interface automatically loads French, Spanish or Chinese translations based
 on your browser preferences. Set `localStorage.lang` to override the detected


### PR DESCRIPTION
# Summary
- add workflow to ensure insight_browser.zip stays under 3 MiB
- document the check in the browser README

# Checks
- [x] `pre-commit run --files .github/workflows/size-check.yml alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md`
- [x] `python check_env.py --auto-install`
- [ ] `pytest -q` *(fails: duplicated timeseries and AgentRuntime import errors)*


------
https://chatgpt.com/codex/tasks/task_e_68419ad3c9a88333b0afa9c1216cecb6