### PR TITLE
[alpha_factory] chore: remove unused stub

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/app.js
@@ -1,3 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-/* global console */
-/* eslint-env browser */


### PR DESCRIPTION
## Summary
- delete unused `insight_browser_v1/src/app.js`
- run package build and test commands

## Testing
- `npm run build` *(fails: Cannot find module '@insight-src/utils/llm.js')*
- `npm test` *(fails: Cannot find module '@insight-src/utils/llm.js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68436e84038c83338877c19781c226de