### PR TITLE
[alpha_factory] add license headers

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/__init__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """MiniMu demo package for MuZero Planning."""
 
 try:

--- a/alpha_factory_v1/demos/muzero_planning/__main__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Command line entry point for the MuZero planning demo."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
+++ b/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 MuZero Planning demo – Cross‑industry Alpha‑Factory illustration.
 Runs a lightweight MuZero agent (MiniMu) on Gymnasium’s CartPole‑v1

--- a/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
+++ b/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
@@ -1,124 +1,125 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "ecfd703e",
-   "metadata": {},
-   "source": [
-    "# MuZero Planning Demo \u2013 Colab\n",
-    "Experience MuZero-style planning in seconds. Run each cell to install dependencies, test the environment and launch a shareable dashboard.\n",
-    "\n",
-    "Add your **OpenAI API key** if you want narrated moves; otherwise Mixtral runs locally for a 100% offline demo."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "ecfd703e",
+      "metadata": {},
+      "source": [
+        "This notebook is licensed under the Apache License 2.0 (SPDX-License-Identifier: Apache-2.0).\n",
+        "# MuZero Planning Demo – Colab\n",
+        "Experience MuZero-style planning in seconds. Run each cell to install dependencies, test the environment and launch a shareable dashboard.\n",
+        "\n",
+        "Add your **OpenAI API key** if you want narrated moves; otherwise Mixtral runs locally for a 100% offline demo."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "fb0bb1be",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install core dependencies\n",
+        "!pip -q install \"torch>=2.1\" gymnasium[classic-control] gradio openai_agents pytest\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "881ead00",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Clone Alpha‑Factory repository\n",
+        "!git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
+        "%cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Run quick sanity tests (optional)\n",
+        "!pytest -q tests/test_muzero_planning.py\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "config-env",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Optional environment settings\n",
+        "MUZERO_ENV_ID = 'CartPole-v1'  # change to try other Gym tasks\n",
+        "HOST_PORT = 7861\n",
+        "MUZERO_EPISODES = 3  # number of episodes to run",
+        "import os\n",
+        "os.environ['MUZERO_ENV_ID'] = MUZERO_ENV_ID\n",
+        "os.environ['HOST_PORT'] = str(HOST_PORT)\n",
+        "os.environ['MUZERO_EPISODES'] = str(MUZERO_EPISODES)\n",
+        "print(f'Environment: {MUZERO_ENV_ID}, episodes={MUZERO_EPISODES}, dashboard → http://localhost:{HOST_PORT}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0afcf7b6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 👉 OPTIONAL: set your OpenAI key for commentary\n",
+        "# import os, getpass\n",
+        "# os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(prompt=\"Enter OpenAI API key: \")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9874987f",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Launch the MuZero Gradio dashboard (shared link will appear below)\n",
+        "import os, subprocess, time, signal, sys, threading\n",
+        "os.environ[\"GRADIO_SHARE\"] = \"1\"\n",
+        "process = subprocess.Popen([sys.executable, \"agent_muzero_entrypoint.py\"])\n",
+        "print(\"⌛ Booting… wait for the public URL ↴\")\n",
+        "try:\n",
+        "    while process.poll() is None:\n",
+        "        time.sleep(5)\n",
+        "except KeyboardInterrupt:\n",
+        "    process.send_signal(signal.SIGINT)\n",
+        "    process.wait()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "shutdown",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# ⏹️ Stop the MuZero dashboard\n",
+        "process.send_signal(signal.SIGINT)\n",
+        "process.wait()\n",
+        "print('MuZero demo stopped.')"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb0bb1be",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install core dependencies\n",
-    "!pip -q install \"torch>=2.1\" gymnasium[classic-control] gradio openai_agents pytest\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "881ead00",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Clone Alpha\u2011Factory repository\n",
-    "!git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
-    "%cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# Run quick sanity tests (optional)\n",
-    "!pytest -q tests/test_muzero_planning.py\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "config-env",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Optional environment settings\n",
-    "MUZERO_ENV_ID = 'CartPole-v1'  # change to try other Gym tasks\n",
-    "HOST_PORT = 7861\n",
-    "MUZERO_EPISODES = 3  # number of episodes to run",
-    "import os\n",
-    "os.environ['MUZERO_ENV_ID'] = MUZERO_ENV_ID\n",
-    "os.environ['HOST_PORT'] = str(HOST_PORT)\n",
-    "os.environ['MUZERO_EPISODES'] = str(MUZERO_EPISODES)\n",
-    "print(f'Environment: {MUZERO_ENV_ID}, episodes={MUZERO_EPISODES}, dashboard \u2192 http://localhost:{HOST_PORT}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0afcf7b6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# \ud83d\udc49\u00a0OPTIONAL: set your OpenAI key for commentary\n",
-    "# import os, getpass\n",
-    "# os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(prompt=\"Enter OpenAI API key: \")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9874987f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Launch the MuZero Gradio dashboard (shared link will appear below)\n",
-    "import os, subprocess, time, signal, sys, threading\n",
-    "os.environ[\"GRADIO_SHARE\"] = \"1\"\n",
-    "process = subprocess.Popen([sys.executable, \"agent_muzero_entrypoint.py\"])\n",
-    "print(\"\u231b\u00a0Booting\u2026 wait for the public URL \u21b4\")\n",
-    "try:\n",
-    "    while process.poll() is None:\n",
-    "        time.sleep(5)\n",
-    "except KeyboardInterrupt:\n",
-    "    process.send_signal(signal.SIGINT)\n",
-    "    process.wait()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "shutdown",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# \u23f9\ufe0f Stop the MuZero dashboard\n",
-    "process.send_signal(signal.SIGINT)\n",
-    "process.wait()\n",
-    "print('MuZero demo stopped.')"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.x"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/alpha_factory_v1/demos/muzero_planning/minimuzero.py
+++ b/alpha_factory_v1/demos/muzero_planning/minimuzero.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Minimal MuZero utilities used by the planning demo."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
+++ b/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 demo_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX headers in MuZero demo modules and script
- note Apache 2.0 licensing in the MuZero planning Colab notebook

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 72 failed, 204 passed, 27 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68420b1030408333a4b42b1b3d689d9a