### PR TITLE
[alpha_factory] enable ADK flag sample

### DIFF
--- a/alpha_factory_v1/.env.sample
+++ b/alpha_factory_v1/.env.sample
@@ -57,6 +57,7 @@ DISABLED_AGENTS=                 # comma-separated list disables specific agents
 # Bridges
 AGENTS_RUNTIME_PORT=5001         # OpenAI Agents runtime port
 BUSINESS_HOST="http://localhost:8000"  # orchestrator base URL
+ALPHA_FACTORY_ENABLE_ADK=false    # true ⇒ expose the ADK gateway
 
 # ─── Governance & telemetry ─────────────────────────────────────────
 OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317


### PR DESCRIPTION
## Summary
- add `ALPHA_FACTORY_ENABLE_ADK` to `.env.sample`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `pre-commit run --config /tmp/no_semgrep.yaml --files alpha_factory_v1/.env.sample`

------
https://chatgpt.com/codex/tasks/task_e_6841a237b4b883339815cb04e2e968e9