### PR TITLE
[alpha_factory] add finance demo env sample

### DIFF
--- a/alpha_factory_v1/demos/finance_alpha/.env.sample
+++ b/alpha_factory_v1/demos/finance_alpha/.env.sample
@@ -1,0 +1,29 @@
+#======================================================================
+#  Finance Alpha Demo — environment template
+#  Copy to `.env` in this directory before running the demo.
+#  Never commit real secrets to version control.
+#======================================================================
+
+# Strategy and ports
+FINANCE_STRATEGY=btc_gld
+PORT_API=8000
+TRACE_WS_PORT=8088
+
+# Core finance settings
+FIN_CYCLE_SECONDS=60
+FIN_START_BALANCE_USD=10000
+FIN_PLANNER_DEPTH=5
+FIN_PROMETHEUS=1
+
+# Universe & risk limits
+ALPHA_UNIVERSE=BTCUSDT,ETHUSDT
+ALPHA_MAX_VAR_USD=50000
+ALPHA_MAX_CVAR_USD=75000
+ALPHA_MAX_DD_PCT=20
+
+# Broker credentials (optional)
+BINANCE_API_KEY=
+BINANCE_API_SECRET=
+
+# Misc
+ADK_MESH=0

--- a/alpha_factory_v1/demos/finance_alpha/README.md
+++ b/alpha_factory_v1/demos/finance_alpha/README.md
@@ -26,9 +26,16 @@ curl -L https://raw.githubusercontent.com/MontrealAI/AGI-Alpha-Agent-v0/main/alp
 
 _No installation beyond Docker, `curl`, and `jq`._
 
-**Customize**  
+**Customize**
 `STRATEGY=my_pair PORT_API=8001 bash deploy_alpha_factory_demo.sh` runs a
 different momentum pair on an alternate port.
+
+### .env Setup
+Copy [.env.sample](.env.sample) to `.env` and tweak values as desired. The
+sample defines defaults such as `FINANCE_STRATEGY=btc_gld`, `PORT_API=8000`,
+`TRACE_WS_PORT=8088`, `FIN_CYCLE_SECONDS=60` and
+`FIN_START_BALANCE_USD=10000`. Any variable you omit falls back to these safe
+defaults when the demo starts.
 
 ---
 


### PR DESCRIPTION
## Summary
- provide `.env.sample` for finance_alpha demo
- mention copying this file in the demo README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(failed to complete: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844319919808333a6616cbe3a1c93d2