### PR TITLE
[alpha_factory] mention ADK auth token

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -123,6 +123,13 @@ orchestrate evolution remotely.
 Set `ALPHA_FACTORY_ENABLE_ADK=1` in `config.env` to auto-start the gateway
 when running `./run_aiga_demo.sh`.
 
+Define `ALPHA_FACTORY_ADK_TOKEN` to require this token on every ADK request:
+
+```env
+ALPHA_FACTORY_ENABLE_ADK=1
+ALPHA_FACTORY_ADK_TOKEN="my_secret_token"
+```
+
 ## 🔐 API authentication
 
 Export `AUTH_BEARER_TOKEN` to require a static token on every API request. For


### PR DESCRIPTION
## Summary
- clarify ADK gateway authentication in the AI-GA meta evolution demo

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: BrowserType.launch executable doesn't exist)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/README.md` *(fails: KeyboardInterrupt during semgrep environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68426dd8b8ac8333800305cc9b50f962