### PR TITLE
[alpha_factory] switch business bridge to httpx

### DIFF
--- a/alpha_factory_v1/backend/utils/llm_provider.py
+++ b/alpha_factory_v1/backend/utils/llm_provider.py
@@ -49,6 +49,7 @@ from types import GeneratorType
 from typing import Any, Dict, Generator, List, Optional, Sequence
 
 from src.monitoring import metrics
+from alpha_factory_v1.backend import metrics_registry
 
 # ──────────────────── optional dependencies ────────────────
 _HAS_PROM = _HAS_TOK = False
@@ -77,9 +78,24 @@ _log.setLevel(logging.INFO)
 
 # ───────────────────── Prometheus metrics ──────────────────
 if _HAS_PROM:
-    _CNT_REQ = Counter("af_llm_requests_total", "LLM requests", ("provider", "status"))
-    _CNT_TOK = Counter("af_llm_tokens_total", "Tokens used", ("provider",))
-    _HIST_LAT = Histogram("af_llm_latency_seconds", "Latency", ("provider",))
+    _CNT_REQ = metrics_registry.get_metric(
+        Counter,
+        "af_llm_requests_total",
+        "LLM requests",
+        ["provider", "status"],
+    )
+    _CNT_TOK = metrics_registry.get_metric(
+        Counter,
+        "af_llm_tokens_total",
+        "Tokens used",
+        ["provider"],
+    )
+    _HIST_LAT = metrics_registry.get_metric(
+        Histogram,
+        "af_llm_latency_seconds",
+        "Latency",
+        ["provider"],
+    )
 else:  # no-op stubs
 
     class _N:

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -7,8 +7,11 @@ import importlib
 
 prometheus_client.REGISTRY = CollectorRegistry()
 prometheus_client.REGISTRY._names_to_collectors.clear()
+getattr(prometheus_client.REGISTRY, "_collector_to_names", {}).clear()
 os.environ.setdefault("OPENAI_API_KEY", "stub")
 import alpha_factory_v1.backend.utils.llm_provider as llm  # noqa: E402
+prometheus_client.REGISTRY._names_to_collectors.clear()
+getattr(prometheus_client.REGISTRY, "_collector_to_names", {}).clear()
 llm = importlib.reload(llm)
 
 


### PR DESCRIPTION
## Summary
- replace `requests` with `httpx.AsyncClient` in business demo bridge
- adjust wait helper and tool functions to await httpx calls
- patch tests to mock `AsyncClient`
- harden `llm_provider` metrics registration

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_openai_bridge_integration.py::TestBusinessAgentIntegration::test_list_agents -q`
- `pytest tests/test_llm_cache.py::TestLLMCacheLRU::test_eviction -q`
- `pytest -q` *(fails: Duplicated timeseries, ImportError, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6841d8e9b6208333a711c9881a616e2b