### PR TITLE
[alpha_factory] fix shebang order

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """OpenAI Agents SDK bridge for the Meta-Agentic Tree Search demo.
 
 This utility registers a small agent that exposes the tree-search loop via the


### PR DESCRIPTION
## Summary
- fix shebang placement for meta-agentic tree search bridge

## Testing
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py` *(fails: mypy, proto-verify)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844815d9d90833396a6f5a7f9c86656