### PR TITLE
[alpha_factory] Extend ADK test coverage

### DIFF
--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -267,6 +267,23 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Best agents", result.stdout)
 
+    def test_bridge_enable_adk(self) -> None:
+        """Bridge accepts the --enable-adk flag."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge",
+                "--episodes",
+                "1",
+                "--enable-adk",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
 
 def test_bridge_online_mode(monkeypatch) -> None:
     pytest.importorskip("openai_agents")


### PR DESCRIPTION
## Summary
- add `test_bridge_enable_adk` to MATS bridge demo tests

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(terminated)*
- `pytest -q tests/test_meta_agentic_tree_search_demo.py::TestMetaAgenticTreeSearchDemo::test_bridge_enable_adk` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844d829409883339539fee1ee830e14