### PR TITLE
[alpha_factory] handle check_env timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Clone the repository and run the helper script to start the Insight demo locally
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
-python check_env.py --auto-install  # verify runtime and install extras
+python check_env.py --auto-install  # verify runtime and install extras (10 min timeout)
 ./quickstart.sh
 ```
 
@@ -120,7 +120,9 @@ Follow these steps when working without internet access.
    `WHEELHOUSE=/media/wheels` when running `pre-commit` or the tests so
    dependencies install from the local cache. See
    [Offline Setup](alpha_factory_v1/scripts/README.md#offline-setup) for more
-   details.
+  details. If package installation hangs for more than ten minutes,
+  `check_env.py` will time out and suggest using `--wheelhouse` for
+  offline installs.
 
 3. **Download a `.gguf` weight** and set ``LLAMA_MODEL_PATH``:
    ```bash
@@ -691,7 +693,7 @@ Cells with \(Δ\mathcal F < 0\) glow 🔵 on Grafana; Ω‑Agents race to harves
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
 ./quickstart.sh --preflight   # optional environment check
-python check_env.py --auto-install  # verify & auto-install deps
+python check_env.py --auto-install  # verify & auto-install deps (10 min timeout)
 # Install runtime dependencies
 pip install -r requirements.lock
 # (If this fails with a network error, create a wheelhouse and rerun
@@ -874,7 +876,7 @@ pip install -r requirements-dev.txt
 Install the project in editable mode so tests resolve imports:
 ```bash
 pip install -e .
-python check_env.py --auto-install
+python check_env.py --auto-install  # times out after 10 minutes
 ```
 
 #### Test Runtime

--- a/check_env.py
+++ b/check_env.py
@@ -107,7 +107,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         cmd += ["-r", str(req_file)]
         print("Ensuring baseline requirements:", " ".join(cmd))
         try:
-            subprocess.run(cmd, check=True)
+            subprocess.run(cmd, check=True, timeout=600)
+        except subprocess.TimeoutExpired:
+            print(
+                "Timed out installing baseline requirements. "
+                "Re-run with '--wheelhouse <path>' to install offline packages."
+            )
+            return 1
         except subprocess.CalledProcessError as exc:
             print("Failed to install baseline requirements", exc.returncode)
             return exc.returncode
@@ -138,7 +144,12 @@ def main(argv: Optional[List[str]] = None) -> int:
             cmd += packages
             print("Attempting automatic install:", " ".join(cmd))
             try:
-                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)
+            except subprocess.TimeoutExpired:
+                print(
+                    "Timed out installing packages. Re-run with '--wheelhouse <path>' " "to install from local wheels."
+                )
+                return 1
             except subprocess.CalledProcessError as exc:
                 stderr = exc.stderr or ""
                 print("Automatic install failed with code", exc.returncode)


### PR DESCRIPTION
## Summary
- add 10 minute timeout when `pip` installs packages in `check_env.py`
- show hint to use `--wheelhouse` when install times out
- document timeout behaviour in README

## Testing
- `pre-commit run --files check_env.py README.md` *(fails: Verify protobuf files are up to date)*
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68448631579c8333a8490d6968301929