### PR TITLE
[alpha_factory] add SPDX header to finance demo

### DIFF
--- a/alpha_factory_v1/demos/finance_alpha/agent_control.py
+++ b/alpha_factory_v1/demos/finance_alpha/agent_control.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Minimal helper to drive the FinanceAgent programmatically.
 
 This script uses the OpenAI Agents SDK when available and falls back to

--- a/alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh
+++ b/alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 # demos/deploy_alpha_factory_demo.sh
 # ─────────────────────────────────────────────────────────────────────────
 # One‑command demo for Alpha‑Factory v1.


### PR DESCRIPTION
## Summary
- add Apache 2.0 headers to finance demo scripts

## Testing
- `pre-commit run --files alpha_factory_v1/demos/finance_alpha/agent_control.py alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684430f6f9788333ae7e0db87af04944