### PR TITLE
[alpha_factory] replace taxonomy llm import

### DIFF
--- a/src/taxonomy.ts
+++ b/src/taxonomy.ts
@@ -161,9 +161,7 @@ export function clusterKeywords(
 
 export async function validateLabel(name: string): Promise<boolean> {
   try {
-    const { chat } = await import(
-      '../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.js'
-    );
+    const { chat } = await import('@insight-src/utils/llm.js');
     const resp = await chat(`Does '${name}' denote a distinct economic activity?`);
     return /^yes/i.test(String(resp).trim());
   } catch {


### PR DESCRIPTION
## Summary
- use `@insight-src` alias for the llm helper

## Testing
- `pre-commit run --files src/taxonomy.ts` *(fails: proto-verify)*
- `python scripts/check_python_deps.py` *(fails: missing numpy)*
- `python check_env.py --auto-install` *(fails to install requirements)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*


------
https://chatgpt.com/codex/tasks/task_e_684361cbb0e48333892f7c5ab8216741