### PR TITLE
[alpha_factory] improve offline build docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -172,6 +172,17 @@ WEB3_STORAGE_TOKEN=<token> python ../../../scripts/fetch_assets.py
 The script retrieves the WebAssembly runtime and supporting files from IPFS,
 verifying checksums to ensure each asset is intact.
 
+### Offline Build Steps
+
+Requires **Node.js ≥20** and **Python ≥3.11**.
+
+1. Copy `.env.sample` to `.env` and set the variables.
+2. Run `WEB3_STORAGE_TOKEN=<token> python ../../../scripts/fetch_assets.py` to download the WASM runtime and model files.
+3. Execute `python manual_build.py` to produce the `dist/` directory.
+4. Open `dist/index.html` to verify offline functionality.
+
+Run `node tests/run.mjs --offline` to confirm the build works without network access.
+
 ## Distribution
 Run `npm run build:dist` to generate `insight_browser.zip` in this directory.
 The archive bundles the production build along with the service worker and

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -36,15 +36,26 @@
       <button id="install-btn" hidden>Install</button>
     </div>
     <div id="legend"></div>
-    <div id="depth-legend"></div>
-    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;">
-      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
-    </footer>
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker
-            .register('service-worker.js')
+      <div id="depth-legend"></div>
+      <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;">
+        This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+      </footer>
+      <section id="offline-build-steps">
+        <h2>Offline Build Steps</h2>
+        <p>Requires <strong>Node.js ≥20</strong> and <strong>Python ≥3.11</strong>.</p>
+        <ol>
+          <li>Copy <code>.env.sample</code> to <code>.env</code> and set the variables.</li>
+          <li>Run <code>WEB3_STORAGE_TOKEN=&lt;token&gt; python ../../../scripts/fetch_assets.py</code> to download the WASM runtime and model files.</li>
+          <li>Execute <code>python manual_build.py</code> to produce the <code>dist/</code> directory.</li>
+          <li>Open <code>dist/index.html</code> to verify offline functionality.</li>
+        </ol>
+        <p>Run <code>node tests/run.mjs --offline</code> to confirm the build works without network access.</p>
+      </section>
+      <script>
+        if ('serviceWorker' in navigator) {
+          window.addEventListener('load', () => {
+            navigator.serviceWorker
+              .register('service-worker.js')
             .catch(() => toast('Service worker registration failed; offline mode disabled.'));
         });
       }


### PR DESCRIPTION
## Summary
- document offline build steps in the Insight Browser README
- embed the new instructions into the built HTML
- parse README from manual_build.py to keep the offline build section in sync

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py` *(failed: proto-verify)*
- `pytest -q` *(failed: 15 failed, 3 passed, 14 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68424af745608333ae1bf49fa3b0ad0b