### PR TITLE
[alpha_factory] Relocate imports in meta_rewrite

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 
 import random
 import logging
+import importlib
+import asyncio
+import os
+import time
+import re
 from typing import List
 
 try:  # pragma: no cover - optional httpx dependency
@@ -26,12 +31,6 @@ def store_sync(messages: list[dict[str, str]]) -> None:
     except Exception:  # noqa: BLE001 - never raise on logging failures
         logging.getLogger(__name__).debug("MCP push failed – continuing without persistence", exc_info=True)
 
-
-import importlib
-import asyncio
-import os
-import time
-import re
 
 
 def meta_rewrite(agents: List[int]) -> List[int]:


### PR DESCRIPTION
## Summary
- move importlib, asyncio, os, time and re imports to the top of `meta_rewrite.py`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: Missing core packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py` *(failed to initialize environment)*

------
https://chatgpt.com/codex/tasks/task_e_68445ae237bc833398342352d5957b0d