### PR TITLE
[alpha_factory] add service worker update test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -29,6 +29,7 @@ run(['node', '--loader', 'ts-node/register', '--test',
   'tests/iframe_worker_cleanup.test.js',
   'tests/onnx_gpu_backend.test.js',
   'tests/error_boundary_limit.test.js',
+  'tests/test_sw_update.js',
   '../../../../tests/taxonomy.test.ts',
   '../../../../tests/memeplex.test.ts'
   ,'../../../../tests/webgl_perf.test.js'

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {promises as fs} from 'fs';
+import path from 'path';
+import http from 'http';
+import {chromium} from 'playwright';
+
+function startServer(dir) {
+  const server = http.createServer((req, res) => {
+    const filePath = path.join(dir, req.url === '/' ? '/index.html' : req.url);
+    fs.readFile(filePath).then(data => {
+      res.writeHead(200);
+      res.end(data);
+    }).catch(() => {
+      res.writeHead(404);
+      res.end();
+    });
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+test('service worker update reloads page', async () => {
+  let browser;
+  const dist = path.resolve(new URL('../dist', import.meta.url).pathname);
+  const server = await startServer(dist);
+  const {port} = server.address();
+  const url = `http://127.0.0.1:${port}/index.html`;
+  const swPath = path.join(dist, 'service-worker.js');
+  const original = await fs.readFile(swPath, 'utf8');
+
+  try {
+    browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(url);
+    await page.waitForSelector('#controls');
+    await page.waitForFunction('navigator.serviceWorker.ready');
+    const initial = await page.evaluate(() => navigator.serviceWorker.controller?.scriptURL);
+
+    const updated = original.replace(/CACHE_VERSION\s*=\s*['\"].*?['\"]/,'CACHE_VERSION="test"');
+    await fs.writeFile(swPath, updated);
+
+    await page.evaluate('navigator.serviceWorker.getRegistration().then(r=>r.update())');
+    await page.waitForFunction('performance.getEntriesByType("navigation").length > 1');
+    const after = await page.evaluate(() => navigator.serviceWorker.controller?.scriptURL);
+
+    assert.notEqual(initial, after);
+    await browser.close();
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('browser')) {
+      test.skip('Playwright browser not installed');
+    } else {
+      throw err;
+    }
+  } finally {
+    if (browser) await browser.close();
+    server.close();
+    await fs.writeFile(swPath, original);
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright test to verify automatic reload on service worker update
- run the new test from the demo test runner

## Testing
- `npm test --offline` *(fails: Cannot find module '@insight-src/utils/llm.js')*


------
https://chatgpt.com/codex/tasks/task_e_6843669d5b3c8333a90ea88e83a20084