### PR TITLE
[alpha_factory] Add MCP vars to MATS demo

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -181,6 +181,11 @@ command line:
   (defaults to ``gpt-4o``).
 - ``ANTHROPIC_MODEL`` – model name for the Anthropic rewriter
   (defaults to ``claude-3-opus-20240229``).
+- ``MCP_ENDPOINT`` – optional URL for Model Context Protocol logging.
+- ``MCP_TIMEOUT_SEC`` – timeout in seconds for MCP requests (defaults to ``10``).
+
+Setting ``MCP_ENDPOINT`` enables prompt logging via the Model Context Protocol
+for later audit.
 
 If ``MATS_REWRITER`` is unset the script picks ``openai`` when an
 ``OPENAI_API_KEY`` is present or ``anthropic`` when ``ANTHROPIC_API_KEY`` is


### PR DESCRIPTION
## Summary
- document optional `MCP_ENDPOINT` and `MCP_TIMEOUT_SEC` env vars
  in the MATS demo README

## Testing
- `python tools/check_env_table.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6844994642508333944ea70f88d7ff70