### PR TITLE
[alpha_factory] clarify openai-agents requirement

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -11,20 +11,23 @@ The AI‑GA Meta‑Evolution service is a conceptual research prototype. Referen
    - Verify all Python packages are available:
      Run the following command from the project root directory:
      ```bash
-     AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
-     ```
-     This attempts to install `openai-agents`, `google-adk` and other required
-     packages if they are missing. Offline environments can point the script to
-     a wheelhouse via `WHEELHOUSE=/path/to/wheels`. **Running this command is
-     mandatory before executing the demos or the unit tests.** The
-     `openai-agents` and `google-adk` packages are optional and only needed when
-     the OpenAI Agents runtime or the ADK gateway is enabled.
+    AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
+    ```
+    This installs `openai-agents` (or the alternative `agents` package) and
+    other requirements if they are missing. Offline environments can point the
+    script to a wheelhouse via `WHEELHOUSE=/path/to/wheels`.
+    **Running this command is mandatory before executing the demos or the unit
+    tests.** The LLM features depend on having either `openai-agents` or
+    `agents` available. The `google-adk` package is only needed when the ADK
+    gateway is enabled.
    - Install the OpenAI Agents SDK if not already present:
-     ```bash
-     pip install openai-agents
-     ```
-     Some distributions package it as the simpler `agents` module; the demo
-     detects both. If `import openai_agents` fails, reinstall the SDK and
+    ```bash
+    pip install -U openai-agents
+    # offline
+    pip install --no-index --find-links /path/to/wheels openai-agents
+    ```
+    Some distributions package it as the simpler `agents` module; the demo
+    detects both. If `import openai_agents` fails, reinstall the SDK and
      confirm your virtual environment is active.
 
 2. **Launch the service**

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -131,15 +131,26 @@ creating the wheelhouse.
 
 ### Installing the OpenAI Agents SDK
 
-The optional OpenAI Agents bridge relies on this package.
+The meta-evolution service depends on the **OpenAI Agents SDK** (or the
+newer `agents` package) for all LLM access, even when running offline.
+The optional bridge described below merely exposes the same tools over the
+OpenAI runtime.
+
+Install from PyPI:
 
 ```bash
-pip install openai-agents
+pip install -U openai-agents
 ```
 
-Some distributions ship it as the simpler `agents` module; the
-demo auto-detects both. If you see `ModuleNotFoundError: openai_agents`,
-reinstall the SDK in the active virtual environment.
+Offline, point `pip` to your wheelhouse:
+
+```bash
+pip install --no-index --find-links /path/to/wheels openai-agents
+```
+
+Some distributions ship the dependency as `agents`. The demo automatically
+detects both. If you encounter `ModuleNotFoundError: openai_agents`, ensure
+the package is installed in the active virtual environment.
 
 ### 🤖 OpenAI Agents bridge
 
@@ -149,8 +160,8 @@ Expose the evolver to the **OpenAI Agents SDK** runtime:
 python alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
 ```
 
-Requires the `openai-agents` package (installed via requirements). When only
-the newer `agents` package is available, the bridge falls back automatically.
+Requires the `openai-agents` or `agents` package (already installed above).
+If both are missing the script exits with an error.
 
 The bridge registers an `aiga_evolver` agent exposing five tools:
 `evolve` (run N generations), `best_alpha` (return the champion),


### PR DESCRIPTION
## Summary
- clarify that the meta-evolution demo requires `openai-agents` or the `agents` package
- document offline install instructions

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt during pip install)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/README.md alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md` *(failed: missing package k6-python)*

------
https://chatgpt.com/codex/tasks/task_e_6844d0bc0a8c833385ea7d750c999fd0