### PR TITLE
[alpha_factory] add aiga service e2e test

### DIFF
--- a/tests/test_aiga_service_e2e.py
+++ b/tests/test_aiga_service_e2e.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end test for the aiga_meta_evolution service."""
+import os
+import subprocess
+import sys
+import time
+import requests
+import pytest
+
+ENTRYPOINT = "alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py"
+
+
+@pytest.mark.e2e
+def test_aiga_service_health() -> None:
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = ""
+    env.setdefault("API_PORT", "8000")
+
+    proc = subprocess.Popen([sys.executable, ENTRYPOINT], env=env)
+    try:
+        url = "http://localhost:8000/health"
+        resp = None
+        for _ in range(100):
+            try:
+                r = requests.get(url, timeout=2)
+                if r.status_code == 200:
+                    resp = r
+                    break
+            except Exception:
+                pass
+            time.sleep(0.1)
+        assert resp is not None, "service did not start"
+        data = resp.json()
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+    assert "status" in data
+    assert "generations" in data
+    assert "best_fitness" in data


### PR DESCRIPTION
## Summary
- add a new end-to-end test for `agent_aiga_entrypoint.py`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 69 failed, 196 passed, 28 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6842702143dc83338e3795ef9fa075f8