### PR TITLE
[alpha_factory] verify service worker checksum

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -463,4 +463,8 @@ if wasm_llm_dir.exists():
 # generate service worker
 generate_service_worker(ROOT, dist_dir, manifest)
 (dist_dir / "service-worker.js").write_bytes((dist_dir / "sw.js").read_bytes())
+sw_actual = sha384(dist_dir / "service-worker.js")
+sw_expected = checksums.get("service-worker.js")
+if sw_expected and sw_expected != sw_actual:
+    sys.exit("Checksum mismatch for service-worker.js")
 check_gzip_size(dist_dir / "insight.bundle.js")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py
@@ -12,3 +12,8 @@ def test_check_gzip_call_present() -> None:
     pattern = r"write_text\(bundle\).*\n\s*check_gzip_size\(dist_dir / \"insight.bundle.js\"\)"
     assert re.search(pattern, text)
 
+
+def test_service_worker_checksum() -> None:
+    browser_dir = Path(__file__).resolve().parents[1]
+    text = (browser_dir / "manual_build.py").read_text()
+    assert 'sha384(dist_dir / "service-worker.js")' in text


### PR DESCRIPTION
## Summary
- check service-worker.js checksum in manual browser build
- test for sha384 call in manual_build.py

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py`
- `pytest insight_browser_v1/tests/test_manual_build_size_limit.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ac0b64608333b926075783b65087