### PR TITLE
[alpha_factory] centralize llm helper

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -62,6 +62,7 @@ if __package__ is None:
 from .openai_agents_bridge import EvolverAgent
 from .meta_evolver import MetaEvolver
 from .curriculum_env import CurriculumEnv
+from .utils import build_llm
 import gradio as gr
 
 try:  # optional JWT auth
@@ -75,9 +76,6 @@ except Exception:  # pragma: no cover - optional
 SERVICE_NAME = os.getenv("SERVICE_NAME", "aiga-meta-evolution")
 GRADIO_PORT = int(os.getenv("GRADIO_PORT", "7862"))
 API_PORT = int(os.getenv("API_PORT", "8000"))
-MODEL_NAME = os.getenv("MODEL_NAME", "gpt-4o-mini")
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OLLAMA_URL = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434/v1")
 MAX_GEN = int(os.getenv("MAX_GEN", "1000"))  # safety rail
 ENABLE_OTEL = os.getenv("ENABLE_OTEL", "false").lower() == "true"
 ENABLE_SENTRY = os.getenv("ENABLE_SENTRY", "false").lower() == "true"
@@ -122,11 +120,7 @@ _REQUEST_LOG: dict[str, list[float]] = {}
 # ---------------------------------------------------------------------------
 # LLM TOOLING ----------------------------------------------------------------
 # ---------------------------------------------------------------------------
-LLM = OpenAIAgent(
-    model=MODEL_NAME,
-    api_key=OPENAI_API_KEY,
-    base_url=(None if OPENAI_API_KEY else OLLAMA_URL),
-)
+LLM = build_llm()
 
 
 @Tool(name="describe_candidate", description="Explain why this architecture might learn fast")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
@@ -7,20 +7,14 @@ a local model when no ``OPENAI_API_KEY`` is configured.
 """
 from __future__ import annotations
 
-import os
-
 try:
     from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
 except Exception as exc:  # pragma: no cover - optional dependency
-    raise SystemExit(
-        "openai-agents package is required. Install with `pip install openai-agents`"
-    ) from exc
+    raise SystemExit("openai-agents package is required. Install with `pip install openai-agents`") from exc
 
-LLM = OpenAIAgent(
-    model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=(None if os.getenv("OPENAI_API_KEY") else os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")),
-)
+from .utils import build_llm
+
+LLM = build_llm()
 
 
 @Tool(name="identify_alpha", description="Suggest current inefficiencies in a domain")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -8,8 +8,6 @@ instance started by ``run_aiga_demo.sh``.
 """
 from __future__ import annotations
 
-import os
-
 try:  # optional dependency
     from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
 except ImportError:  # pragma: no cover - fallback for legacy package
@@ -31,16 +29,13 @@ if __package__ is None:
 
 from .meta_evolver import MetaEvolver
 from .curriculum_env import CurriculumEnv
+from .utils import build_llm
 
 
 # ---------------------------------------------------------------------------
 # LLM setup -----------------------------------------------------------------
 # ---------------------------------------------------------------------------
-LLM = OpenAIAgent(
-    model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=(None if os.getenv("OPENAI_API_KEY") else os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")),
-)
+LLM = build_llm()
 
 # single MetaEvolver instance reused across tool invocations
 EVOLVER = MetaEvolver(env_cls=CurriculumEnv, llm=LLM)

--- a/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for the AI-GA Meta-Evolution demo."""
+from __future__ import annotations
+
+import os
+
+try:
+    from openai_agents import OpenAIAgent
+except Exception as exc:  # pragma: no cover - optional dependency
+    raise SystemExit("openai-agents package is required. Install with `pip install openai-agents`") from exc
+
+
+def build_llm() -> OpenAIAgent:
+    """Create the default ``OpenAIAgent`` instance."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    return OpenAIAgent(
+        model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+        api_key=api_key,
+        base_url=None if api_key else os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1"),
+    )

--- a/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
@@ -9,14 +9,12 @@ variable is set.
 """
 from __future__ import annotations
 
-import os
-
 try:
     from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
 except ImportError as exc:  # pragma: no cover
-    raise SystemExit(
-        "openai_agents package is required. Install with `pip install openai-agents`"
-    ) from exc
+    raise SystemExit("openai_agents package is required. Install with `pip install openai-agents`") from exc
+
+from .utils import build_llm
 
 from alpha_opportunity_stub import identify_alpha
 from alpha_conversion_stub import convert_alpha
@@ -24,6 +22,7 @@ from alpha_conversion_stub import convert_alpha
 try:
     from alpha_factory_v1.backend import adk_bridge
     from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+
     ADK_AVAILABLE = True
 except Exception:  # pragma: no cover - optional
     ADK_AVAILABLE = False
@@ -31,11 +30,7 @@ except Exception:  # pragma: no cover - optional
 # ---------------------------------------------------------------------------
 # LLM setup -----------------------------------------------------------------
 # ---------------------------------------------------------------------------
-LLM = OpenAIAgent(
-    model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=(None if os.getenv("OPENAI_API_KEY") else os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")),
-)
+LLM = build_llm()
 
 
 @Tool(name="discover_alpha", description="List market opportunities in a domain")


### PR DESCRIPTION
## Summary
- add `build_llm` helper to AIGA meta-evolution demo
- reuse the helper in entrypoints and stubs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/utils.py alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a361a2f0833397f413d638965fe3