### PR TITLE
[alpha_factory] add market data option to MATS demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -182,7 +182,8 @@ gateway for remote control via the A2A protocol.
 The default environment is a simple number‑line task defined in `mats/env.py` where each agent must approach a target integer. Pass `--target 7` (for example) to experiment with different goals.
 Use `--seed 42` to reproduce a specific search trajectory.
 
-> **Tip:** Set `--market-data my_feed.csv` to replay real tick data.
+> **Tip:** Replay real tick data with:
+> `python run_demo.py --market-data my_feed.csv`
 
 ## 6 Repository layout
 ```

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -153,6 +153,28 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Best agents", result.stdout)
 
+    def test_run_demo_market_data(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+            fh.write("6,6,6")
+            feed_path = fh.name
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo",
+                "--episodes",
+                "2",
+                "--market-data",
+                feed_path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best agents", result.stdout)
+
     def test_bridge_fallback(self) -> None:
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary
- support `--market-data` option for the Meta-Agentic Tree Search demo
- forward the new argument through the OpenAI Agents bridge
- show example usage in README
- test CSV loading via CLI

## Testing
- `pytest tests/test_meta_agentic_tree_search_demo.py::TestMetaAgenticTreeSearchDemo::test_run_demo_market_data -q`
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md tests/test_meta_agentic_tree_search_demo.py` *(failed: unused-ignore, no-untyped-def, proto-verify)*


------
https://chatgpt.com/codex/tasks/task_e_68447ccdf31083339127379dfa077ec2