### PR TITLE
[alpha_factory] add npm setup helper

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -43,8 +43,12 @@ runtime and `wasm-gpt2` model, then install the Node modules and compile the
 bundle:
 ```bash
 python ../../../scripts/fetch_assets.py
-npm ci            # installs dependencies from package-lock.json
+./setup.sh        # installs dependencies when node_modules is missing
 npm run build     # or `python manual_build.py` for offline builds
+```
+Run the tests with:
+```bash
+./setup.sh && npm test
 ```
 The build script reads `.env` automatically and injects the values into
 `dist/index.html` as `window.PINNER_TOKEN`, `window.IPFS_GATEWAY` and

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Ensure Node.js 20+
+node build/version_check.js
+
+if [[ -d node_modules ]]; then
+  echo "node_modules already present"
+  exit 0
+fi
+
+echo "Installing npm dependencies..."
+if ! npm ci --no-progress; then
+  echo "ERROR: npm ci failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- automate `npm ci` for the Insight browser
- document new helper script in Build & Run instructions

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 71 failed, 206 passed)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.sh alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_68425dfda43083339de3ccedb0f873c3