### PR TITLE
[alpha_factory] fix ruff warnings in tests

### DIFF
--- a/tests/security/test_csp.py
+++ b/tests/security/test_csp.py
@@ -2,8 +2,8 @@ import pytest
 from pathlib import Path
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def test_csp_no_violations() -> None:

--- a/tests/test_api_rate_limit.py
+++ b/tests/test_api_rate_limit.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")

--- a/tests/test_api_server_static.py
+++ b/tests/test_api_server_static.py
@@ -9,7 +9,7 @@ from collections import deque
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 from click.testing import CliRunner
 
 os.environ.setdefault("API_TOKEN", "test-token")

--- a/tests/test_backtrack_boost.py
+++ b/tests/test_backtrack_boost.py
@@ -1,13 +1,8 @@
 import asyncio
-import asyncio
-import asyncio
-import random
-
-import asyncio
 import random
 
 from src.evolve import Candidate, InMemoryArchive, evolve
-from src.simulation.mats_ops import backtrack_boost  # ensure import works
+from src.simulation.mats_ops import backtrack_boost  # ensure import works  # noqa: F401
 
 
 def _diversity(values):

--- a/tests/test_browser_ui.py
+++ b/tests/test_browser_ui.py
@@ -3,8 +3,8 @@ import pytest
 from pathlib import Path
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def test_metrics_update_during_sim() -> None:

--- a/tests/test_bus_fuzz.py
+++ b/tests/test_bus_fuzz.py
@@ -10,10 +10,10 @@ from typing import Any
 import pytest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, settings, strategies as st
-from hypothesis.strategies import composite
+from hypothesis import given, settings, strategies as st  # noqa: E402
+from hypothesis.strategies import composite  # noqa: E402
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging  # noqa: E402
 
 
 json_scalars = st.one_of(

--- a/tests/test_bus_large_payloads_property.py
+++ b/tests/test_bus_large_payloads_property.py
@@ -10,9 +10,9 @@ from unittest import mock
 import pytest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings, strategies as st  # noqa: E402
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging  # noqa: E402
 
 
 @settings(max_examples=10, deadline=None)

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -13,8 +13,8 @@ import pytest
 
 pytest.importorskip("fastapi")
 pytest.importorskip("grpc")
-from fastapi.testclient import TestClient
-import grpc
+from fastapi.testclient import TestClient  # noqa: E402
+import grpc  # noqa: E402
 
 from src.critics import DualCriticService, create_app
 

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
-import sys
 import csv
 import json
 import hashlib

--- a/tests/test_devnet_broadcast.py
+++ b/tests/test_devnet_broadcast.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 import tempfile
 

--- a/tests/test_dual_critic.py
+++ b/tests/test_dual_critic.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 from src.evaluators import (
     LogicCritic,

--- a/tests/test_edge_runner.py
+++ b/tests/test_edge_runner.py
@@ -4,7 +4,6 @@ import os
 import unittest
 from unittest.mock import patch
 
-from alpha_factory_v1 import edge_runner
 from alpha_factory_v1.utils.env import _env_int
 
 

--- a/tests/test_evolution_panel_reload.py
+++ b/tests/test_evolution_panel_reload.py
@@ -2,8 +2,8 @@ import pytest
 from pathlib import Path
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def test_evolution_panel_persists_after_reload() -> None:

--- a/tests/test_evolution_worker.py
+++ b/tests/test_evolution_worker.py
@@ -5,11 +5,11 @@ from typing import Iterator
 
 import pytest
 
-httpx = pytest.importorskip("httpx")
-uvicorn = pytest.importorskip("uvicorn")
+httpx = pytest.importorskip("httpx")  # noqa: E402
+uvicorn = pytest.importorskip("uvicorn")  # noqa: E402
 
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src import evolution_worker
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import evolution_worker  # noqa: E402
 
 
 def _free_port() -> int:

--- a/tests/test_evolution_worker_safe_extract.py
+++ b/tests/test_evolution_worker_safe_extract.py
@@ -6,10 +6,10 @@ from typing import Iterator
 
 import pytest
 
-httpx = pytest.importorskip("httpx")
-uvicorn = pytest.importorskip("uvicorn")
+httpx = pytest.importorskip("httpx")  # noqa: E402
+uvicorn = pytest.importorskip("uvicorn")  # noqa: E402
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src import evolution_worker
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src import evolution_worker  # noqa: E402
 
 
 def _free_port() -> int:

--- a/tests/test_insight_endpoint.py
+++ b/tests/test_insight_endpoint.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")

--- a/tests/test_insight_health.py
+++ b/tests/test_insight_health.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 # Ensure required environment variables are present for the API
 os.environ.setdefault("API_TOKEN", "test-token")

--- a/tests/test_install_button.py
+++ b/tests/test_install_button.py
@@ -2,8 +2,8 @@ import pytest
 from pathlib import Path
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def test_install_button_shows_on_event() -> None:

--- a/tests/test_ledger_devnet_e2e.py
+++ b/tests/test_ledger_devnet_e2e.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 import tempfile
 

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -8,7 +8,7 @@ import importlib
 prometheus_client.REGISTRY = CollectorRegistry()
 prometheus_client.REGISTRY._names_to_collectors.clear()
 os.environ.setdefault("OPENAI_API_KEY", "stub")
-import alpha_factory_v1.backend.utils.llm_provider as llm
+import alpha_factory_v1.backend.utils.llm_provider as llm  # noqa: E402
 llm = importlib.reload(llm)
 
 

--- a/tests/test_memory_fabric_sqlite.py
+++ b/tests/test_memory_fabric_sqlite.py
@@ -42,7 +42,7 @@ class TestMemoryFabricSQLiteWarning(unittest.TestCase):
         os.environ.pop("PGHOST", None)
         with mock.patch.object(memf, "np", None, create=True):
             with self.assertLogs("AlphaFactory.MemoryFabric", level="WARNING") as cm:
-                with memf.MemoryFabric() as fabric:
+                with memf.MemoryFabric() as fabric:  # noqa: F841
                     pass
         os.environ.pop("VECTOR_STORE_USE_SQLITE", None)
         self.assertTrue(any("numpy required for SQLite" in msg for msg in cm.output))

--- a/tests/test_metrics_exposure.py
+++ b/tests/test_metrics_exposure.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")

--- a/tests/test_metrics_router.py
+++ b/tests/test_metrics_router.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import pytest
 
 pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")

--- a/tests/test_muzero_cli.py
+++ b/tests/test_muzero_cli.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-import subprocess, sys
+import subprocess
+import sys
 
 
 def test_cli_help() -> None:

--- a/tests/test_orchestrator_bus_tls_env.py
+++ b/tests/test_orchestrator_bus_tls_env.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - optional
     HAVE_CRYPTO = False
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
 
 
 def _free_port() -> int:

--- a/tests/test_orchestrator_env.py
+++ b/tests/test_orchestrator_env.py
@@ -3,7 +3,6 @@ import importlib
 import os
 import unittest
 from unittest import mock
-from alpha_factory_v1.backend import orchestrator as _orch
 
 
 class TestOrchestratorEnv(unittest.TestCase):

--- a/tests/test_orchestrator_grpc.py
+++ b/tests/test_orchestrator_grpc.py
@@ -6,7 +6,6 @@ import sys
 import types
 import unittest
 from unittest import mock
-from alpha_factory_v1.backend import orchestrator as _orch
 
 
 class TestServeGrpc(unittest.TestCase):

--- a/tests/test_orchestrator_rest.py
+++ b/tests/test_orchestrator_rest.py
@@ -9,7 +9,7 @@ import os
 import pytest
 
 pytest.importorskip("fastapi", reason="fastapi is required for REST API tests")
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
 from alpha_factory_v1.backend import orchestrator
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for self-improvement prompt loading."""
 
-from pathlib import Path
 
 import yaml
 

--- a/tests/test_pwa_offline.py
+++ b/tests/test_pwa_offline.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def _start_server(directory: Path):

--- a/tests/test_quickstart_offline.py
+++ b/tests/test_quickstart_offline.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def test_quickstart_offline() -> None:

--- a/tests/test_replay_metrics.py
+++ b/tests/test_replay_metrics.py
@@ -1,5 +1,4 @@
 import csv
-import pytest
 
 from src.simulation import replay
 

--- a/tests/test_retry_property.py
+++ b/tests/test_retry_property.py
@@ -3,9 +3,9 @@ import asyncio
 import pytest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, strategies as st, settings, assume
+from hypothesis import given, strategies as st, settings, assume  # noqa: E402
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import retry
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import retry  # noqa: E402
 
 
 @settings(max_examples=25)

--- a/tests/test_reviewer_agent.py
+++ b/tests/test_reviewer_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 
 from src.agents.reviewer_agent import ReviewerAgent
-from src.evolve import InMemoryArchive, evolve, Candidate
+from src.evolve import InMemoryArchive, evolve
 
 
 async def _noop_eval(genome: str) -> tuple[float, float]:

--- a/tests/test_run_muzero_demo.py
+++ b/tests/test_run_muzero_demo.py
@@ -9,7 +9,6 @@ import socket
 import subprocess
 from pathlib import Path
 
-import pytest
 
 
 def test_run_muzero_demo_invokes_docker(tmp_path: Path) -> None:

--- a/tests/test_safety_agent.py
+++ b/tests/test_safety_agent.py
@@ -46,7 +46,7 @@ def test_blocked_payload_not_stored(tmp_path) -> None:
     ledger = logging.Ledger(str(tmp_path / "ledger.db"), broadcast=False)
 
     mem = FilteringMemoryAgent(bus, ledger, str(tmp_path / "mem.log"))
-    guardian = safety_agent.SafetyGuardianAgent(bus, ledger)
+    guardian = safety_agent.SafetyGuardianAgent(bus, ledger)  # noqa: F841  # needed to register handler
     chaos = chaos_agent.ChaosAgent(bus, ledger, burst=1)
 
     async def run() -> None:

--- a/tests/test_safety_block.py
+++ b/tests/test_safety_block.py
@@ -31,7 +31,7 @@ def test_malicious_message_blocked(tmp_path) -> None:
     ledger = logging.Ledger(str(tmp_path / "ledger.db"), broadcast=False)
 
     mem = memory_agent.MemoryAgent(bus, ledger, str(tmp_path / "mem.log"))
-    guardian = safety_agent.SafetyGuardianAgent(bus, ledger)
+    guardian = safety_agent.SafetyGuardianAgent(bus, ledger)  # noqa: F841
     chaos = chaos_agent.ChaosAgent(bus, ledger, burst=1)
 
     async def run() -> None:

--- a/tests/test_safety_filter.py
+++ b/tests/test_safety_filter.py
@@ -23,7 +23,7 @@ def test_allows_safe_patch() -> None:
     diff = _read("safe_patch.diff")
     assert not is_patch_safe(diff)
 
-from src.simulation import SelfRewriteOperator
+from src.simulation import SelfRewriteOperator  # noqa: E402
 
 
 def test_rewrite_blocks_malicious() -> None:

--- a/tests/test_safety_guardian.py
+++ b/tests/test_safety_guardian.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import sys
 import tempfile
 import unittest
 from unittest import mock

--- a/tests/test_safety_guardian_fuzz.py
+++ b/tests/test_safety_guardian_fuzz.py
@@ -4,17 +4,15 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-import types
 
 import pytest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, settings, strategies as st
-from hypothesis.strategies import composite
+from hypothesis import given, settings, strategies as st  # noqa: E402
+from hypothesis.strategies import composite  # noqa: E402
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent  # noqa: E402
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging  # noqa: E402
 
 
 

--- a/tests/test_safety_guardian_property.py
+++ b/tests/test_safety_guardian_property.py
@@ -4,20 +4,18 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-import types
 import pathlib
 from unittest import mock
 
 import pytest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import assume, given, settings, strategies as st
-from hypothesis.strategies import composite
+from hypothesis import assume, given, settings, strategies as st  # noqa: E402
+from hypothesis.strategies import composite  # noqa: E402
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging as insight_logging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent  # noqa: E402
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging  # noqa: E402
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import logging as insight_logging  # noqa: E402
 
 
 class DummyBus:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import json
 from pathlib import Path
 from unittest.mock import patch
@@ -8,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 rocketry = pytest.importorskip("rocketry")
-from src import scheduler
+from src import scheduler  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/tests/test_score_proof.py
+++ b/tests/test_score_proof.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from src.archive.db import ArchiveDB, ArchiveEntry
 from src.snark import (
-    generate_score_proof,
     publish_score_proof,
     verify_score_proof,
     verify_onchain,

--- a/tests/test_self_improver.py
+++ b/tests/test_self_improver.py
@@ -83,9 +83,9 @@ def test_improve_repo_requires_git(monkeypatch, tmp_path: Path) -> None:
             str(repo_dir), str(patch_file), "metric.txt", str(log_file)
         )
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging
-from src.agents.self_improver_agent import SelfImproverAgent
-from prometheus_client import REGISTRY
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging  # noqa: E402
+from src.agents.self_improver_agent import SelfImproverAgent  # noqa: E402
+from prometheus_client import REGISTRY  # noqa: E402
 
 class DummyLedger:
     def log(self, _env) -> None:

--- a/tests/test_sw_offline_reload.py
+++ b/tests/test_sw_offline_reload.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def _start_server(directory: Path):

--- a/tests/test_umap_fallback.py
+++ b/tests/test_umap_fallback.py
@@ -3,8 +3,8 @@ import pytest
 from pathlib import Path
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 DEF_GEN = 3

--- a/tests/test_verify_wheel.py
+++ b/tests/test_verify_wheel.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-import base64
 import unittest
 from pathlib import Path
 

--- a/tests/test_wasm_base64.py
+++ b/tests/test_wasm_base64.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import pytest
 
 pw = pytest.importorskip("playwright.sync_api")
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
 
 
 def test_pyodide_base64_global() -> None:


### PR DESCRIPTION
## Summary
- silence E402 errors following `pytest.importorskip`
- drop unused imports flagged by ruff
- mark unused variables in tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in Collector, Interrupted: 2 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6841c4b140d8833396c6a654b03a8a8c