### PR TITLE
[alpha_factory] Add Node 22 success test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
@@ -10,10 +10,7 @@ import pytest
 def test_requires_node_20() -> None:
     browser_dir = Path(__file__).resolve().parents[1]
     script = browser_dir / "build.js"
-    node_code = (
-        "Object.defineProperty(process.versions,'node',{value:'19.0.0'});"
-        f" import('./{script.name}')"
-    )
+    node_code = "Object.defineProperty(process.versions,'node',{value:'19.0.0'});" f" import('./{script.name}')"
     res = subprocess.run(
         ["node", "-e", node_code],
         cwd=browser_dir,
@@ -24,10 +21,22 @@ def test_requires_node_20() -> None:
     assert "Node.js 20+ is required. Current version: 19.0.0" in res.stderr
 
 
+def test_allows_node_22() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    script = browser_dir / "build.js"
+    node_code = "Object.defineProperty(process.versions,'node',{value:'22.0.0'});" f" import('./{script.name}')"
+    res = subprocess.run(
+        ["node", "-e", node_code],
+        cwd=browser_dir,
+        text=True,
+        capture_output=True,
+    )
+    assert res.returncode == 0, res.stderr
+
+
 def test_requires_python_311() -> None:
     browser_dir = Path(__file__).resolve().parents[1]
     script = browser_dir / "manual_build.py"
     with mock.patch.object(sys, "version_info", (3, 10)):
         with pytest.raises(SystemExit):
             runpy.run_path(script, run_name="__main__")
-


### PR DESCRIPTION
## Summary
- extend the Node version tests to check that build.js runs with Node 22

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 154 failed, 568 passed, 52 skipped)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py` *(fails: mypy and proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_68430fe85c248333bab183c3a7664793