### PR TITLE
[alpha_factory] add offline wheelhouse info

### DIFF
--- a/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
+++ b/alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh
@@ -14,6 +14,31 @@ if [[ -f ../check_env.py ]]; then
   fi
 fi
 
+# Install MuZero specific requirements when AUTO_INSTALL_MISSING is set
+verify_muzero_deps() {
+  python - <<'EOF'
+import importlib, sys
+missing = [pkg for pkg in ("torch", "gymnasium", "gradio") if importlib.util.find_spec(pkg) is None]
+if missing:
+    print("Missing: " + ", ".join(missing))
+    sys.exit(1)
+EOF
+}
+
+if ! verify_muzero_deps; then
+  if [[ "${AUTO_INSTALL_MISSING:-0}" == "1" ]]; then
+    pip_args=()
+    if [[ -n "${WHEELHOUSE:-}" ]]; then
+      pip_args+=(--no-index --find-links "$WHEELHOUSE")
+    fi
+    pip install "${pip_args[@]}" -r "$demo_dir/requirements.txt"
+    verify_muzero_deps || { echo "🚨  Missing MuZero dependencies" >&2; exit 1; }
+  else
+    echo "🚨  Missing MuZero dependencies. Re-run with AUTO_INSTALL_MISSING=1" >&2
+    exit 1
+  fi
+fi
+
 command -v docker >/dev/null 2>&1 || {
   echo "🚨  Docker is required → https://docs.docker.com/get-docker/"; exit 1; }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,25 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
 2. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 3. Execute `pytest -q`.
 
+### Offline install
+
+Create a wheelhouse with the MuZero demo and development requirements:
+
+```bash
+mkdir -p wheels
+pip wheel -r requirements.txt -w wheels
+pip wheel -r alpha_factory_v1/demos/muzero_planning/requirements.txt -w wheels
+pip wheel -r requirements-dev.txt -w wheels
+```
+
+Install and run the tests without contacting PyPI:
+
+```bash
+WHEELHOUSE=$(pwd)/wheels pip install --no-index --find-links "$WHEELHOUSE" -r requirements-dev.txt
+WHEELHOUSE=$(pwd)/wheels python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+PYTHONPATH=$(pwd) WHEELHOUSE="$WHEELHOUSE" pytest -q
+```
+
 Missing optional dependencies often cause failures. Re-run the environment check or pass `--wheelhouse` to install them offline.
 
 When running from the repository root without installation:

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -1,0 +1,23 @@
+# Offline Wheelhouse
+
+This directory stores prebuilt wheels so the MuZero Planning demo and
+unit tests can run without network access. Build the wheelhouse on a
+machine with connectivity and copy it here:
+
+```bash
+mkdir -p wheels
+pip wheel -r requirements.txt -w wheels
+pip wheel -r alpha_factory_v1/demos/muzero_planning/requirements.txt -w wheels
+pip wheel -r requirements-dev.txt -w wheels
+```
+
+Set `WHEELHOUSE=$(pwd)/wheels` before running the setup script or tests:
+
+```bash
+WHEELHOUSE=$(pwd)/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
+WHEELHOUSE=$(pwd)/wheels AUTO_INSTALL_MISSING=1 \
+  python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+```
+
+`run_muzero_demo.sh` and `pytest` pick up the `WHEELHOUSE` environment
+variable automatically when this directory exists.


### PR DESCRIPTION
## Summary
- add README for `wheels/` describing how to build a local wheelhouse
- document offline wheel install procedure in `tests/README.md`
- verify MuZero demo dependencies before docker build

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 14 failed, 3 passed, 14 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68425e971e108333ab7b0001d50ece27