### PR TITLE
[alpha_factory] offline setup docs

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -57,6 +57,21 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
 
 > **Offline/Private mode** — leave `OPENAI_API_KEY=` blank in <code>config.env</code>; the stack falls back to <strong>Ollama ✕ Mixtral‑8x7B</strong> and stays air‑gapped.
 
+## Offline Setup
+
+When running without internet access:
+
+1. Pre-download `wearable_daily.csv` and `edu_progress.csv` from the
+   <a href="https://github.com/MontrealAI/demo-assets">demo-assets</a> repository.
+2. Place both files in `offline_samples/` before executing
+   <code>./run_experience_demo.sh</code> so the orchestrator can read them.
+3. If the environment check cannot reach PyPI, set `SKIP_ENV_CHECK=1` to skip
+   that step:
+   ```bash
+   SKIP_ENV_CHECK=1 ./run_experience_demo.sh
+   ```
+
+
 ### 🔧 Configure &amp; advanced usage
 
 1. Copy the sample environment file and tweak as desired:

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -55,6 +55,8 @@ while [[ $# -gt 0 ]]; do
 Usage: ./run_experience_demo.sh [--live]
 
 --live   Start real-time collectors (wearables-sim, RSS feeds, etc.)
+Place pre-downloaded CSVs in ./offline_samples/ for air-gapped runs.
+Set SKIP_ENV_CHECK=1 to bypass Python package checks.
 EOF
       exit 0 ;;
     *) die "Unknown flag: $1" ;;


### PR DESCRIPTION
## Summary
- document offline setup for Era of Experience demo
- mention offline options in run_experience_demo.sh help text

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843bd849c5c83339c3dad3a840fd33b