### PR TITLE
[alpha_factory] add locale parity test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -320,6 +320,9 @@ checks. `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` prevents Playwright from fetching
 browsers. Optionally set `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` when using
 pre‑downloaded binaries.
 
+The Jest test `locale_parity.test.js` verifies that all translation files share
+the same set of keys.
+
 ## Development
 
 - Run `pre-commit run --all-files` to format and lint the code.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/locale_parity.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/locale_parity.test.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+const fs = require('fs');
+const path = require('path');
+
+const en = require('../src/i18n/en.json');
+
+const dir = path.join(__dirname, '../src/i18n');
+
+test('all locale files share the same keys', () => {
+  const baseKeys = Object.keys(en).sort();
+  for (const file of fs.readdirSync(dir)) {
+    if (file === 'en.json') continue;
+    const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+    const keys = Object.keys(data).sort();
+    expect(keys).toEqual(baseKeys);
+  }
+});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -29,6 +29,7 @@ run(['node', '--loader', 'ts-node/register', '--test',
   'tests/iframe_worker_cleanup.test.js',
   'tests/onnx_gpu_backend.test.js',
   'tests/error_boundary_limit.test.js',
+  'tests/locale_parity.test.js',
   'tests/test_sw_update.js',
   '../../../../tests/taxonomy.test.ts',
   '../../../../tests/memeplex.test.ts'


### PR DESCRIPTION
## Summary
- add Jest locale parity test to verify translation files
- run test in the browser demo runner
- document the locale parity check

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/locale_parity.test.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68442a5d02008333a33d544787c31d6c