### PR TITLE
[alpha_factory] docs: reference browser PWA instructions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -230,6 +230,9 @@ docker run -it --rm -p 8501:8501   -e OPENAI_API_KEY=$OPENAI_API_KEY   ghcr.io/m
 # →  open http://localhost:8501  (Streamlit dashboard)
 ```
 
+For offline builds or the browser-based PWA, see
+[insight_browser_v1/README.md](insight_browser_v1/README.md).
+
 ---
 
 ## 3 Architecture


### PR DESCRIPTION
## Summary
- link to the Insight Browser README for offline/PWA builds

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435d0aae94833396c5a79766a97b33