### PR TITLE
[alpha_factory] add meta agentic bridge test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -50,3 +50,7 @@ pip install -e .
 pytest -q
 ```
 - Playwright test `test_umap_fallback.py` ensures the simulator uses random UMAP coordinates when Pyodide is blocked.
+The `test_bridge_online_mode` case in `test_meta_agentic_tree_search_demo.py` requires the `openai-agents` package. Set `OPENAI_API_KEY=dummy` and run:
+```bash
+OPENAI_API_KEY=dummy pytest tests/test_meta_agentic_tree_search_demo.py::test_bridge_online_mode
+```

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -2,6 +2,7 @@
 import subprocess
 import sys
 import unittest
+import pytest
 from alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge import (
     DEFAULT_MODEL_NAME,
 )
@@ -197,6 +198,26 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
+
+
+def test_bridge_online_mode(monkeypatch) -> None:
+    pytest.importorskip("openai_agents")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge",
+            "--episodes",
+            "1",
+            "--rewriter",
+            "openai",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Best agents" in result.stdout
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- test MATS OpenAI bridge in online mode
- document how to run the test with openai-agents

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68445018bfbc8333b4093d251fce3f19