### PR TITLE
[alpha_factory] compute impact score via LLM

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -108,3 +108,18 @@ test('prune ranks by score and novelty', async () => {
   const seeds = runs.map((r) => r.seed).sort();
   expect(seeds).toEqual([1, 3]);
 });
+
+jest.mock('../src/utils/llm.ts', () => ({
+  chat: jest.fn(() => Promise.resolve('5')),
+}));
+const { chat } = require('../src/utils/llm.ts');
+
+test('add calls chat when api key set and stores impact score', async () => {
+  global.localStorage = { getItem: () => 'k' };
+  const a = new Archive('jest');
+  await a.open();
+  await a.add(9, {}, [{ logic: 1, feasible: 1 }]);
+  expect(chat).toHaveBeenCalled();
+  const runs = await a.list();
+  expect(runs[0].impactScore).toBeCloseTo(runs[0].score + 5);
+});


### PR DESCRIPTION
## Summary
- detect OPENAI_API_KEY when adding runs
- use chat() to estimate economic impact and store `impactScore`
- weight parent selection by `impactScore`
- test that add() calls chat() when API key is present

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(failed: KeyboardInterrupt)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842e96067248333a75a8e0ef8a44eb8