### PR TITLE
[alpha_factory] expose RNG in selectParents

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -211,6 +211,9 @@ unavailable, the archive falls back to an in-memory store and data is lost on
 refresh. The **Evolution** panel
 lists archived runs with their score and novelty. Click **Re-spawn** next to a
 row to restart the simulation using that seed.
+The method `selectParents(count, beta?, gamma?, rand?)` returns weighted
+samples from the archive. Pass a seeded `rand` function to ensure deterministic
+results in tests or simulations.
 
 ## Arena & Meme Cloud
 The **Arena panel** allows quick debates between roles on any candidate in the

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -180,7 +180,12 @@ export class Archive {
     );
   }
 
-  async selectParents(count: number, beta = 1, gamma = 1): Promise<InsightRun[]> {
+  async selectParents(
+    count: number,
+    beta = 1,
+    gamma = 1,
+    rand: () => number = Math.random,
+  ): Promise<InsightRun[]> {
     const runs = await this.list();
     if (!runs.length) return [];
     const scoreW = runs.map((r) => Math.exp(beta * r.score));
@@ -200,7 +205,7 @@ export class Archive {
     for (let i = 0; i < weights.length; i++) weights[i] /= wSum;
     const selected: InsightRun[] = [];
     for (let i = 0; i < Math.min(count, runs.length); i++) {
-      let r = Math.random();
+      let r = rand();
       let idx = 0;
       for (; idx < weights.length; idx++) {
         if (r < weights[idx]) break;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -31,7 +31,7 @@ test('selectParents returns entries', async () => {
   await a.open();
   await a.add(1, {}, [{logic:0.2,feasible:0.2}]);
   await a.add(2, {}, [{logic:0.8,feasible:0.8}]);
-  const parents = await a.selectParents(1);
+  const parents = await a.selectParents(1, 1, 1, () => 0.5);
   expect(parents.length).toBe(1);
   expect([1,2]).toContain(parents[0].seed);
 });


### PR DESCRIPTION
## Summary
- add `rand` argument to `selectParents`
- update tests to use deterministic RNG
- document new parameter in Insight browser README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6841e93f67048333bf1038554c36ea08