### PR TITLE
[alpha_factory] update evolver bridge docs

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -137,9 +137,10 @@ python alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
 Requires the `openai-agents` package (installed via requirements). When only
 the newer `agents` package is available, the bridge falls back automatically.
 
-The bridge registers an `aiga_evolver` agent exposing four tools:
+The bridge registers an `aiga_evolver` agent exposing five tools:
 `evolve` (run N generations), `best_alpha` (return the champion),
-`checkpoint` (persist state), and `reset` (fresh population).
+`checkpoint` (persist state), `reset` (fresh population), and
+`history` (past fitness scores).
 It works offline by routing to the local Mixtral server when no API key
 is configured.
 


### PR DESCRIPTION
## Summary
- document that the OpenAI Agents bridge registers five tools
- list `history` alongside the original tools

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to complete, interrupted)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68446807162c83339a18f1fcd3c1b55c