### PR TITLE
[alpha_factory] Fix MATS bridge Path import

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -12,7 +12,7 @@ import os
 import argparse
 import importlib.util
 import sys
-import pathlib
+from pathlib import Path
 
 DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
 
@@ -31,7 +31,7 @@ def verify_env() -> None:
 
 if __package__ is None:  # pragma: no cover - allow direct execution
     # Ensure imports resolve when running the script directly
-    sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+    sys.path.append(str(Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.meta_agentic_tree_search_v0"
 
 try:

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -221,6 +221,28 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_bridge_market_data(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+            fh.write("6,6,6")
+            feed_path = fh.name
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge",
+                "--episodes",
+                "1",
+                "--market-data",
+                feed_path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
 
 def test_bridge_online_mode(monkeypatch) -> None:
     pytest.importorskip("openai_agents")


### PR DESCRIPTION
## Summary
- fix openai_agents_bridge Path import
- add test running mats bridge with `--market-data`

## Testing
- `python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge --episodes 1`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: missing numpy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844a7d3ca648333a354860362819ddf