### PR TITLE
[alpha_factory] fix sleep parsing and test

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -38,6 +38,7 @@ import datetime as dt
 import json
 import logging
 import math
+import re
 from typing import Dict, Any, AsyncIterator, List
 
 from fastapi import FastAPI
@@ -165,7 +166,8 @@ def _fitness_reward(evt: Dict[str, Any]) -> float:
     if "Run" in act or "Cycle" in act or "Yoga" in act:
         return 1.0
     if "Sleep" in act:
-        hrs = float(act.split()[1][:-1])  # crude parse
+        match = re.search(r"\d+(?:\.\d+)?", act)
+        hrs = float(match.group(0)) if match else 0.0  # extract first numeric value
         return max(0, min(1.0, hrs / 8.0))
     return 0.0
 

--- a/tests/test_era_experience.py
+++ b/tests/test_era_experience.py
@@ -10,11 +10,13 @@ from alpha_factory_v1.demos.era_of_experience.stub_agents import (
     FederatedExperienceAgent,
 )
 
+
 class TestEraOfExperience(unittest.TestCase):
     def test_experience_stream_yields_event(self) -> None:
         async def get_event():
             gen = demo.experience_stream()
             return await anext(gen)
+
         evt = asyncio.run(get_event())
         self.assertIsInstance(evt, dict)
         self.assertIn("kind", evt)
@@ -29,6 +31,11 @@ class TestEraOfExperience(unittest.TestCase):
             self.assertGreaterEqual(val, 0.0)
             self.assertLessEqual(val, 1.0)
 
+    def test_fitness_reward_parses_sleep(self) -> None:
+        evt = {"payload": {"activity": "Sleep 7 h 45 m"}}
+        val = demo._fitness_reward(evt)
+        self.assertIsInstance(val, float)
+
     def test_simple_env_runs(self) -> None:
         env = SimpleExperienceEnv()
         state = env.reset()
@@ -42,6 +49,6 @@ class TestEraOfExperience(unittest.TestCase):
         self.assertTrue(hasattr(exp, "act"))
         self.assertTrue(hasattr(fed, "handle_request"))
 
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()
-


### PR DESCRIPTION
## Summary
- fix fitness reward to parse sleep duration using regex
- add regression test ensuring `_fitness_reward` handles "Sleep 7 h 45 m"

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(failed: Installation stalled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google', ...)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py tests/test_era_experience.py` *(failed: mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843b73062b883338e9e9c188f03451e