### PR TITLE
[alpha_factory] support openai agents module alias

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -148,22 +148,29 @@ def check_network(host: str = "pypi.org", timeout: float = 2.0) -> bool:
 
 
 def check_openai_agents_version(min_version: str = "0.0.14") -> bool:
-    """Verify ``openai_agents`` is new enough when installed."""
+    """Verify the installed Agents runtime is new enough.
+
+    This checks both the ``openai_agents`` and ``agents`` packages.
+    """
     import importlib
 
-    spec = importlib.util.find_spec("openai_agents")
-    if spec is None:  # not installed
-        return True
+    module_name = "openai_agents"
+    spec = importlib.util.find_spec(module_name)
+    if spec is None:
+        module_name = "agents"
+        spec = importlib.util.find_spec(module_name)
+        if spec is None:  # not installed
+            return True
 
-    mod = importlib.import_module("openai_agents")
+    mod = importlib.import_module(module_name)
     version = getattr(mod, "__version__", "0")
     if _version_lt(version, min_version):
         banner(
-            f"openai_agents {version} detected; >={min_version} required",
+            f"{module_name} {version} detected; >={min_version} required",
             "RED",
         )
         return False
-    banner(f"openai_agents {version} detected", "GREEN")
+    banner(f"{module_name} {version} detected", "GREEN")
     return True
 
 

--- a/tests/test_preflight_openai_agents_version.py
+++ b/tests/test_preflight_openai_agents_version.py
@@ -9,47 +9,38 @@ from alpha_factory_v1.scripts import preflight
 
 
 class TestPreflightOpenAIAgentsVersion(unittest.TestCase):
-    def test_old_version_fails(self) -> None:
-        fake_mod = types.SimpleNamespace(__version__="0.0.13")
+    def _run_check(self, module_name: str, version: str) -> bool:
+        fake_mod = types.SimpleNamespace(__version__=version)
         orig_import_module = importlib.import_module
         orig_find_spec = importlib.util.find_spec
 
         def _fake_import(name: str, *args: Any, **kwargs: Any) -> object:
-            if name == "openai_agents":
+            if name == module_name:
                 return fake_mod
             return orig_import_module(name, *args, **kwargs)
 
         def _fake_find_spec(name: str, *args: Any, **kwargs: Any) -> object:
-            if name == "openai_agents":
+            if name == module_name:
                 return object()
+            if name in {"openai_agents", "agents"}:
+                return None
             return orig_find_spec(name, *args, **kwargs)
 
         with (
             mock.patch("importlib.import_module", side_effect=_fake_import),
             mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
         ):
-            self.assertFalse(preflight.check_openai_agents_version())
+            return preflight.check_openai_agents_version()
+
+    def test_old_version_fails(self) -> None:
+        for name in ("openai_agents", "agents"):
+            with self.subTest(module=name):
+                self.assertFalse(self._run_check(name, "0.0.13"))
 
     def test_new_version_ok(self) -> None:
-        fake_mod = types.SimpleNamespace(__version__="0.0.15")
-        orig_import_module = importlib.import_module
-        orig_find_spec = importlib.util.find_spec
-
-        def _fake_import(name: str, *args: Any, **kwargs: Any) -> object:
-            if name == "openai_agents":
-                return fake_mod
-            return orig_import_module(name, *args, **kwargs)
-
-        def _fake_find_spec(name: str, *args: Any, **kwargs: Any) -> object:
-            if name == "openai_agents":
-                return object()
-            return orig_find_spec(name, *args, **kwargs)
-
-        with (
-            mock.patch("importlib.import_module", side_effect=_fake_import),
-            mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
-        ):
-            self.assertTrue(preflight.check_openai_agents_version())
+        for name in ("openai_agents", "agents"):
+            with self.subTest(module=name):
+                self.assertTrue(self._run_check(name, "0.0.15"))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- update `check_openai_agents_version` to check `openai_agents` then `agents`
- extend preflight tests for both module names

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_archive_quota_toast, test_assets_replaced, test_slider_updates_hash_and_restarts)*
- `pre-commit run --files alpha_factory_v1/scripts/preflight.py tests/test_preflight_openai_agents_version.py` *(failed due to environment initialization)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1386ac08333a15a3ebc72511f46