### PR TITLE
[alpha_factory] test for browser console errors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -36,6 +36,7 @@ run(['node', '--loader', 'ts-node/register', '--test',
 ]);
 run([
   'pytest',
+  'tests/test_no_console_errors.py',
   '../../../../tests/test_quickstart_offline.py',
   '../../../../tests/test_evolution_panel_reload.py',
   '../../../../tests/test_sw_offline_reload.py',

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_no_console_errors.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_no_console_errors.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure no console errors occur when loading the demo."""
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
+
+
+def test_no_console_errors() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            errors: list[str] = []
+            page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            assert not errors, f"Console errors: {errors}"
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- add a Playwright test that fails on browser console errors
- run that test from `run.mjs`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 66 failed, 167 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842de261ab083338cffeeb7d7264fb0