### PR TITLE
[alpha_factory] gate debug globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,8 @@ Build the PWA and open `dist/index.html` to run the demo locally.
 The quick-start guide `docs/insight_browser_quickstart.pdf` is copied to
 `dist/insight_browser_quickstart.pdf` during the build so it is available
 alongside the compiled assets.
+Set `window.DEBUG = true` before loading the page to expose debugging helpers
+such as `window.pop`.
 
 For evolutionary experiments you can run the optional
 [evolution worker](docs/DESIGN.md#evolution-worker) container and POST a tarball

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -34,6 +34,8 @@ Copy [`.env.sample`](.env.sample) to `.env` then review the variables:
 - `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
 - Browsers with WebGPU can accelerate the local model using the ONNX runtime.
   Use the GPU toggle in the power panel to switch between WebGPU and WASM.
+- Set `window.DEBUG = true` before loading the page to expose debugging helpers
+  like `window.pop` and `window.coldZone`.
 
 See [`.env.sample`](.env.sample) for the full list of supported variables.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/global.d.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/global.d.ts
@@ -9,6 +9,7 @@ declare global {
     OTEL_ENDPOINT?: string;
     IPFS_GATEWAY?: string;
     USE_GPU?: boolean;
+    DEBUG?: boolean;
     pop?: import('./state/serializer').Individual[];
     coldZone?: unknown;
     recordedPrompts?: string[];

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
@@ -99,7 +99,9 @@ export async function initSimulatorPanel(
     if (!f) return;
     pop = f.population;
     gen = f.gen;
-    window.pop = pop;
+    if (window.DEBUG) {
+      window.pop = pop;
+    }
     const target = 'node' in view ? view.node() : view;
     renderFrontier(target as unknown as HTMLElement, pop, (d, el) =>
       selectPoint(d, el as unknown as HTMLElement)
@@ -150,8 +152,10 @@ export async function initSimulatorPanel(
       });
       frameIds.push(fid);
       count = g.gen;
-      window.pop = g.population;
-      if (g.population[0] && g.population[0].umap) {
+      if (window.DEBUG) {
+        window.pop = g.population;
+      }
+      if (window.DEBUG && g.population[0] && g.population[0].umap) {
         const pts = g.population.map((p: Individual) => p.umap);
         window.coldZone = detectColdZone(pts);
       }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py
@@ -18,6 +18,7 @@ def test_offline_pwa_and_share() -> None:
         browser = p.chromium.launch()
         context = browser.new_context()
         page = context.new_page()
+        page.add_init_script("window.DEBUG = true")
 
         def ipfs_handler(route):
             route.fulfill(
@@ -87,6 +88,7 @@ def test_service_worker_registration_failure_toast() -> None:
     with sync_playwright() as p:
         browser = p.chromium.launch()
         page = browser.new_page()
+        page.add_init_script("window.DEBUG = true")
         page.add_init_script(
             "navigator.serviceWorker.register = () => Promise.reject('fail')"
         )

--- a/tests/test_umap_fallback.py
+++ b/tests/test_umap_fallback.py
@@ -30,6 +30,7 @@ def test_umap_fallback_random_coordinates() -> None:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page()
+            page.add_init_script("window.DEBUG = true")
             page.route("**/pyodide.js", lambda route: route.abort())
             page.goto(url)
             page.wait_for_selector("#controls")


### PR DESCRIPTION
## Summary
- expose browser debug globals only when `window.DEBUG` is true
- document the new flag in both READMEs
- update tests to enable `window.DEBUG`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 17 failed, 3 passed, 14 skipped)*
- `grep -R "window.pop" alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist | head -n 5`
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/global.d.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_pwa_offline.py tests/test_umap_fallback.py` *(fails: environment setup interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68430484cfe08333a958948ddac0f1f3