### PR TITLE
[alpha_factory] add aiga service health test

### DIFF
--- a/tests/test_aiga_service.py
+++ b/tests/test_aiga_service.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit test for agent_aiga_entrypoint FastAPI service."""
+
+from typing import Any, cast
+
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.usefixtures("non_network")
+def test_health_endpoint() -> None:
+    """Verify /health returns expected metrics."""
+    module = importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.agent_aiga_entrypoint")
+    client = TestClient(cast(Any, module.app))
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) >= {"status", "generations", "best_fitness"}


### PR DESCRIPTION
## Summary
- add unit test for AIGA meta-evolution service health endpoint

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install --wheelhouse /tmp/empty` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pre-commit run --files tests/test_aiga_service.py` *(failed to initialize environments)*
- `black tests/test_aiga_service.py`
- `ruff check tests/test_aiga_service.py`
- `mypy --config-file mypy.ini tests/test_aiga_service.py` *(Interrupted)*
- `pytest tests/test_aiga_service.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68447cd3e82483338562b8940d6df5df