### PR TITLE
[alpha_factory] Document wheelhouse build steps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented in this file.
 - Documented `API_RATE_LIMIT`, `AGI_ISLAND_BACKENDS` and `ALERT_WEBHOOK_URL`
   environment variables.
 - Added [`src/tools/analyse_backtrack.py`](../src/tools/analyse_backtrack.py) for visualising archive backtracks.
+- Documented how to build a wheelhouse for offline installs and updated
+  `tests/README.md` with the instructions.
 - Added CI workflow running lint, type checks, tests and Docker build with
   automated image deployment on tags and rollback on failure. Metrics are
   exported via OpenTelemetry and can be viewed in Grafana or the Streamlit

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -12,6 +12,10 @@ mkdir -p /media/wheels
 pip wheel -r requirements.txt -w /media/wheels
 pip wheel -r requirements-dev.txt -w /media/wheels
 ```
+These wheels cover the runtime and development dependencies needed for the test
+suite. Copy the directory to the offline host and set
+`WHEELHOUSE=/media/wheels` so `check_env.py` and `pytest` install packages from
+this local cache.
 
 You can optionally compile a lock file from these wheels:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,9 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
 
 ### Offline install
 
-Create a wheelhouse with the MuZero demo and development requirements:
+Create a wheelhouse so the tests run without contacting PyPI. Build wheels for
+`requirements.txt` and `requirements-dev.txt` (include the MuZero demo if
+needed):
 
 ```bash
 mkdir -p wheels


### PR DESCRIPTION
## Summary
- expand offline docs with wheelhouse instructions
- clarify wheelhouse usage in `tests/README.md`
- note wheelhouse doc in changelog

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Missing core packages)*
- `pytest -k test_no_network -q` *(fails: ModuleNotFoundError: numpy)*
- `pre-commit run --files docs/OFFLINE.md tests/README.md docs/CHANGELOG.md` *(fails: hook `proto-verify`)*

------
https://chatgpt.com/codex/tasks/task_e_68444b63d158833388000d42c979c971