### PR TITLE
[alpha_factory] use randomUUID for replay ids

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
@@ -31,3 +31,14 @@ test('share and import frames maintain order and cid', async () => {
   expect(cid1).toBe(cid);
   expect(cid2).toBe(cid);
 });
+
+test('addFrame generates unique ids', async () => {
+  const db = new ReplayDB('jest');
+  await db.open();
+  const ids = new Set();
+  for (let i = 0; i < 100; i++) {
+    const id = await db.addFrame(null, { i });
+    expect(ids.has(id)).toBe(false);
+    ids.add(id);
+  }
+});

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -62,7 +62,13 @@ export class ReplayDB {
    * @returns The new frame ID.
    */
   async addFrame(parent: number | null, delta: ReplayDelta): Promise<number> {
-    const id = Date.now() + Math.floor(Math.random() * 1000);
+    let id: number;
+    if (typeof (crypto as any).randomUUID === 'function') {
+      const uuid = (crypto as any).randomUUID().replace(/-/g, '');
+      id = parseInt(uuid.slice(0, 13), 16);
+    } else {
+      id = Date.now() + Math.floor(Math.random() * 1000);
+    }
     const frame: ReplayFrame = { id, parent, delta, timestamp: Date.now() };
     await withStore('readwrite', (s) => s.put(frame, id));
     return id;


### PR DESCRIPTION
## Summary
- generate replay IDs with `crypto.randomUUID` when available
- ensure replay ids are unique across many insertions

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(failed to run due to missing deps)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `npm test` in `insight_browser_v1` *(fails: Missing dependency "esbuild")*

------
https://chatgpt.com/codex/tasks/task_e_6843a6d7f4148333b5abca0682c2c4f4