### PR TITLE
[alpha_factory] add license headers to demo scripts

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/run_aiga_demo.sh
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/run_aiga_demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 # ────────────────────────────────────────────────────────────────
 # AI-GA Meta-Evolution – one-command launcher
 # Works on: Linux, macOS, WSL2 (Docker Desktop ≥ 4.28)

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/__init__.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 # Demo package

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Cross‑Industry alpha discovery helper.
 
 This minimal command‑line tool surfaces potential "alpha" opportunities

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 # Alpha-Factory v1 👁️✨  – Cross-Industry AGENTIC α-AGI demo bootstrap
 # Fully production-grade, security-attested, CI-ready one-liner installer


### PR DESCRIPTION
## Summary
- add SPDX headers to demo scripts in cross_industry_alpha_factory
- add SPDX header to run_aiga_demo.sh

## Testing
- `python scripts/check_python_deps.py`
- `timeout 5 python check_env.py --auto-install` *(fails: Timed out during install)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844aadaa1fc8333a75e30439ee1ab61