### PR TITLE
[alpha_factory] update SW hash comments

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -56,6 +56,10 @@ The build script reads `.env` automatically and injects the values into
 Set it in `localStorage` or provide it at runtime when prompted.
 It also copies `dist/sw.js` to `dist/service-worker.js` which `index.html`
 registers for offline support.
+`npm run build` (or `python manual_build.py`) also replaces the
+`__SW_HASH__` placeholder in `index.html` with the SHA-384 digest of
+`service-worker.js` so the browser can verify the script before
+registration.
 After rebuilding the demo, the service worker automatically skips the waiting
 phase and reloads the page so users always run the latest version.
 The unbuilt `index.html` falls back to `'self'` for the IPFS and telemetry

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -61,6 +61,8 @@
     <script>
       const SW_URL = 'service-worker.js';
       const SW_HASH = '__SW_HASH__';
+      // Replaced with the SHA-384 digest of service-worker.js during
+      // `npm run build` (or `python manual_build.py`)
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', async () => {
           try {


### PR DESCRIPTION
## Summary
- clarify SW_HASH replacement in the browser demo
- document SW_HASH handling in insight_browser_v1 README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: Missing dependency "esbuild" and Playwright browsers)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: semgrep environment initialization interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6842efa4c46c83339e7b2737091ce875