### PR TITLE
[alpha_factory] improve check_env and production guides

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -10,11 +10,14 @@ This short guide distils the steps required to run the **AI‑GA Meta‑Evolutio
    - Verify all Python packages are available:
      Run the following command from the project root directory:
      ```bash
-    AUTO_INSTALL_MISSING=1 python check_env.py
+     AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
      ```
      This attempts to install `openai-agents`, `google-adk` and other required
      packages if they are missing. Offline environments can point the script to
-     a wheelhouse via `WHEELHOUSE=/path/to/wheels`.
+     a wheelhouse via `WHEELHOUSE=/path/to/wheels`. **Running this command is
+     mandatory before executing the demos or the unit tests.** The
+     `openai-agents` and `google-adk` packages are optional and only needed when
+     the OpenAI Agents runtime or the ADK gateway is enabled.
    - Install the OpenAI Agents SDK if not already present:
      ```bash
      pip install openai-agents

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -13,9 +13,12 @@ This guide summarises the minimal steps required to run the **Alpha‑AGI Busine
    - For API protection set either `AUTH_BEARER_TOKEN` or `JWT_PUBLIC_KEY`/`JWT_ISSUER`.
    - Validate that all Python packages are available. From the project root run:
      ```bash
-     AUTO_INSTALL_MISSING=1 python check_env.py
+     AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
      ```
-     Provide `WHEELHOUSE=/path/to/wheels` for air‑gapped setups.
+     Provide `WHEELHOUSE=/path/to/wheels` for air‑gapped setups. **Running this
+     command is mandatory before executing the demos or running the test suite.**
+     The `openai-agents` and `google-adk` packages are optional and are only
+     required when using the OpenAI Agents runtime or the Google ADK gateway.
 
 2. **Launch the service**
    - **Docker** (recommended for consistent environments):


### PR DESCRIPTION
## Summary
- ensure `check_env.py` installs baseline requirements
- document mandatory environment checks in production guides

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: Operation cancelled by user)*
- `pytest -q` *(failed: 6 failed, 16 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68431d2284f4833384cd80ecd7370453