### PR TITLE
[alpha_factory] use LOG_LEVEL env var

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -63,7 +63,7 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
 
    ```bash
    cp config.env.sample config.env
-   $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, LIVE_FEED, etc.
+   $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, LOG_LEVEL, LIVE_FEED, etc.
    ```
    You may override the path for built-in offline samples with
    `SAMPLE_DATA_DIR=/path/to/csvs`.

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -27,6 +27,7 @@ Environment vars (optional):
     MODEL_NAME          – default gpt-4o-mini
     TEMPERATURE         – default 0.2
     LIVE_FEED           – 1 to mix in real wearable/web data
+    LOG_LEVEL           – default INFO
 """
 from __future__ import annotations
 import os
@@ -71,7 +72,7 @@ MODEL       = os.getenv("MODEL_NAME", "gpt-4o-mini")
 TEMP        = float(os.getenv("TEMPERATURE", "0.2"))
 LIVE_FEED   = bool(int(os.getenv("LIVE_FEED", "0")))
 PORT        = int(os.getenv("PORT", "7860"))
-LOG_LVL     = os.getenv("LOGLEVEL", "INFO").upper()
+LOG_LVL     = os.getenv("LOG_LEVEL", "INFO").upper()
 
 logging.basicConfig(
     level=LOG_LVL,

--- a/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
+++ b/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
@@ -20,6 +20,7 @@ x-common-env: &common-env
   OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
   MODEL_NAME: "${MODEL_NAME:-gpt-4o-mini}"
   TEMPERATURE: "${TEMPERATURE:-0.2}"
+  LOG_LEVEL: "${LOG_LEVEL:-INFO}"
   # ↓ live metrics (optional)
   PROM_PUSHGATEWAY: "http://prom-push:9091"
 


### PR DESCRIPTION
## Summary
- rename LOGLEVEL to LOG_LEVEL in era-of-experience entrypoint
- propagate LOG_LEVEL variable through compose file
- document LOG_LEVEL usage in README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(failed: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843a3f3f7f483338f8e0882e6d3d2b4