### PR TITLE
[alpha_factory] fix env check path in guide

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -10,7 +10,7 @@ This short guide distils the steps required to run the **AI‑GA Meta‑Evolutio
    - Verify all Python packages are available:
      Run the following command from the project root directory:
      ```bash
-     AUTO_INSTALL_MISSING=1 python alpha_factory_v1/check_env.py
+    AUTO_INSTALL_MISSING=1 python check_env.py
      ```
      This attempts to install `openai-agents`, `google-adk` and other required
      packages if they are missing. Offline environments can point the script to


### PR DESCRIPTION
## Summary
- fix path to `check_env.py` in the AI-GA Meta-Evolution production guide

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 25 failed, 4 passed, 17 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68426870826c83339ce4846e1c0649e6