### PR TITLE
[alpha_factory] add shared env validation

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -10,6 +10,7 @@ import { createRequire } from 'module';
 import { copyAssets, checkGzipSize, generateServiceWorker } from './build/common.js';
 import { injectEnv } from './build/env_inject.js';
 import { requireNode20 } from './build/version_check.js';
+import { validateEnv } from './build/env_validate.js';
 
 const manifest = JSON.parse(
   fsSync.readFileSync(new URL('./build_assets.json', import.meta.url), 'utf8')
@@ -43,27 +44,9 @@ const { Web3Storage, File } = await import('web3.storage');
 const dotenv = (await import('dotenv')).default;
 dotenv.config();
 
-function validateEnv() {
-  for (const key of ['PINNER_TOKEN', 'WEB3_STORAGE_TOKEN']) {
-    const val = process.env[key];
-    if (val !== undefined && !val.trim()) {
-      throw new Error(`${key} may not be empty`);
-    }
-  }
-  for (const key of ['IPFS_GATEWAY', 'OTEL_ENDPOINT']) {
-    const val = process.env[key];
-    if (val) {
-      try {
-        new URL(val);
-      } catch {
-        throw new Error(`Invalid URL in ${key}`);
-      }
-    }
-  }
-}
 
 try {
-  validateEnv();
+  validateEnv(process.env);
 } catch (err) {
   console.error(err.message || err);
   process.exit(1);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/env_validate.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/env_validate.js
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { pathToFileURL } from 'url';
+
+export function validateEnv(env) {
+  for (const key of ['PINNER_TOKEN', 'WEB3_STORAGE_TOKEN']) {
+    const val = env[key];
+    if (val !== undefined && !String(val).trim()) {
+      throw new Error(`${key} may not be empty`);
+    }
+  }
+  for (const key of ['IPFS_GATEWAY', 'OTEL_ENDPOINT']) {
+    const val = env[key];
+    if (val) {
+      try {
+        new URL(val);
+      } catch {
+        throw new Error(`Invalid URL in ${key}`);
+      }
+    }
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    validateEnv(process.env);
+  } catch (err) {
+    console.error(err.message || err);
+    process.exit(1);
+  }
+}

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -53,23 +53,15 @@ try:
 except Exception as exc:  # pragma: no cover - optional dep
     print(f"[manual_build] failed to load .env: {exc}", file=sys.stderr)
 
-
-def _validate_env() -> None:
-    """Validate tokens and URLs in the environment."""
-    for key in ("PINNER_TOKEN", "WEB3_STORAGE_TOKEN"):
-        val = os.getenv(key)
-        if val is not None and not val.strip():
-            sys.exit(f"{key} may not be empty")
-
-    for key in ("IPFS_GATEWAY", "OTEL_ENDPOINT"):
-        val = os.getenv(key)
-        if val:
-            p = urlparse(val)
-            if not p.scheme or not p.netloc:
-                sys.exit(f"Invalid URL in {key}")
-
-
-_validate_env()
+try:
+    subprocess.run(
+        ["node", "build/env_validate.js"],
+        cwd=ROOT,
+        check=True,
+        env=os.environ,
+    )
+except subprocess.CalledProcessError as exc:
+    sys.exit(exc.returncode)
 
 
 def copy_assets(

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_validate.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_validate.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "env_var,value,message",
+    [
+        ("PINNER_TOKEN", " ", "PINNER_TOKEN may not be empty"),
+        ("IPFS_GATEWAY", "foo", "Invalid URL in IPFS_GATEWAY"),
+    ],
+)  # type: ignore[misc]
+def test_env_validation_fails(env_var: str, value: str, message: str) -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    script = browser_dir / "build" / "env_validate.js"
+    env = os.environ.copy()
+    env[env_var] = value
+    res = subprocess.run(
+        ["node", str(script)],
+        cwd=browser_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 1
+    assert message in res.stderr


### PR DESCRIPTION
## Summary
- consolidate environment validation logic in new `env_validate.js`
- use the shared function in both the Node and Python build scripts
- unit test environment validation

## Testing
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_validate.py`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/env_validate.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_env_validate.py` *(fails: Makefile:26: *** missing separator.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_6843085e634083338f47efee9395a6a5