### PR TITLE
[alpha_factory] remove ts-nocheck from browser

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { createStore, set, get, del, values } from './utils/keyval.ts';
 import type { EvaluatorGenome } from './evaluator_genome.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/config/params.ts
@@ -1,8 +1,15 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export const defaults={seed:42,pop:80,gen:60,mutations:['gaussian'],adaptive:false};
 const MAX_VAL=500;
-export function parseHash(h=window.location.hash){
+export interface Params {
+  seed: number;
+  pop: number;
+  gen: number;
+  mutations?: string[];
+  adaptive?: boolean;
+}
+
+export function parseHash(h: string = window.location.hash): Params {
   if(!h || h==='#'){
     try{
       const stored=localStorage.getItem('insightParams');
@@ -20,16 +27,18 @@ export function parseHash(h=window.location.hash){
   }
   const q=new URLSearchParams(h.replace(/^#\/?/,''));
   return{
-    seed:+q.get('s')||defaults.seed,
-    pop:Math.min(+q.get('p')||defaults.pop,MAX_VAL),
-    gen:Math.min(+q.get('g')||defaults.gen,MAX_VAL),
+    seed:+(q.get('s') ?? '')||defaults.seed,
+    pop:Math.min(+(q.get('p') ?? '')||defaults.pop,MAX_VAL),
+    gen:Math.min(+(q.get('g') ?? '')||defaults.gen,MAX_VAL),
     mutations:(q.get('m')||defaults.mutations.join(',')).split(',').filter(Boolean),
     adaptive:q.get('a')==='1'||defaults.adaptive
   };
 }
-export function toHash(p){
+export function toHash(p: Params): string{
   const q=new URLSearchParams();
-  q.set('s',p.seed);q.set('p',p.pop);q.set('g',p.gen);
+  q.set('s', String(p.seed));
+  q.set('p', String(p.pop));
+  q.set('g', String(p.gen));
   if(p.mutations) q.set('m',p.mutations.join(','));
   if(p.adaptive) q.set('a','1');
   return'#/'+q.toString();

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts
@@ -1,16 +1,23 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
+import type { Individual as BaseIndividual } from '../state/serializer.ts';
+
+export interface Mutant extends BaseIndividual {
+  strategy: string;
+  depth: number;
+  horizonYears: number;
+}
+
 export function mutate(
-  pop: any[],
+  pop: Mutant[],
   rand: () => number,
   strategies: string[],
   gen = 0,
   adaptive = false,
   scale = 1,
   gpu = false,
-): any[] {
-  const clamp = (v) => Math.min(1, Math.max(0, v));
-  const mutants = [];
+): Mutant[] {
+  const clamp = (v: number): number => Math.min(1, Math.max(0, v));
+  const mutants: Mutant[] = [];
   function converged() {
     if (!adaptive) return false;
     const meanL = pop.reduce((s, d) => s + (d.logic ?? 0), 0) / pop.length;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/lib/pyodide.d.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/lib/pyodide.d.ts
@@ -1,0 +1,1 @@
+export function loadPyodide(opts: any): Promise<any>;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.ts
@@ -1,15 +1,17 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import * as Plot from '@observablehq/plot';
+import * as d3 from 'd3';
 import { plotCanvas } from './plotCanvas.ts';
 import { paretoFront } from '../utils/pareto.ts';
 import { depthColor } from './colors.ts';
 import { drawHeatmap } from './canvasLayer.ts';
 
+import type { Individual } from '../state/serializer.ts';
+
 export function renderFrontier(
   container: HTMLElement,
-  pop: any[],
-  onSelect?: (d: any, el: SVGCircleElement) => void,
+  pop: Individual[],
+  onSelect?: (d: Individual, el: SVGCircleElement) => void,
 ): void {
   const front = paretoFront(pop).sort((a, b) => a.logic - b.logic);
 
@@ -18,8 +20,8 @@ export function renderFrontier(
     x: 'logic',
     y: 'feasible',
     r: 3,
-    fill: (d) => depthColor(d.depth ?? 0, maxDepth),
-    title: (d) => `${d.summary ?? ''}\n${d.critic ?? ''}`,
+    fill: (d: Individual) => depthColor(d.depth ?? 0, maxDepth),
+    title: (d: Individual) => `${d.summary ?? ''}\n${d.critic ?? ''}`,
   };
 
   const marks = [
@@ -48,8 +50,11 @@ export function renderFrontier(
   const svg = plot.querySelector('svg') || plot;
   drawHeatmap(svg, pop, (d) => d.logic * 500, (d) => (1 - d.feasible) * 500);
   if (onSelect) {
-    d3.select(plot).selectAll('circle').on('click', function (_, d) {
-      onSelect(d, this);
-    });
+    d3
+      .select(plot)
+      .selectAll<SVGCircleElement, Individual>('circle')
+      .on('click', function (_, d) {
+        onSelect(d, this);
+      });
   }
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/simulator.ts
@@ -1,8 +1,8 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { lcg } from './utils/rng.ts';
-import { mutate } from './evolve/mutate.ts';
+import { mutate, type Mutant } from './evolve/mutate.ts';
 import { paretoFront } from './utils/pareto.ts';
+import type { Individual as BaseIndividual } from './state/serializer.ts';
 
 export interface SimulatorConfig {
   popSize: number;
@@ -23,9 +23,7 @@ export interface Generation {
   metrics: { avgLogic: number; avgFeasible: number; frontSize: number };
 }
 
-interface Individual {
-  logic: number;
-  feasible: number;
+interface Individual extends BaseIndividual {
   strategy: string;
   depth: number;
   horizonYears: number;
@@ -75,8 +73,8 @@ export class Simulator {
         front = result.front;
         metrics = result.metrics;
       } else {
-        pop = mutate(pop, rand, options.mutations ?? ['gaussian'], gen + 1, options.adaptive);
-        front = paretoFront(pop);
+        pop = mutate(pop, rand, options.mutations ?? ['gaussian'], gen + 1, options.adaptive) as Individual[];
+        front = paretoFront(pop) as Individual[];
         pop.forEach((d) => (d.front = front.includes(d)));
         pop = front.concat(pop.slice(0, options.popSize - 10));
         metrics = {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/AnalyticsPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/AnalyticsPanel.ts
@@ -1,7 +1,7 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { t } from './i18n.ts';
-export function initAnalyticsPanel(): { update: (stats: any) => void; recordWorkerTime: (ms: number) => void } {
+import type { Individual } from '../state/serializer.ts';
+export function initAnalyticsPanel(): { update: (pop: Individual[], gen: number, entropy: number) => void; recordWorkerTime: (ms: number) => void } {
   const panel = document.createElement('div');
   panel.id = 'analytics-panel';
   panel.setAttribute('role', 'region');
@@ -57,7 +57,7 @@ export function initAnalyticsPanel(): { update: (stats: any) => void; recordWork
   panel.appendChild(canvas);
   document.body.appendChild(panel);
   const ctx = canvas.getContext('2d');
-  const hist = [];
+  const hist: number[] = [];
   let workerAvg = 0;
   let workerSamples = 0;
 
@@ -84,7 +84,7 @@ export function initAnalyticsPanel(): { update: (stats: any) => void; recordWork
     URL.revokeObjectURL(a.href);
   });
 
-  function update(pop, gen, entropy) {
+  function update(pop: Individual[], gen: number, entropy: number): void {
     if (!ctx) return;
     hist.push(entropy);
     if (hist.length > canvas.width) hist.shift();
@@ -118,15 +118,15 @@ export function initAnalyticsPanel(): { update: (stats: any) => void; recordWork
     });
     ctx.stroke();
 
-    if (performance.memory) {
-      const mb = performance.memory.usedJSHeapSize / 1048576;
+    if ((performance as any).memory) {
+      const mb = (performance as any).memory.usedJSHeapSize / 1048576;
       memEl.textContent = `mem ${mb.toFixed(1)} MB`;
     }
     const fpsTxt = document.getElementById('fps-meter')?.textContent || '';
     fpsEl.textContent = fpsTxt;
     workerEl.textContent = `worker ${workerAvg.toFixed(1)} ms`;
   }
-  function recordWorkerTime(ms) {
+  function recordWorkerTime(ms: number): void {
     workerSamples += 1;
     workerAvg += (ms - workerAvg) / workerSamples;
   }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/ArenaPanel.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { t } from './i18n.ts';
 import type { Individual } from '../state/serializer.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/CriticPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/CriticPanel.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export function initCriticPanel(): { show: (scores: Record<string, number>, element?: SVGCircleElement | null) => void } {
   const root = document.createElement('div');
@@ -31,9 +30,9 @@ export function initCriticPanel(): { show: (scores: Record<string, number>, elem
   root.appendChild(table);
   document.body.appendChild(root);
 
-  let highlighted = null;
+  let highlighted: SVGCircleElement | null = null;
 
-  function drawSpider(scores) {
+  function drawSpider(scores: Record<string, number>): void {
     const labels = Object.keys(scores);
     const values = Object.values(scores);
     const size = 200;
@@ -41,7 +40,7 @@ export function initCriticPanel(): { show: (scores: Record<string, number>, elem
     const radius = center - 20;
     const step = (Math.PI * 2) / labels.length;
     svg.innerHTML = '';
-    const pts = [];
+    const pts: string[] = [];
     labels.forEach((label, i) => {
       const angle = i * step - Math.PI / 2;
       const r = radius * (values[i] ?? 0);
@@ -53,15 +52,15 @@ export function initCriticPanel(): { show: (scores: Record<string, number>, elem
       const tx = center + (radius + 12) * Math.cos(angle);
       const ty = center + (radius + 12) * Math.sin(angle);
       const line = document.createElementNS('http://www.w3.org/2000/svg','line');
-      line.setAttribute('x1', center);
-      line.setAttribute('y1', center);
-      line.setAttribute('x2', lx);
-      line.setAttribute('y2', ly);
+      line.setAttribute('x1', String(center));
+      line.setAttribute('y1', String(center));
+      line.setAttribute('x2', String(lx));
+      line.setAttribute('y2', String(ly));
       line.setAttribute('stroke', '#ccc');
       svg.appendChild(line);
       const text = document.createElementNS('http://www.w3.org/2000/svg','text');
-      text.setAttribute('x', tx);
-      text.setAttribute('y', ty);
+      text.setAttribute('x', String(tx));
+      text.setAttribute('y', String(ty));
       text.setAttribute('font-size', '10');
       text.setAttribute('text-anchor', 'middle');
       text.setAttribute('dominant-baseline', 'middle');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/EvolutionPanel.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { loadTaxonomy, saveTaxonomy, proposeSectorNodes } from '@insight-src/taxonomy.ts';
 import { loadMemes } from '@insight-src/memeplex.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { setUseGpu } from '../utils/llm.ts';
 
@@ -34,14 +33,14 @@ export function initPowerPanel(): { update: (e: any) => void; gpuToggle: HTMLInp
   } catch {
     gpuToggle.checked = true;
   }
-  window.USE_GPU = gpuToggle.checked && !!navigator.gpu;
+  window.USE_GPU = gpuToggle.checked && !!(navigator as any).gpu;
   setUseGpu(window.USE_GPU);
   gpuToggle.addEventListener('change', () => {
-    window.USE_GPU = gpuToggle.checked && !!navigator.gpu;
+    window.USE_GPU = gpuToggle.checked && !!(navigator as any).gpu;
     setUseGpu(window.USE_GPU);
   });
   document.body.appendChild(panel);
-  function update(e) {
+  function update(e: unknown): void {
     pre.textContent = JSON.stringify(e, null, 2);
   }
   return { update, gpuToggle };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { Simulator } from '../simulator.ts';
 import type { Individual } from '../state/serializer.ts';
@@ -18,17 +17,11 @@ export interface PowerPanel {
 }
 
 declare const view: any;
-declare function selectPoint(d: any, elem?: HTMLElement): void;
-declare let pop: any[];
+declare function selectPoint(d: Individual, elem?: HTMLElement): void;
+declare let pop: Individual[];
 declare let gen: number;
 declare const info: HTMLElement & { text?: (s: string) => void };
 
-declare global {
-  interface Window {
-    pop?: any;
-    coldZone?: unknown;
-  }
-}
 
 export async function initSimulatorPanel(
   archive: Archive,
@@ -103,8 +96,10 @@ export async function initSimulatorPanel(
     if (!f) return;
     pop = f;
     gen = i;
-    window.pop = pop;
-    renderFrontier(view.node ? view.node() : view, pop, selectPoint);
+    (window as any).pop = pop;
+    renderFrontier(view.node ? view.node() : view, pop, (d, el) =>
+      selectPoint(d, el as unknown as HTMLElement)
+    );
     info.textContent = `gen ${i}`;
     if (inspectPre) inspectPre.textContent = JSON.stringify(f, null, 2);
   }
@@ -153,10 +148,10 @@ export async function initSimulatorPanel(
       });
       frameIds.push(fid);
       count = g.gen;
-      window.pop = g.population;
+      (window as any).pop = g.population;
       if (g.population[0] && g.population[0].umap) {
         const pts = g.population.map((p: Individual) => p.umap);
-        window.coldZone = detectColdZone(pts);
+        (window as any).coldZone = detectColdZone(pts);
       }
       progress.value = count / Number(genInput.value);
       status.textContent = `gen ${count} front ${g.fronts.length}`;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/dragdrop.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/dragdrop.ts
@@ -1,17 +1,17 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export function initDragDrop(el: HTMLElement, onDrop: (data: string | ArrayBuffer | null) => void): void {
-  function over(ev) {
+  function over(ev: DragEvent): void {
     ev.preventDefault();
     el.classList.add('drag');
   }
-  function leave() {
+  function leave(): void {
     el.classList.remove('drag');
   }
-  function drop(ev) {
+  function drop(ev: DragEvent): void {
     ev.preventDefault();
     el.classList.remove('drag');
-    const file = ev.dataTransfer.files && ev.dataTransfer.files[0];
+    const dt = ev.dataTransfer;
+    const file = dt && dt.files && dt.files[0];
     if (!file) return;
     const reader = new FileReader();
     reader.onload = () => onDrop(reader.result);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/fpsMeter.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/fpsMeter.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export function initFpsMeter(isRunning: () => boolean): void {
   if (document.getElementById('fps-meter')) return;
@@ -19,7 +18,7 @@ export function initFpsMeter(isRunning: () => boolean): void {
   });
   document.body.appendChild(el);
   let last = 0;
-  function frame(ts) {
+  function frame(ts: number): void {
     if (isRunning()) {
       if (last) {
         const fps = 1000 / (ts - last);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/gestures.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/gestures.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export function initGestures(svg: SVGSVGElement, view: SVGGraphicsElement): void {
   const state = { pointers: new Map(), lastDist: 0 };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/i18n.ts
@@ -1,8 +1,8 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
-import enStrings from '../i18n/en.json';
+import enStringsJson from '../i18n/en.json';
 
-let strings = enStrings;
+const enStrings: Record<string, string> = enStringsJson as Record<string, string>;
+let strings: Record<string, string> = enStrings;
 export let currentLanguage = 'en';
 
 export async function initI18n(): Promise<void> {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.ts
@@ -1,7 +1,15 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { t } from '../ui/i18n.ts';
-let log = [];
+interface ErrorEntry {
+  type: string;
+  message: string;
+  url?: string;
+  line?: number;
+  column?: number;
+  stack?: string;
+  ts: number;
+}
+let log: ErrorEntry[] = [];
 
 export function initErrorBoundary() {
   try {
@@ -9,7 +17,7 @@ export function initErrorBoundary() {
   } catch {
     log = [];
   }
-  function record(entry: any) {
+  function record(entry: ErrorEntry): void {
     log.push(entry);
     try {
       localStorage.setItem('errorLog', JSON.stringify(log));
@@ -40,11 +48,11 @@ export function initErrorBoundary() {
   };
 }
 
-export function getErrorLog(): any[] {
+export function getErrorLog(): ErrorEntry[] {
   return log.slice();
 }
 
-export function clearErrorLog() {
+export function clearErrorLog(): void {
   log = [];
   try {
     localStorage.removeItem('errorLog');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/pareto.ts
@@ -1,6 +1,7 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
-export function paretoFront(pop: any[]): any[] {
+import type { Individual } from '../state/serializer.ts';
+
+export function paretoFront(pop: Individual[]): Individual[] {
   if (pop.length === 0) return [];
 
   // Sort by logic (desc) then feasible (desc) and scan once.
@@ -8,7 +9,7 @@ export function paretoFront(pop: any[]): any[] {
     (a, b) => b.logic - a.logic || b.feasible - a.feasible,
   );
 
-  const front = [];
+  const front: Individual[] = [];
   let bestFeasible = -Infinity;
   for (const p of sorted) {
     if (p.feasible >= bestFeasible) {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/rng.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/rng.ts
@@ -1,11 +1,10 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 export function lcg(seed: number) {
-  function rand() {
+  function rand(): number {
     seed = Math.imul(1664525, seed) + 1013904223 >>> 0;
     return seed / 2 ** 32;
   }
-  rand.state = () => seed;
-  rand.set = (s) => { seed = s >>> 0; };
+  rand.state = (): number => seed;
+  rand.set = (s: number): void => { seed = s >>> 0; };
   return rand;
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.ts
@@ -1,15 +1,14 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { loadPyodide } from '../lib/pyodide.js';
 
-let pyodideReady;
-async function initPy() {
+let pyodideReady: any;
+async function initPy(): Promise<any> {
   if (!pyodideReady) {
     try {
       let opts = { indexURL: './wasm/' };
-      if (window.PYODIDE_WASM_BASE64) {
+      if ((window as any).PYODIDE_WASM_BASE64) {
         const bytes = Uint8Array.from(
-          atob(window.PYODIDE_WASM_BASE64),
+          atob((window as any).PYODIDE_WASM_BASE64),
           c => c.charCodeAt(0)
         );
         const blob = new Blob([bytes], { type: 'application/wasm' });
@@ -18,14 +17,14 @@ async function initPy() {
       }
       pyodideReady = await loadPyodide(opts);
     } catch (err) {
-      toast('Pyodide failed to load');
+      (window as any).toast?.('Pyodide failed to load');
       return Promise.reject(err);
     }
   }
   return pyodideReady;
 }
 
-export async function run(params = {}) {
+export async function run(params: { seed?: number } = {}): Promise<any> {
   const pyodide = await initPy();
   const seed = params.seed ?? 0;
   await pyodide.runPythonAsync(`import random; random.seed(${seed})`);
@@ -35,4 +34,4 @@ export async function run(params = {}) {
   return JSON.parse(out);
 }
 
-window.Insight = { run };
+(window as any).Insight = { run };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/critics.ts
@@ -1,8 +1,7 @@
-// @ts-nocheck
 // SPDX-License-Identifier: Apache-2.0
 import { createStore, set, values } from '../utils/keyval.ts';
 
-export async function loadExamples(url = './data/critics/innovations.txt') {
+export async function loadExamples(url = './data/critics/innovations.txt'): Promise<string[]> {
   try {
     const res = await fetch(url);
     if (!res.ok) return [];
@@ -14,6 +13,11 @@ export async function loadExamples(url = './data/critics/innovations.txt') {
 }
 
 export class LogicCritic {
+  private examples: string[];
+  public prompt: string;
+  private index: Record<string, number>;
+  private scale: number;
+
   constructor(examples: string[] = [], prompt: string = 'judge logic') {
     this.examples = examples;
     this.prompt = prompt;
@@ -24,7 +28,7 @@ export class LogicCritic {
     this.scale = Math.max(this.examples.length - 1, 1);
   }
 
-  score(genome) {
+  score(genome: string): number {
     const key = String(genome).toLowerCase();
     const pos = this.index[key] ?? -1;
     const base = pos >= 0 ? (pos + 1) / (this.scale + 1) : 0;
@@ -35,12 +39,15 @@ export class LogicCritic {
 }
 
 export class FeasibilityCritic {
+  private examples: string[];
+  public prompt: string;
+
   constructor(examples: string[] = [], prompt: string = 'judge feasibility') {
     this.examples = examples;
     this.prompt = prompt;
   }
 
-  static jaccard(a, b) {
+  static jaccard(a: string[], b: string[]): number {
     const sa = new Set(a);
     const sb = new Set(b);
     if (!sa.size || !sb.size) return 0;
@@ -50,7 +57,7 @@ export class FeasibilityCritic {
     return inter / union;
   }
 
-  score(genome) {
+  score(genome: string): number {
     const tokens = String(genome).toLowerCase().split(/\s+/);
     let best = 0;
     for (const ex of this.examples) {
@@ -64,18 +71,20 @@ export class FeasibilityCritic {
 }
 
 export class JudgmentDB {
+  private store: ReturnType<typeof createStore>;
+
   constructor(name: string = 'critic-judgments') {
     this.store = createStore(name, 'judgments');
   }
 
-  async add(genome, scores) {
-    await set(Date.now() + Math.random(), { genome, scores }, this.store);
+  async add(genome: string, scores: Record<string, number>): Promise<void> {
+    await set(String(Date.now() + Math.random()), { genome, scores }, this.store);
   }
 
-  async querySimilar(genome) {
-    const all = await values(this.store);
+  async querySimilar(genome: string): Promise<{ genome: string; scores: Record<string, number> } | null> {
+    const all = await values(this.store) as Array<{ genome: string; scores: Record<string, number> }>;
     const tokens = String(genome).toLowerCase().split(/\s+/);
-    let best = null;
+    let best: { genome: string; scores: Record<string, number> } | null = null;
     let bestSim = -1;
     for (const rec of all) {
       const sim = FeasibilityCritic.jaccard(tokens, rec.genome.toLowerCase().split(/\s+/));
@@ -113,7 +122,7 @@ export async function scoreGenome(
   db?: JudgmentDB,
   threshold = 0.6,
 ): Promise<{ scores: Record<string, number>; cons: number }> {
-  const scores = {};
+  const scores: Record<string, number> = {};
   for (const c of critics) {
     scores[c.constructor.name] = c.score(genome);
   }
@@ -129,17 +138,17 @@ export async function scoreGenome(
   const cons = consilience(scores);
   if (cons < threshold) {
     for (const c of critics) if (c.prompt) c.prompt = mutatePrompt(c.prompt);
-    if (typeof window !== 'undefined') {
-      window.recordedPrompts = critics.map(c => c.prompt);
-    }
+      if (typeof window !== 'undefined') {
+        (window as any).recordedPrompts = critics.map(c => c.prompt || '');
+      }
   }
   return { scores, cons };
 }
 
 if (typeof window !== 'undefined') {
-  window.JudgmentDB = JudgmentDB;
-  window.consilience = consilience;
-  window.scoreGenome = scoreGenome;
-  window.LogicCritic = LogicCritic;
-  window.FeasibilityCritic = FeasibilityCritic;
+  (window as any).JudgmentDB = JudgmentDB;
+  (window as any).consilience = consilience;
+  (window as any).scoreGenome = scoreGenome;
+  (window as any).LogicCritic = LogicCritic;
+  (window as any).FeasibilityCritic = FeasibilityCritic;
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -10,7 +10,9 @@
       "@insight-src/*": ["../../../../src/*"]
     },
     "allowJs": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/global.d.ts", "worker/**/*.ts"]
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { mutate } from '../src/evolve/mutate.js';
+import { mutate, type Mutant } from '../src/evolve/mutate.js';
 import { paretoFront } from '../src/utils/pareto.js';
 import { lcg } from '../src/utils/rng.js';
 import { t } from '../src/ui/i18n.js';
@@ -89,7 +89,7 @@ self.onmessage = async (
   const rand = lcg(0);
   rand.set(rngState);
   let next: Individual[] = mutate(
-    pop,
+    pop as unknown as Mutant[],
     rand,
     mutations,
     gen,


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` comments and add types for insight browser demo
- enable JSON module resolution in the browser tsconfig

## Testing
- `npm run typecheck`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in CollectorRegistry; ImportError: cannot import name 'AgentRuntime')*
- `pre-commit run --files ...` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6841abd55a8883339358254af14cfe3a