### PR TITLE
[alpha_factory] cap telemetry queue

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -36,8 +36,11 @@ export function initTelemetry(t) {
   const enabled = consent === 'true';
   const queueKey = 'telemetryQueue';
   const metrics = { ts: Date.now(), session: '', generations: 0, shares: 0 };
-  const queue = JSON.parse(localStorage.getItem(queueKey) || '[]');
   const MAX_QUEUE_SIZE = 100;
+  const queue = JSON.parse(localStorage.getItem(queueKey) || '[]');
+  if (queue.length > MAX_QUEUE_SIZE) {
+    queue.splice(0, queue.length - MAX_QUEUE_SIZE);
+  }
 
   const ready = (async () => {
     let sid = localStorage.getItem('telemetrySession');
@@ -74,7 +77,7 @@ export function initTelemetry(t) {
   function flush() {
     if (!enabled) return;
     metrics.ts = Date.now();
-    if (queue.length >= MAX_QUEUE_SIZE) {
+    while (queue.length >= MAX_QUEUE_SIZE) {
       queue.shift();
     }
     queue.push({ ...metrics });


### PR DESCRIPTION
## Summary
- enforce a maximum telemetry queue size
- truncate over-capacity entries when loading existing queue
- test queue never exceeds 100 records

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in Collector)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py src/telemetry.js` *(fails: semgrep environment init)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf0f481883338ea61ac30b90a7e7