### PR TITLE
[alpha_factory] Update offline npm test docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -130,7 +130,14 @@ Failing to replace placeholders will break offline mode.
 3. Confirm no placeholder text remains in `lib/` or `wasm*/`.
 4. Execute `npm run build` or `python manual_build.py`.
 
-5. Run `npm test --offline` to execute the suite with pre‑installed browsers.
+5. Run the tests offline:
+
+   ```bash
+   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test --offline
+   ```
+
+   Set `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` when using a custom
+   directory of Playwright binaries.
 
 Failing to run the fetch script leaves offline mode disabled.
 
@@ -240,17 +247,18 @@ the local GPT‑2 critic.
 ## Running Browser Tests
 
 The demo includes a small Playwright and Pytest suite. **Node.js ≥20** is
-required. After fetching the WebAssembly assets simply run:
+required. After fetching the WebAssembly assets run the tests with Playwright in
+offline mode:
 
 ```bash
-npm test
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test --offline
 ```
 
-This command now builds the bundle automatically before running the tests. It
+This command builds the bundle automatically before running the tests. It
 launches Playwright to exercise `dist/index.html` and then runs the Python
-checks. Offline setups can point Playwright at pre‑downloaded browsers by
-exporting `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` or skip the download step
-with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`.
+checks. `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` prevents Playwright from fetching
+browsers. Optionally set `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` when using
+pre‑downloaded binaries.
 
 ## Development
 

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -46,3 +46,10 @@ python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 
 The command prints `Environment OK` when all required packages are available.
 
+## Browser Demo Tests
+
+The Insight browser demo includes Playwright-based tests that can run without
+internet access. See the [README](../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md#running-browser-tests)
+for detailed steps. Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and optionally
+`PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` before executing `npm test`.
+


### PR DESCRIPTION
## Summary
- document offline npm test process for Insight browser
- cross-link offline browser test docs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md docs/OFFLINE.md`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ValueError in test_llm_cache.py)*

------
https://chatgpt.com/codex/tasks/task_e_6841ba56aca08333bc40cb049b13ae3e