### PR TITLE
[alpha_factory] docs: add offline setup instructions for MATS

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -150,25 +150,24 @@ mats-bridge --episodes 3
 `scores.csv` file for further analysis. A ready‑to‑run Colab notebook is also
 provided as `colab_meta_agentic_tree_search.ipynb`.
 
-### Offline setup
-When installing without network access, first build a wheelhouse on a
+## Offline Setup
+When installing without network access, first build wheels on a
 machine with connectivity:
 
 ```bash
-mkdir -p /media/wheels
-pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r requirements.txt -w /tmp/wheels
 ```
 
-Copy `/media/wheels` to the offline machine and set `WHEELHOUSE` so
-`pip` installs from this directory:
+Copy `/tmp/wheels` to the offline machine and install packages from the
+local wheelhouse:
 
 ```bash
-WHEELHOUSE=/media/wheels pip install -r requirements.txt
+WHEELHOUSE=/tmp/wheels pip install -r requirements.txt
 ```
 
 The repository's setup script automatically uses a `wheels/` directory
-in the project root when present, so placing your pre-built wheels
-there also works.
+in the project root when present, so placing your pre-built wheels there
+also works.
 
 ### Environment variables
 The demo consults a few environment variables when choosing a rewrite strategy

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
@@ -26,6 +26,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Offline Setup\n",
+    "If you need to install without network access, build wheels on a machine with internet connectivity:\n",
+    "\n",
+    "```bash\n",
+    "pip wheel -r requirements.txt -w /tmp/wheels\n",
+    "```\n",
+    "\n",
+    "Copy `/tmp/wheels` to this runtime and install packages from there:\n",
+    "\n",
+    "```bash\n",
+    "WHEELHOUSE=/tmp/wheels pip install -r requirements.txt\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2 \u00b7 Optional API keys"
    ]
   },


### PR DESCRIPTION
## Summary
- document offline setup steps in the MATS demo README
- add offline install guidance in the Colab notebook

## Testing
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb` *(with heavy hooks skipped)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844cfe68d448333a957ac02c81ddcd1