### PR TITLE
[alpha_factory] add TRACE_WS_PORT env

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,10 +833,10 @@ curl -L https://raw.githubusercontent.com/MontrealAI/AGI-Alpha-Agent-v0/main/alp
 
 The script pulls the signed demo container, runs a BTC/GLD strategy, prints open
 positions and P&L, and exposes the trace‑graph UI at
-<http://localhost:8088>.
+<http://localhost:${TRACE_WS_PORT}>.
 
 Need a different pair or port? Use environment variables:
-`STRATEGY=my_pair PORT_API=8001 bash deploy_alpha_factory_demo.sh`
+`STRATEGY=my_pair PORT_API=8001 TRACE_WS_PORT=9000 bash deploy_alpha_factory_demo.sh`
 
 No GPU → falls back to GGML Llama‑3‑8B‑Q4.
 No `OPENAI_API_KEY` → switches to local SBERT + heuristics.

--- a/alpha_factory_v1/demos/finance_alpha/README.md
+++ b/alpha_factory_v1/demos/finance_alpha/README.md
@@ -27,7 +27,7 @@ curl -L https://raw.githubusercontent.com/MontrealAI/AGI-Alpha-Agent-v0/main/alp
 2. Container starts with the *BTC / GLD* momentum strategy.
 3. The script verifies the API port is free and waits for the health endpoint.
 4. The script prints JSON tables for **positions** and **P&L**.
-5. You get a link to the live **trace‑graph UI** (`http://localhost:8088`).
+5. You get a link to the live **trace‑graph UI** (`http://localhost:${TRACE_WS_PORT}`).
 6. Container stops automatically when you close the terminal.
 
 _No installation beyond Docker, `curl`, and `jq`._

--- a/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
+++ b/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
@@ -50,6 +50,7 @@
    "source": [
     "IMG = \"ghcr.io/montrealai/alphafactory_pro:cpu-slim-latest\"\n",
     "PORT_API = 8000\n",
+    "TRACE_WS_PORT = 8088\n",
     "CONTAINER = \"af_nb_demo\"\n",
     "STRATEGY = \"btc_gld\"  # change to your own\n"
    ]
@@ -78,10 +79,13 @@
     "        return s.connect_ex(('localhost', port)) != 0\n",
     "if not port_free(PORT_API):\n",
     "    raise RuntimeError(f'Port {PORT_API} is already in use')\n",
+    "if not port_free(TRACE_WS_PORT):\n",
+    "    raise RuntimeError(f'Port {TRACE_WS_PORT} is already in use')\n",
     "\n",
     "print('\ud83d\ude80 Starting Alpha\u2011Factory \u2026')\n",
     "cid = subprocess.check_output(['docker','run','-d','--rm','--name',CONTAINER,\n",
-    "    '-p', f'{PORT_API}:8000','-e', f'FINANCE_STRATEGY={STRATEGY}', IMG], text=True).strip()\n",
+    "    '-p', f'{PORT_API}:8000', '-p', f'{TRACE_WS_PORT}:{TRACE_WS_PORT}',\n",
+    "    '-e', f'FINANCE_STRATEGY={STRATEGY}', '-e', f'TRACE_WS_PORT={TRACE_WS_PORT}', IMG], text=True).strip()\n",
     "\n",
     "for _ in range(90):\n",
     "    try:\n",
@@ -152,7 +156,7 @@
   "metadata": {},
    "source": [
     "##\u00a04\u00a0\u00b7\u00a0Explore the trace\u2011graph \u2728\n",
-    "Open [http://localhost:8088](http://localhost:8088) in your browser to watch\n",
+    "Open [http://localhost:{TRACE_WS_PORT}](http://localhost:{TRACE_WS_PORT}) in your browser to watch\n",
     "the planner emit decisions and tool\u2011calls in real time."
    ]
   },
@@ -164,7 +168,7 @@
    "outputs": [],
    "source": [
     "from IPython.display import IFrame, display\n",
-    "display(IFrame('http://localhost:8088', width='100%', height=500))\n"
+    "display(IFrame(f'http://localhost:{TRACE_WS_PORT}', width='100%', height=500))\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- expose TRACE_WS_PORT in finance demo script
- check TRACE_WS_PORT availability and map container port accordingly
- reference TRACE_WS_PORT in docs and notebook

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/finance_alpha/README.md alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb` *(skipped heavy hooks)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: Operation cancelled by user)*
- `pytest -q` *(failed to import numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68443e7ff6dc8333ad4d19fd4a4829dd