### PR TITLE
[alpha_factory] add offline wheelhouse instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ Follow these steps when working without internet access.
    `WHEELHOUSE` is unset:
    ```bash
    WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
-   WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
-     python check_env.py --auto-install --wheelhouse /media/wheels
-   pip check
-   ```
+  WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
+    python check_env.py --auto-install --wheelhouse /media/wheels
+  pip check
+  ```
+   See [Offline Setup](alpha_factory_v1/scripts/README.md#offline-setup) for
+   more details.
 
 3. **Download a `.gguf` weight** and set ``LLAMA_MODEL_PATH``:
    ```bash

--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -88,6 +88,28 @@ given JSON file exists before uploading.
 
 ---
 
+## Offline Setup
+
+When working on an air‑gapped machine build wheels ahead of time and tell
+``check_env.py`` where to find them.
+
+1. **Build wheels** from the lock file:
+   ```bash
+   mkdir -p /media/wheels
+   pip wheel -r requirements.lock -w /media/wheels
+   pip wheel -r requirements-dev.txt -w /media/wheels
+   ```
+
+2. **Run the environment check** using your wheelhouse:
+   ```bash
+   WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
+     python check_env.py --auto-install --wheelhouse /media/wheels
+   ```
+   When a ``wheels/`` directory exists in the repository root, the setup
+   scripts automatically set ``WHEELHOUSE`` for you.
+
+---
+
 ## 🛡️ Security & Compliance
 
 * **Secrets stay secret** — `.env` is `.gitignore`‑d; Kubernetes `Secret` template provided.


### PR DESCRIPTION
## Summary
- document offline wheelhouse steps for `alpha_factory_v1/scripts`
- link to new instructions from the offline mode section

## Testing
- `pre-commit run --files README.md alpha_factory_v1/scripts/README.md` *(with several hooks skipped)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_68419ee33400833393ef289ea9b87c48