### PR TITLE
[alpha_factory] add regl renderer and fps test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
@@ -21,6 +21,7 @@
         "gzip-size-cli": "^5.1.0",
         "jsdom": "^26.1.0",
         "onnxruntime-web": "^1.18.0",
+        "regl": "^2.1.1",
         "serve": "^14.2.0",
         "tailwindcss": "^3.4.0",
         "ts-node": "^10.9.1",
@@ -10207,6 +10208,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/regl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.1.tgz",
+      "integrity": "sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -29,6 +29,7 @@
     "gzip-size-cli": "^5.1.0",
     "jsdom": "^26.1.0",
     "onnxruntime-web": "^1.18.0",
+    "regl": "^2.1.1",
     "serve": "^14.2.0",
     "tailwindcss": "^3.4.0",
     "ts-node": "^10.9.1",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/frontier.ts
@@ -33,9 +33,9 @@ export function renderFrontier(
     }),
   ];
 
-  marks.push(
-    pop.length > 10000 ? plotCanvas(Plot.dot(pop, dotOptions)) : Plot.dot(pop, dotOptions),
-  );
+  if (pop.length <= 10000) {
+    marks.push(Plot.dot(pop, dotOptions));
+  }
 
   const plot = Plot.plot({
     width: 500,
@@ -48,6 +48,9 @@ export function renderFrontier(
   container.innerHTML = '';
   container.append(plot);
   const svg = plot.querySelector('svg') || plot;
+  if (pop.length > 10000) {
+    plotCanvas(svg, pop, (d) => d.logic * 500, (d) => (1 - d.feasible) * 500, (d) => depthColor(d.depth ?? 0, maxDepth));
+  }
   drawHeatmap(svg, pop, (d) => d.logic * 500, (d) => (1 - d.feasible) * 500);
   if (onSelect) {
     d3

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/plotCanvas.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/render/plotCanvas.ts
@@ -1,6 +1,103 @@
 // SPDX-License-Identifier: Apache-2.0
-// Minimal stub for @observablehq/plot-canvas
-// This implementation simply returns the mark unchanged.
-export function plotCanvas(mark: any): any {
-  return mark;
+import createREGL from 'regl';
+
+let ctxCache: WeakMap<HTMLCanvasElement, ReturnType<typeof createREGL>> = new WeakMap();
+
+function parseColor(color: string): [number, number, number, number] {
+  const c = document.createElement('canvas');
+  const ctx = c.getContext('2d')!;
+  ctx.fillStyle = color;
+  const computed = ctx.fillStyle;
+  if (computed.startsWith('#')) {
+    const n = parseInt(computed.slice(1), 16);
+    const r = (n >> 16) & 255;
+    const g = (n >> 8) & 255;
+    const b = n & 255;
+    return [r / 255, g / 255, b / 255, 1];
+  }
+  const m = computed.match(/\d+(\.\d+)?/g);
+  if (m) {
+    return [
+      Number(m[0]) / 255,
+      Number(m[1]) / 255,
+      Number(m[2]) / 255,
+      m[3] ? Number(m[3]) : 1,
+    ];
+  }
+  return [0, 0, 0, 1];
+}
+
+function ensureGL(parent: any): [HTMLCanvasElement, ReturnType<typeof createREGL>] {
+  const node = parent.node ? parent.node() : parent;
+  let canvas = node.querySelector<HTMLCanvasElement>('canvas.webgl-layer');
+  if (!canvas) {
+    const svg = (node.ownerSVGElement || node) as SVGSVGElement;
+    const vb = svg.viewBox?.baseVal;
+    const width = vb && vb.width ? vb.width : svg.clientWidth;
+    const height = vb && vb.height ? vb.height : svg.clientHeight;
+    canvas = document.createElement('canvas');
+    canvas.className = 'webgl-layer';
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.position = 'absolute';
+    canvas.style.left = '0';
+    canvas.style.top = '0';
+    canvas.style.pointerEvents = 'none';
+    node.appendChild(canvas);
+  }
+  let regl = ctxCache.get(canvas);
+  if (!regl) {
+    regl = createREGL({ canvas });
+    ctxCache.set(canvas, regl);
+  }
+  return [canvas, regl];
+}
+
+export function plotCanvas(
+  parent: HTMLElement | SVGSVGElement,
+  pop: any[],
+  x: (d: any) => number,
+  y: (d: any) => number,
+  colorFn: (d: any) => string,
+): void {
+  const [canvas, regl] = ensureGL(parent);
+  const positions = pop.map((d) => [x(d), y(d)]);
+  const colors = pop.map((d) => parseColor(colorFn(d)));
+  const draw = regl({
+    attributes: {
+      position: positions,
+      color: colors,
+    },
+    uniforms: {
+      pointSize: 6,
+    },
+    vert: `
+    precision mediump float;
+    attribute vec2 position;
+    attribute vec4 color;
+    uniform float pointSize;
+    varying vec4 vColor;
+    void main() {
+      vColor = color;
+      gl_PointSize = pointSize;
+      gl_Position = vec4(
+        position.x / ${canvas.width}.0 * 2.0 - 1.0,
+        1.0 - position.y / ${canvas.height}.0 * 2.0,
+        0.0,
+        1.0);
+    }`,
+    frag: `
+    precision mediump float;
+    varying vec4 vColor;
+    void main() {
+      gl_FragColor = vColor;
+    }`,
+    count: positions.length,
+  });
+  function frame() {
+    regl.clear({ color: [0, 0, 0, 0], depth: 1 });
+    draw();
+    requestAnimationFrame(frame);
+  }
+  frame();
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -31,6 +31,7 @@ run(['node', '--loader', 'ts-node/register', '--test',
   'tests/error_boundary_limit.test.js',
   '../../../../tests/taxonomy.test.ts',
   '../../../../tests/memeplex.test.ts'
+  ,'../../../../tests/webgl_perf.test.js'
 ]);
 run([
   'pytest',

--- a/tests/webgl_perf.test.js
+++ b/tests/webgl_perf.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dist = resolve(__dirname, 'alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html');
+
+async function measureFps(page) {
+  await page.waitForSelector('#fps-meter');
+  await page.waitForTimeout(2000);
+  const text = await page.innerText('#fps-meter');
+  return parseFloat(text.split(/[\s]/)[0]);
+}
+
+test('webgl renderer maintains 60fps with 5k points', async () => {
+  const url = dist + '#seed=1&pop=5000&gen=1';
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(url);
+  const fps = await measureFps(page);
+  await browser.close();
+  assert.ok(fps >= 60, `fps=${fps}`);
+});


### PR DESCRIPTION
## Summary
- switch plotCanvas to WebGL via regl
- call plotCanvas for large populations
- include regl devDependency
- cover fps with a new Playwright test

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 69 failed, 194 passed, 27 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6841ddb39de88333b05f6690e3400ed7