### PR TITLE
[alpha_factory] improve workflow demo ADK gating

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
@@ -3,8 +3,9 @@
 
 This script chains the ``alpha_discovery`` and ``alpha_conversion``
 stubs via the OpenAI Agents runtime. It works offline when
-``OPENAI_API_KEY`` is unset and optionally exposes the agent over
-the Google ADK gateway if available.
+``OPENAI_API_KEY`` is unset and can publish the agent over the
+Google ADK gateway when the ``ALPHA_FACTORY_ENABLE_ADK`` environment
+variable is set.
 """
 from __future__ import annotations
 
@@ -21,6 +22,7 @@ from alpha_opportunity_stub import identify_alpha
 from alpha_conversion_stub import convert_alpha
 
 try:
+    from alpha_factory_v1.backend import adk_bridge
     from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
     ADK_AVAILABLE = True
 except Exception:  # pragma: no cover - optional
@@ -66,7 +68,7 @@ def main() -> None:
     runtime.register(agent)
     print("Registered WorkflowAgent with runtime")
 
-    if ADK_AVAILABLE:
+    if ADK_AVAILABLE and adk_bridge.adk_enabled():
         auto_register([agent])
         maybe_launch()
         print("WorkflowAgent exposed via ADK gateway")


### PR DESCRIPTION
## Summary
- guard workflow_demo ADK launch behind `adk_enabled`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails to install dependencies)*
- `pytest tests/test_openai_bridge.py -k aiga_bridge_compiles -q`

------
https://chatgpt.com/codex/tasks/task_e_684384a3db488333a33858454fa6c4db