### PR TITLE
[alpha_factory] clarify openai_agents for MuZero demo

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -46,6 +46,18 @@ pip install -r requirements.txt
 python -m alpha_factory_v1.demos.muzero_planning
 ```
 
+### Optional `openai_agents`
+
+For narrated actions and tool calls, install `openai_agents` version
+`>=0.0.16`:
+
+```bash
+pip install -U 'openai_agents>=0.0.16'
+```
+
+Leaving `OPENAI_API_KEY` empty keeps the demo offline and falls back to
+**Ollama ✕ Mixtral** if available.
+
 ### Command-line options
 
 You can override the environment, episode count and port directly from the CLI:


### PR DESCRIPTION
## Summary
- document the optional `openai_agents` package in the MuZero planning demo
- note Mixtral via Ollama fallback when no API key is provided

## Testing
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,eslint-insight-browser,semgrep pre-commit run --files alpha_factory_v1/demos/muzero_planning/README.md`
- `pytest -q` *(fails: 37 failed, 9 passed, 17 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68420e6839d08333ba1d6ebf5e7de759