### PR TITLE
[alpha_factory] Extend PWA offline test

### DIFF
--- a/tests/test_pwa_offline.py
+++ b/tests/test_pwa_offline.py
@@ -40,6 +40,21 @@ def test_quickstart_pdf_offline() -> None:
             page.wait_for_function("navigator.serviceWorker.ready")
             page.reload()
             page.wait_for_function("navigator.serviceWorker.controller !== null")
+            pdf_cached = page.evaluate(
+                """
+                (async () => {
+                  const names = await caches.keys();
+                  for (const n of names) {
+                    const c = await caches.open(n);
+                    if (await c.match('insight_browser_quickstart.pdf')) {
+                      return true;
+                    }
+                  }
+                  return false;
+                })()
+                """
+            )
+            assert pdf_cached, "PDF not cached by service worker"
             context.set_offline(True)
             resp = page.goto(url + "/insight_browser_quickstart.pdf")
             assert resp and resp.ok, "PDF not served offline"


### PR DESCRIPTION
## Summary
- verify `insight_browser_quickstart.pdf` is cached by the service worker
- ensure PDF loads while offline

## Testing
- `python check_env.py --auto-install`
- `pytest -q tests/test_pwa_offline.py` *(fails: skipped due to missing Playwright browser)*
- `pre-commit run --files tests/test_pwa_offline.py` *(fails: semgrep environment initialization interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68421d757a9083338280f545bab5ecad