### PR TITLE
[alpha_factory] add Pyodide type hints

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/wasm/bridge.ts
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import { loadPyodide } from '../lib/pyodide.js';
 
+interface Pyodide {
+  globals: { set(key: string, value: unknown): void; get(key: string): string };
+  runPythonAsync(code: string): Promise<unknown>;
+  runPython(code: string): unknown;
+}
+
 export const bridgeEvents = new EventTarget();
 export const PY_LOAD_START = 'py-load-start';
 export const PY_LOAD_END = 'py-load-end';
 
-let pyodideReady: any;
-async function initPy(): Promise<any> {
+let pyodideReady: Pyodide | null = null;
+async function initPy(): Promise<Pyodide> {
   if (!pyodideReady) {
     bridgeEvents.dispatchEvent(new Event(PY_LOAD_START));
     try {
@@ -28,16 +34,16 @@ async function initPy(): Promise<any> {
       bridgeEvents.dispatchEvent(new Event(PY_LOAD_END));
     }
   }
-  return pyodideReady;
+  return pyodideReady as Pyodide;
 }
 
-export async function run(params: { seed?: number } = {}): Promise<any> {
+export async function run(params: { seed?: number } = {}): Promise<unknown> {
   const pyodide = await initPy();
   const seed = params.seed ?? 0;
   await pyodide.runPythonAsync(`import random; random.seed(${seed})`);
   const code = `\nfrom forecast import forecast_disruptions\nfrom simulation import sector\nres = forecast_disruptions([sector.Sector('x')], 1, seed=${seed})\nimport json\nprint(json.dumps([{'year': r.year, 'capability': r.capability} for r in res]))`;
   await pyodide.runPythonAsync('import forecast, mats');
-  const out = pyodide.runPython(code);
+  const out = pyodide.runPython(code) as string;
   return JSON.parse(out);
 }
 


### PR DESCRIPTION
## Summary
- define a minimal `Pyodide` interface
- use `Pyodide` for `pyodideReady`
- update `initPy()` and `run()` signatures

## Testing
- `npm run typecheck` *(fails: Cannot find module 'd3', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68442c0d48c483338134c3661909363d