### PR TITLE
[alpha_factory] update finance demo script

### DIFF
--- a/alpha_factory_v1/demos/finance_alpha/README.md
+++ b/alpha_factory_v1/demos/finance_alpha/README.md
@@ -38,8 +38,10 @@ runs a different momentum pair and exposes the trace‑graph on an alternate
 port.
 
 ### .env Setup
-Copy [.env.sample](.env.sample) to `.env` and tweak values as desired. Every
-variable can also be overridden directly on the command line:
+Copy [.env.sample](.env.sample) to `.env` next to the script. The demo
+automatically sources this file before reading any environment variables so
+values defined inside are forwarded to the container.
+Each variable can still be overridden directly on the command line:
 `PORT_API=8001 TRACE_WS_PORT=9000 bash deploy_alpha_factory_demo.sh`.
 
 | Variable | Purpose | Default |


### PR DESCRIPTION
## Summary
- source `.env` before setting defaults in `deploy_alpha_factory_demo.sh`
- forward `.env` variables like `FIN_CYCLE_SECONDS` to `docker run`
- document automatic `.env` loading in the demo README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh alpha_factory_v1/demos/finance_alpha/README.md` *(fails: Verify requirements.lock is up to date)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy)*
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684439ef9fb883339948d191ebc7938f