### PR TITLE
[alpha_factory] Skip wasm preload when inlined

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -238,6 +238,8 @@ async function bundle() {
   const wasmBuf = fsSync.readFileSync(wasmPath);
   verify(wasmBuf, 'pyodide.asm.wasm');
   const wasmBase64 = wasmBuf.toString('base64');
+  const wasmSri =
+    'sha384-' + createHash('sha384').update(wasmBuf).digest('base64');
 
   for (const name of ['pyodide.js', 'pyodide_py.tar', 'packages.json']) {
     const p = path.join('wasm', name);
@@ -251,6 +253,12 @@ async function bundle() {
     verify(buf, 'wasm-gpt2.tar');
     gpt2Base64 = buf.toString('base64');
   } catch {}
+  if (!wasmBase64) {
+    outHtml = outHtml.replace(
+      '</head>',
+      `<link rel="preload" href="wasm/pyodide.asm.wasm" as="fetch" type="application/wasm" integrity="${wasmSri}" crossorigin="anonymous" />\n</head>`,
+    );
+  }
   const bundlePath = `${OUT_DIR}/insight.bundle.js`;
   let bundleText = await fs.readFile(bundlePath, 'utf8');
   const d3Code = await fs.readFile('d3.v7.min.js', 'utf8');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -10,7 +10,6 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="manifest.json" />
     <!-- styles injected by insight.bundle.js -->
-  <link rel="preload" href="wasm/pyodide.asm.wasm" as="fetch" type="application/wasm" integrity="sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo" crossorigin="anonymous" />
 </head>
   <body class="min-h-screen flex flex-col">
     <header class="hero relative py-16">

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -400,15 +400,16 @@ if wasm_dir.exists():
             expected = checksums.get(name)
             if expected and expected != actual:
                 sys.exit(f"Checksum mismatch for {name}")
-    out_html = out_html.replace(
-        "</head>",
-        (
-            f'<link rel="preload" '
-            f'href="{manifest["dirs"]["wasm"]}/pyodide.asm.wasm" '
-            f'as="fetch" type="application/wasm" integrity="{wasm_sri}" '
-            'crossorigin="anonymous" />\n</head>'
-        ),
-    )  # noqa: E501
+    if not wasm_b64:
+        out_html = out_html.replace(
+            "</head>",
+            (
+                f'<link rel="preload" '
+                f'href="{manifest["dirs"]["wasm"]}/pyodide.asm.wasm" '
+                f'as="fetch" type="application/wasm" integrity="{wasm_sri}" '
+                'crossorigin="anonymous" />\n</head>'
+            ),
+        )  # noqa: E501
 else:
     wasm_sri = None
 (dist_dir / "index.html").write_text(out_html)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_single_network_request.py
@@ -17,12 +17,15 @@ def test_single_network_request() -> None:
         page = browser.new_page()
         js_requests: list[str] = []
         map_requests: list[str] = []
+        wasm_requests: list[str] = []
 
         def handle_request(req: Request) -> None:
             if req.url.endswith(".js") and not req.url.endswith("sw.js"):
                 js_requests.append(req.url)
             elif req.url.endswith(".map"):
                 map_requests.append(req.url)
+            elif req.url.endswith(".wasm"):
+                wasm_requests.append(req.url)
 
         page.on("request", handle_request)
         page.goto(url)
@@ -30,4 +33,5 @@ def test_single_network_request() -> None:
         expected = page.url.replace("index.html", "insight.bundle.js")
         assert js_requests == [expected]
         assert map_requests == []
+        assert wasm_requests == []
         browser.close()

--- a/tests/security/test_csp.py
+++ b/tests/security/test_csp.py
@@ -27,8 +27,10 @@ def test_csp_no_violations() -> None:
             page.goto(url)
             page.wait_for_selector("#controls")
             link = page.query_selector("link[rel='preload'][href='wasm/pyodide.asm.wasm']")
-            assert link is not None
-            assert link.get_attribute("integrity")
+            if link is None:
+                assert page.evaluate("window.PYODIDE_WASM_BASE64")
+            else:
+                assert link.get_attribute("integrity")
             policy = page.get_attribute("meta[http-equiv='Content-Security-Policy']", "content")
             assert "https://api.openai.com" in policy
             assert not any("Content Security Policy" in v for v in violations)


### PR DESCRIPTION
## Summary
- avoid adding preload tag when wasm is embedded
- refresh generated dist/index.html
- check CSP tests for embedded wasm
- ensure the browser test checks for any wasm requests

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 135 failed, 512 passed, 43 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6842078e39e48333aceccca0ecfe0599