### PR TITLE
[alpha_factory] cap error log size

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.ts
@@ -10,6 +10,7 @@ interface ErrorEntry {
   ts: number;
 }
 let log: ErrorEntry[] = [];
+const MAX_LOG_ENTRIES = 50;
 
 export function initErrorBoundary() {
   try {
@@ -17,8 +18,14 @@ export function initErrorBoundary() {
   } catch {
     log = [];
   }
+  if (log.length > MAX_LOG_ENTRIES) {
+    log = log.slice(-MAX_LOG_ENTRIES);
+  }
   function record(entry: ErrorEntry): void {
     log.push(entry);
+    if (log.length > MAX_LOG_ENTRIES) {
+      log.shift();
+    }
     try {
       localStorage.setItem('errorLog', JSON.stringify(log));
     } catch {}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/error_boundary_limit.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/error_boundary_limit.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { initErrorBoundary, getErrorLog, clearErrorLog } from '../src/utils/errorBoundary.ts';
+
+function makeMocks() {
+  const store = {};
+  global.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => {
+      store[k] = String(v);
+    },
+    removeItem: (k) => {
+      delete store[k];
+    },
+  };
+  global.window = { toast() {} };
+}
+
+test('error log retains last 50 entries', () => {
+  makeMocks();
+  clearErrorLog();
+  initErrorBoundary();
+  for (let i = 1; i <= 55; i++) {
+    window.onerror(`err${i}`, 'f.js', i, 0, new Error(String(i)));
+  }
+  const logs = getErrorLog();
+  assert.equal(logs.length, 50);
+  assert.equal(logs[0].message, 'err6');
+  assert.equal(logs[49].message, 'err55');
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -28,6 +28,7 @@ run(['node', '--loader', 'ts-node/register', '--test',
   'tests/replay_cid.test.js',
   'tests/iframe_worker_cleanup.test.js',
   'tests/onnx_gpu_backend.test.js',
+  'tests/error_boundary_limit.test.js',
   '../../../../tests/taxonomy.test.ts',
   '../../../../tests/memeplex.test.ts'
 ]);


### PR DESCRIPTION
## Summary
- limit stored entries in errorBoundary.ts to latest 50
- add regression test for error cap and register in run.mjs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/errorBoundary.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/error_boundary_limit.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs`
- `python check_env.py --auto-install`
- `pytest -q`
- `npm test` *(fails: Missing dependency "esbuild")*

------
https://chatgpt.com/codex/tasks/task_e_6841b769d54c8333b2a12d27b2806713