### PR TITLE
[alpha_factory] clarify check_env wheelhouse requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,8 @@ Follow these steps when installing without internet access:
   The `verify-alpha-colab-requirements-lock` hook relies on this lock file.
 
  - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
-- Run `python scripts/check_python_deps.py` to quickly verify that `numpy`, `yaml` and `pandas` are installed. If it reports missing packages, execute `python check_env.py --auto-install` before running the tests. When working offline pass `--wheelhouse <path>` or set `WHEELHOUSE` so `pip` installs from the local cache.
-- After setup, validate with `python check_env.py --auto-install`. When `WHEELHOUSE` is set, run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly offline.
+- Run `python scripts/check_python_deps.py` to quickly verify that `numpy`, `yaml` and `pandas` are installed. If it reports missing packages, execute `python check_env.py --auto-install` before running the tests. This step fetches packages from PyPI, so in air‑gapped setups you **must** pass `--wheelhouse <path>` or set `WHEELHOUSE` so `pip` installs from the local cache.
+ - After setup, validate with `python check_env.py --auto-install`. This command reaches out to PyPI unless `--wheelhouse <path>` or the `WHEELHOUSE` environment variable is supplied. When working offline run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly.
 - The unit tests rely on `fastapi`, `opentelemetry-api`, `openai-agents` and `google-adk`. `./codex/setup.sh` installs these packages automatically. When skipping the setup script, run
   `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no
   missing packages before running `pytest`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,14 +13,17 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    ```bash
    pip install -r requirements-demo.txt
    ```
-3. Run `python check_env.py --auto-install` (provide `--wheelhouse <dir>` when offline).
+3. Run `python check_env.py --auto-install` to ensure optional packages are installed. The command
+   downloads dependencies from PyPI, so it **requires an internet connection or a local
+   wheelhouse** supplied via `--wheelhouse <dir>`.
 4. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 5. Execute `pytest -q`.
 
 ### Offline install
 
-Create a wheelhouse so the tests run without contacting PyPI. Build wheels for
-`requirements.txt` and `requirements-dev.txt` (include the MuZero demo if
+Create a wheelhouse so the tests run without contacting PyPI. Build the wheels on
+a machine with connectivity and copy the directory to the offline host. Include
+`requirements.txt` and `requirements-dev.txt` (add the MuZero demo requirements if
 needed):
 
 ```bash
@@ -37,6 +40,10 @@ WHEELHOUSE=$(pwd)/wheels pip install --no-index --find-links "$WHEELHOUSE" -r re
 WHEELHOUSE=$(pwd)/wheels python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 PYTHONPATH=$(pwd) WHEELHOUSE="$WHEELHOUSE" pytest -q
 ```
+
+The `check_env.py` command will fail offline unless `--wheelhouse` is provided.
+Ensure the `WHEELHOUSE` environment variable points to your wheel directory
+before running `pytest`.
 
 Missing optional dependencies often cause failures. Re-run the environment check or pass `--wheelhouse` to install them offline.
 


### PR DESCRIPTION
## Summary
- note that `check_env.py --auto-install` fetches packages from PyPI
- clarify a local wheelhouse is required when offline

## Testing
- `pre-commit run --files tests/README.md AGENTS.md` *(fails: proto-verify hook missing dependencies)*
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684478c52afc8333a1c59b607cabf24a