### PR TITLE
[alpha_factory] add ADK gateway startup test

### DIFF
--- a/tests/test_adk_gateway_startup.py
+++ b/tests/test_adk_gateway_startup.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ADK gateway startup unit tests."""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def stub_adk(monkeypatch):
+    """Provide a minimal google_adk stub."""
+    dummy = types.ModuleType("google_adk")
+
+    class _Router:
+        def __init__(self):
+            self.app = object()
+
+        def register_agent(self, _agent):
+            pass
+
+    dummy.Router = _Router
+    dummy.Agent = object
+    dummy.AgentException = Exception
+    monkeypatch.setitem(sys.modules, "google_adk", dummy)
+    monkeypatch.setenv("ALPHA_FACTORY_ENABLE_ADK", "1")
+    yield
+    monkeypatch.delenv("ALPHA_FACTORY_ENABLE_ADK", raising=False)
+    sys.modules.pop("google_adk", None)
+
+
+def test_maybe_launch_starts_uvicorn(stub_adk, monkeypatch):
+    """maybe_launch should call uvicorn.run when ADK is enabled."""
+    uvicorn = pytest.importorskip("uvicorn")
+    from alpha_factory_v1.backend import adk_bridge as module
+    module = importlib.reload(module)
+
+    called = {}
+
+    def fake_run(app, host, port, log_level="info", **kw):
+        called["app"] = app
+        called["host"] = host
+        called["port"] = port
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    class DummyThread:
+        def __init__(self, target, *a, **k):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(module.threading, "Thread", DummyThread)
+
+    module.maybe_launch(host="1.2.3.4", port=1234)
+    assert called == {"app": module._ensure_router().app, "host": "1.2.3.4", "port": 1234}


### PR DESCRIPTION
## Summary
- add unit test for `adk_bridge.maybe_launch`
- stub out `google_adk` to verify uvicorn invocation

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q tests/test_adk_gateway_startup.py`

------
https://chatgpt.com/codex/tasks/task_e_684471cdbf7c8333b34c9a3795a94f76