### PR TITLE
[alpha_factory] add dependency check script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ Follow these steps when installing without internet access:
   The `verify-alpha-colab-requirements-lock` hook relies on this lock file.
 
 - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
+- Run `python scripts/check_python_deps.py` to quickly verify that `numpy` and
+  other required packages are installed. If it reports missing packages,
+  execute `python check_env.py --auto-install` before running the tests.
 - After setup, validate with `python check_env.py --auto-install`. When `WHEELHOUSE` is set, run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly offline.
 - The unit tests rely on `fastapi`, `opentelemetry-api`, `openai-agents` and `google-adk`. `./codex/setup.sh` installs these packages automatically. When skipping the setup script, run
   `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no
@@ -271,7 +274,8 @@ install dependencies without internet access.
 - Keep commits focused and descriptive. Use meaningful commit messages.
 - Ensure `git status` shows a clean working tree before committing.
 - Remove stray build artifacts with `git clean -fd` if needed.
-- Run `python check_env.py --auto-install` and `pytest -q` before committing. \
+- Run `python scripts/check_python_deps.py` followed by
+  `python check_env.py --auto-install` and `pytest -q` before committing. \
   Document any remaining test failures in the PR description.
 - See [tests/README.md](tests/README.md) for details on running the suite locally,
   including setting `PYTHONPATH` or installing in editable mode.
@@ -314,7 +318,9 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
 ### Troubleshooting
 - If the stack fails to start, verify Docker and Docker Compose are running.
 - Setup errors usually mean Python is older than 3.11. Use Python 3.11 or 3.12 (>=3.11,<3.13).
-- Missing optional packages can cause test failures; run `python check_env.py --auto-install`.
+- Missing optional packages can cause test failures; first run
+  `python scripts/check_python_deps.py` and then
+  `python check_env.py --auto-install` if required.
 
 For detailed troubleshooting steps, see [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md).
 

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -1,13 +1,14 @@
 # Release Checklist
 
 1. Run `pre-commit run --all-files`.
-2. Run `python check_env.py --auto-install`.
-3. Execute `pytest -q` and ensure all tests pass.
-4. Build the web client with `make build_web`.
-5. Update `docs/CHANGELOG.md` with the new version.
-6. Commit changes and tag the release: `git tag -s vX.Y.Z -m "vX.Y.Z"`.
-7. Push commits and tags to GitHub.
-8. The `CI` workflow builds the image and uploads release artifacts.
+2. Run `python scripts/check_python_deps.py`.
+3. Run `python check_env.py --auto-install`.
+4. Execute `pytest -q` and ensure all tests pass.
+5. Build the web client with `make build_web`.
+6. Update `docs/CHANGELOG.md` with the new version.
+7. Commit changes and tag the release: `git tag -s vX.Y.Z -m "vX.Y.Z"`.
+8. Push commits and tags to GitHub.
+9. The `CI` workflow builds the image and uploads release artifacts.
 
 ## Tweet Copy
 

--- a/scripts/check_python_deps.py
+++ b/scripts/check_python_deps.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Quick dependency check for tests.
+
+This lightweight helper verifies that ``numpy`` and a few
+core packages are installed.  It is intended as a fast
+pre-flight check before running the full environment
+validation or the test suite.
+
+When any package is missing the script prints a message
+and exits with an error, instructing the user to run
+``python check_env.py --auto-install`` for the complete
+setup.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+REQUIRED = ["numpy", "pytest"]
+
+
+def main() -> int:
+    missing: list[str] = []
+    for pkg in REQUIRED:
+        if importlib.util.find_spec(pkg) is None:
+            missing.append(pkg)
+    if missing:
+        print("Missing packages:", ", ".join(missing))
+        print("Run 'python check_env.py --auto-install' to install them.")
+        return 1
+    print("All required packages available.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_python_deps.py` for lightweight dependency checks
- document running the new script in `AGENTS.md`
- update release checklist in `LAUNCH.md`

## Testing
- `pre-commit run --files scripts/check_python_deps.py AGENTS.md LAUNCH.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 37 failed, 16 passed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684261f4487883338fb4d42520298f41