### PR TITLE
[alpha_factory] test gradio dependency and port collision

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
+++ b/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
@@ -54,13 +54,17 @@ except Exception:  # pragma: no cover - provide graceful degrade
 
 try:
     import gradio as gr
+    _HAVE_GRADIO = True
 except ModuleNotFoundError:  # pragma: no cover - allow CLI help without gradio
 
     class _MissingGradio:
         def __getattr__(self, name: str):  # noqa: D401
-            raise ModuleNotFoundError("gradio is required for this feature. Install with: pip install gradio")
+            raise ModuleNotFoundError(
+                "gradio is required for this feature. Install with: pip install gradio"
+            )
 
     gr = _MissingGradio()  # type: ignore[misc]
+    _HAVE_GRADIO = False
 
 # ── Minimal MuZero utilities --------------------------------------------------
 # (full implementation lives in demo/minimuzero.py, imported here)
@@ -114,6 +118,11 @@ if adk_bridge and adk_bridge.adk_enabled():  # pragma: no cover - optional
 
 # ── Gradio UI -----------------------------------------------------------------
 def launch_dashboard():
+    if not _HAVE_GRADIO:
+        raise RuntimeError(
+            "gradio is required for this feature. Install with: pip install gradio"
+        )
+
     with gr.Blocks(title="MuZero Planning Demo") as demo:
         vid = gr.Video(label="Live environment")
         log = gr.Markdown()

--- a/tests/test_agent_muzero_entrypoint.py
+++ b/tests/test_agent_muzero_entrypoint.py
@@ -1,0 +1,23 @@
+import importlib
+import builtins
+import sys
+import pytest
+
+MODULE = "alpha_factory_v1.demos.muzero_planning.agent_muzero_entrypoint"
+
+
+def test_launch_dashboard_missing_gradio(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "gradio":
+            raise ModuleNotFoundError(name)
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop(MODULE, None)
+    mod = importlib.import_module(MODULE)
+    mod = importlib.reload(mod)
+
+    with pytest.raises(RuntimeError, match="gradio is required"):
+        mod.launch_dashboard()

--- a/tests/test_run_muzero_demo.py
+++ b/tests/test_run_muzero_demo.py
@@ -38,3 +38,37 @@ def test_run_muzero_demo_invokes_docker(tmp_path: Path) -> None:
 
     assert log_file.read_text(), "Docker stub was not invoked"
     assert "compose" in log_file.read_text()
+
+
+def test_run_muzero_demo_port_in_use(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src = repo_root / "alpha_factory_v1"
+    dst = tmp_path / "alpha_factory_v1"
+    shutil.copytree(src, dst)
+
+    script = dst / "demos" / "muzero_planning" / "run_muzero_demo.sh"
+    log_file = tmp_path / "docker.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(f"#!/usr/bin/env bash\necho docker >> '{log_file}'\nexit 0\n")
+    docker_stub.chmod(0o755)
+
+    lsof_stub = bin_dir / "lsof"
+    lsof_stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+    lsof_stub.chmod(0o755)
+
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    port = sock.getsockname()[1]
+
+    env = os.environ.copy()
+    env.update({"PATH": f"{bin_dir}:{env.get('PATH', '')}", "HOST_PORT": str(port)})
+
+    result = subprocess.run(["bash", str(script)], env=env, capture_output=True, text=True)
+    sock.close()
+
+    assert result.returncode == 1
+    assert "already in use" in result.stderr
+    assert not log_file.exists() or not log_file.read_text()


### PR DESCRIPTION
## Summary
- check gradio is installed in MuZero dashboard entrypoint
- add test for missing gradio dependency
- extend run_muzero_demo tests to cover port already in use

## Testing
- `pre-commit run --files alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py tests/test_run_muzero_demo.py tests/test_agent_muzero_entrypoint.py` *(fails: Interrupted)*
- `python check_env.py --auto-install`
- `pytest tests/test_run_muzero_demo.py tests/test_agent_muzero_entrypoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68421415cff08333a62a4b5381521657