### PR TITLE
[alpha_factory] docs: clarify MATS test requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ grpcio-tools
 pytest-httpx
 pre-commit
 
+numpy
 PyYAML
 types-PyYAML
 types-requests

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,7 +54,8 @@ pip install -e .
 pytest -q
 ```
 - Playwright test `test_umap_fallback.py` ensures the simulator uses random UMAP coordinates when Pyodide is blocked.
-The `test_bridge_online_mode` case in `test_meta_agentic_tree_search_demo.py` requires the `openai-agents` package. Set `OPENAI_API_KEY=dummy` and run:
+- The `test_bridge_online_mode` case in `test_meta_agentic_tree_search_demo.py` requires the `openai-agents` package. Set `OPENAI_API_KEY=dummy` and run:
 ```bash
 OPENAI_API_KEY=dummy pytest tests/test_meta_agentic_tree_search_demo.py::test_bridge_online_mode
 ```
+- The meta-agentic tree search tests also rely on `numpy` and `pyyaml`. These packages are included in `requirements-dev.txt`, so running `pip install -r requirements-dev.txt` will install them.


### PR DESCRIPTION
## Summary
- mention numpy and pyyaml for MATS tests
- include numpy in requirements-dev.txt

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: operation cancelled due to long install)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68447990ab24833392c6e3c062862960