### PR TITLE
[alpha_factory] add MATS requirements lock check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
         language: python
         additional_dependencies: [pip-tools]
         pass_filenames: false
+      - id: verify-mats-requirements-lock
+        name: Verify MATS demo requirements.lock is up to date
+        entry: python scripts/verify_mats_requirements_lock.py
+        language: python
+        additional_dependencies: [pip-tools]
+        pass_filenames: false
       - id: verify-backend-requirements-lock
         name: Verify backend requirements-lock.txt is up to date
         entry: python scripts/verify_backend_requirements_lock.py

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -138,7 +138,7 @@ The ADK layer is optional so the demo still runs completely offline.
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/meta_agentic_tree_search_v0
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt          # torch, gymnasium, networkx, etc.
+pip install -r requirements.lock         # torch, gymnasium, networkx, etc.
 python run_demo.py --verify-env          # optional sanity check
 python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --seed 42 --model gpt-4o
 # or equivalently

--- a/scripts/verify_mats_requirements_lock.py
+++ b/scripts/verify_mats_requirements_lock.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure meta_agentic_tree_search_v0 requirements.lock matches requirements.txt."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    req_txt = repo_root / "alpha_factory_v1" / "demos" / "meta_agentic_tree_search_v0" / "requirements.txt"
+    lock_file = repo_root / "alpha_factory_v1" / "demos" / "meta_agentic_tree_search_v0" / "requirements.lock"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "requirements.lock"
+        pip_compile = shutil.which("pip-compile")
+        if pip_compile:
+            cmd = [pip_compile]
+        else:
+            cmd = [sys.executable, "-m", "piptools", "compile"]
+        wheelhouse = os.getenv("WHEELHOUSE")
+        cmd += ["--quiet"]
+        if wheelhouse:
+            cmd += ["--no-index", "--find-links", wheelhouse]
+        cmd += ["--generate-hashes", str(req_txt), "-o", str(out_path)]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            return result.returncode
+        if not lock_file.exists() or out_path.read_bytes() != lock_file.read_bytes():
+            extra = ""
+            if wheelhouse:
+                extra = f"--no-index --find-links {wheelhouse} "
+            msg = (
+                "alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock is outdated. Run 'pip-compile "
+                f"{extra}--quiet --generate-hashes alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.txt -o "
+                "alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock'\n"
+            )
+            sys.stderr.write(msg)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `verify-mats-requirements-lock` hook for the MATS demo
- document installing from `requirements.lock`
- script to verify the lock file for the MATS demo

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `pre-commit run --files .pre-commit-config.yaml scripts/verify_mats_requirements_lock.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md` *(fails: interrupted during environment init)*

------
https://chatgpt.com/codex/tasks/task_e_68445f07342883338210288707e1b8ae