### PR TITLE
[alpha_factory] docs: add ADK gateway verification

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -39,6 +39,23 @@ This short guide distils the steps required to run the **AI‑GA Meta‑Evolutio
    - OpenAPI docs: [http://localhost:8000/docs](http://localhost:8000/docs)
    - Prometheus metrics: [http://localhost:8000/metrics](http://localhost:8000/metrics)
 
+### Verifying the ADK Gateway
+When `ALPHA_FACTORY_ENABLE_ADK=true` and the optional `google-adk` package are
+present, the orchestrator exposes an ADK gateway.  Check the logs for a line
+similar to:
+
+```
+ADK gateway listening on http://0.0.0.0:${ALPHA_FACTORY_ADK_PORT}  (A2A protocol)
+```
+
+Confirm the gateway is reachable:
+
+```bash
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/docs
+# or
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz
+```
+
 5. **Persisting state**
    - Checkpoints are written to the directory specified by `CHECKPOINT_DIR` (default `./checkpoints`).
    - The service automatically reloads the latest checkpoint on start-up.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -37,6 +37,22 @@ This guide summarises the minimal steps required to run the **Alpha‑AGI Busine
    - Gradio dashboard: [http://localhost:7860](http://localhost:7860)
    - Prometheus metrics: [http://localhost:8000/metrics](http://localhost:8000/metrics)
 
+### Verifying the ADK Gateway
+When `ALPHA_FACTORY_ENABLE_ADK=true` and the optional `google-adk` package are
+installed, the service spawns an ADK gateway.  Look for a log message like:
+
+```
+ADK gateway listening on http://0.0.0.0:${ALPHA_FACTORY_ADK_PORT}  (A2A protocol)
+```
+
+Confirm connectivity with:
+
+```bash
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/docs
+# or
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz
+```
+
 5. **Shutting down**
    - Docker: `./run_business_v1_demo.sh --stop`
    - Native Python: press `Ctrl+C`; the orchestrator shuts down gracefully.


### PR DESCRIPTION
## Summary
- add subsection on verifying the ADK gateway to the demo production guides

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_68419da2658c8333bb6c87e240416374