### PR TITLE
[alpha_factory] refresh PWA on update

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -56,6 +56,8 @@ The build script reads `.env` automatically and injects the values into
 Set it in `localStorage` or provide it at runtime when prompted.
 It also copies `dist/sw.js` to `dist/service-worker.js` which `index.html`
 registers for offline support.
+After rebuilding the demo, the service worker automatically skips the waiting
+phase and reloads the page so users always run the latest version.
 The unbuilt `index.html` falls back to `'self'` for the IPFS and telemetry
 origins, but running `npm run build` (or `python manual_build.py`) replaces
 these defaults with the real values from `.env`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -63,7 +63,31 @@
         window.addEventListener('load', () => {
           navigator.serviceWorker
             .register('service-worker.js')
-            .catch(() => toast('Service worker registration failed; offline mode disabled.'));
+            .then((registration) => {
+              navigator.serviceWorker.ready.then(() => {
+                registration.addEventListener('updatefound', () => {
+                  const newWorker = registration.installing;
+                  if (!newWorker) return;
+                  newWorker.addEventListener('statechange', () => {
+                    if (
+                      newWorker.state === 'installed' &&
+                      navigator.serviceWorker.controller
+                    ) {
+                      newWorker.postMessage({ type: 'SKIP_WAITING' });
+                      toast('Update available. Refreshing…');
+                      navigator.serviceWorker.addEventListener(
+                        'controllerchange',
+                        () => location.reload(),
+                        { once: true },
+                      );
+                    }
+                  });
+                });
+              });
+            })
+            .catch(() =>
+              toast('Service worker registration failed; offline mode disabled.'),
+            );
         });
       }
     </script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -38,5 +38,6 @@ run([
   'pytest',
   '../../../../tests/test_quickstart_offline.py',
   '../../../../tests/test_evolution_panel_reload.py',
-  '../../../../tests/test_sw_offline_reload.py'
+  '../../../../tests/test_sw_offline_reload.py',
+  '../../../../tests/test_pwa_update_reload.py'
 ]);

--- a/tests/test_pwa_update_reload.py
+++ b/tests/test_pwa_update_reload.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify a new build reloads the Insight demo."""
+
+import http.server
+import threading
+import subprocess
+from functools import partial
+from pathlib import Path
+import shutil
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
+
+
+def _start_server(directory: Path):
+    handler = partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    server = http.server.ThreadingHTTPServer(("localhost", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+@pytest.mark.skipif(not shutil.which("npm"), reason="npm not installed")  # type: ignore[misc]
+def test_update_triggers_reload(tmp_path: Path) -> None:
+    repo = Path(__file__).resolve().parents[1] / (
+        "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+    )
+    subprocess.check_call(["npm", "run", "build"], cwd=repo)
+
+    dist = repo / "dist"
+    server, thread = _start_server(dist)
+    host, port = server.server_address
+    url = f"http://{host}:{port}/index.html"
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            page = context.new_page()
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            page.wait_for_function("navigator.serviceWorker.ready")
+            page.evaluate("window.__loadCount = (window.__loadCount || 0) + 1")
+
+            # rebuild to create a new service worker
+            subprocess.check_call(["npm", "run", "build"], cwd=repo)
+            page.evaluate("navigator.serviceWorker.getRegistration().then(r => r.update())")
+            page.wait_for_function(
+                "document.getElementById('toast').textContent.includes('Refreshing')"
+            )
+            page.wait_for_function("performance.getEntriesByType('navigation').length > 1")
+            assert page.evaluate("performance.getEntriesByType('navigation').length") >= 2
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- send SKIP_WAITING to new service worker and refresh when it activates
- document auto updates for the Insight Browser
- run new reload test via npm test

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Playwright browsers not installed)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs tests/test_pwa_update_reload.py` *(fails: environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_6842698f039883339c6438b0eeebc96a