### PR TITLE
[alpha_factory] copy quickstart early

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -79,6 +79,7 @@ try {
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), '..', '..', '..', '..');
 const aliasRoot = path.join(repoRoot, 'src');
+const quickstartPdf = path.join(repoRoot, manifest.quickstart_pdf);
 const aliasPlugin = {
   name: 'alias',
   setup(build) {
@@ -213,9 +214,11 @@ async function bundle() {
     `<meta http-equiv="Content-Security-Policy" content="${csp}" />`
   );
   await copyAssets(manifest, repoRoot, OUT_DIR);
-  const pdf = path.join(repoRoot, 'docs/insight_browser_quickstart.pdf');
-  if (fsSync.existsSync(pdf)) {
-    await fs.copyFile(pdf, path.join(OUT_DIR, 'insight_browser_quickstart.pdf'));
+  if (fsSync.existsSync(quickstartPdf)) {
+    await fs.copyFile(
+      quickstartPdf,
+      path.join(OUT_DIR, 'insight_browser_quickstart.pdf'),
+    );
   }
   const envScript = injectEnv(process.env);
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -353,9 +353,8 @@ out_html = re.sub(
 )
 
 copy_assets(manifest, repo_root, dist_dir)
-pdf_src = repo_root / "docs/insight_browser_quickstart.pdf"
-if pdf_src.exists():
-    (dist_dir / pdf_src.name).write_bytes(pdf_src.read_bytes())
+if quickstart_pdf.exists():
+    (dist_dir / quickstart_pdf.name).write_bytes(quickstart_pdf.read_bytes())
 
 app_sri = sha384(dist_dir / "insight.bundle.js")
 checksums = manifest["checksums"]

--- a/tests/test_pwa_offline.py
+++ b/tests/test_pwa_offline.py
@@ -43,6 +43,9 @@ def test_quickstart_pdf_offline() -> None:
             context.set_offline(True)
             resp = page.goto(url + "/insight_browser_quickstart.pdf")
             assert resp and resp.ok, "PDF not served offline"
+            page.reload()
+            resp = page.goto(url + "/insight_browser_quickstart.pdf")
+            assert resp and resp.ok, "PDF not served offline after reload"
             browser.close()
     except PlaywrightError as exc:
         pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- copy quickstart PDF before Workbox runs
- keep Python build in sync
- check offline reload for quickstart PDF

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 73 failed, 204 passed, 27 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0b21860833397ceb10e541d083f