### PR TITLE
[alpha_factory] Add Quick-Start section to browser README

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -1,9 +1,13 @@
 ### 🔬 Browser-only Insight demo
 A zero-backend Pareto explorer lives in
-`demos/alpha_agi_insight_v1/insight_browser_v1/`.
+`demos/alpha_agi_insight_v1/insight_browser_v1/`. See the **Quick-Start** section below for a short walkthrough.
 
 ## Disclaimer
 This demo is a conceptual research prototype describing aspirational goals and does not contain real general intelligence. Use at your own risk.
+
+## Quick-Start
+Open [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf)
+for a concise overview of the build and launch steps.
 
 ## Prerequisites
 - **Node.js ≥20** is required for offline PWA support and by `manual_build.py`


### PR DESCRIPTION
## Summary
- mention the Quick-Start section at the top of the browser README
- add a Quick-Start paragraph linking to docs/insight_browser_quickstart.pdf

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: `proto-verify` hook)*

------
https://chatgpt.com/codex/tasks/task_e_6843c199d47083339c4d608446033f1d