### PR TITLE
[alpha_factory] docs: add test setup instructions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,16 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # 🧪 Root Test Suite
 
-These integration tests expect the `alpha_factory_v1` package to be importable. When running from the repository root without installation, set `PYTHONPATH` so Python can locate the source tree:
+These integration tests expect the `alpha_factory_v1` package to be importable.
 
-Run `python check_env.py --auto-install` first to confirm all dependencies are available.
+## Setup
+
+1. Run `python check_env.py --auto-install` (provide `--wheelhouse <dir>` when offline).
+2. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
+3. Execute `pytest -q`.
+
+Missing optional dependencies often cause failures. Re-run the environment check or pass `--wheelhouse` to install them offline.
+
+When running from the repository root without installation:
 
 ```bash
 export PYTHONPATH=$(pwd)
 python -m pytest -q tests
 ```
 
-Alternatively install the package in editable mode first:
+Alternatively install the package first:
 
 ```bash
 pip install -e .


### PR DESCRIPTION
## Summary
- describe how to run the test suite
- mention failure cases when deps are missing

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: several browser tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68421dabcb2c833389adbf70fca8d2c2