### PR TITLE
[alpha_factory] add SPDX headers

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/__init__.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 # Demo package

--- a/alpha_factory_v1/demos/aiga_meta_evolution/__main__.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .start_aiga_demo import main
 
 if __name__ == "__main__":

--- a/alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """curriculum_env.py – Self‑Evolving Grid‑World (v2.0, 2025‑04‑23)
 ============================================================================
 Breaks new ground for Pillar‑3 research by guaranteeing **solvable levels**,

--- a/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
 # © 2025 MONTREAL.AI  Apache-2.0 License
 """MetaEvolver v3.0 (2025‑04‑23)

--- a/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 """Cross-platform launcher for the AI-GA meta-evolution demo.
 


### PR DESCRIPTION
## Summary
- insert Apache-2.0 SPDX line at top of aiga meta evolution demo modules

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 38 failed, 8 passed, 23 skipped)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py alpha_factory_v1/demos/aiga_meta_evolution/__main__.py alpha_factory_v1/demos/aiga_meta_evolution/__init__.py` *(fails to install hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68430fa121e08333a248cb3828a11c65