### PR TITLE
[alpha_factory] handle idb deletion errors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -190,14 +190,30 @@ export class Archive {
     );
     const keep = runs.slice(0, max);
     const remove = runs.slice(max);
-    await Promise.all(remove.map((r) => del(r.id, this.runStore)));
+    for (const r of remove) {
+      try {
+        await del(r.id, this.runStore);
+      } catch (err: unknown) {
+        if (err instanceof DOMException) {
+          console.warn('Failed to delete run', r.id, err);
+        } else {
+          throw err;
+        }
+      }
+    }
     const keepIds = new Set(keep.map((r) => r.evalId));
     const evals = (await values(this.evalStore)) as EvaluatorRecord[];
-    await Promise.all(
-      evals
-        .filter((e) => !keepIds.has(e.id))
-        .map((e) => del(e.id, this.evalStore))
-    );
+    for (const e of evals.filter((ev) => !keepIds.has(ev.id))) {
+      try {
+        await del(e.id, this.evalStore);
+      } catch (err: unknown) {
+        if (err instanceof DOMException) {
+          console.warn('Failed to delete evaluator', e.id, err);
+        } else {
+          throw err;
+        }
+      }
+    }
   }
 
   async selectParents(

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -123,3 +123,20 @@ test('add calls chat when api key set and stores impact score', async () => {
   const runs = await a.list();
   expect(runs[0].impactScore).toBeCloseTo(runs[0].score + 5);
 });
+
+test('prune logs warning when deletion fails', async () => {
+  const keyval = require('../src/utils/keyval.ts');
+  const origDel = keyval.del;
+  keyval.del = jest.fn(() => { throw new DOMException('fail'); });
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  const a = new Archive('jest');
+  await a.open();
+  await a.add(1, {}, []);
+  await expect(a.prune(0)).resolves.toBeUndefined();
+
+  expect(warn).toHaveBeenCalled();
+
+  keyval.del = origDel;
+  warn.mockRestore();
+});

--- a/src/utils/llm.js
+++ b/src/utils/llm.js
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+export * from '../../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.ts';


### PR DESCRIPTION
## Summary
- handle DOMException in browser archive pruning
- test del() failure handling
- stub llm.js module for build tooling

## Testing
- `npm run build` *(fails: Could not resolve assets and WorkboxConfigError)*
- `npm test` *(fails: WorkboxConfigError during build step)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(failed to run)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js src/utils/llm.js` *(failed: interrupted during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_6843a97875e88333b6f6eeff1feba2a6