### PR TITLE
[alpha_factory] install dev requirements in tests

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
+          pip install -r requirements-dev.txt
       - name: Run replay harness
         run: python scripts/run_replay_bench.py
       - name: Run micro benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
+          pip install -r requirements-dev.txt
           pip install pytest pytest-cov pytest-benchmark mutmut
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
+          pip install -r requirements-dev.txt
       - name: Start API server
         run: |
           API_TOKEN=test-token python -m src.interface.api_server &

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
+          pip install -r requirements-dev.txt
       - name: Run transfer test
         run: |
           python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli transfer-test --models "o3-mini,llama-3" --top-n 5

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
+          pip install -r requirements-dev.txt
       - name: Run 2-year simulation
         run: |
           python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \

--- a/check_env.py
+++ b/check_env.py
@@ -21,6 +21,15 @@ import argparse
 from pathlib import Path
 from typing import List, Optional
 
+CORE = ["numpy", "yaml", "pandas"]
+
+
+def warn_missing_core() -> None:
+    missing = [pkg for pkg in CORE if importlib.util.find_spec(pkg) is None]
+    if missing:
+        print("WARNING: Missing core packages:", ", ".join(missing))
+
+
 REQUIRED = [
     "pytest",
     "prometheus_client",
@@ -85,6 +94,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
 
     args = parser.parse_args(argv)
+
+    warn_missing_core()
 
     wheelhouse = args.wheelhouse or os.getenv("WHEELHOUSE")
     auto = args.auto_install or os.getenv("AUTO_INSTALL_MISSING") == "1"

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,9 +5,13 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
 
 ## Setup
 
-1. Run `python check_env.py --auto-install` (provide `--wheelhouse <dir>` when offline).
-2. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
-3. Execute `pytest -q`.
+1. Install the development requirements:
+   ```bash
+   pip install -r requirements-dev.txt
+   ```
+2. Run `python check_env.py --auto-install` (provide `--wheelhouse <dir>` when offline).
+3. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
+4. Execute `pytest -q`.
 
 ### Offline install
 


### PR DESCRIPTION
## Summary
- ensure development requirements installed before running tests
- warn if core packages like numpy are missing
- mention pip install -r requirements-dev.txt in setup docs

## Testing
- `pre-commit run --files check_env.py tests/README.md .github/workflows/ci.yml .github/workflows/bench.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/smoke.yml` *(skipped heavy hooks)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684444c82da88333baa98e21731261e4