### PR TITLE
[alpha_factory] add telemetry configs

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/infra/otel-config.yaml
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/infra/otel-config.yaml
@@ -1,0 +1,14 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/alpha_factory_v1/demos/aiga_meta_evolution/infra/prometheus.yml
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/infra/prometheus.yml
@@ -1,0 +1,16 @@
+# Minimal Prometheus config for Alpha-Factory
+# Scrapes the orchestrator metrics and itself
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'alphafactory'
+    static_configs:
+      - targets: ['alphafactory:8000']
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8889']


### PR DESCRIPTION
## Summary
- add Prometheus and OpenTelemetry configs for AIGA meta evolution demo

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(fails to finish)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google', etc.)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/infra/prometheus.yml alpha_factory_v1/demos/aiga_meta_evolution/infra/otel-config.yaml` *(fails: Interrupted)*
- `docker compose --profile telemetry up` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436e99c9408333b0c47e73784bcf32