### PR TITLE
[alpha_factory] Add data-dir option to alpha_report CLI

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -138,6 +138,12 @@ Result: an agent that <strong>evolves faster than you can refresh the page</stro
 | `colab_era_of_experience.ipynb` | Cloud twin notebook |
 | `alpha_report.py` | CLI helper printing current offline alpha signals |
 
+Run it with local CSVs:
+
+```bash
+python alpha_report.py --data-dir path/to/offline_samples
+```
+
 ---
 
 ## 🔌 Extending

--- a/tests/test_alpha_report_cli.py
+++ b/tests/test_alpha_report_cli.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+import subprocess
+import sys
+from pathlib import Path
+import unittest
+
+
+class TestAlphaReportCLI(unittest.TestCase):
+    """Ensure the alpha_report CLI runs with a custom data directory."""
+
+    def test_run_with_data_dir(self) -> None:
+        data_dir = Path(
+            "alpha_factory_v1/demos/macro_sentinel/offline_samples"
+        ).as_posix()
+        result = subprocess.run(
+            [
+                sys.executable,
+                "alpha_factory_v1/demos/era_of_experience/alpha_report.py",
+                "--data-dir",
+                data_dir,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Alpha signals", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- allow passing `--data-dir` to alpha_report CLI
- show CLI example in `era_of_experience` README
- test running the alpha_report CLI with a custom data directory

## Testing
- `python scripts/check_python_deps.py`
- `AUTO_INSTALL_MISSING=0 python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed to import numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6843ba0321ac8333a92ecb77ff821e7e