### PR TITLE
[alpha_factory] verify workbox integrity

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -63,6 +63,12 @@ export async function generateServiceWorker(outDir, manifest, version) {
   await fs.unlink(swTemp);
   const swData = await fs.readFile(swDest);
   const swHash = createHash('sha384').update(swData).digest('base64');
+  let wbPath = path.join(outDir, 'workbox-sw.js');
+  if (!fsSync.existsSync(wbPath)) wbPath = path.join(outDir, 'lib', 'workbox-sw.js');
+  let wbHash = '';
+  if (fsSync.existsSync(wbPath)) {
+    wbHash = createHash('sha384').update(fsSync.readFileSync(wbPath)).digest('base64');
+  }
   const indexPath = path.join(outDir, 'index.html');
   let indexText = await fs.readFile(indexPath, 'utf8');
   indexText = indexText.replace(".register('sw.js')", ".register('service-worker.js')");
@@ -72,4 +78,7 @@ export async function generateServiceWorker(outDir, manifest, version) {
     `$1 'sha384-${swHash}'`
   );
   await fs.writeFile(indexPath, indexText);
+  let swText = swData.toString('utf8');
+  swText = swText.replace('__WORKBOX_SW_HASH__', `sha384-${wbHash}`);
+  await fs.writeFile(swDest, swText);
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -61,9 +61,16 @@ injectManifest({{
     finally:
         temp_sw.unlink(missing_ok=True)
     sw_hash = sha384(sw_dest)
+    wb_path = dist_dir / "workbox-sw.js"
+    if not wb_path.exists():
+        wb_path = dist_dir / "lib" / "workbox-sw.js"
+    wb_hash = sha384(wb_path) if wb_path.exists() else ""
     index_path = dist_dir / "index.html"
     text = index_path.read_text()
     text = text.replace(".register('sw.js')", ".register('service-worker.js')")
     text = text.replace("__SW_HASH__", sw_hash)
     text = re.sub(r"(script-src 'self' 'wasm-unsafe-eval')", rf"\1 '{sw_hash}'", text)
     index_path.write_text(text)
+    sw_text = sw_dest.read_text()
+    sw_text = sw_text.replace("__WORKBOX_SW_HASH__", wb_hash)
+    sw_dest.write_text(sw_text)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
@@ -1,44 +1,59 @@
 // SPDX-License-Identifier: Apache-2.0
 /* eslint-env serviceworker */
-importScripts('workbox-sw.js');
+const WORKBOX_SW_HASH = '__WORKBOX_SW_HASH__';
 import {precacheAndRoute} from 'workbox-precaching';
 import {registerRoute} from 'workbox-routing';
 import {CacheFirst} from 'workbox-strategies';
 
 // replaced during build
 const CACHE_VERSION = '__CACHE_VERSION__';
-workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});
-
-// include translation JSON files in the precache
-precacheAndRoute(self.__WB_MANIFEST);
-
-registerRoute(
-  ({request, url}) =>
-    request.destination === 'script' ||
-    request.destination === 'worker' ||
-    request.destination === 'font' ||
-    url.pathname.endsWith('.wasm') ||
-    (url.pathname.includes('/ipfs/') && url.pathname.endsWith('.json')),
-  new CacheFirst({cacheName: `${CACHE_VERSION}-assets`})
-);
-
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
+async function init() {
+  const res = await fetch('workbox-sw.js');
+  const buf = await res.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-384', buf);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+  if (`sha384-${b64}` !== WORKBOX_SW_HASH) {
+    throw new Error('workbox-sw.js hash mismatch');
   }
-});
+  importScripts(URL.createObjectURL(new Blob([buf], {type: 'application/javascript'})));
+  workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});
 
-self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys().then((names) =>
-      Promise.all(
-        names.map((name) => {
-          if (!name.startsWith(CACHE_VERSION)) {
-            return caches.delete(name);
-          }
-          return undefined;
-        }),
-      ),
-    ),
+  // include translation JSON files in the precache
+  precacheAndRoute(self.__WB_MANIFEST);
+
+  registerRoute(
+    ({request, url}) =>
+      request.destination === 'script' ||
+      request.destination === 'worker' ||
+      request.destination === 'font' ||
+      url.pathname.endsWith('.wasm') ||
+      (url.pathname.includes('/ipfs/') && url.pathname.endsWith('.json')),
+    new CacheFirst({cacheName: `${CACHE_VERSION}-assets`})
   );
+
+  self.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+      self.skipWaiting();
+    }
+  });
+
+  self.addEventListener('activate', (event) => {
+    event.waitUntil(
+      caches.keys().then((names) =>
+        Promise.all(
+          names.map((name) => {
+            if (!name.startsWith(CACHE_VERSION)) {
+              return caches.delete(name);
+            }
+            return undefined;
+          }),
+        ),
+      ),
+    );
+  });
+}
+
+init().catch((err) => {
+  console.error('Service worker failed to initialize', err);
+  self.registration.unregister();
 });

--- a/tests/test_workbox_integrity.py
+++ b/tests/test_workbox_integrity.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+import http.server
+import threading
+import shutil
+from functools import partial
+from pathlib import Path
+import re
+
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
+
+
+def _start_server(directory: Path):
+    handler = partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    server = http.server.ThreadingHTTPServer(("localhost", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_workbox_hash_mismatch(tmp_path: Path) -> None:
+    repo = Path(__file__).resolve().parents[1]
+    src = repo / "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/dist"
+    dist = tmp_path / "dist"
+    shutil.copytree(src, dist)
+    sw_file = dist / "service-worker.js"
+    text = sw_file.read_text()
+    text = re.sub(r"(WORKBOX_SW_HASH = '\)[^']+(\')", r"\1sha384-invalid\2", text)
+    sw_file.write_text(text)
+
+    server, thread = _start_server(dist)
+    host, port = server.server_address
+    url = f"http://{host}:{port}/index.html"
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            page = context.new_page()
+            page.goto(url)
+            page.wait_for_selector("#controls")
+            page.wait_for_function(
+                "document.getElementById('toast').textContent.includes('offline mode disabled')"
+            )
+            assert page.evaluate("navigator.serviceWorker.controller") is None
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- verify `workbox-sw.js` integrity in `sw.js`
- inject workbox hash in the build scripts
- test registration fails when the hash mismatches

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 14 failed, 3 passed, 15 skipped)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js tests/test_workbox_integrity.py` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68431e1dc0d08333b490d8518c4cc74d