### PR TITLE
[alpha_factory] add PG_PASSWORD doc entry

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -78,7 +78,7 @@ When running without internet access:
 
    ```bash
    cp config.env.sample config.env
-   $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, LOG_LEVEL, LIVE_FEED, etc.
+   $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, PG_PASSWORD, LOG_LEVEL, LIVE_FEED, etc.
    ```
    You may override the path for built-in offline samples with
    `SAMPLE_DATA_DIR=/path/to/csvs`.

--- a/alpha_factory_v1/demos/era_of_experience/config.env.sample
+++ b/alpha_factory_v1/demos/era_of_experience/config.env.sample
@@ -31,6 +31,8 @@ FITNESS_REWARD_WEIGHT=0.50       # weight on `fitness_reward()` backend
 EDUCATION_REWARD_WEIGHT=0.50     # weight on `education_reward()` backend
 
 ###########################  Optional services  ##############################
+# TimescaleDB password used by the live-feed logger (user = experience)
+PG_PASSWORD=alpha
 # DATABASE_URL=postgresql://alpha:alpha@timescaledb:5432/experience
 PROMETHEUS_PORT=9090             # metrics scrape port for Prometheus / Grafana
 


### PR DESCRIPTION
## Summary
- document TimescaleDB password for the experience demo
- mention PG_PASSWORD in README instructions

## Testing
- `python scripts/check_python_deps.py` *(fails: missing packages)*
- `python check_env.py --auto-install` *(cancelled due to long install)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/config.env.sample alpha_factory_v1/demos/era_of_experience/README.md` *(initialization started but interrupted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843c0f2ef4083338a778e3e20fad1bb