### PR TITLE
[alpha_factory] Add quick start callout

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -41,6 +41,14 @@
 13. [License](#license)
 14. [Resources](#resources)
 
+> **Quick Start**
+> ```bash
+> python start_alpha_business.py      # launch the orchestrator
+> python openai_agents_bridge.py      # expose via OpenAI Agents
+> python gradio_dashboard.py          # interactive dashboard
+> ```
+> See the [Quick Start](#quick) and [Deployment Recipes](#deploy) sections for advanced options.
+
 ---
 
 <a id="why"></a>


### PR DESCRIPTION
## Summary
- document key launch commands in a quick-start box

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in Collector; openai bridge integration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841bab8a7288333ab74e05dd41f13da