### PR TITLE
[alpha_factory] fix aiga meta evolution imports

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -52,9 +52,16 @@ try:
     from alpha_factory_v1.backend import adk_bridge
 except Exception:  # pragma: no cover - optional dependency
     adk_bridge = None
-from openai_agents_bridge import EvolverAgent
-from meta_evolver import MetaEvolver
-from curriculum_env import CurriculumEnv
+if __package__ is None:
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent))
+    __package__ = "alpha_factory_v1.demos.aiga_meta_evolution"
+
+from .openai_agents_bridge import EvolverAgent
+from .meta_evolver import MetaEvolver
+from .curriculum_env import CurriculumEnv
 import gradio as gr
 
 try:  # optional JWT auth

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -22,8 +22,15 @@ try:
 except Exception:  # pragma: no cover - optional
     ADK_AVAILABLE = False
 
-from meta_evolver import MetaEvolver
-from curriculum_env import CurriculumEnv
+if __package__ is None:
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent))
+    __package__ = "alpha_factory_v1.demos.aiga_meta_evolution"
+
+from .meta_evolver import MetaEvolver
+from .curriculum_env import CurriculumEnv
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update relative imports for aiga demo scripts
- add `__package__` guard so scripts work when run directly or as modules

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py` *(fails: interrupted during environment install)*

------
https://chatgpt.com/codex/tasks/task_e_68437031d3cc8333add7b6f0168a5d3a