### PR TITLE
[alpha_factory] add missing environment defaults

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/config.env.sample
+++ b/alpha_factory_v1/demos/era_of_experience/config.env.sample
@@ -18,6 +18,7 @@ MAX_TOKENS=4096                 # token cap for reasoning/tool calls
 ###########################  Offline fallback  ###############################
 OLLAMA_MODEL=mixtral:instruct    # pulled on first run (≈ 13 GB)
 OLLAMA_URL=http://ollama:11434   # internal service; override for LAN cache
+# LLM_BASE_URL=http://ollama:11434/v1  # custom base URL when OPENAI_API_KEY is unset
 
 ###########################  Experience agent  ###############################
 STREAM_RATE_HZ=1                 # synthetic experience events per second
@@ -36,6 +37,7 @@ PROMETHEUS_PORT=9090             # metrics scrape port for Prometheus / Grafana
 ###########################  Observability  ##################################
 LOG_LEVEL=INFO                   # DEBUG | INFO | WARNING | ERROR
 ALLOWED_ORIGINS=*                # CORS for Gradio / proxy front-ends
+# PORT=7860                       # web UI port
 
 ###############################################################################
 # 💡 TIP: No env vars? No problem. Just run the demo — it auto-switches to


### PR DESCRIPTION
## Summary
- add commented sample settings for `LLM_BASE_URL` and `PORT` in the Era-of-Experience demo

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: could not install dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6843a8e303208333a4354d40ed0a1edf