### PR TITLE
[alpha_factory] improve MATS docs

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -143,7 +143,8 @@ python run_demo.py --verify-env          # optional sanity check
 python run_demo.py --config configs/default.yaml --episodes 500 --target 5 --seed 42 --model gpt-4o
 # or equivalently
 python -m alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo --episodes 500 --target 5
-# installed script
+# installed scripts
+mats-demo --episodes 5
 mats-bridge --episodes 3
 ```
 `run_demo.py` prints a per‑episode scoreboard.  Pass `--log-dir logs` to save a


### PR DESCRIPTION
# Summary
- mention `mats-demo` console script in the Meta-Agentic Tree Search README

# Checks
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md` *(failed: semgrep download interrupted)*
- `python scripts/check_python_deps.py` *(failed: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(failed: pip install stalled)*
- `pytest -k meta_agentic_tree_search_demo -q` *(failed: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6844e132c2c083338a2777d8845d0a61