### PR TITLE
[alpha_factory] Update Python quick-start docs

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -97,6 +97,15 @@ python alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py --help
 python -m alpha_factory_v1.demos.aiga_meta_evolution --help
 ```
 
+Launch the local Mixtral server in another terminal if it is not already
+running:
+
+```bash
+docker run -p 11434:11434 ollama/ollama:latest --models mixtral:instruct
+```
+
+Set `OLLAMA_BASE_URL` when binding the server to a different host or port.
+
 Set `OPENAI_API_KEY` in your environment to enable cloud models. Without
 it the demo falls back to the bundled offline mixtral model.
 


### PR DESCRIPTION
## Summary
- expand instructions for Python quick-start
- show how to launch Ollama locally and note `OLLAMA_BASE_URL`

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy missing)*
- `python check_env.py --auto-install` *(fails: network install blocked)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6843a17c9ea08333b497d3d4305de11b