### PR TITLE
[alpha_factory] include ADK vars in AIGA config sample

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample
@@ -78,5 +78,7 @@ RESOURCES_LIMIT_MEM="4Gi"
 NODE_SELECTOR=""                        # e.g. gpu=true
 GPU_ENABLE=false                        # set true for CUDA runtime
 ALPHA_FACTORY_ENABLE_ADK=0              # 1 → expose Google ADK gateway
+ALPHA_FACTORY_ADK_PORT=9000             # ADK port when enabled
+ALPHA_FACTORY_ADK_TOKEN=""              # optional ADK auth token
 
 # End of file – happy hacking!


### PR DESCRIPTION
## Summary
- add `ALPHA_FACTORY_ADK_PORT` and `ALPHA_FACTORY_ADK_TOKEN` to `aiga_meta_evolution/config.env.sample`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample` *(fails: Makefile missing separator)*
- `python scripts/check_python_deps.py` *(reports missing numpy, pandas)*
- `python check_env.py --auto-install` *(failed: operation canceled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6844a1136e348333b91d36e8d286c4e3