### PR TITLE
[alpha_factory] check node version in manual build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -29,17 +29,14 @@ _require_python_311()
 ROOT = Path(__file__).resolve().parent
 try:
     subprocess.run(
-        [
-            "node",
-            "build/version_check.js",
-        ],
+        ["node", "build/version_check.js"],
         cwd=ROOT,
         check=True,
     )
 except FileNotFoundError:
     sys.exit("Node.js 20+ is required. Install Node.js and ensure 'node' is in your PATH.")  # noqa: E501
-except subprocess.CalledProcessError as exc:
-    sys.exit(exc.returncode)
+except subprocess.CalledProcessError:
+    sys.exit("Node.js 20+ is required.")
 
 # load environment variables
 env_file = Path(__file__).resolve().parent / ".env"


### PR DESCRIPTION
## Summary
- call `build/version_check.js` via node in manual_build.py
- exit with a clear error when Node is too old

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(failed to install packages)*
- `pytest -q tests/test_manual_build_missing_tsc.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `npm test` in insight_browser_v1 *(fails: Missing dependency "esbuild")*

------
https://chatgpt.com/codex/tasks/task_e_68435e7e7f908333aff2cfd30af78d40