### PR TITLE
[alpha_factory] note quoting paths in env files

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,7 @@ PORT=8000
 # Set to 1 to force local models only
 AGI_INSIGHT_OFFLINE=0
 # Path to local Llama model (optional)
+# Windows paths may require quotes, e.g., "C:\\path\\to\\file"
 LLAMA_MODEL_PATH=
 # gRPC bus port for agent coordination
 AGI_INSIGHT_BUS_PORT=6006

--- a/README.md
+++ b/README.md
@@ -785,6 +785,8 @@ omitted and `AGI_INSIGHT_ALLOW_INSECURE=1`, the bus starts without TLS.
 See [bus_tls.md](alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md)
 for instructions and example volume mounts.
 
+`.env.sample` notes that paths on Windows may require quotes (e.g., `C:\\path\\to\\file`).
+
 #### Supported Environment Variables
 
 | Variable | Default | Purpose |


### PR DESCRIPTION
## Summary
- mention quoting Windows paths in `.env.sample`
- reference that note in the README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: requires installation)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684399d9ab348333a91ca4eb198ee5fb