### PR TITLE
[alpha_factory] remove inaccurate coverage badge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -8,7 +8,6 @@
 </p>
 
  <img alt="build" src="https://img.shields.io/badge/build-passing-brightgreen">
- <img alt="coverage" src="https://img.shields.io/badge/coverage-100%25-success">
  <img alt="license" src="https://img.shields.io/badge/license-Apache--2.0-blue">
  <img alt="status"  src="https://img.shields.io/badge/status-production-green">
 </p>


### PR DESCRIPTION
## Summary
- drop outdated coverage badge from the alpha_agi_business_v1 README

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_agent_base.py --cov=alpha_factory_v1 --cov-report=term`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_v1/README.md` *(fails: KeyboardInterrupt while initializing semgrep)*

------
https://chatgpt.com/codex/tasks/task_e_68421f26f6608333b09d434e92cdd4be