### PR TITLE
[alpha_factory] insert Apache license headers

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/__init__.py
+++ b/alpha_factory_v1/demos/era_of_experience/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Demo package
 from .alpha_detection import (
     detect_yield_curve_alpha,

--- a/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_detection.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Alpha detection utilities for Era-of-Experience demo.
 
 This module demonstrates how one might detect simple "alpha" signals

--- a/alpha_factory_v1/demos/era_of_experience/alpha_report.py
+++ b/alpha_factory_v1/demos/era_of_experience/alpha_report.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python
 """Generate a simple alpha opportunity report using offline samples.
 

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/__init__.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 """
 reward_backends · Alpha‑Factory v1 👁️✨

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/curiosity_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/curiosity_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 """
 curiosity_reward.py – Alpha‑Factory v1 👁️✨
@@ -42,8 +43,9 @@ __all__ = ["reward"]
 _LOG = logging.getLogger(__name__)
 
 # ─────────────────────────── configuration ──────────────────────────────
-_MAX_ENTRIES = 50_000           # LRU capacity for seen hashes
-_HASH_TRUNCATE = 4096           # bytes of repr() to hash
+_MAX_ENTRIES = 50_000  # LRU capacity for seen hashes
+_HASH_TRUNCATE = 4096  # bytes of repr() to hash
+
 
 # ─────────────────────────── internal state ─────────────────────────────
 class _LRUCounter(OrderedDict):
@@ -67,13 +69,16 @@ class _LRUCounter(OrderedDict):
                 _LOG.debug("[curiosity_reward] LRU evict %s", popped_h)
             return prev
 
+
 _seen = _LRUCounter(_MAX_ENTRIES)
+
 
 # ─────────────────────────── helpers ────────────────────────────────────
 def _hash_observation(obs: Any) -> str:
     """Return a stable SHA‑1 hex digest for an arbitrary Python object."""
-    data = repr(obs).encode("utf-8", errors="replace")[: _HASH_TRUNCATE]
+    data = repr(obs).encode("utf-8", errors="replace")[:_HASH_TRUNCATE]
     return hashlib.sha1(data).hexdigest()
+
 
 # ─────────────────────────── public API ─────────────────────────────────
 def reward(state: Any, action: Any, result: Any) -> float:  # noqa: D401

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/education_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/education_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 """
 education_reward.py  – Era‑of‑Experience demo
@@ -108,11 +109,7 @@ def reward(state: Any, action: Any, result: Any) -> float:
     # ------------------------------------------------------------------------
     skill = _skill_from_event(result) or _skill_from_event(action) or "generic"
 
-    last_24h = [
-        evt
-        for evt in history
-        if (now - evt.get("time", now)).total_seconds() < 60 * 60 * 24
-    ]
+    last_24h = [evt for evt in history if (now - evt.get("time", now)).total_seconds() < 60 * 60 * 24]
     skills_counter = Counter(_skill_from_event(evt) for evt in last_24h)
 
     diversity_bonus = 0.0
@@ -140,11 +137,7 @@ def reward(state: Any, action: Any, result: Any) -> float:
     # 4) Mastery spacing (encourage revisiting after ~1 day)
     # ------------------------------------------------------------------------
     last_same_skill = next(
-        (
-            evt
-            for evt in reversed(history)
-            if _skill_from_event(evt) == skill
-        ),
+        (evt for evt in reversed(history) if _skill_from_event(evt) == skill),
         None,
     )
     mastery_bonus = 0.0
@@ -159,9 +152,7 @@ def reward(state: Any, action: Any, result: Any) -> float:
     # 5) Aggregate with exponential decay weight (recent events matter more)
     # ------------------------------------------------------------------------
     recency_weight = _exponential_decay(0.0)  # always 1.0 for *this* event
-    reward_value = recency_weight * (
-        diversity_bonus + session_bonus + mastery_bonus
-    )
+    reward_value = recency_weight * (diversity_bonus + session_bonus + mastery_bonus)
 
     # Clip safeguard
     return max(0.0, min(1.0, reward_value + random.uniform(-0.01, 0.01)))

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/efficiency_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/efficiency_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 efficiency_reward.py – Alpha‑Factory v1 👁️✨
 ───────────────────────────────────────────────────────────────────────────────
@@ -64,6 +65,7 @@ __all__ = ("reward",)
 
 _log = logging.getLogger(__name__)
 
+
 # ─────────────────────────── configurable baselines ───────────────────────────
 def _env_float(name: str, default: float) -> float:
     """Fetch *name* from env or fall back to *default* (must be > 0)."""
@@ -75,10 +77,10 @@ def _env_float(name: str, default: float) -> float:
 
 
 # Baseline targets (tweak for your infra or via env)
-_LAT_MS: float   = _env_float("EFF_BSLN_LAT_MS",   500.0)   # ms
-_TOKENS: float   = _env_float("EFF_BSLN_TOKENS",   1500.0)  # tokens
-_COST_USD: float = _env_float("EFF_BSLN_COST_USD", 0.01)    # dollars
-_ENERGY_J: float = _env_float("EFF_BSLN_ENERGY_J", 50.0)    # joules
+_LAT_MS: float = _env_float("EFF_BSLN_LAT_MS", 500.0)  # ms
+_TOKENS: float = _env_float("EFF_BSLN_TOKENS", 1500.0)  # tokens
+_COST_USD: float = _env_float("EFF_BSLN_COST_USD", 0.01)  # dollars
+_ENERGY_J: float = _env_float("EFF_BSLN_ENERGY_J", 50.0)  # joules
 
 # Weights for penalty blend – must sum to 1.0
 _WEIGHTS = (0.4, 0.3, 0.2, 0.1)
@@ -102,7 +104,7 @@ def _clip01(x: float) -> float:
 
 
 # ──────────────────────────────── main entry ‑ API ───────────────────────────
-def reward(state: Any, action: Any, result: Any) -> float:   # noqa: D401
+def reward(state: Any, action: Any, result: Any) -> float:  # noqa: D401
     """
     Efficiency reward ∈ [0, 1]
 
@@ -130,16 +132,11 @@ def reward(state: Any, action: Any, result: Any) -> float:   # noqa: D401
 
     try:
         latency_p = _norm(float(result.get("latency_ms", 0.0)), _LAT_MS)
-        tokens_p  = _norm(float(result.get("tokens", 0.0)),     _TOKENS)
-        cost_p    = _norm(float(result.get("cost_usd", 0.0)),   _COST_USD)
-        energy_p  = _norm(float(result.get("energy_j", 0.0)),   _ENERGY_J)
+        tokens_p = _norm(float(result.get("tokens", 0.0)), _TOKENS)
+        cost_p = _norm(float(result.get("cost_usd", 0.0)), _COST_USD)
+        energy_p = _norm(float(result.get("energy_j", 0.0)), _ENERGY_J)
 
-        penalty = (
-            _WEIGHTS[0] * latency_p +
-            _WEIGHTS[1] * tokens_p  +
-            _WEIGHTS[2] * cost_p    +
-            _WEIGHTS[3] * energy_p
-        )
+        penalty = _WEIGHTS[0] * latency_p + _WEIGHTS[1] * tokens_p + _WEIGHTS[2] * cost_p + _WEIGHTS[3] * energy_p
 
         reward_val = value / (1.0 + penalty)
     except Exception as exc:  # noqa: BLE001

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/energy_balance_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/energy_balance_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """energy_balance_reward.py — Alpha‑Factory v1 👁️✨
 ========================================================================
 Reward backend that promotes **healthy daily energy balance**.
@@ -65,6 +66,7 @@ _lock = _th.Lock()
 
 _DEFAULT_BMR = 1650  # kcal, population‑level average
 
+
 # ----------------------------------------------------------------------
 # Helper utilities
 # ----------------------------------------------------------------------
@@ -82,11 +84,13 @@ def _iso_day(date_str: str | None) -> str:
             _logger.warning("energy_balance_reward: unparseable date %s", date_str)
             return _dt.date.today().isoformat()
 
+
 def _as_int(val: Any, fallback: int = 0) -> int:
     try:
         return int(val)
     except Exception:
         return fallback
+
 
 def _score(net: int) -> float:
     abs_net = abs(net)
@@ -95,6 +99,7 @@ def _score(net: int) -> float:
     if abs_net <= 600:
         return 0.5
     return 0.0
+
 
 def _update_day(res: Dict[str, Any]) -> Tuple[int, int, int]:
     """Atomically update ledger and return aggregate tuple (cin, cout, bmr)."""
@@ -107,6 +112,7 @@ def _update_day(res: Dict[str, Any]) -> Tuple[int, int, int]:
             bmr = max(0, _as_int(res["bmr"], _DEFAULT_BMR))
         _ledger[day] = (cin, cout, bmr)
         return _ledger[day]
+
 
 # ----------------------------------------------------------------------
 # Public entry point
@@ -123,9 +129,15 @@ def reward(state: Any, action: Any, result: Any) -> float:  # noqa: D401
 
     _logger.debug(
         "energy_balance_reward: day=%s cal_in=%d cal_out=%d bmr=%d net=%d reward=%.2f",
-        _iso_day(result.get("date")), cal_in, cal_out, bmr, net, score
+        _iso_day(result.get("date")),
+        cal_in,
+        cal_out,
+        bmr,
+        net,
+        score,
     )
     return score
+
 
 # ----------------------------------------------------------------------
 # Unit test (run with `python energy_balance_reward.py`)

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/fitness_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/fitness_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """fitness_reward · Alpha-Factory v1 👁
 ----------------------------------------------------------------------
 Grounded reward back-end focused on *physical well-being*.
@@ -39,10 +40,10 @@ __all__ = ["reward"]  # explicit export for auto-discovery tools
 # ----------------------------------------------------------------------
 # Constants (targets & weights)
 # ----------------------------------------------------------------------
-_TARGET_STEPS = 10_000      # per day
-_TARGET_REST_HR = 60        # beats per minute
-_TARGET_SLEEP = 8.0         # hours
-_TARGET_CAL = 2_100         # kilocalories
+_TARGET_STEPS = 10_000  # per day
+_TARGET_REST_HR = 60  # beats per minute
+_TARGET_SLEEP = 8.0  # hours
+_TARGET_CAL = 2_100  # kilocalories
 
 _WEIGHTS = {
     "steps": 0.25,

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/habit_consistency_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/habit_consistency_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 """
 habit_consistency_reward.py – Alpha‑Factory v1 👁️✨
@@ -66,11 +67,11 @@ __all__ = ["reward"]
 _LOG: Final = _lg.getLogger(__name__)
 
 # ─────────────────────────────── config ──────────────────────────────────────
-FIRST_SIGHT_REWARD:   Final[float] = 0.25
-DELTA_THRESHOLDS:     Final[Dict[float, float]] = {
-    36.0: 1.0,        # ≤ 1.5 days
-    72.0: 0.5,        # ≤ 3   days
-    168.0: 0.2,       # ≤ 1   week
+FIRST_SIGHT_REWARD: Final[float] = 0.25
+DELTA_THRESHOLDS: Final[Dict[float, float]] = {
+    36.0: 1.0,  # ≤ 1.5 days
+    72.0: 0.5,  # ≤ 3   days
+    168.0: 0.2,  # ≤ 1   week
 }
 # Anything above max(DELTA_THRESHOLDS) → 0.0
 
@@ -79,6 +80,7 @@ _ISO_FMT_COMPACT: Final[str] = "%Y-%m-%dT%H:%M:%S"
 # ─────────────────────────── internal state ──────────────────────────────────
 _last_seen: Dict[str, _dt.datetime] = {}
 _lock = _th.Lock()
+
 
 # ─────────────────────────── helper functions ────────────────────────────────
 def _normalise_habit(raw: str | None) -> str | None:

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/novel_solution_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/novel_solution_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 """
 novel_solution_reward.py – Alpha‑Factory v1 👁️✨
@@ -51,12 +52,12 @@ from typing import Any, List, Dict
 _lock = _th.Lock()
 
 # ── hyper‑parameters (env‑tunable) ────────────────────────────────────
-_TAU_LOW  = float(_os.getenv("NOVEL_TAU_LOW", 0.25))   # novelty threshold
+_TAU_LOW = float(_os.getenv("NOVEL_TAU_LOW", 0.25))  # novelty threshold
 _TAU_HIGH = float(_os.getenv("NOVEL_TAU_HIGH", 0.75))  # redundancy threshold
-_MAX_MEM  = int(_os.getenv("NOVEL_MEM_LIMIT", 2048))   # ring‑buffer length
+_MAX_MEM = int(_os.getenv("NOVEL_MEM_LIMIT", 2048))  # ring‑buffer length
 
 # ── in‑memory ring buffers ───────────────────────────────────────────
-_sig_mem: List[int]         = []
+_sig_mem: List[int] = []
 _emb_mem: List[List[float]] | None = None
 _idx = 0  # ring pointer
 
@@ -64,6 +65,7 @@ _idx = 0  # ring pointer
 _have_embed = False
 try:
     import importlib as _imp
+
     _st = _imp.import_module("sentence_transformers")
     _model_name = _os.getenv("EMBED_MODEL", "all-MiniLM-L6-v2")
     _model = _st.SentenceTransformer(_model_name)
@@ -71,10 +73,11 @@ try:
 except Exception:
     _have_embed = False
 
+
 # ── helpers ──────────────────────────────────────────────────────────
 def _simhash(text: str) -> int:
     """Return 64‑bit SimHash of *text*."""
-    hv = [0]*64
+    hv = [0] * 64
     for token in text.split():
         h = int.from_bytes(_hl.sha1(token.encode()).digest()[:8], "big")
         for i in range(64):
@@ -92,10 +95,10 @@ def _sim_sig(a: int, b: int) -> float:
 
 
 def _cos(a: List[float], b: List[float]) -> float:
-    dot = sum(x*y for x, y in zip(a, b))
-    na  = _math.sqrt(sum(x*x for x in a)) or 1e-9
-    nb  = _math.sqrt(sum(x*x for x in b)) or 1e-9
-    return max(0.0, min(1.0, dot / (na*nb)))
+    dot = sum(x * y for x, y in zip(a, b))
+    na = _math.sqrt(sum(x * x for x in a)) or 1e-9
+    nb = _math.sqrt(sum(x * x for x in b)) or 1e-9
+    return max(0.0, min(1.0, dot / (na * nb)))
 
 
 def _to_text(obj: Any) -> str:
@@ -103,6 +106,7 @@ def _to_text(obj: Any) -> str:
         return obj
     try:
         import json as _json
+
         return _json.dumps(obj, sort_keys=True, ensure_ascii=False)
     except Exception:
         return repr(obj)
@@ -124,7 +128,7 @@ def reward(state: Any, action: Any, result: Any) -> float:  # noqa: D401
         for j, old_sig in enumerate(_sig_mem):
             s = _sim_sig(sig, old_sig)
             if _have_embed and _emb_mem is not None:
-                s = 0.75*s + 0.25*_cos(emb, _emb_mem[j])
+                s = 0.75 * s + 0.25 * _cos(emb, _emb_mem[j])
             sims.append(s)
 
         sim = max(sims) if sims else 0.0

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/safety_compliance_reward.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/safety_compliance_reward.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """safety_compliance_reward.py – Alpha‑Factory v1 👁️✨
 ================================================================
 Reward backend that *rewards policy compliance* and *penalises safety
@@ -50,6 +51,7 @@ _log = logging.getLogger(__name__)
 _seen_request_ids: Set[str] = set()
 _lock = threading.Lock()
 
+
 # --------------------------------------------------------------------------- #
 #  Helpers                                                                    #
 # --------------------------------------------------------------------------- #
@@ -91,8 +93,8 @@ def reward(state: Any, action: Any, result: Any) -> float:  # noqa: D401
     # ------------------------------------------------------------------ #
     #  Extract & sanitise fields                                         #
     # ------------------------------------------------------------------ #
-    violation    = _to_bool(result.get("violation", False))
-    autocorrect  = _to_bool(result.get("autocorrected", False))
+    violation = _to_bool(result.get("violation", False))
+    autocorrect = _to_bool(result.get("autocorrected", False))
 
     # Severity: float ∈ [0,10], infer 0 if missing / bad
     try:

--- a/alpha_factory_v1/demos/era_of_experience/reward_backends/template.py
+++ b/alpha_factory_v1/demos/era_of_experience/reward_backends/template.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Reward backend template · Alpha-Factory v1 👁️✨
 ---------------------------------------------------------------------
 Minimal skeleton illustrating how to craft a custom reward backend.
@@ -14,6 +15,7 @@ from typing import Any
 import math
 
 __all__ = ["reward"]
+
 
 def reward(state: Any, action: Any, result: Any) -> float:
     """Example reward function normalising ``result['score']``.

--- a/alpha_factory_v1/demos/era_of_experience/simulation/__init__.py
+++ b/alpha_factory_v1/demos/era_of_experience/simulation/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tiny simulation stubs for Era-of-Experience demo."""
 from .env_stub import SimpleExperienceEnv
+
 __all__ = ["SimpleExperienceEnv"]

--- a/alpha_factory_v1/demos/era_of_experience/simulation/env_stub.py
+++ b/alpha_factory_v1/demos/era_of_experience/simulation/env_stub.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Simple Gym-like environment stub.
 
 This minimal environment illustrates how the

--- a/alpha_factory_v1/demos/era_of_experience/stub_agents.py
+++ b/alpha_factory_v1/demos/era_of_experience/stub_agents.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Stub agents illustrating potential OpenAI SDK and Google ADK workflows.
 
 This module provides bare-bones agent classes demonstrating how the
@@ -14,6 +15,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+
 def _safe_import_agent(module_name: str, class_name: str) -> type:
     """Safely import an agent class, falling back to `object` if unavailable."""
     try:
@@ -24,6 +26,7 @@ def _safe_import_agent(module_name: str, class_name: str) -> type:
         return agent_class
     except Exception:  # pragma: no cover - optional dependency
         return object  # type: ignore
+
 
 Agent = _safe_import_agent("openai_agents", "Agent")  # OpenAI Agents SDK
 ADKAgent = _safe_import_agent("google_adk", "Agent")  # Google ADK


### PR DESCRIPTION
## Summary
- add SPDX license headers to the Era of Experience demo modules

## Testing
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/__init__.py alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py alpha_factory_v1/demos/era_of_experience/alpha_detection.py alpha_factory_v1/demos/era_of_experience/alpha_report.py alpha_factory_v1/demos/era_of_experience/reward_backends/__init__.py alpha_factory_v1/demos/era_of_experience/reward_backends/curiosity_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/education_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/efficiency_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/energy_balance_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/fitness_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/habit_consistency_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/novel_solution_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/safety_compliance_reward.py alpha_factory_v1/demos/era_of_experience/reward_backends/template.py alpha_factory_v1/demos/era_of_experience/simulation/__init__.py alpha_factory_v1/demos/era_of_experience/simulation/env_stub.py alpha_factory_v1/demos/era_of_experience/stub_agents.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843b35c7bb8833387d93eadad30ffa5