### PR TITLE
[alpha_factory] Hardening telemetry localStorage access

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py
@@ -198,3 +198,25 @@ def test_localstorage_failure_disables_telemetry() -> None:
         page.evaluate("window.dispatchEvent(new Event('beforeunload'))")
         assert not errors
         browser.close()
+
+
+def test_no_uncaught_error_on_setitem_failure() -> None:
+    dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"
+    url = dist.as_uri()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        errors: list[str] = []
+        page.on("pageerror", lambda err: errors.append(str(err)))
+        page.goto(url)
+        page.evaluate(
+            "window.OTEL_ENDPOINT='https://example.com';"
+            "window.confirm=() => true;"
+            "Object.defineProperty(localStorage,'setItem',{value:()=>{throw new Error('boom');},configurable:true});"
+        )
+        page.reload()
+        page.wait_for_selector("#controls")
+        page.evaluate("window.dispatchEvent(new Event('beforeunload'))")
+        assert not errors
+        browser.close()

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -26,6 +26,12 @@ export function initTelemetry(t) {
 
   const consentKey = 'telemetryConsent';
   let disabled = false;
+  try {
+    localStorage.getItem(consentKey);
+  } catch (err) {
+    console.warn('telemetry disabled', err);
+    disabled = true;
+  }
   function lsGet(key) {
     if (disabled) return null;
     try {


### PR DESCRIPTION
## Summary
- disable telemetry when localStorage access throws
- test localStorage failures don't raise errors

## Testing
- `pre-commit run eslint-insight-browser`
- `pytest -k "localstorage_failure_disables_telemetry or no_uncaught_error_on_setitem_failure" alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_telemetry.py -q` *(fails: Page.wait_for_selector timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6843b9846bf08333a70c1a478e483e90