### PR TITLE
[alpha_factory] clarify cross alpha stub

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -7,6 +7,9 @@ will query OpenAI when an ``OPENAI_API_KEY`` is configured for live ideas.
 Discovered items are logged to ``cross_alpha_log.json`` by default.  The
 queried model defaults to ``gpt-4o-mini`` but can be overridden with
 ``--model`` or ``CROSS_ALPHA_MODEL``.
+
+The suggestions returned by this stub are purely illustrative examples and
+should **not** be considered financial advice.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- expand docs in cross_alpha_discovery_stub to note that suggestions are illustrative only

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy)*
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py` *(failed: KeyboardInterrupt during environment setup)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6843691e01f08333bd63611683246b23