### PR TITLE
[alpha_factory] allow custom offline samples dir

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -82,10 +82,15 @@ When running without internet access:
    cp config.env.sample config.env
    $EDITOR config.env      # set OPENAI_API_KEY, MODEL_NAME, PG_PASSWORD, LOG_LEVEL, LIVE_FEED, etc.
    ```
-   You may override the path for built-in offline samples with
-   `SAMPLE_DATA_DIR=/path/to/csvs`.
-   Sample CSVs (`wearable_daily.csv`, `edu_progress.csv`) are shipped in
-   `offline_samples/` so the demo also works without internet access.
+You may override the path for built-in offline samples by exporting
+`SAMPLE_DATA_DIR` before launching the demo:
+
+```bash
+SAMPLE_DATA_DIR=/path/to/csvs ./run_experience_demo.sh
+```
+
+Sample CSVs (`wearable_daily.csv`, `edu_progress.csv`) are shipped in
+`offline_samples/` so the demo also works without internet access.
 
 2. Enable real-time collectors and metrics with the `--live` flag:
 

--- a/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
+++ b/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
@@ -96,9 +96,10 @@ services:
       REDIS_URL: "redis://redis:6379/0"
       DATABASE_URL: "postgresql://experience:${PG_PASSWORD:-experience}@timescaledb:5432/exp_stream"
       LLM_BASE_URL: "${LLM_BASE_URL:-http://ollama:11434/v1}"
-      SAMPLE_DATA_DIR: "${SAMPLE_DATA_DIR:-/app/demo/offline_samples}"
+      SAMPLE_DATA_DIR: "/app/demo/offline_samples"
     volumes:
       - ./:/app/demo:ro
+      - ${SAMPLE_DATA_DIR:-./offline_samples}:/app/demo/offline_samples:ro
     depends_on:
       qdrant:
         condition: service_healthy

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -42,6 +42,7 @@ root_dir="${demo_dir%/*/*}"                    # → …/alpha_factory_v1
 compose_file="$demo_dir/docker-compose.experience.yml"
 env_file="$demo_dir/config.env"
 sample_dir="${SAMPLE_DATA_DIR:-$demo_dir/offline_samples}"
+sample_dir="$(realpath -m "$sample_dir")"
 offline_dir="$sample_dir"
 export SAMPLE_DATA_DIR="$sample_dir"
 


### PR DESCRIPTION
## Summary
- handle absolute `SAMPLE_DATA_DIR` in demo launcher
- mount the directory inside docker-compose
- document `SAMPLE_DATA_DIR` usage with `run_experience_demo.sh`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/README.md alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684441d6c6c0833383b263379a62328d