### PR TITLE
[alpha_factory] Add ADK integration notes

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -123,6 +123,16 @@ Enable the optional ADK gateway with ``--enable-adk`` (or set
 ``ALPHA_FACTORY_ENABLE_ADK=true``) to expose the agent over the A2A protocol.
 This prints a short completion summary after executing the demo loop.
 
+### 4.4 · Google ADK Integration
+Install the ``google-adk`` package to communicate over the A2A protocol:
+
+```bash
+pip install google-adk
+```
+
+Set ``ALPHA_FACTORY_ENABLE_ADK=true`` or pass ``--enable-adk`` to enable the gateway.
+The ADK layer is optional so the demo still runs completely offline.
+
 ## 5 Quick start
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git


### PR DESCRIPTION
## Summary
- explain how to enable Google ADK in the MATS demo

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy, yaml, pandas missing)*
- `python check_env.py --auto-install` *(fails: installation interrupted)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445643a0a483339d2a59b665de2074