### PR TITLE
[alpha_factory] add runtime port option to business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -28,8 +28,10 @@ This short guide summarises how to launch the business demo either locally or in
 
    Alternatively, run the orchestrator directly with:
    ```bash
-   python run_business_v1_local.py --bridge --open-ui
-   ```
+  python run_business_v1_local.py --bridge --open-ui
+  # customise the Agents runtime port
+  python run_business_v1_local.py --bridge --runtime-port 6001
+  ```
    This starts the Agents bridge and opens the REST docs automatically once the service is ready.
 
 Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -164,6 +164,8 @@ python start_alpha_business.py --submit-best
 python run_business_v1_local.py --bridge --auto-install
 # expose orchestrator on a custom port
 python run_business_v1_local.py --bridge --port 9000
+# expose the Agents runtime on a custom port
+python run_business_v1_local.py --bridge --runtime-port 6001
 # automatically open the REST docs in your browser
 python run_business_v1_local.py --bridge --open-ui
 # Set `ALPHA_OPPS_FILE` to use a custom opportunity list

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -44,7 +44,7 @@ def _set_business_host(host: str) -> None:
         pass
 
 
-def _start_bridge(host: str) -> None:
+def _start_bridge(host: str, runtime_port: int) -> None:
     """Start the OpenAI Agents bridge in a background thread.
 
     Parameters
@@ -53,6 +53,7 @@ def _start_bridge(host: str) -> None:
         Base URL for the orchestrator that the bridge should
         communicate with (e.g. ``"http://localhost:8000"``).
     """
+    os.environ["AGENTS_RUNTIME_PORT"] = str(runtime_port)
     try:
         from alpha_factory_v1.demos.alpha_agi_business_v1 import openai_agents_bridge
     except Exception as exc:  # pragma: no cover - optional dep
@@ -110,6 +111,13 @@ def main(argv: list[str] | None = None) -> None:
         help="Expose orchestrator on this port (default: 8000)",
     )
     parser.add_argument(
+        "--runtime-port",
+        type=int,
+        default=5001,
+        metavar="PORT",
+        help="Expose Agents runtime on this port (default: 5001)",
+    )
+    parser.add_argument(
         "--auto-install",
         action="store_true",
         help="Attempt automatic installation of missing packages",
@@ -160,7 +168,7 @@ def main(argv: list[str] | None = None) -> None:
     from alpha_factory_v1.demos.alpha_agi_business_v1 import alpha_agi_business_v1
     if args.bridge:
         host = os.getenv("BUSINESS_HOST", f"http://localhost:{args.port}")
-        _start_bridge(host)
+        _start_bridge(host, args.runtime_port)
 
     if args.open_ui:
         url = os.getenv("BUSINESS_HOST", f"http://localhost:{args.port}") + "/docs"

--- a/tests/test_alpha_business_v1_script.py
+++ b/tests/test_alpha_business_v1_script.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import os
 import py_compile
 import unittest
 from pathlib import Path
@@ -16,6 +17,29 @@ class TestAlphaBusinessV1Script(unittest.TestCase):
         """Ensure the one-click helper launcher compiles."""
         path = Path('alpha_factory_v1/demos/alpha_agi_business_v1/start_alpha_business.py')
         py_compile.compile(path, doraise=True)
+
+    def test_runtime_port_env(self) -> None:
+        """--runtime-port propagates AGENTS_RUNTIME_PORT."""
+        from unittest.mock import patch
+
+        mod = __import__(
+            'alpha_factory_v1.demos.alpha_agi_business_v1.run_business_v1_local',
+            fromlist=['main']
+        )
+
+        captured = {}
+
+        def fake_start_bridge(host: str, runtime_port: int) -> None:  # type: ignore
+            captured['env'] = os.getenv('AGENTS_RUNTIME_PORT')
+            captured['port'] = runtime_port
+
+        with patch.object(mod, '_start_bridge', fake_start_bridge), \
+             patch.object(mod, 'check_env'):  # type: ignore
+            with patch('alpha_factory_v1.demos.alpha_agi_business_v1.alpha_agi_business_v1.main'):
+                mod.main(['--bridge', '--runtime-port', '7001'])
+
+        self.assertEqual(captured['port'], 7001)
+        self.assertEqual(captured['env'], '7001')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying `--runtime-port` in `run_business_v1_local.py`
- document new option in the Business v1 README and quick start
- test that the CLI argument sets `AGENTS_RUNTIME_PORT`

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: duplicated timeseries in CollectorRegistry, openai_bridge_import)*

------
https://chatgpt.com/codex/tasks/task_e_6841ab5ac258833395e7696b6666bca1