### PR TITLE
[alpha_factory] support agents fallback

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -101,7 +101,8 @@ Expose the evolver to the **OpenAI Agents SDK** runtime:
 python alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
 ```
 
-Requires the `openai-agents` package (installed via requirements).
+Requires the `openai-agents` package (installed via requirements). When only
+the newer `agents` package is available, the bridge falls back automatically.
 
 The bridge registers an `aiga_evolver` agent exposing four tools:
 `evolve` (run N generations), `best_alpha` (return the champion),

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -12,13 +12,12 @@ import os
 
 try:  # optional dependency
     from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
-except ImportError as exc:  # pragma: no cover - missing package
-    raise SystemExit(
-        "openai_agents package is required. Install with `pip install openai-agents`"
-    ) from exc
+except ImportError:  # pragma: no cover - fallback for legacy package
+    from agents import Agent, AgentRuntime, OpenAIAgent, Tool  # type: ignore
 
 try:
     from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+
     ADK_AVAILABLE = True
 except Exception:  # pragma: no cover - optional
     ADK_AVAILABLE = False

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -1,43 +1,97 @@
 # SPDX-License-Identifier: Apache-2.0
+import builtins
+import importlib
 import py_compile
+import sys
+import types
 import unittest
 from pathlib import Path
+
 
 class TestOpenAIBridge(unittest.TestCase):
     def test_asi_bridge_compiles(self):
         """Ensure the ASI demo bridge compiles."""
-        path = Path('alpha_factory_v1/demos/alpha_asi_world_model/openai_agents_bridge.py')
+        path = Path("alpha_factory_v1/demos/alpha_asi_world_model/openai_agents_bridge.py")
         py_compile.compile(path, doraise=True)
 
     def test_meta_bridge_compiles(self):
         """Ensure the meta-agentic demo bridge compiles."""
-        path = Path('alpha_factory_v1/demos/meta_agentic_agi/openai_agents_bridge.py')
+        path = Path("alpha_factory_v1/demos/meta_agentic_agi/openai_agents_bridge.py")
         py_compile.compile(path, doraise=True)
 
     def test_business_bridge_compiles(self):
         """Ensure the business demo bridge compiles."""
-        path = Path('alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py')
+        path = Path("alpha_factory_v1/demos/alpha_agi_business_v1/openai_agents_bridge.py")
         py_compile.compile(path, doraise=True)
 
     def test_aiga_bridge_compiles(self):
         """Ensure the AI-GA demo bridge compiles."""
-        path = Path('alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py')
+        path = Path("alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py")
         py_compile.compile(path, doraise=True)
 
     def test_cross_industry_bridge_compiles(self):
         """Ensure the cross-industry demo bridge compiles."""
-        path = Path('alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py')
+        path = Path("alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py")
         py_compile.compile(path, doraise=True)
 
     def test_mats_bridge_compiles(self):
         """Ensure the MATS demo bridge compiles."""
-        path = Path('alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py')
+        path = Path("alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py")
         py_compile.compile(path, doraise=True)
 
     def test_insight_bridge_compiles(self):
         """Ensure the α‑AGI Insight demo bridge compiles."""
-        path = Path('alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py')
+        path = Path("alpha_factory_v1/demos/alpha_agi_insight_v0/openai_agents_bridge.py")
         py_compile.compile(path, doraise=True)
 
-if __name__ == '__main__':
+    def test_aiga_bridge_import_paths(self, monkeypatch):
+        """Import the AI‑GA bridge with both `openai_agents` and `agents`."""
+
+        stub = types.ModuleType("openai_agents")
+        stub.Agent = object
+        stub.AgentRuntime = object
+        stub.OpenAIAgent = object
+
+        def _tool(*_a, **_k):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+        stub.Tool = _tool
+
+        # Import using openai_agents module
+        monkeypatch.setitem(sys.modules, "openai_agents", stub)
+        sys.modules.pop("agents", None)
+        mod = importlib.reload(
+            importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.openai_agents_bridge")
+        )
+        self.assertIs(mod.Agent, stub.Agent)
+
+        # Import using agents fallback
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        sys.modules.pop("openai_agents", None)
+
+        stub_agents = types.ModuleType("agents")
+        stub_agents.Agent = object
+        stub_agents.AgentRuntime = object
+        stub_agents.OpenAIAgent = object
+        stub_agents.Tool = _tool
+        monkeypatch.setitem(sys.modules, "agents", stub_agents)
+
+        orig_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "openai_agents":
+                raise ModuleNotFoundError(name)
+            return orig_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        mod = importlib.reload(
+            importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.openai_agents_bridge")
+        )
+        self.assertIs(mod.Agent, stub_agents.Agent)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fall back to the `agents` package when `openai_agents` is missing
- note the compatibility import in the meta-evolution demo docs
- test the bridge using both import paths

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py alpha_factory_v1/demos/aiga_meta_evolution/README.md tests/test_openai_bridge.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 73 failed, 204 passed, 32 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6842e930cb94833386014e867d879805