### PR TITLE
[alpha_factory] add missing TS type stubs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/types/observablehq__plot.d.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/types/observablehq__plot.d.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+declare module '@observablehq/plot';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/types/onnxruntime-web.d.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/types/onnxruntime-web.d.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+declare module 'onnxruntime-web';


### PR DESCRIPTION
## Summary
- add ambient module declaration for `@observablehq/plot`
- add ambient module declaration for `onnxruntime-web`
- run TypeScript type check to confirm the stubs work

## Testing
- `npm run typecheck`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Duplicated timeseries in Collector; bridge integration errors)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/types/observablehq__plot.d.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/types/onnxruntime-web.d.ts`

------
https://chatgpt.com/codex/tasks/task_e_6841cd0a64508333bc36518844f0d1d2