### PR TITLE
[alpha_factory] add SPDX headers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /* global console */
 /* eslint-env browser */
 export function hello() {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "seed": "Seed",
   "population": "Population",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "seed": "Semilla",
   "population": "Población",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "seed": "Graine",
   "population": "Population",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/zh.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/zh.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "seed": "种子",
   "population": "种群",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/lib/pyodide.d.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/lib/pyodide.d.ts
@@ -1,1 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
 export function loadPyodide(opts: any): Promise<any>;


### PR DESCRIPTION
## Summary
- add Apache 2.0 headers to insight_browser source files

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/es.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/fr.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/zh.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/lib/pyodide.d.ts --color never`

------
https://chatgpt.com/codex/tasks/task_e_6841d3404a088333a2e9c83f81402dad