### PR TITLE
[alpha_factory] improve optional dependency messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ python -m webbrowser http://localhost:8000/docs
 ```
 The adapters initialise automatically when these optional packages are present.
 
+### Optional Packages
+
+Install these extras to unlock additional features:
+
+- `pip install gradio` – enables the MuZero planning dashboard.
+- `pip install openai-agents` – activates the official Agents runtime used for commentary.
+- `pip install google-adk` and set `ALPHA_FACTORY_ENABLE_ADK=true` – starts the Google ADK gateway for cross‑organisation agent exchange.
+
 To regenerate `requirements.lock` from `requirements.txt` with hashes, run:
 
 ```bash

--- a/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
+++ b/alpha_factory_v1/demos/muzero_planning/agent_muzero_entrypoint.py
@@ -10,18 +10,35 @@ but trimmed to <300 LoC for pedagogy.
 """
 
 import os
+import sys
 from typing import Any
 
 # Optional Google ADK gateway for Agent-to-Agent federation
 try:
     from alpha_factory_v1.backend import adk_bridge
+
+    if not getattr(adk_bridge, "_ADK_OK", True):
+        print(
+            "Google ADK not installed. Install with: pip install google-adk \n"
+            "and set ALPHA_FACTORY_ENABLE_ADK=true to enable the gateway.",
+            file=sys.stderr,
+        )
 except Exception:  # pragma: no cover - optional dependency
     adk_bridge = None
+    print(
+        "Google ADK integration unavailable. Install with: pip install google-adk "
+        "and set ALPHA_FACTORY_ENABLE_ADK=true to enable the gateway.",
+        file=sys.stderr,
+    )
 
 
 try:  # OpenAI Agents SDK is optional
     from agents import Agent, AgentRuntime, Tool, OpenAIAgent
 except Exception:  # pragma: no cover - provide graceful degrade
+    print(
+        "OpenAI Agents SDK not installed. Install with: pip install openai-agents",
+        file=sys.stderr,
+    )
 
     class OpenAIAgent:
         def __init__(self, *_, **__):
@@ -58,6 +75,7 @@ try:
 
     _HAVE_GRADIO = True
 except ModuleNotFoundError:  # pragma: no cover - allow CLI help without gradio
+    print("Gradio not installed. Install with: pip install gradio", file=sys.stderr)
 
     class _MissingGradio:
         def __getattr__(self, name: str):  # noqa: D401


### PR DESCRIPTION
## Summary
- warn when optional dependencies aren't installed
- describe optional packages in the README

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 70 failed, 201 passed, 28 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6842648c5e588333b3046b1909a71bcf