### PR TITLE
[alpha_factory] warn when node missing for PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,15 @@ Follow these steps when working without internet access.
    export LLAMA_MODEL_PATH=~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf
    ```
 
-4. **Fetch and build the browser assets** to run the Insight demo fully offline:
+4. **Fetch and build the browser assets** (requires **Node.js**) to run the Insight demo fully offline:
    ```bash
    cd alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
    python ../../../scripts/fetch_assets.py
    npm ci
    npm run build
    ```
+   Skipping this step or running without Node.js prevents the service worker
+   from being generated, so offline functionality is limited.
 5. **Skip browser downloads** when running the web demo tests offline:
    ```bash
    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -45,14 +45,16 @@ injectManifest({{
         subprocess.run(["node", "-e", node_script], check=True)
     except FileNotFoundError:
         print(
-            "[manual_build] node not found; skipping service worker generation",
+            "[manual_build] node not found; service worker not generated – offline features disabled",
             file=sys.stderr,
         )
+        return
     except subprocess.CalledProcessError as exc:
         print(
             f"[manual_build] workbox build failed: {exc}; offline features disabled",
             file=sys.stderr,
         )
+        return
     finally:
         temp_sw.unlink(missing_ok=True)
     sw_hash = sha384(sw_dest)


### PR DESCRIPTION
## Summary
- print a clearer message and return when service worker generation can't run
- document that building browser assets requires Node.js for offline features

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: environment limitations)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py README.md` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684264b7e1e083338aec8f5489a94570