### PR TITLE
[alpha_factory] reorganize meta_rewrite imports

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-import random
 import logging
 import importlib
 import asyncio
 import os
 import time
 import re
+import random
 from typing import List
 
 try:  # pragma: no cover - optional httpx dependency
@@ -30,7 +30,6 @@ def store_sync(messages: list[dict[str, str]]) -> None:
         httpx.post(f"{endpoint}/context", json=payload, timeout=timeout)
     except Exception:  # noqa: BLE001 - never raise on logging failures
         logging.getLogger(__name__).debug("MCP push failed – continuing without persistence", exc_info=True)
-
 
 
 def meta_rewrite(agents: List[int]) -> List[int]:


### PR DESCRIPTION
## Summary
- place optional imports after logging in `meta_rewrite.py`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py` *(fails: mypy errors)*
- `python check_env.py --auto-install` *(fails: interrupted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68445efb8590833382d887534ede4a76