### PR TITLE
[alpha_factory] add docstrings to mats modules

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py
@@ -1,48 +1,64 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Evaluation environments for the MATS demo.
+"""Toy environments for the Meta Agentic Tree Search demo.
 
-This module exposes a lightweight :class:`NumberLineEnv` used by the unit tests
-and demo loop along with a placeholder :class:`LiveBrokerEnv` that illustrates
-how one might integrate real market data.  The live broker variant currently
-inherits the toy environment so the rest of the demo remains fully runnable
-offline.  It accepts an optional market data feed so advanced users can plug in
-their own price sources.
+The module exposes :class:`NumberLineEnv` used throughout the tests and demo
+loop and :class:`LiveBrokerEnv`, a stub showing how live market data could be
+plugged in.
 """
 from __future__ import annotations
 
 import random
 from typing import List
 
+
 class NumberLineEnv:
     """Toy environment where agents aim for a target integer."""
 
     def __init__(self, target: int = 5) -> None:
+        """Initialize the environment.
+
+        Args:
+            target: Desired integer agents should match.
+        """
+
         self.target = target
 
     def rollout(self, agents: List[int]) -> float:
-        """Return a pseudo reward after a single rollout."""
+        """Return a pseudo reward after a single rollout.
+
+        Args:
+            agents: Candidate integer policies.
+
+        Returns:
+            Simulated reward value.
+        """
         distance = sum(abs(a - self.target) for a in agents)
         noise = random.random() * 0.1
         return -distance + noise
 
 
 class LiveBrokerEnv(NumberLineEnv):
-    """Placeholder environment hooking into a live execution broker.
+    """Placeholder environment that could connect to a live broker.
 
-    Parameters
-    ----------
-    target:
-        Target integer used by the base :class:`NumberLineEnv` logic.
-    market_data:
-        Optional sequence of numbers representing live prices.  When omitted the
-        environment behaves exactly like :class:`NumberLineEnv`.
+    Args:
+        target: Target integer used by :class:`NumberLineEnv` logic.
+        market_data: Optional sequence of prices that override ``target``.
     """
 
     def __init__(self, target: int = 5, market_data: List[int] | None = None) -> None:
+        """Initialize the environment.
+
+        Args:
+            target: Desired integer agents should match.
+            market_data: Optional price sequence used as live targets.
+        """
+
         super().__init__(target=target)
         self.market_data = list(market_data) if market_data else []
 
     def rollout(self, agents: List[int]) -> float:
+        """Return reward using current market data if available."""
+
         if self.market_data:
             self.target = self.market_data.pop(0)
         return super().rollout(agents)

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Evaluation utilities for the MATS demo."""
+"""Evaluation helpers for the Meta Agentic Tree Search demo.
+
+Exposes :func:`evaluate` which scores integer policies in a toy environment.
+"""
 from __future__ import annotations
 
 from typing import List
@@ -7,17 +10,15 @@ from .env import NumberLineEnv
 
 
 def evaluate(agents: List[int], env: NumberLineEnv | None = None) -> float:
-    """Return a pseudo reward for the agents using ``env``.
+    """Return a pseudo reward for ``agents``.
 
-    Parameters
-    ----------
-    agents:
-        Current candidate policies represented as integers.
-    env:
-        Optional environment instance.  A new :class:`NumberLineEnv` is created
-        when omitted so the function remains backward compatible.
+    Args:
+        agents: Candidate integer policy.
+        env: Optional environment instance.
+
+    Returns:
+        Calculated reward from the environment.
     """
 
     environment = env or NumberLineEnv()
     return environment.rollout(agents)
-

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Placeholder meta-rewrite function."""
+"""Policy rewrite helpers for the MATS demo.
+
+The module provides :func:`meta_rewrite` along with optional OpenAI and
+Anthropic integrations used to tweak integer policies.
+"""
 
 from __future__ import annotations
 
@@ -33,7 +37,15 @@ def store_sync(messages: list[dict[str, str]]) -> None:
 
 
 def meta_rewrite(agents: List[int]) -> List[int]:
-    """Return a modified copy of ``agents`` with a small random change."""
+    """Return ``agents`` with one element randomly tweaked.
+
+    Args:
+        agents: Current candidate policy.
+
+    Returns:
+        Modified policy list.
+    """
+
     new_agents = list(agents)
     idx = random.randrange(len(new_agents))
     new_agents[idx] += random.choice([-1, 1])
@@ -41,11 +53,14 @@ def meta_rewrite(agents: List[int]) -> List[int]:
 
 
 def _parse_numbers(text: str, fallback: List[int]) -> List[int]:
-    """Return integers parsed from ``text`` or a simple increment fallback.
+    """Return integers parsed from ``text`` with a fallback.
 
-    The helper ensures the returned list has the same length as ``fallback`` so
-    the rest of the demo remains stable even when the LLM response is malformed
-    or incomplete. If ``fallback`` is an empty list, an empty list is returned.
+    Args:
+        text: Raw text containing numbers.
+        fallback: Policy used when parsing fails.
+
+    Returns:
+        List of integers matching the length of ``fallback``.
     """
     numbers = [int(n) for n in re.findall(r"-?\d+", text)]
     if not fallback:
@@ -56,16 +71,17 @@ def _parse_numbers(text: str, fallback: List[int]) -> List[int]:
 
 
 def openai_rewrite(agents: List[int], model: str | None = None) -> List[int]:
-    """Improve ``agents`` using OpenAI Agents SDK and Google ADK when available.
+    """Rewrite ``agents`` using the OpenAI Agents SDK when possible.
 
-    The routine falls back to :func:`meta_rewrite` when the required
-    libraries are missing or any error occurs.  This keeps the demo
-    functional in fully offline environments. When the optional
-    dependencies are present, a tiny ``RewriterAgent`` is instantiated
-    and invoked once to illustrate how the Agents SDK could be wired
-    into the search loop.  The implementation uses ``asyncio`` under the
-    hood but exposes a synchronous API so the rest of the demo can run
-    without an event loop.
+    Args:
+        agents: Policy to rewrite.
+        model: Optional model name.
+
+    Returns:
+        Modified policy list.
+
+    Falls back to :func:`meta_rewrite` when dependencies are missing or
+    any error occurs.
     """
 
     have_oai = importlib.util.find_spec("openai_agents") is not None
@@ -144,7 +160,15 @@ def openai_rewrite(agents: List[int], model: str | None = None) -> List[int]:
 
 
 def anthropic_rewrite(agents: List[int], model: str | None = None) -> List[int]:
-    """Improve ``agents`` using the Anthropic API when available."""
+    """Rewrite ``agents`` using the Anthropic API when available.
+
+    Args:
+        agents: Policy to rewrite.
+        model: Optional model name.
+
+    Returns:
+        Modified policy list.
+    """
 
     have_anthropic = importlib.util.find_spec("anthropic") is not None
     if have_anthropic and os.getenv("ANTHROPIC_API_KEY"):

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Simple best-first tree search utilities."""
+"""Simple best-first search helpers for integer policies.
+
+The module defines :class:`Node` and :class:`Tree` used by the search loop.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +13,8 @@ import math
 
 @dataclass
 class Node:
+    """A single state in the search tree."""
+
     agents: List[int]
     reward: float = 0.0
     visits: int = 0
@@ -18,13 +23,22 @@ class Node:
 
 
 class Tree:
-    """Minimal UCB1-style search tree."""
+    """Minimal UCB1-style search tree for integer policies."""
 
     def __init__(self, root: Node, exploration: float = 1.4) -> None:
+        """Initialize the tree.
+
+        Args:
+            root: Root node of the tree.
+            exploration: Exploration constant for UCB1.
+        """
+
         self.root = root
         self.exploration = exploration
 
     def select(self) -> Node:
+        """Return the next leaf node following the UCB1 rule."""
+
         node = self.root
         while node.children:
             node = max(
@@ -35,10 +49,14 @@ class Tree:
         return node
 
     def add_child(self, parent: Node, child: Node) -> None:
+        """Attach ``child`` to ``parent``."""
+
         child.parent = parent
         parent.children.append(child)
 
     def backprop(self, node: Node) -> None:
+        """Propagate ``node``'s reward up to the root."""
+
         reward = node.reward
         current: Optional[Node] = node
         while current is not None:
@@ -47,6 +65,8 @@ class Tree:
             current = current.parent
 
     def best_leaf(self) -> Node:
+        """Return the visited leaf with highest average reward."""
+
         best = self.root
         stack = [self.root]
         while stack:


### PR DESCRIPTION
## Summary
- add Google-style docstrings to Meta Agentic Tree Search demo modules

## Testing
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/env.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/meta_rewrite.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/tree.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/mats/evaluators.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844d4964dc883339eb8cbf312af1b3c