### PR TITLE
[alpha_factory] document wheel builds for offline deployments

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -20,6 +20,11 @@ The AI‑GA Meta‑Evolution service is a conceptual research prototype. Referen
     tests.** The LLM features depend on having either `openai-agents` or
     `agents` available. The `google-adk` package is only needed when the ADK
     gateway is enabled.
+   - Build wheels for the optional agent packages on a machine with internet access:
+     ```bash
+     pip wheel openai-agents google-adk -w /path/to/wheels
+     ```
+     Provide this directory via `WHEELHOUSE` when installing on the production host.
    - Install the OpenAI Agents SDK if not already present:
     ```bash
     pip install -U openai-agents

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -116,15 +116,20 @@ it the demo falls back to the bundled offline mixtral model.
 
 ### Offline dependency setup
 
-When working **air‑gapped**, build a wheel cache in advance and tell
-`check_env.py` where to find it. Set the `WHEELHOUSE` environment variable and
-run the helper with `--wheelhouse <dir>` to install packages from that
-directory:
+Follow these steps when working **air‑gapped**:
 
-```bash
-WHEELHOUSE=/path/to/wheels AUTO_INSTALL_MISSING=1 \
-  python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
-```
+- Build wheels using the same Python version as your virtual environment:
+  ```bash
+  mkdir -p /path/to/wheels
+  pip wheel -r ../../requirements.txt -w /path/to/wheels
+  pip wheel openai-agents google-adk -w /path/to/wheels
+  ```
+
+- Install from the wheelhouse so `check_env.py` can resolve all dependencies:
+  ```bash
+  WHEELHOUSE=/path/to/wheels AUTO_INSTALL_MISSING=1 \
+    python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+  ```
 
 See [scripts/README.md](../../scripts/README.md#offline-setup) for details on
 creating the wheelhouse.

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -16,9 +16,16 @@ This guide summarises the minimal steps required to run the **Alpha‑AGI Busine
      AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
      ```
      Provide `WHEELHOUSE=/path/to/wheels` for air‑gapped setups. **Running this
-     command is mandatory before executing the demos or running the test suite.**
-     The `openai-agents` and `google-adk` packages are optional and are only
-     required when using the OpenAI Agents runtime or the Google ADK gateway.
+      command is mandatory before executing the demos or running the test suite.**
+      The `openai-agents` and `google-adk` packages are optional and are only
+      required when using the OpenAI Agents runtime or the Google ADK gateway.
+   - Build wheels for these optional packages when preparing an offline
+      deployment:
+      ```bash
+      pip wheel openai-agents google-adk -w /path/to/wheels
+      ```
+      Provide this directory via `WHEELHOUSE` during installation on the
+      production host.
 
 2. **Launch the service**
    - **Docker** (recommended for consistent environments):


### PR DESCRIPTION
## Summary
- document building optional `openai-agents` and `google-adk` wheels
- mention using `WHEELHOUSE` in the production guides

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed due to dependency installation)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6844d4a278988333adf8d3ca29eb42e4