### PR TITLE
[alpha_factory] add market data output test

### DIFF
--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -243,6 +243,30 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_bridge_market_data_output(self) -> None:
+        """Bridge handles CSV input and prints agent summary."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+            fh.write("1,2,3")
+            csv_file = fh.name
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge",
+                "--episodes",
+                "1",
+                "--market-data",
+                csv_file,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Best agents", result.stdout)
+
 
 def test_bridge_online_mode(monkeypatch) -> None:
     pytest.importorskip("openai_agents")


### PR DESCRIPTION
## Summary
- test meta-agentic tree search bridge with NamedTemporaryFile

## Testing
- `pre-commit run --files tests/test_meta_agentic_tree_search_demo.py` *(fails: proto-verify)*
- `pytest -q` *(fails: 103 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6844ab619a988333a456d3f7e5287f75