### PR TITLE
[alpha_factory] clarify alpha detector data path

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -53,7 +53,9 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
   * live trace‑graph 🪄
   * reward dashboards 📈
   * interactive chat / tool console 💬
-  * built‑in alpha detectors (yield curve & supply‑chain) 🔍
+  * built‑in alpha detectors (yield curve & supply‑chain) 🔍 — they read from
+    `alpha_factory_v1/demos/macro_sentinel/offline_samples/`, and the CSV
+    snapshots are already included in the repository
 
 > **Offline/Private mode** — leave `OPENAI_API_KEY=` blank in <code>config.env</code>; the stack falls back to <strong>Ollama ✕ Mixtral‑8x7B</strong> and stays air‑gapped.
 


### PR DESCRIPTION
## Summary
- document source CSVs for alpha detectors

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(failed: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/README.md` *(failed: proto-verify hook error)*

------
https://chatgpt.com/codex/tasks/task_e_6843c2bf519883338455d7351f250cb6