### PR TITLE
[alpha_factory] add missing license header

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 #  run_experience_demo.sh – Era-of-Experience • Alpha-Factory v1 👁️✨
 #


### PR DESCRIPTION
## Summary
- add SPDX license notice after the shebang in `run_experience_demo.sh`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh` *(fails: Verify protobuf files are up to date)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt during pip install)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6843a16978108333ab1857b94e8a567a