### PR TITLE
[alpha_factory] Add disclaimer for sovereign demo

### DIFF
--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
@@ -3,6 +3,9 @@
 A minimal showcase of a self-directed agent with token-gated access.
 Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.
 
+## Disclaimer
+References to AGI or superintelligence describe the aspirational design goals of this demo. The agent shown here is not a true artificial general intelligence and should not be treated as such.
+
 ## Features
 1. Docker-based deployment with one command.
 2. Flask web interface served at `http://localhost:5000`.


### PR DESCRIPTION
## Summary
- clarify that references to AGI or superintelligence are aspirational in `sovereign_agentic_agialpha_agent_v0`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Missing packages)*
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68447669a9688333bdf7c11fc4c93c0a