### PR TITLE
[alpha_factory] add verify-only mode

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.github/workflows/demo.yml
@@ -25,6 +25,8 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Verify assets
+        run: python ../../../../scripts/fetch_assets.py --verify-only
       - name: Build
         run: npm run build -- --verbose
         env:


### PR DESCRIPTION
## Summary
- verify Insight demo assets via `--verify-only` flag
- verify assets in Insight browser workflow before build

## Testing
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub pre-commit run --files scripts/fetch_assets.py .github/workflows/demo.yml`

------
https://chatgpt.com/codex/tasks/task_e_6843c2f0a5f08333a58776d16851d6ca