### PR TITLE
[alpha_factory] add wheelhouse instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Follow these steps when working without internet access.
 1. **Build a wheelhouse** on a machine with connectivity:
    ```bash
    mkdir -p /media/wheels
-   pip wheel -r requirements.lock -w /media/wheels
+   pip wheel -r requirements.txt -w /media/wheels
    pip wheel -r requirements-dev.txt -w /media/wheels
    ```
 
@@ -103,12 +103,15 @@ Follow these steps when working without internet access.
    `WHEELHOUSE` is unset:
    ```bash
    WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
-  WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
-    python check_env.py --auto-install --wheelhouse /media/wheels
-  pip check
-  ```
-   See [Offline Setup](alpha_factory_v1/scripts/README.md#offline-setup) for
-   more details.
+   WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
+     python check_env.py --auto-install --wheelhouse /media/wheels
+   pip check
+   ```
+   `check_env.py` uses the wheels under `/media/wheels`. Set
+   `WHEELHOUSE=/media/wheels` when running `pre-commit` or the tests so
+   dependencies install from the local cache. See
+   [Offline Setup](alpha_factory_v1/scripts/README.md#offline-setup) for more
+   details.
 
 3. **Download a `.gguf` weight** and set ``LLAMA_MODEL_PATH``:
    ```bash

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -266,12 +266,19 @@ In fully offline environments provide a local wheel via the `WHEELHOUSE` environ
 
 ### 💾 Offline wheel install
 
-Build a wheelhouse as shown in [AGENTS.md](../../../AGENTS.md#offline-setup) and
-set `WHEELHOUSE` to its path. Run the environment check to install any missing
-packages from those wheels:
+Create a wheelhouse on a machine with internet access:
 
 ```bash
-python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+mkdir -p /media/wheels
+pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r requirements-dev.txt -w /media/wheels
+```
+
+Set `WHEELHOUSE=/media/wheels` and run the environment check to install from
+these local wheels. Use the same variable when running `pre-commit` or tests:
+
+```bash
+python check_env.py --auto-install --wheelhouse /media/wheels
 ```
 
 ### 🎛️ Local Gradio Dashboard


### PR DESCRIPTION
## Summary
- document how to build a wheelhouse
- mention using wheelhouse for `check_env.py`, `pre-commit` and tests

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_business_v1/README.md` *(fails: Verify protobuf files are up to date)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: several browser tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842179ac1fc8333a34e2d4e8e302ab6