### PR TITLE
[alpha_factory] fix notebook paths

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
+++ b/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
@@ -154,7 +154,7 @@
    "source": [
     "import subprocess, sys, pathlib, threading, queue, re, time, textwrap\n",
     "\n",
-    "root = pathlib.Path('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience')\n",
+    "    root = pathlib.Path.cwd() / 'alpha_factory_v1' / 'demos' / 'era_of_experience'\n",
     "proc = subprocess.Popen([\n",
     "        sys.executable, 'agent_experience_entrypoint.py'],\n",
     "        cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,\n",
@@ -191,7 +191,7 @@
    "outputs": [],
    "source": [
     "import asyncio, sys, json, importlib, pathlib\n",
-    "sys.path.append('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience')\n",
+    "sys.path.append(str(pathlib.Path.cwd() / 'alpha_factory_v1' / 'demos' / 'era_of_experience'))\n",
     "exp = importlib.import_module('agent_experience_entrypoint')\n",
     "\n",
     "# an asynchronous generator yields experience events\n",
@@ -241,11 +241,11 @@
    "source": [
     "import pandas as pd\n",
     "from pathlib import Path\n",
-    "csv_path = Path('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/macro_sentinel/offline_samples/yield_curve.csv')\n",
+    "csv_path = (Path.cwd() / 'alpha_factory_v1' / 'demos' / 'macro_sentinel' / 'offline_samples' / 'yield_curve.csv')\n",
     "data = pd.read_csv(csv_path)\n",
     "spread = float(data['10y'][0]) - float(data['3m'][0])\n",
     "msg = 'Curve inverted \u2192 consider long bonds' if spread < 0 else 'Curve normal'\n",
-    "print(f'Yield curve spread: {spread:.2f} | {msg}')"
+    "print(f'Yield curve spread: {spread:.2f} | {msg}')\n"
    ]
   },
   {
@@ -257,11 +257,11 @@
    "source": [
     "import pandas as pd\n",
     "from pathlib import Path\n",
-    "csv_path = root.parent / 'macro_sentinel/offline_samples/stable_flows.csv'\n",
+    "csv_path = (Path.cwd() / 'alpha_factory_v1' / 'demos' / 'macro_sentinel' / 'offline_samples' / 'stable_flows.csv')\n",
     "data = pd.read_csv(csv_path)\n",
     "flow = float(data['usd_mn'][0])\n",
     "msg = 'Bottleneck risk' if flow < 50 else 'Supply chain normal'\n",
-    "print(f'Stable flows: {flow:.1f} M USD | {msg}')"
+    "print(f'Stable flows: {flow:.1f} M USD | {msg}')\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix Colab notebook paths to work outside `AGI-Alpha-Agent-v0` directory

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843a9c1b208833388cc8686dd2125cf