### PR TITLE
[alpha_factory] clarify env check in experience README

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -255,8 +255,10 @@ Verify the demo locally with Python's builtin test runner:
 python -m unittest tests.test_era_experience
 ```
 
-Run `python ../../../check_env.py --auto-install` first to ensure optional
-packages like `pytest` and `openai-agents` are available.
+Run `python ../../../check_env.py --auto-install` first and make sure it
+completes successfully before running any tests. Tests will fail if core
+packages such as `numpy` are missing, in addition to optional ones like
+`pytest` and `openai-agents`.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that `python ../../../check_env.py --auto-install` must succeed before running tests
- warn that unit tests fail when core packages such as `numpy` are missing

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(fails: network unreachable)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68443045e9508333afbefe8443552cdd