### PR TITLE
[alpha_factory] update archive pruning

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -168,10 +168,14 @@ export class Archive {
   async prune(max = 50): Promise<void> {
     const runs = await this.list();
     if (runs.length <= max) return;
-    runs.sort((a, b) => a.timestamp - b.timestamp);
-    const remove = runs.slice(0, runs.length - max);
+    runs.sort(
+      (a, b) =>
+        b.score + b.novelty - (a.score + a.novelty) || b.timestamp - a.timestamp,
+    );
+    const keep = runs.slice(0, max);
+    const remove = runs.slice(max);
     await Promise.all(remove.map((r) => del(r.id, this.runStore)));
-    const keepIds = new Set(runs.slice(runs.length - max).map((r) => r.evalId));
+    const keepIds = new Set(keep.map((r) => r.evalId));
     const evals = (await values(this.evalStore)) as EvaluatorRecord[];
     await Promise.all(
       evals


### PR DESCRIPTION
## Summary
- adjust archive pruning to rank by score+novelty
- remove eval records no longer referenced by remaining runs
- update Archive tests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 72 failed, 204 passed, 27 skipped)*
- `npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test` *(fails: Missing dependency "esbuild")*

------
https://chatgpt.com/codex/tasks/task_e_6841f2cd6e048333b47cc27a98fc8104