### PR TITLE
[alpha_factory] remove unused hello

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
@@ -1,6 +1,3 @@
 // SPDX-License-Identifier: Apache-2.0
 /* global console */
 /* eslint-env browser */
-export function hello() {
-  console.log('Hello');
-}


### PR DESCRIPTION
## Summary
- delete the unused `hello()` function from `app.js`

## Testing
- `npm run build` *(fails: TS2347 in plotCanvas.ts)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 72 failed, 202 passed, 27 skipped)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6841e45e5ba88333b1a277e5e2fa5bee