### PR TITLE
[alpha_factory] enforce sandbox message origin

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/sandbox.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/sandbox.ts
@@ -18,7 +18,7 @@ let w;
 window.addEventListener('message',e=>{
   if(e.data.type==='start'){
     w=new Worker(e.data.url,{type:'module'});
-    w.onmessage=d=>parent.postMessage(d.data,'*');
+    w.onmessage=d=>parent.postMessage(d.data,location.origin);
   }else if(w){
     w.postMessage(e.data);
   }
@@ -33,7 +33,7 @@ window.addEventListener('message',e=>{
     document.body.appendChild(iframe);
 
     const worker: any = {
-      postMessage: (m: any) => iframe.contentWindow!.postMessage(m, '*'),
+      postMessage: (m: any) => iframe.contentWindow!.postMessage(m, location.origin),
       terminate() {
         iframe.remove();
         URL.revokeObjectURL(iframe.src);
@@ -44,14 +44,14 @@ window.addEventListener('message',e=>{
     };
 
     const handler = (e: MessageEvent) => {
-      if (e.source === iframe.contentWindow && worker.onmessage) {
+      if (e.source === iframe.contentWindow && e.origin === location.origin && worker.onmessage) {
         worker.onmessage(e);
       }
     };
     window.addEventListener('message', handler);
 
     iframe.onload = () => {
-      iframe.contentWindow!.postMessage({ type: 'start', url: workerUrl }, '*');
+      iframe.contentWindow!.postMessage({ type: 'start', url: workerUrl }, location.origin);
       resolve(worker as unknown as Worker);
     };
   });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/sandbox_origin.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/sandbox_origin.test.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createSandboxWorker } from '../src/utils/sandbox.ts';
+
+let lastHandler;
+const windowMock = {
+  addEventListener(type, handler) {
+    if (type === 'message') lastHandler = handler;
+  },
+  removeEventListener() {},
+};
+
+const iframeMock = {
+  sandbox: '',
+  style: {},
+  src: '',
+  contentWindow: { postMessage() {} },
+  onload: () => {},
+  remove() {},
+};
+
+const documentMock = {
+  createElement() { return iframeMock; },
+  body: { appendChild() {} },
+};
+
+const URLMock = {
+  createObjectURL() { return 'blob:xyz'; },
+  revokeObjectURL() {},
+};
+
+global.window = windowMock;
+global.document = documentMock;
+global.URL = URLMock;
+global.location = { origin: 'http://example.com' };
+
+test('messages from other origins are ignored', async () => {
+  const p = createSandboxWorker('x.js');
+  iframeMock.onload();
+  const w = await p;
+  let count = 0;
+  w.onmessage = () => { count += 1; };
+
+  lastHandler({ source: iframeMock.contentWindow, origin: 'http://evil.com', data: 'bad' });
+  assert.equal(count, 0);
+
+  lastHandler({ source: iframeMock.contentWindow, origin: 'http://example.com', data: 'good' });
+  assert.equal(count, 1);
+});

--- a/src/interface/web_client/src/utils/sandbox.ts
+++ b/src/interface/web_client/src/utils/sandbox.ts
@@ -18,7 +18,7 @@ let w;
 window.addEventListener('message',e=>{
   if(e.data.type==='start'){
     w=new Worker(e.data.url,{type:'module'});
-    w.onmessage=d=>parent.postMessage(d.data,'*');
+    w.onmessage=d=>parent.postMessage(d.data,location.origin);
   }else if(w){
     w.postMessage(e.data);
   }
@@ -33,7 +33,7 @@ window.addEventListener('message',e=>{
     document.body.appendChild(iframe);
 
     const worker: any = {
-      postMessage: (m: any) => iframe.contentWindow!.postMessage(m, '*'),
+      postMessage: (m: any) => iframe.contentWindow!.postMessage(m, location.origin),
       terminate() {
         iframe.remove();
         URL.revokeObjectURL(iframe.src);
@@ -44,14 +44,14 @@ window.addEventListener('message',e=>{
     };
 
     const handler = (e: MessageEvent) => {
-      if (e.source === iframe.contentWindow && worker.onmessage) {
+      if (e.source === iframe.contentWindow && e.origin === location.origin && worker.onmessage) {
         worker.onmessage(e);
       }
     };
     window.addEventListener('message', handler);
 
     iframe.onload = () => {
-      iframe.contentWindow!.postMessage({ type: 'start', url: workerUrl }, '*');
+      iframe.contentWindow!.postMessage({ type: 'start', url: workerUrl }, location.origin);
       resolve(worker as unknown as Worker);
     };
   });


### PR DESCRIPTION
## Summary
- ensure sandbox workers only postMessage to the same origin
- only forward messages from matching origins
- test that mismatched origins are ignored

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 67 failed, 181 passed)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/sandbox.ts src/interface/web_client/src/utils/sandbox.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/sandbox_origin.test.js --hook-stage manual` *(fails to initialize semgrep)*


------
https://chatgpt.com/codex/tasks/task_e_684255034ed4833389722a3a783773d9