### PR TITLE
[alpha_factory] Add env cleanup in MuZero tests

### DIFF
--- a/tests/test_muzero_planning.py
+++ b/tests/test_muzero_planning.py
@@ -7,6 +7,10 @@ class TestMiniMu(unittest.TestCase):
     def setUp(self):
         self.mu = MiniMu(env_id="CartPole-v1")
 
+    def tearDown(self):
+        """Close the Gym environment after each test."""
+        self.mu.env.close()
+
     def test_policy_distribution(self):
         obs = self.mu.reset()
         policy = self.mu.policy(obs)


### PR DESCRIPTION
## Summary
- ensure gym environments close between `MiniMu` tests

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_muzero_planning.py -q`
- ❌ `pytest -q` *(fails: 37 failed, 10 passed, 18 skipped, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68424b8d0c688333acb195dead6c957a