### PR TITLE
[alpha_factory] add config setup helper

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -3,7 +3,7 @@
 This guide summarises the minimal steps required to run the **Alpha‑AGI Business v1** demo in a production‑like environment. The service works fully offline but upgrades automatically when `OPENAI_API_KEY` is present.
 
 1. **Prepare the configuration**
-   - Copy `config.env.sample` to `config.env` and edit as needed.
+   - Run `python scripts/setup_config.py` to create `config.env` if missing and edit as needed.
    - Set `OPENAI_API_KEY` to enable cloud models or leave empty to use the bundled local fallbacks.
    - Optionally enable the Google ADK gateway by setting `ALPHA_FACTORY_ENABLE_ADK=true`.
    - Set `MCP_ENDPOINT` to push logs to a Model Context Protocol server (optional).

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -173,7 +173,7 @@ python run_business_v1_local.py --bridge --open-ui
 
 ```bash
 # Optional configuration
-cp config.env.sample config.env
+python scripts/setup_config.py
 # Edit the `config.env` file to set variables such as:
 #   - OPENAI_API_KEY
 #   - YFINANCE_SYMBOL

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/scripts/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/scripts/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utility scripts for alpha_agi_business_v1 demo."""
+
+__all__ = ["setup_config"]

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/scripts/setup_config.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/scripts/setup_config.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Create `config.env` for the Alpha-AGI Business demo."""
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def ensure_config(directory: Path) -> tuple[Path, bool]:
+    """Ensure ``config.env`` exists in ``directory``.
+
+    Returns the path and whether it was created.
+    """
+    config = directory / "config.env"
+    if config.exists():
+        return config, False
+    sample = directory / "config.env.sample"
+    shutil.copyfile(sample, config)
+    return config, True
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Create config.env if missing")
+    parser.add_argument(
+        "--dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Demo directory (default: parent of this script)",
+    )
+    args = parser.parse_args(argv)
+    path, created = ensure_config(args.dir)
+    if created:
+        print(f"Created {path}. Edit this file to set secrets.")
+    else:
+        print(f"{path} already exists. Edit it to update secrets.")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_setup_config.py
+++ b/tests/test_setup_config.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+from alpha_factory_v1.demos.alpha_agi_business_v1.scripts import setup_config
+
+
+def test_setup_config_creates_file(tmp_path: Path) -> None:
+    sample = tmp_path / "config.env.sample"
+    sample.write_text("SECRET=1\n")
+    path, created = setup_config.ensure_config(tmp_path)
+    assert created is True
+    assert path == tmp_path / "config.env"
+    assert path.read_text() == "SECRET=1\n"


### PR DESCRIPTION
## Summary
- add setup_config helper for `alpha_agi_business_v1` demo
- mention helper in README and PRODUCTION_GUIDE
- test helper logic

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_v1/scripts/setup_config.py alpha_factory_v1/demos/alpha_agi_business_v1/scripts/__init__.py alpha_factory_v1/demos/alpha_agi_business_v1/README.md alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md tests/test_setup_config.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_llm_cache.py, tests/test_openai_bridge_integration.py)*

------
https://chatgpt.com/codex/tasks/task_e_6841b4dbd5788333a9673c22c6375d81