### PR TITLE
[alpha_factory] use SAMPLE_DATA_DIR in experience demo

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
+++ b/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
@@ -96,6 +96,7 @@ services:
       REDIS_URL: "redis://redis:6379/0"
       DATABASE_URL: "postgresql://experience:${PG_PASSWORD:-experience}@timescaledb:5432/exp_stream"
       LLM_BASE_URL: "${LLM_BASE_URL:-http://ollama:11434/v1}"
+      SAMPLE_DATA_DIR: "${SAMPLE_DATA_DIR:-/app/demo/offline_samples}"
     volumes:
       - ./:/app/demo:ro
     depends_on:

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -41,7 +41,9 @@ demo_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
 root_dir="${demo_dir%/*/*}"                    # → …/alpha_factory_v1
 compose_file="$demo_dir/docker-compose.experience.yml"
 env_file="$demo_dir/config.env"
-offline_dir="$demo_dir/offline_samples"
+sample_dir="${SAMPLE_DATA_DIR:-$demo_dir/offline_samples}"
+offline_dir="$sample_dir"
+export SAMPLE_DATA_DIR="$sample_dir"
 
 cd "$root_dir"                                # required for build context
 
@@ -55,7 +57,7 @@ while [[ $# -gt 0 ]]; do
 Usage: ./run_experience_demo.sh [--live]
 
 --live   Start real-time collectors (wearables-sim, RSS feeds, etc.)
-Place pre-downloaded CSVs in ./offline_samples/ for air-gapped runs.
+Place pre-downloaded CSVs in $SAMPLE_DATA_DIR (defaults to ./offline_samples/) for air-gapped runs.
 Set SKIP_ENV_CHECK=1 to bypass Python package checks.
 EOF
       exit 0 ;;
@@ -95,7 +97,7 @@ EOF
 fi
 
 ############################## offline samples ################################
-say "Syncing offline experience snapshots"
+say "Syncing offline experience snapshots in $offline_dir"
 mkdir -p "$offline_dir"
 declare -A urls=(
   [wearable_daily.csv]=https://raw.githubusercontent.com/MontrealAI/demo-assets/main/wearable_daily.csv


### PR DESCRIPTION
## Summary
- allow `run_experience_demo.sh` to read `SAMPLE_DATA_DIR` instead of a fixed path
- propagate the variable to docker compose

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml` *(failed: environment initialization interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844378b5d7c8333aa6b55c7f87c70ba