### PR TITLE
[alpha_factory] add missing locale fallback test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -189,7 +189,8 @@ archive on each pull request and fails if `insight_browser.zip` grows beyond
 ## Locale Support
 The interface automatically loads French, Spanish or Chinese translations based
 on your browser preferences. Set `localStorage.lang` to override the detected
-language.
+language. When the chosen locale file is missing, a warning appears in the
+browser console and the demo falls back to the built‑in English strings.
 
 ## Toolbar & Controls
 - **CSV** – export the current population as `population.csv`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_missing_locale_fallback.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_missing_locale_fallback.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify fallback when a translation file is missing."""
+from pathlib import Path
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
+
+
+def test_missing_locale_warning_and_english_fallback() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            warnings: list[str] = []
+            page.on("console", lambda msg: warnings.append(msg.text) if msg.type == "warning" else None)
+            page.add_init_script("localStorage.setItem('lang','xx')")
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            label_text = page.locator("#controls label").first.inner_text()
+            assert "Seed" in label_text
+            assert warnings, "Expected a console warning for missing locale"
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- verify fallback when a locale file is missing
- mention locale fallback in README

## Testing
- `python check_env.py --auto-install`
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_missing_locale_fallback.py`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_missing_locale_fallback.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: Makefile:26: *** missing separator.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_68421f4d4b548333af3abd7e23012fee