### PR TITLE
[alpha_factory] add license headers to test files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 import sys
 import types

--- a/tests/security/test_csp.py
+++ b/tests/security/test_csp.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from pathlib import Path
 

--- a/tests/test_agent_logging.py
+++ b/tests/test_agent_logging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 from unittest import mock
 

--- a/tests/test_archive_policy.py
+++ b/tests/test_archive_policy.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import hashlib

--- a/tests/test_assets_replaced.py
+++ b/tests/test_assets_replaced.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pathlib
 
 

--- a/tests/test_backtrack_boost.py
+++ b/tests/test_backtrack_boost.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import random
 

--- a/tests/test_build_quickstart_pdf.py
+++ b/tests/test_build_quickstart_pdf.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import shutil
 from pathlib import Path

--- a/tests/test_chaos_agent.py
+++ b/tests/test_chaos_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import asyncio

--- a/tests/test_chaos_monkey.py
+++ b/tests/test_chaos_monkey.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from src.critics import DualCriticService

--- a/tests/test_code_diff.py
+++ b/tests/test_code_diff.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 import subprocess
 import sys

--- a/tests/test_codegen_safety.py
+++ b/tests/test_codegen_safety.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import safety_agent
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging

--- a/tests/test_curriculum_switcher.py
+++ b/tests/test_curriculum_switcher.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from src.eval.fitness import compute_fitness, CurriculumSwitcher

--- a/tests/test_demo_registration.py
+++ b/tests/test_demo_registration.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import io
 import logging
 import unittest

--- a/tests/test_dgm_import.py
+++ b/tests/test_dgm_import.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from src.archive.db import ArchiveDB

--- a/tests/test_diff_mutation.py
+++ b/tests/test_diff_mutation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 import subprocess
 import sys

--- a/tests/test_distribution_zip.py
+++ b/tests/test_distribution_zip.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import shutil
 import zipfile

--- a/tests/test_dual_critic.py
+++ b/tests/test_dual_critic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 from src.evaluators import (
     LogicCritic,

--- a/tests/test_evolution_panel_reload.py
+++ b/tests/test_evolution_panel_reload.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from pathlib import Path
 

--- a/tests/test_evolution_worker.py
+++ b/tests/test_evolution_worker.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import socket
 import threading
 import time

--- a/tests/test_evolve.py
+++ b/tests/test_evolve.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 
 from src.evolve import Candidate, InMemoryArchive, evolve

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import time

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import contextlib
 import time

--- a/tests/test_install_button.py
+++ b/tests/test_install_button.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from pathlib import Path
 

--- a/tests/test_island_backends.py
+++ b/tests/test_island_backends.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config

--- a/tests/test_lead_time_evaluator.py
+++ b/tests/test_lead_time_evaluator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.evaluators import lead_time
 
 

--- a/tests/test_manual_build_missing_tsc.py
+++ b/tests/test_manual_build_missing_tsc.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import shutil
 import subprocess

--- a/tests/test_meta_refinement_agent.py
+++ b/tests/test_meta_refinement_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 from unittest.mock import patch
 

--- a/tests/test_multi_objective.py
+++ b/tests/test_multi_objective.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import time
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation import mats
 

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 import random
 from unittest import mock

--- a/tests/test_openai_bridge_integration.py
+++ b/tests/test_openai_bridge_integration.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import sys
 import types

--- a/tests/test_phase_order.py
+++ b/tests/test_phase_order.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 
 from src.evolve import InMemoryArchive, evolve, Phase

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import time
 from pathlib import Path
 from typing import Any

--- a/tests/test_replay_metrics.py
+++ b/tests/test_replay_metrics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import csv
 
 from src.simulation import replay

--- a/tests/test_replay_scenarios.py
+++ b/tests/test_replay_scenarios.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import time
 
 import pytest

--- a/tests/test_reviewer_agent.py
+++ b/tests/test_reviewer_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import asyncio

--- a/tests/test_selector_ablation.py
+++ b/tests/test_selector_ablation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from experiments.ablate_selector import run
 
 

--- a/tests/test_selector_v2.py
+++ b/tests/test_selector_v2.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/tests/test_self_evolution.py
+++ b/tests/test_self_evolution.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 from unittest.mock import patch
 

--- a/tests/test_self_improve_prompting.py
+++ b/tests/test_self_improve_prompting.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import random
 from pathlib import Path
 

--- a/tests/test_simulator_init.py
+++ b/tests/test_simulator_init.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import shutil
 import subprocess
 from pathlib import Path

--- a/tests/test_solution_archive.py
+++ b/tests/test_solution_archive.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import time
 from src.archive.solution_archive import SolutionArchive
 

--- a/tests/test_tools_undo.py
+++ b/tests/test_tools_undo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from pathlib import Path
 

--- a/tests/test_ui_xss_safety.py
+++ b/tests/test_ui_xss_safety.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 def test_no_innerhtml_usage() -> None:


### PR DESCRIPTION
## Summary
- add Apache license header to Python files missing it in tests/

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 71 failed, 199 passed, 27 skipped)*
- `pre-commit run --files $(cat /tmp/missing_headers.txt)` *(fails: interrupted due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef2add608333ba3b89abc2bd1e95