### PR TITLE
[alpha_factory] handle prune deletions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts
@@ -190,13 +190,31 @@ export class Archive {
     );
     const keep = runs.slice(0, max);
     const remove = runs.slice(max);
-    await Promise.all(remove.map((r) => del(r.id, this.runStore)));
+    await Promise.all(
+      remove.map((r) =>
+        del(r.id, this.runStore).catch((err: unknown) => {
+          if (err instanceof DOMException) {
+            console.warn('Failed to delete run', r.id, err);
+          } else {
+            throw err;
+          }
+        }),
+      ),
+    );
     const keepIds = new Set(keep.map((r) => r.evalId));
     const evals = (await values(this.evalStore)) as EvaluatorRecord[];
     await Promise.all(
       evals
         .filter((e) => !keepIds.has(e.id))
-        .map((e) => del(e.id, this.evalStore))
+        .map((e) =>
+          del(e.id, this.evalStore).catch((err: unknown) => {
+            if (err instanceof DOMException) {
+              console.warn('Failed to delete evaluator', e.id, err);
+            } else {
+              throw err;
+            }
+          }),
+        )
     );
   }
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -123,3 +123,18 @@ test('add calls chat when api key set and stores impact score', async () => {
   const runs = await a.list();
   expect(runs[0].impactScore).toBeCloseTo(runs[0].score + 5);
 });
+
+test('prune continues when del throws DOMException', async () => {
+  const a = new Archive('jest');
+  await a.open();
+  await a.add(1, {}, [{ logic: 0, feasible: 0 }]);
+  await a.add(2, {}, [{ logic: 0, feasible: 0 }]);
+  const kv = require('../src/utils/keyval.ts');
+  const spy = jest
+    .spyOn(kv, 'del')
+    .mockImplementation(() => {
+      throw new DOMException('fail');
+    });
+  await expect(a.prune(1)).resolves.toBeUndefined();
+  spy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- catch DOMException when deleting old runs or evaluator records
- keep pruning even when deletions fail
- test prune continues on deletion failure

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: ModuleNotFoundError: numpy)*
- `npm ci`
- `npm run build` *(failed: Cannot find module '@insight-src/utils/llm.js')*
- `npx -y jest alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js` *(failed: no jest config)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/archive.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js` *(failed: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6843ae2285488333a078f188795e91b6