### PR TITLE
[alpha_factory] improve dependency checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,10 +107,8 @@ Follow these steps when installing without internet access:
   ```
   The `verify-alpha-colab-requirements-lock` hook relies on this lock file.
 
-- See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
-- Run `python scripts/check_python_deps.py` to quickly verify that `numpy` and
-  other required packages are installed. If it reports missing packages,
-  execute `python check_env.py --auto-install` before running the tests.
+ - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
+- Run `python scripts/check_python_deps.py` to quickly verify that `numpy`, `yaml` and `pandas` are installed. If it reports missing packages, execute `python check_env.py --auto-install` before running the tests. When working offline pass `--wheelhouse <path>` or set `WHEELHOUSE` so `pip` installs from the local cache.
 - After setup, validate with `python check_env.py --auto-install`. When `WHEELHOUSE` is set, run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly offline.
 - The unit tests rely on `fastapi`, `opentelemetry-api`, `openai-agents` and `google-adk`. `./codex/setup.sh` installs these packages automatically. When skipping the setup script, run
   `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no
@@ -276,9 +274,10 @@ install dependencies without internet access.
 - Keep commits focused and descriptive. Use meaningful commit messages.
 - Ensure `git status` shows a clean working tree before committing.
 - Remove stray build artifacts with `git clean -fd` if needed.
-- Run `python scripts/check_python_deps.py` followed by
-  `python check_env.py --auto-install` and `pytest -q` before committing. \
-  Document any remaining test failures in the PR description.
+ - Run `python scripts/check_python_deps.py` followed by
+    `python check_env.py --auto-install` (use `--wheelhouse <path>` when offline)
+    and `pytest -q` before committing. Document any remaining test failures in
+    the PR description.
 - See [tests/README.md](tests/README.md) for details on running the suite locally,
   including setting `PYTHONPATH` or installing in editable mode.
 - Summarize your changes and test results in the PR body.
@@ -320,9 +319,10 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
 ### Troubleshooting
 - If the stack fails to start, verify Docker and Docker Compose are running.
 - Setup errors usually mean Python is older than 3.11. Use Python 3.11 or 3.12 (>=3.11,<3.13).
-- Missing optional packages can cause test failures; first run
+ - Missing optional packages can cause test failures; first run
   `python scripts/check_python_deps.py` and then
-  `python check_env.py --auto-install` if required.
+  `python check_env.py --auto-install` (pass `--wheelhouse <path>` when offline)
+  if required.
 
 For detailed troubleshooting steps, see [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md).
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -511,6 +511,7 @@ the `alpha_factory_v1` package. Either install the project or export
 
 ```bash
 export PYTHONPATH=$(pwd)  # if running from the repo root without installation
+python check_env.py --auto-install  # verify optional packages
 pytest -q          # unit + integration suite
 pytest -m e2e      # full 5-year forecast smoke-test
 ```
@@ -537,6 +538,15 @@ WHEELHOUSE=/media/wheels pytest -q
 
 `playwright` and other heavy packages must exist in the wheelhouse for tests to
 pass offline.
+
+### Troubleshooting
+
+If `check_env.py` reports missing packages, ensure `WHEELHOUSE` points to a
+directory of wheels and rerun:
+
+```bash
+python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+```
 
 ---
 

--- a/scripts/check_python_deps.py
+++ b/scripts/check_python_deps.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Quick dependency check for tests.
 
-This lightweight helper verifies that ``numpy`` and a few
-core packages are installed.  It is intended as a fast
+This lightweight helper verifies that ``numpy``, ``yaml`` and ``pandas``
+along with a few core packages are installed.  It is intended as a fast
 pre-flight check before running the full environment
 validation or the test suite.
 
@@ -18,7 +18,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 
-REQUIRED = ["numpy", "pytest"]
+REQUIRED = ["numpy", "pytest", "yaml", "pandas"]
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- verify `yaml` and `pandas` via `scripts/check_python_deps.py`
- document using `--wheelhouse` with `check_env.py`
- mention environment check in demo README with troubleshooting tips

## Testing
- `pre-commit run --files AGENTS.md alpha_factory_v1/demos/alpha_agi_insight_v1/README.md scripts/check_python_deps.py` *(failed: proto-verify missing separator)*
- `python scripts/check_python_deps.py` *(failed: Missing packages: numpy, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68443eb3ce0083338f09af6a60d9fe3f