### PR TITLE
[alpha_factory] add muzero demo disclaimer

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -16,6 +16,11 @@ one‑command experience**.
 You’ll see a MuZero‑style agent improvise physics, deploy Monte‑Carlo search,
 and **stabilise CartPole** — all inside your browser. No GPU, no PhD required.
 
+> **Disclaimer**
+> This demo is a conceptual research prototype. References to "AGI" and
+> "superintelligence" describe aspirational goals and do not indicate the
+> presence of a real general intelligence. Use at your own risk.
+
 ---
 
 ## 🚀 Quick Start

--- a/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
+++ b/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
@@ -6,7 +6,8 @@
       "metadata": {},
       "source": [
         "This notebook is licensed under the Apache License 2.0 (SPDX-License-Identifier: Apache-2.0).\n",
-        "# MuZero Planning Demo – Colab\n",
+        "This demo is a conceptual research prototype. References to \"AGI\" and \"superintelligence\" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.\n",
+        "# MuZero Planning Demo \u2013 Colab\n",
         "Experience MuZero-style planning in seconds. Run each cell to install dependencies, test the environment and launch a shareable dashboard.\n",
         "\n",
         "Add your **OpenAI API key** if you want narrated moves; otherwise Mixtral runs locally for a 100% offline demo."
@@ -30,7 +31,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Clone Alpha‑Factory repository\n",
+        "# Clone Alpha\u2011Factory repository\n",
         "!git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git\n",
         "%cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/muzero_planning"
       ]
@@ -60,7 +61,7 @@
         "os.environ['MUZERO_ENV_ID'] = MUZERO_ENV_ID\n",
         "os.environ['HOST_PORT'] = str(HOST_PORT)\n",
         "os.environ['MUZERO_EPISODES'] = str(MUZERO_EPISODES)\n",
-        "print(f'Environment: {MUZERO_ENV_ID}, episodes={MUZERO_EPISODES}, dashboard → http://localhost:{HOST_PORT}')"
+        "print(f'Environment: {MUZERO_ENV_ID}, episodes={MUZERO_EPISODES}, dashboard \u2192 http://localhost:{HOST_PORT}')"
       ]
     },
     {
@@ -70,7 +71,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# 👉 OPTIONAL: set your OpenAI key for commentary\n",
+        "# \ud83d\udc49\u00a0OPTIONAL: set your OpenAI key for commentary\n",
         "# import os, getpass\n",
         "# os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(prompt=\"Enter OpenAI API key: \")"
       ]
@@ -86,7 +87,7 @@
         "import os, subprocess, time, signal, sys, threading\n",
         "os.environ[\"GRADIO_SHARE\"] = \"1\"\n",
         "process = subprocess.Popen([sys.executable, \"agent_muzero_entrypoint.py\"])\n",
-        "print(\"⌛ Booting… wait for the public URL ↴\")\n",
+        "print(\"\u231b\u00a0Booting\u2026 wait for the public URL \u21b4\")\n",
         "try:\n",
         "    while process.poll() is None:\n",
         "        time.sleep(5)\n",
@@ -102,7 +103,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# ⏹️ Stop the MuZero dashboard\n",
+        "# \u23f9\ufe0f Stop the MuZero dashboard\n",
         "process.send_signal(signal.SIGINT)\n",
         "process.wait()\n",
         "print('MuZero demo stopped.')"


### PR DESCRIPTION
## Summary
- state that MuZero planning demo is a conceptual research prototype
- add same warning at start of Colab notebook

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: TypeError and AssertionError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684257aa4b3483339cba0d60bef92639