### PR TITLE
[alpha_factory] docs: clarify wheelhouse workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,13 +715,15 @@ pip install -r requirements.lock
 ./quickstart.sh               # creates venv, installs deps, launches
 # Use `--wheelhouse /path/to/wheels` to install offline packages when
 # the host has no internet access. The setup script automatically
-# sets `WHEELHOUSE` to `./wheels` when that directory exists. Running
-# `python check_env.py --auto-install --wheelhouse /path/to/wheels`
-# installs any missing optional packages. Example offline setup:
+# sets `WHEELHOUSE` to `./wheels` when that directory exists. When
+# working offline, run `python check_env.py --auto-install --wheelhouse
+# /path/to/wheels` to verify and install packages. The setup script
+# exits with a message if neither network nor a wheelhouse are available.
+# Example offline workflow:
 #   export WHEELHOUSE=/media/wheels
-#   python check_env.py --auto-install --wheelhouse $WHEELHOUSE
-# The setup script exits with a message if neither network nor a wheelhouse
-# are available.
+#   python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+#   WHEELHOUSE=$WHEELHOUSE ./quickstart.sh
+#   WHEELHOUSE=$WHEELHOUSE pytest -q
 # open the docs in your browser
 python -m webbrowser http://localhost:8000/docs
 # Alternatively, ``python alpha_factory_v1/quickstart.py`` provides the same

--- a/tools/check_env_table.py
+++ b/tools/check_env_table.py
@@ -39,7 +39,7 @@ def parse_agents_table(path: Path) -> set[str]:
         return set()
 
     table_vars: set[str] = set()
-    for line in text[start + 1 :]:
+    for line in text[start + 1 :]:  # noqa: E203
         if line.startswith("|"):
             match = re.search(r"`([^`]+)`", line)
             if match:
@@ -57,7 +57,7 @@ def parse_runbook_checklist(path: Path) -> list[str]:
     except ValueError:
         return []
     items: list[str] = []
-    for line in text[start + 1 :]:
+    for line in text[start + 1 :]:  # noqa: E203
         line = line.strip()
         if not line:
             if items:


### PR DESCRIPTION
## Summary
- mention offline `check_env.py --auto-install --wheelhouse` in the Quick-Start
- show how to set `WHEELHOUSE` when calling `quickstart.sh` or running tests
- keep `tools/check_env_table.py` aligned with linting rules

## Testing
- `pre-commit run --files README.md tools/check_env_table.py` *(skipped some hooks)*
- `python tools/check_env_table.py`

------
https://chatgpt.com/codex/tasks/task_e_6844da8ef2808333bf2c7e72b47e33f0