### PR TITLE
[alpha_factory] add Apache headers in MATS demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Meta-Agentic Tree Search v0 demo package."""
 
 from . import mats

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Core components for the Meta-Agentic Tree Search demo."""
 
 from .tree import Node, Tree

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Evaluation environments for the MATS demo.
 
 This module exposes a lightweight :class:`NumberLineEnv` used by the unit tests

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Evaluation utilities for the MATS demo."""
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Placeholder meta-rewrite function."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Simple best-first tree search utilities."""
 
 from __future__ import annotations

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Minimal Meta-Agentic Tree Search demo."""
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to the Meta-Agentic Tree Search demo files

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing core packages)*
- `python check_env.py --auto-install` *(fails: network access required)*
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6844593a0298833398e18a05070d7bbc