### PR TITLE
[alpha_factory] docs: remind to run check_env before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,10 @@ Install the project in editable mode so tests resolve imports:
 pip install -e .
 python check_env.py --auto-install  # times out after 10 minutes
 ```
+Run `python check_env.py --auto-install` again before executing `pytest` to
+ensure optional dependencies are present. In offline setups pass
+`--wheelhouse <dir>` (or set `WHEELHOUSE`) so packages install from the local
+wheel cache.
 
 #### Test Runtime
 


### PR DESCRIPTION
## Summary
- remind developers to run `python check_env.py --auto-install` again before running the test suite
- mention the `--wheelhouse` option for offline installs

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails due to network access)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68448a63f3088333af00dfbb2d0dec1e