### PR TITLE
[alpha_factory] modernize openai_rewrite

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -71,7 +71,7 @@ The script automatically falls back to the offline rewriter when the
 dependencies are unavailable so the notebook remains runnable anywhere.
 
 When the optional `openai` package is also present, `openai_rewrite` uses
-`ChatCompletion` to refine candidate integer policies.  Supply an
+`OpenAI().chat.completions.create` to refine candidate integer policies.  Supply an
 `OPENAI_API_KEY` environment variable to activate this behaviour.  Without a
 key or in fully offline environments the routine simply increments the
 proposed policy elements so the rest of the demo keeps working.  You can

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -9,7 +9,7 @@ import random
 import sys
 import pathlib
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Any
 
 if __package__ is None:  # pragma: no cover - allow execution via `python run_demo.py`
     # Add repository root so package imports resolve when executed directly
@@ -30,7 +30,7 @@ from .mats.env import NumberLineEnv
 def verify_environment() -> None:
     """Best-effort runtime dependency check."""
     try:
-        import check_env  # type: ignore
+        import check_env
 
         check_env.main([])
     except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover - optional helper
@@ -80,6 +80,9 @@ def run(
             or ("anthropic" if os.getenv("ANTHROPIC_API_KEY") else None)
             or "random"
         )
+    from typing import Callable
+
+    rewrite_fn: Callable[[List[int]], List[int]]
     if rewriter == "openai":
         rewrite_fn = lambda ag: openai_rewrite(ag, model=model)
     elif rewriter == "anthropic":
@@ -109,7 +112,7 @@ def run(
         log_fh.close()
 
 
-def load_config(path: Path) -> dict:
+def load_config(path: Path) -> dict[str, Any]:
     """Load a YAML configuration file with a minimal fallback parser."""
     if not path.exists():
         return {}
@@ -121,7 +124,7 @@ def load_config(path: Path) -> dict:
         if ":" in line:
             key, val = line.split(":", 1)
             val = val.strip()
-            if val.replace('.', '', 1).isdigit():
+            if val.replace(".", "", 1).isdigit():
                 cfg[key.strip()] = float(val) if "." in val else int(val)
             else:
                 cfg[key.strip()] = val


### PR DESCRIPTION
## Summary
- modernize OpenAI usage in `meta_rewrite.py`
- clarify openai call in README
- add typing fixes for `run_demo.py`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684473ea2c8c8333af58bd04d00c42c9