### PR TITLE
[alpha_factory] document OpenAI Agents install

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -15,6 +15,13 @@ This short guide distils the steps required to run the **AI‑GA Meta‑Evolutio
      This attempts to install `openai-agents`, `google-adk` and other required
      packages if they are missing. Offline environments can point the script to
      a wheelhouse via `WHEELHOUSE=/path/to/wheels`.
+   - Install the OpenAI Agents SDK if not already present:
+     ```bash
+     pip install openai-agents
+     ```
+     Some distributions package it as the simpler `agents` module; the demo
+     detects both. If `import openai_agents` fails, reinstall the SDK and
+     confirm your virtual environment is active.
 
 2. **Launch the service**
    - Using Docker:

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -93,6 +93,18 @@ python -m alpha_factory_v1.demos.aiga_meta_evolution --help
 Set `OPENAI_API_KEY` in your environment to enable cloud models. Without
 it the demo falls back to the bundled offline mixtral model.
 
+### Installing the OpenAI Agents SDK
+
+The optional OpenAI Agents bridge relies on this package.
+
+```bash
+pip install openai-agents
+```
+
+Some distributions ship it as the simpler `agents` module; the
+demo auto-detects both. If you see `ModuleNotFoundError: openai_agents`,
+reinstall the SDK in the active virtual environment.
+
 ### 🤖 OpenAI Agents bridge
 
 Expose the evolver to the **OpenAI Agents SDK** runtime:


### PR DESCRIPTION
## Summary
- document how to install the OpenAI Agents SDK in the meta-evolution demo
- note that some distros expose `agents` instead of `openai_agents`
- show troubleshooting advice for missing imports

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_service_worker_registration_failure_toast, test_pyodide_fallback, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6842f57bf8c4833392a2210e013e493c