### PR TITLE
[alpha_factory] update production guide

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -12,14 +12,16 @@ The AI‑GA Meta‑Evolution service is a conceptual research prototype. Referen
      Run the following command from the project root directory:
      ```bash
     AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
-    ```
-    This installs `openai-agents` (or the alternative `agents` package) and
-    other requirements if they are missing. Offline environments can point the
-    script to a wheelhouse via `WHEELHOUSE=/path/to/wheels`.
-    **Running this command is mandatory before executing the demos or the unit
-    tests.** The LLM features depend on having either `openai-agents` or
-    `agents` available. The `google-adk` package is only needed when the ADK
-    gateway is enabled.
+     ```
+     This installs `openai-agents` (or the alternative `agents` package) and
+     other requirements if they are missing. Offline environments can point the
+     script to a wheelhouse via `WHEELHOUSE=/path/to/wheels`.
+     **Running this command is mandatory before executing the demos or the unit
+     tests.** The LLM features depend on having either `openai-agents` or
+     `agents` available. The `google-adk` package is only needed when the ADK
+     gateway is enabled.
+   - Run `python scripts/check_python_deps.py` first to verify core packages,
+     then `AUTO_INSTALL_MISSING=1 python check_env.py --auto-install`.
    - Build wheels for the optional agent packages on a machine with internet access:
      ```bash
      pip wheel openai-agents google-adk -w /path/to/wheels


### PR DESCRIPTION
## Summary
- clarify environment validation in PRODUCTION_GUIDE

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `AUTO_INSTALL_MISSING=1 python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6844dad31e1083338136963ccb99453c