### PR TITLE
[alpha_factory] document pre-commit usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,14 @@ Python must report 3.11 or 3.12 and Docker Compose must be at least 2.5.
   python3 -m venv .venv
   source .venv/bin/activate
   pip install -U pip
+  pip install pre-commit
   ```
   On Windows PowerShell:
   ```powershell
   python -m venv .venv
   .\.venv\Scripts\Activate.ps1
   pip install -U pip
+  pip install pre-commit
   ```
 - The script `alpha_factory_v1/scripts/preflight.py` enforces this requirement.
 - From the repository root, run `./codex/setup.sh` to install the project in editable mode

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ pre-commit run --files <paths>   # before each commit
 Run `pre-commit run --all-files` once after the setup script to confirm
 everything is formatted correctly. These commands mirror the steps in
 [AGENTS.md](AGENTS.md) and keep commits consistent.
+Before opening a pull request, run `pre-commit run --all-files` to ensure
+all hooks succeed.
 
 When editing the web UI, preserve existing ARIA labels so the interface
 remains accessible.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ cryptography
 hypothesis
 grpcio-tools
 pytest-httpx
+pre-commit
 
 PyYAML
 types-PyYAML


### PR DESCRIPTION
## Summary
- list `pre-commit` in requirements-dev.txt
- suggest installing pre-commit when preparing the environment in AGENTS.md
- advise running `pre-commit run --all-files` before submitting a PR in README

## Testing
- `pre-commit run --files AGENTS.md README.md requirements-dev.txt` *(fails: proto-verify)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684316f3f2548333849094e52b2d45c5