### PR TITLE
[alpha_factory] add mats bridge entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ sequenceDiagram
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|
 |11|`muzero_planning`|♟|MuZero in 60 s; online world‑model with MCTS.|Distills planning research into a one‑command demo.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
-|13|`meta_agentic_tree_search_v0`|🌳|Recursive agent rewrites via best‑first search.|Rapidly surfaces AGI-driven trading alpha.|`mats-demo --episodes 10`|
+|13|`meta_agentic_tree_search_v0`|🌳|Recursive agent rewrites via best‑first search.|Rapidly surfaces AGI-driven trading alpha.|`mats-bridge --episodes 3`|
 |14|`alpha_agi_insight_v1`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`alpha-agi-insight-v1 --episodes 5`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -64,7 +64,7 @@ Opens **http://localhost:7860** with a Gradio portal to every demo. Works on ma
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|
 |11|`muzero_planning`|♟|MuZero in 60 s; online world‑model with MCTS.|Distills planning research into a one‑command demo.|`./alpha_factory_v1/demos/muzero_planning/run_muzero_demo.sh`|
 |12|`self_healing_repo`|🩹|CI fails → agent crafts patch ⇒ PR green again.|Maintains pipeline uptime alpha.|`docker compose -f demos/docker-compose.selfheal.yml up`|
-|13|`meta_agentic_tree_search_v0`|🌳|Recursive agent rewrites via best‑first search.|Rapidly surfaces AGI-driven trading alpha.|`mats-demo --episodes 10`|
+|13|`meta_agentic_tree_search_v0`|🌳|Recursive agent rewrites via best‑first search.|Rapidly surfaces AGI-driven trading alpha.|`mats-bridge --episodes 3`|
 |14|`alpha_agi_insight_v0`|👁️|Zero‑data search ranking AGI‑disrupted sectors.|Forecasts sectors primed for AGI transformation.|`python -m alpha_factory_v1.demos.alpha_agi_insight_v0 --verify-env`|
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -102,11 +102,11 @@ The `openai_agents_bridge.py` script exposes the search loop via the
 the bridge to control the demo through API calls or the Agents runtime UI:
 
 ```bash
-python openai_agents_bridge.py --help
+mats-bridge --help
 ```
 Run a quick environment check with ``--verify-env`` if desired:
 ```bash
-python openai_agents_bridge.py --verify-env --episodes 3 --target 4 --model gpt-4o
+mats-bridge --verify-env --episodes 3 --target 4 --model gpt-4o
 ```
 The bridge exposes a small :func:`verify_env` helper that performs the same
 sanity check programmatically. Call it from Python or rely on the command
@@ -116,7 +116,7 @@ remains reproducible anywhere. When running offline you can still invoke
 `run_search` directly to verify the helper logic:
 
 ```bash
-python openai_agents_bridge.py --episodes 3 --target 4 --model gpt-4o
+mats-bridge --episodes 3 --target 4 --model gpt-4o
 python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge --episodes 3 --target 4
 ```
 Enable the optional ADK gateway with ``--enable-adk`` (or set
@@ -144,7 +144,7 @@ python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --see
 # or equivalently
 python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 500 --target 5
 # installed script
-mats-demo --episodes 10
+mats-bridge --episodes 3
 ```
 `run_demo.py` prints a per‑episode scoreboard.  Pass `--log-dir logs` to save a
 `scores.csv` file for further analysis. A ready‑to‑run Colab notebook is also

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ alpha-agi-insight-v1-api = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.inte
 aii = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli:main"
 verify-wheel-sig = "alpha_factory_v1.scripts.verify_wheel_sig:main"
 mats-demo = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo:main"
+mats-bridge = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here

--- a/tests/test_mats_bridge_entrypoint.py
+++ b/tests/test_mats_bridge_entrypoint.py
@@ -1,0 +1,19 @@
+import importlib.metadata as im
+import unittest
+
+
+class TestMatsBridgeEntryPoint(unittest.TestCase):
+    """Verify the mats-bridge console script is registered."""
+
+    def test_entry_point_resolves(self) -> None:
+        eps = im.entry_points().select(group="console_scripts")
+        match = [ep for ep in eps if ep.name == "mats-bridge"]
+        self.assertTrue(match, "mats-bridge entry point not found")
+        self.assertEqual(
+            match[0].value,
+            "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge:main",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `mats-bridge` console script
- document `mats-bridge --episodes 3` as the recommended run command
- add unit test for the console entry point

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to complete)*
- `pytest -q` *(fails: 103 errors during collection)*
- `pre-commit run --files pyproject.toml README.md alpha_factory_v1/demos/README.md alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md tests/test_mats_bridge_entrypoint.py` *(failed: initialization interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844855ca8688333920e06732304c323