### PR TITLE
[alpha_factory] refactor tree backprop

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 import math
 
+
 @dataclass
 class Node:
     agents: List[int]
@@ -39,10 +40,11 @@ class Tree:
 
     def backprop(self, node: Node) -> None:
         reward = node.reward
-        while node is not None:
-            node.visits += 1
-            node.reward += reward
-            node = node.parent
+        current: Optional[Node] = node
+        while current is not None:
+            current.visits += 1
+            current.reward += reward
+            current = current.parent
 
     def best_leaf(self) -> Node:
         best = self.root
@@ -53,4 +55,3 @@ class Tree:
                 best = n
             stack.extend(n.children)
         return best
-


### PR DESCRIPTION
## Summary
- refactor MATS tree backprop to use a local variable
- annotate the variable to avoid mypy complaints

## Testing
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py` *(failed: couldn't initialize environment)*
- `mypy --strict --follow-imports=skip alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py`
- `python scripts/check_python_deps.py` *(failed: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(failed to install requirements)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684471c35d3c8333b898fdc8f43bb05c