### PR TITLE
[alpha_factory] Improve toolbar accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ Run `pre-commit run --all-files` once after the setup script to confirm
 everything is formatted correctly. These commands mirror the steps in
 [AGENTS.md](AGENTS.md) and keep commits consistent.
 
+When editing the web UI, preserve existing ARIA labels so the interface
+remains accessible.
+
 ### Development Setup
 Install the Python dependencies with the helper script:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="#quickstart">Quick-start</a> •
+  <a href="#quickstart" aria-label="Jump to quickstart">Quick-start</a> •
   <a href="#architecture">Architecture</a> •
   <a href="#cli-usage">CLI</a> •
   <a href="#web-ui">Web UI</a> •

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -301,12 +301,16 @@ window.addEventListener('DOMContentLoaded',async()=>{
   const tb=document.getElementById("toolbar");
   const csvBtn=document.createElement("button");
   csvBtn.textContent=t('csv');
+  csvBtn.setAttribute('aria-label','Export CSV');
   const pngBtn=document.createElement("button");
   pngBtn.textContent=t('png');
+  pngBtn.setAttribute('aria-label','Download PNG');
   const shareBtn=document.createElement("button");
   shareBtn.textContent=t('share');
+  shareBtn.setAttribute('aria-label','Share simulation');
   const themeBtn=document.createElement("button");
   themeBtn.textContent=t('theme');
+  themeBtn.setAttribute('aria-label','Toggle theme');
   tb.appendChild(csvBtn);
   tb.appendChild(pngBtn);
   tb.appendChild(shareBtn);


### PR DESCRIPTION
## Summary
- add ARIA labels to toolbar buttons in the insight browser
- label the Quick-start link in the Insight README
- remind contributors to keep ARIA labels when editing the UI

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 38 failed, 10 passed, 19 skipped)*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js` *(failed: environment setup interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6842fdbbd16883338271ee287082a331