### PR TITLE
[alpha_factory] Add PowerShell setup scripts

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -49,12 +49,12 @@ Pyodide runtime and `wasm-gpt2` model, then install the Node modules and
 compile the bundle:
 ```bash
 npm run fetch-assets
-./setup.sh        # installs dependencies when node_modules is missing
-npm run build     # or `python manual_build.py` for offline builds
+./setup.sh        # installs dependencies when node_modules is missing (use `./setup.ps1` on Windows)
+npm run build     # or `python manual_build.py` or `./manual_build.ps1` for offline builds
 ```
 Run the tests with:
 ```bash
-./setup.sh && npm test
+./setup.sh && npm test    # on Windows use `./setup.ps1`
 ```
 The build script reads `.env` automatically and injects the values into
 `dist/index.html` as `window.PINNER_TOKEN`, `window.IPFS_GATEWAY` and
@@ -119,8 +119,8 @@ Use `manual_build.py` for air‑gapped environments:
    Failing to replace placeholders will break offline mode.
 3. Run `node build/version_check.js` to ensure Node.js **v20** or newer is
    installed. `manual_build.py` exits if this check fails.
-4. `python manual_build.py` – bundles the app, generates `dist/sw.js` and embeds
-   your `.env` settings.
+4. `python manual_build.py` – or run `./manual_build.ps1` – bundles the app,
+   generates `dist/sw.js` and embeds your `.env` settings.
 5. `npm start` or open `dist/index.html` directly to run the demo.
 
 The script requires Python ≥3.11. It loads `.env` automatically and injects
@@ -135,7 +135,7 @@ Follow these steps when building without internet access:
 2. Verify checksums match `build_assets.json` and ensure no files under
    `wasm/` or `lib/` contain the word "placeholder".
 3. `npm ci` to install the locked dependencies.
-4. Execute `python manual_build.py` to generate the PWA in `dist/`.
+4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`.
 5. Launch with `npm start` or pin the directory with `ipfs add -r dist`.
 
 Failing to replace placeholders will break offline mode.
@@ -145,7 +145,7 @@ Failing to replace placeholders will break offline mode.
 1. Run `npm run fetch-assets`.
 2. `npm ci` to install dependencies from `package-lock.json`.
 3. Confirm no placeholder text remains in `lib/` or `wasm*/`.
-4. Execute `python manual_build.py` to generate the PWA in `dist/`. Use
+4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`. Use
    `npm run build` when internet access is available.
 
 5. Run the tests offline:
@@ -194,7 +194,7 @@ Requires **Node.js ≥20** and **Python ≥3.11**.
 
 1. Copy `.env.sample` to `.env` and set the variables.
 2. Run `WEB3_STORAGE_TOKEN=<token> npm run fetch-assets` to download the WASM runtime and model files.
-3. Execute `python manual_build.py` to produce the `dist/` directory.
+3. Execute `python manual_build.py` (or `./manual_build.ps1`) to produce the `dist/` directory.
 4. Open `dist/index.html` to verify offline functionality.
 
 Run `node tests/run.mjs --offline` to confirm the build works without network access.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.ps1
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.ps1
@@ -1,0 +1,31 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: Apache-2.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location $scriptDir
+
+# Verify Node.js 20+
+try {
+    node build/version_check.js
+} catch {
+    Write-Error 'Node.js 20+ is required.'
+    exit 1
+}
+
+# Verify Python >=3.11
+$pyVersionOutput = & python --version
+if ($LASTEXITCODE -ne 0) {
+    Write-Error 'Python is required.'
+    exit 1
+}
+$match = [regex]::Match($pyVersionOutput, '(\d+)\.(\d+)')
+if (!$match.Success -or [int]$match.Groups[1].Value -lt 3 -or ([int]$match.Groups[1].Value -eq 3 -and [int]$match.Groups[2].Value -lt 11)) {
+    Write-Error "Python >=3.11 required. Current version: $pyVersionOutput"
+    exit 1
+}
+
+python manual_build.py @Args
+exit $LASTEXITCODE
+

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.ps1
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.ps1
@@ -1,0 +1,23 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: Apache-2.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location $scriptDir
+
+# Ensure Node.js 20+
+node build/version_check.js
+
+if (Test-Path 'node_modules') {
+    Write-Host 'node_modules already present'
+    exit 0
+}
+
+Write-Host 'Installing npm dependencies...'
+npm ci --no-progress
+if ($LASTEXITCODE -ne 0) {
+    Write-Error 'ERROR: npm ci failed'
+    exit 1
+}
+


### PR DESCRIPTION
## Summary
- add `setup.ps1` and `manual_build.ps1` to Insight browser demo
- reference Windows scripts in the README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(interrupted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.ps1 alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.ps1 alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(failed to complete due to environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68437372e638833386bbab40123f2ef5