### PR TITLE
[alpha_factory] use crypto.randomUUID for replay ids

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
@@ -35,10 +35,9 @@ test('share and import frames maintain order and cid', async () => {
 test('addFrame generates unique ids', async () => {
   const db = new ReplayDB('jest');
   await db.open();
-  const ids = new Set();
+  const ids = [];
   for (let i = 0; i < 100; i++) {
-    const id = await db.addFrame(null, { i });
-    expect(ids.has(id)).toBe(false);
-    ids.add(id);
+    ids.push(await db.addFrame(null, { i }));
   }
+  expect(new Set(ids).size).toBe(100);
 });

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -62,13 +62,11 @@ export class ReplayDB {
    * @returns The new frame ID.
    */
   async addFrame(parent: number | null, delta: ReplayDelta): Promise<number> {
-    let id: number;
-    if (typeof (crypto as any).randomUUID === 'function') {
-      const uuid = (crypto as any).randomUUID().replace(/-/g, '');
-      id = parseInt(uuid.slice(0, 13), 16);
-    } else {
-      id = Date.now() + Math.floor(Math.random() * 1000);
-    }
+    const uuidFn = (globalThis.crypto as Crypto | undefined)?.randomUUID;
+    const id =
+      typeof uuidFn === 'function'
+        ? parseInt(uuidFn.call(globalThis.crypto).replace(/-/g, '').slice(0, 13), 16)
+        : Date.now() + Math.floor(Math.random() * 1000);
     const frame: ReplayFrame = { id, parent, delta, timestamp: Date.now() };
     await withStore('readwrite', (s) => s.put(frame, id));
     return id;


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID` when available to generate replay IDs
- verify uniqueness over 100 insertions in Jest tests

## Testing
- `npm test` *(fails: Could not resolve ../lib/bundle.esm.min.js)*

------
https://chatgpt.com/codex/tasks/task_e_6843b73f0c7083338a04313c5e0167a2