### PR TITLE
[alpha_factory] Add setup_env helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,16 @@ Run `pre-commit run --all-files` once after the setup script to confirm
 everything is formatted correctly. These commands mirror the steps in
 [AGENTS.md](AGENTS.md) and keep commits consistent.
 
+### Development Setup
+Install the Python dependencies with the helper script:
+
+```bash
+scripts/setup_env.sh
+```
+
+The script checks for Python 3.11–3.12 and installs `requirements.txt` and
+`requirements-dev.txt`.
+
 ## 📜 Table of Contents
 0. [Design Philosophy](#0-design-philosophy)  
 1. [System Topology 🗺️](#1-system-topology)  

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Install project dependencies for development.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+PYTHON=${PYTHON:-python3}
+version="$($PYTHON - <<'PY'
+import sys
+print(f"{sys.version_info.major}.{sys.version_info.minor}")
+PY
+)"
+if [[ "$version" != 3.11 && "$version" != 3.12 ]]; then
+  echo "Python 3.11 or 3.12 required; found $version" >&2
+  exit 1
+fi
+$PYTHON -m pip install -U pip
+$PYTHON -m pip install -r requirements.txt -r requirements-dev.txt
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- add `scripts/setup_env.sh` to install requirements
- document running the setup script in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 2 errors)*
- `pre-commit run --files README.md scripts/setup_env.sh` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6841c15b59ac8333b121d88f7a1c41bb