### PR TITLE
[alpha_factory] document ADK flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ template). The sample file now lists every variable with its default value.
 | `TRACE_WS_PORT` | Trace graph WebSocket port | `8088` |
 | `AGENTS_RUNTIME_PORT` | OpenAI Agents runtime port | `5001` |
 | `BUSINESS_HOST` | Base orchestrator URL for bridges | `"http://localhost:8000"` |
+| `ALPHA_FACTORY_ENABLE_ADK` | Set to `true` to start the Google ADK gateway | `false` |
 | `LOGLEVEL` | Logging level | `INFO` |
 | `API_TOKEN` | Bearer token for the demo API | `REPLACE_ME_TOKEN` |
 | `API_RATE_LIMIT` | Requests per minute per IP | `60` |


### PR DESCRIPTION
## Summary
- document `ALPHA_FACTORY_ENABLE_ADK` in the environment variable table

## Testing
- `python tools/check_env_table.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ed3c19cc8333847500947942a8ca