### PR TITLE
[alpha_factory] verify service worker integrity

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -66,10 +66,7 @@ export async function generateServiceWorker(outDir, manifest, version) {
   const indexPath = path.join(outDir, 'index.html');
   let indexText = await fs.readFile(indexPath, 'utf8');
   indexText = indexText.replace(".register('sw.js')", ".register('service-worker.js')");
-  indexText = indexText.replace(
-    '</body>',
-    `<script src="service-worker.js" integrity="sha384-${swHash}" crossorigin="anonymous"></script>\n</body>`
-  );
+  indexText = indexText.replace('__SW_HASH__', `sha384-${swHash}`);
   indexText = indexText.replace(
     /(script-src 'self' 'wasm-unsafe-eval')/,
     `$1 'sha384-${swHash}'`

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -25,7 +25,10 @@ def check_gzip_size(path: Path, max_bytes: int = 2 * 1024 * 1024) -> None:
         sys.exit(f"gzip size {len(compressed)} bytes exceeds limit")
 
 
-def generate_service_worker(root: Path, dist_dir: Path, manifest: dict) -> None:
+from typing import Any
+
+
+def generate_service_worker(root: Path, dist_dir: Path, manifest: dict[str, Any]) -> None:
     """Create ``sw.js`` using workbox and inject it into ``index.html``."""
     sw_src = root / "sw.js"
     sw_dest = dist_dir / "sw.js"
@@ -61,9 +64,6 @@ injectManifest({{
     index_path = dist_dir / "index.html"
     text = index_path.read_text()
     text = text.replace(".register('sw.js')", ".register('service-worker.js')")
-    text = text.replace(
-        "</body>",
-        f'<script src="service-worker.js" integrity="{sw_hash}" crossorigin="anonymous"></script>\n</body>',
-    )
+    text = text.replace("__SW_HASH__", sw_hash)
     text = re.sub(r"(script-src 'self' 'wasm-unsafe-eval')", rf"\1 '{sw_hash}'", text)
     index_path.write_text(text)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -42,7 +42,8 @@
     "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
     "pyodide.js": "sha384-okMTEZ8ZyBqYdx16cV0ouuwwg/XsRvqpTMEVld4H1PCCCZ0WfHuAfpGY61KFM8Uc",
     "pyodide_py.tar": "sha384-rPiQj50jWaYANJhJndPDROq8z252DlRmXhzjVa9sDOeMJlrKZ5DIWRLd6UrnhZau",
-    "packages.json": "sha384-aa2pOjyGkOWdUDx78GrRC8Bk/k2+/qhHRXOGWfm1YaqwUgpoOJCIr2yCuLRVoEm7"
+    "packages.json": "sha384-aa2pOjyGkOWdUDx78GrRC8Bk/k2+/qhHRXOGWfm1YaqwUgpoOJCIr2yCuLRVoEm7",
+    "service-worker.js": "sha384-o4otzwjbNKzpYYcqiTHOYyd9asjheSu1P8UVzmVl3HU8cvmE86GWhOgWUjkJ6gXT"
   },
   "quickstart_pdf": "docs/insight_browser_quickstart.pdf"
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist/index.html
@@ -52,16 +52,28 @@
         <p>Run <code>node tests/run.mjs --offline</code> to confirm the build works without network access.</p>
       </section>
       <script>
+        const SW_URL = 'service-worker.js';
+        const SW_HASH = 'sha384-o4otzwjbNKzpYYcqiTHOYyd9asjheSu1P8UVzmVl3HU8cvmE86GWhOgWUjkJ6gXT';
         if ('serviceWorker' in navigator) {
-          window.addEventListener('load', () => {
-            navigator.serviceWorker
-              .register('service-worker.js')
-            .catch(() => toast('Service worker registration failed; offline mode disabled.'));
-        });
-      }
-    </script>
+          window.addEventListener('load', async () => {
+            try {
+              const res = await fetch(SW_URL);
+              const buf = await res.arrayBuffer();
+              const digest = await crypto.subtle.digest('SHA-384', buf);
+              const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+              if (`sha384-${b64}` !== SW_HASH) {
+                throw new Error('Service worker hash mismatch');
+              }
+              navigator.serviceWorker
+                .register(SW_URL)
+                .catch(() => toast('Service worker registration failed; offline mode disabled.'));
+            } catch {
+              toast('Service worker registration failed; offline mode disabled.');
+            }
+          });
+        }
+      </script>
     <script type="module" src="insight.bundle.js" integrity="sha384-Ncy+MhWgRJkawvIEODZrYnn88OwB4Xkn87PI44g280p2BhU0AVEe7k8s7ZQFCrxi" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('aHR0cHM6Ly9pcGZzLmlvL2lwZnM=');</script>
-<script src="service-worker.js" integrity="sha384-o4otzwjbNKzpYYcqiTHOYyd9asjheSu1P8UVzmVl3HU8cvmE86GWhOgWUjkJ6gXT" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -59,35 +59,48 @@
       crossorigin="anonymous"
     ></script>
     <script>
+      const SW_URL = 'service-worker.js';
+      const SW_HASH = '__SW_HASH__';
       if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker
-            .register('service-worker.js')
-            .then((registration) => {
-              navigator.serviceWorker.ready.then(() => {
-                registration.addEventListener('updatefound', () => {
-                  const newWorker = registration.installing;
-                  if (!newWorker) return;
-                  newWorker.addEventListener('statechange', () => {
-                    if (
-                      newWorker.state === 'installed' &&
-                      navigator.serviceWorker.controller
-                    ) {
-                      newWorker.postMessage({ type: 'SKIP_WAITING' });
-                      toast('Update available. Refreshing…');
-                      navigator.serviceWorker.addEventListener(
-                        'controllerchange',
-                        () => location.reload(),
-                        { once: true },
-                      );
-                    }
+        window.addEventListener('load', async () => {
+          try {
+            const res = await fetch(SW_URL);
+            const buf = await res.arrayBuffer();
+            const digest = await crypto.subtle.digest('SHA-384', buf);
+            const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+            if (`sha384-${b64}` !== SW_HASH) {
+              throw new Error('Service worker hash mismatch');
+            }
+            navigator.serviceWorker
+              .register(SW_URL)
+              .then((registration) => {
+                navigator.serviceWorker.ready.then(() => {
+                  registration.addEventListener('updatefound', () => {
+                    const newWorker = registration.installing;
+                    if (!newWorker) return;
+                    newWorker.addEventListener('statechange', () => {
+                      if (
+                        newWorker.state === 'installed' &&
+                        navigator.serviceWorker.controller
+                      ) {
+                        newWorker.postMessage({ type: 'SKIP_WAITING' });
+                        toast('Update available. Refreshing…');
+                        navigator.serviceWorker.addEventListener(
+                          'controllerchange',
+                          () => location.reload(),
+                          { once: true },
+                        );
+                      }
+                    });
                   });
                 });
-              });
-            })
-            .catch(() =>
-              toast('Service worker registration failed; offline mode disabled.'),
-            );
+              })
+              .catch(() =>
+                toast('Service worker registration failed; offline mode disabled.'),
+              );
+          } catch {
+            toast('Service worker registration failed; offline mode disabled.');
+          }
         });
       }
     </script>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_service_worker_present.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_service_worker_present.py
@@ -1,7 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Ensure the built demo includes service-worker.js."""
+"""Ensure the service worker registers without a script tag."""
 from pathlib import Path
 
-def test_service_worker_exists() -> None:
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def test_service_worker_registers() -> None:
     dist = Path(__file__).resolve().parents[1] / "dist"
+    html = dist / "index.html"
     assert (dist / "service-worker.js").is_file()
+    assert '<script src="service-worker.js"' not in html.read_text()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(html.as_uri())
+        page.wait_for_selector("#controls")
+        page.wait_for_function(
+            "navigator.serviceWorker && (navigator.serviceWorker.controller || navigator.serviceWorker.ready)"
+        )
+        browser.close()


### PR DESCRIPTION
## Summary
- avoid injecting the service worker script
- register the worker after verifying its SHA-384 hash
- keep CSP hash updates and propagate the hash from build scripts
- adjust tests for the new registration logic

## Testing
- `pre-commit run --files build/common.js build/common.py build_assets.json dist/index.html index.html tests/test_service_worker_present.py` *(skipped proto and requirements checks)*
- `pytest -q` *(fails: 38 failed, 15 passed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68426e648b808333977d73b30a6f2cb1