### PR TITLE
[alpha_factory] Fix Quick Start comment duplication

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -155,7 +155,6 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
 python start_alpha_business.py
 
 # automatically queue the highest scoring demo opportunity
-# automatically queue the highest scoring demo opportunity
 python start_alpha_business.py --submit-best
 
 # Docker-based run (add --pull to use GHCR, --gpu for NVIDIA)


### PR DESCRIPTION
## Summary
- deduplicate the quick start note about auto-queueing the best opportunity

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_v1/README.md` *(fails: Makefile missing separator)*
- `pytest -q` *(fails: 2 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6841a082f728833395b104823ab04daa