### PR TITLE
[alpha_factory] fix muzero demo imports

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -46,13 +46,13 @@ pip install -r requirements.txt
 python -m alpha_factory_v1.demos.muzero_planning
 ```
 
-### Optional `openai_agents`
+### Optional `openai-agents`
 
-For narrated actions and tool calls, install `openai_agents` version
+For narrated actions and tool calls, install `openai-agents` version
 `>=0.0.16`:
 
 ```bash
-pip install -U 'openai_agents>=0.0.16'
+pip install -U 'openai-agents>=0.0.16'
 ```
 
 Leaving `OPENAI_API_KEY` empty keeps the demo offline and falls back to

--- a/alpha_factory_v1/demos/muzero_planning/__init__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__init__.py
@@ -5,7 +5,7 @@ try:
     from .agent_muzero_entrypoint import launch_dashboard
 except ImportError:  # pragma: no cover - optional deps may be missing
 
-    def launch_dashboard() -> None:  # type: ignore[return-type]
+    def launch_dashboard() -> None:
         """Placeholder when optional dependencies are absent."""
         raise RuntimeError("gradio and other optional packages are required for the MuZero demo")
 

--- a/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
+++ b/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 try:  # OpenAI Agents SDK is optional
-    from openai_agents import Agent, AgentRuntime, Tool, OpenAIAgent
+    from agents import Agent, AgentRuntime, Tool, OpenAIAgent
 except Exception:  # pragma: no cover - provide graceful degrade
 
     class OpenAIAgent:
@@ -117,7 +117,7 @@ if adk_bridge and adk_bridge.adk_enabled():  # pragma: no cover - optional
 
 
 # ── Gradio UI -----------------------------------------------------------------
-def launch_dashboard():
+def launch_dashboard() -> None:
     if not _HAVE_GRADIO:
         raise RuntimeError("gradio is required for this feature. Install with: pip install gradio")
 
@@ -125,7 +125,7 @@ def launch_dashboard():
         vid = gr.Video(label="Live environment")
         log = gr.Markdown()
 
-        async def run():
+        async def run() -> tuple[list[bytes], str]:
             mu = MiniMu(env_id=ENV_ID)
             frames = []
             commentary = []


### PR DESCRIPTION
## Summary
- update MuZero planning README to reference `openai-agents`
- import `agents` package in MuZero demo
- add missing type hints for the demo entry point

## Testing
- `python -m alpha_factory_v1.demos.muzero_planning --help`
- `pytest -q tests/test_muzero_planning.py`
- `pre-commit run --files alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py alpha_factory_v1/demos/muzero_planning/README.md alpha_factory_v1/demos/muzero_planning/__init__.py` *(with SKIP=mypy,proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,eslint-insight-browser)*


------
https://chatgpt.com/codex/tasks/task_e_684250113390833385014256e04decbc