### PR TITLE
[alpha_factory] update default ledger path

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -213,7 +213,7 @@ Turn a discovered opportunity into a short execution plan:
 python alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py --alpha "Battery arbitrage"
 ```
 
-The tool outputs a three‑step JSON plan and logs it to `alpha_conversion_log.json`. When `OPENAI_API_KEY` is configured, it queries an OpenAI model; otherwise a sample plan is returned.
+The tool outputs a three‑step JSON plan and logs it to `~/.aiga/alpha_conversion_log.json` by default. When `OPENAI_API_KEY` is configured, it queries an OpenAI model; otherwise a sample plan is returned.
 
 ## 🤝 End‑to‑end workflow
 

--- a/tests/test_alpha_conversion_stub.py
+++ b/tests/test_alpha_conversion_stub.py
@@ -6,15 +6,15 @@ import unittest
 from pathlib import Path
 import tempfile
 
-STUB = 'alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py'
+STUB = "alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py"
 
 
 class TestAlphaConversionStub(unittest.TestCase):
     def test_generate_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            ledger = Path(tmp) / 'plan.json'
+            ledger = Path(tmp) / "plan.json"
             result = subprocess.run(
-                [sys.executable, STUB, '--alpha', 'test opportunity', '--ledger', str(ledger)],
+                [sys.executable, STUB, "--alpha", "test opportunity", "--ledger", str(ledger)],
                 capture_output=True,
                 text=True,
             )
@@ -22,8 +22,21 @@ class TestAlphaConversionStub(unittest.TestCase):
             self.assertTrue(ledger.exists())
             data = json.loads(ledger.read_text())
             self.assertIsInstance(data, dict)
-            self.assertIn('steps', data)
+            self.assertIn("steps", data)
+
+    def test_default_ledger_path(self) -> None:
+        ledger = Path.home() / ".aiga" / "alpha_conversion_log.json"
+        if ledger.exists():
+            ledger.unlink()
+        result = subprocess.run(
+            [sys.executable, STUB, "--alpha", "test opportunity"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(ledger.exists())
+        ledger.unlink()
 
 
-if __name__ == '__main__':  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- change default ledger in `alpha_conversion_stub.py` to `~/.aiga/alpha_conversion_log.json`
- create parent directory automatically when missing
- document the new path in the demo README
- test default ledger location

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py alpha_factory_v1/demos/aiga_meta_evolution/README.md tests/test_alpha_conversion_stub.py` *(skipped: proto-verify, verify-requirements-lock, verify-alpha-requirements-lock, verify-alpha-colab-requirements-lock, verify-backend-requirements-lock, verify-env-docs)*
- `pytest -q tests/test_alpha_conversion_stub.py`

------
https://chatgpt.com/codex/tasks/task_e_6843a98f1ec48333aa2d70c7a39768be