### PR TITLE
[alpha_factory] Update demo doc line length

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -116,7 +116,10 @@ cross‑process collaboration.
 
 ## 🎓 Colab (two clicks)
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb)
+[![Open In Colab][colab-badge]][colab-notebook]
+
+[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
+[colab-notebook]: https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
 
 Colab spins up the same dashboard via an ngrok tunnel — handy when Docker isn’t.
 It installs the tiny MuZero package, runs a quick sanity test and opens a shareable link.


### PR DESCRIPTION
## Summary
- shorten the MuZero demo README link with reference syntax

## Testing
- `pre-commit run --files alpha_factory_v1/demos/muzero_planning/README.md` *(failed: remote error)*
- `python check_env.py --auto-install`
- `pytest -q` *(failures)*

------
https://chatgpt.com/codex/tasks/task_e_684223dead088333aae921e34376a525