### PR TITLE
[alpha_factory] Add ESLint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,8 @@ repos:
         entry: python scripts/dp_scrubber.py
         language: python
         pass_filenames: false
+      - id: eslint-insight-browser
+        name: Lint Insight Browser with ESLint
+        entry: scripts/run_eslint.sh
+        language: system
+        types: [javascript]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,9 @@ pre-commit run --files <paths>   # before each commit
     `verify-backend-requirements-lock` ensure each `requirements-lock` file
     matches its `requirements.txt`. They rely on `pip-tools`.
   - Hooks are configured in `.pre-commit-config.yaml` at the repository root.
+  - Hook `eslint-insight-browser` lints the Insight browser demo. It runs `npm ci`
+    in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` before
+    invoking `eslint`.
 
 #### Pre-commit in Air-Gapped Setups
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
@@ -1,0 +1,5 @@
+/* global console */
+/* eslint-env browser */
+export function hello() {
+  console.log('Hello');
+}

--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+# Install npm dependencies deterministically
+npm --prefix "$BROWSER_DIR" ci >/dev/null
+# Run eslint on provided file paths using the flat config
+ESLINT_USE_FLAT_CONFIG=true npx --prefix "$BROWSER_DIR" eslint --config "$BROWSER_DIR/eslint.config.js" "$@"


### PR DESCRIPTION
## Summary
- add `eslint-insight-browser` hook to `.pre-commit-config.yaml`
- run `npm ci` before eslint via `scripts/run_eslint.sh`
- document the hook in `AGENTS.md`
- add sample `src/app.js` for lint demo

## Testing
- `pre-commit run eslint-insight-browser --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6841b39a1fc483339c1cd4b6245e617b