### PR TITLE
[alpha_factory] Add MetaEvolver architecture diagram

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -165,6 +165,11 @@ ALPHA_FACTORY_ENABLE_ADK=1
 ALPHA_FACTORY_ADK_TOKEN="my_secret_token"
 ```
 
+The optional ADK gateway integrates with the OpenAI Agents SDK bridge and
+underlying LLM providers as shown below.
+
+![Bridge overview](bridge_overview.svg)
+
 ## 🔐 API authentication
 
 Export `AUTH_BEARER_TOKEN` to require a static token on every API request. For

--- a/alpha_factory_v1/demos/aiga_meta_evolution/bridge_overview.svg
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/bridge_overview.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="200" font-family="Arial" font-size="14">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="20" y="60" width="120" height="40" fill="#e0e0ff" stroke="#000" />
+  <text x="80" y="85" text-anchor="middle">MetaEvolver</text>
+
+  <line x1="140" y1="80" x2="250" y2="80" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="250" y="60" width="140" height="40" fill="#ffe0e0" stroke="#000" />
+  <text x="320" y="85" text-anchor="middle">FastAPI + Gradio</text>
+
+  <line x1="390" y1="80" x2="500" y2="80" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="500" y="60" width="100" height="40" fill="#e0ffe0" stroke="#000" />
+  <text x="550" y="85" text-anchor="middle">Agents SDK</text>
+
+  <line x1="550" y1="100" x2="550" y2="140" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="480" y="140" width="140" height="40" fill="#ffffe0" stroke="#000" />
+  <text x="550" y="165" text-anchor="middle">ADK Gateway (opt)</text>
+
+  <line x1="320" y1="100" x2="320" y2="140" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="250" y="140" width="140" height="40" fill="#e0ffff" stroke="#000" />
+  <text x="320" y="165" text-anchor="middle">Ollama / OpenAI LLMs</text>
+</svg>


### PR DESCRIPTION
## Summary
- add `bridge_overview.svg` with MetaEvolver bridge flow
- reference the new diagram from the meta evolution README

## Testing
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(fails: missing packages)*
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68447f8273448333990cbc0808b2c6c7