### PR TITLE
[alpha_factory] add Apache headers

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/__init__.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Minimal support package for the governance demo."""
 
 from .governance_sim import main, run_sim, summarise_with_agent

--- a/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 """Minimal Monte-Carlo simulation for the governance whitepaper demo.
 


### PR DESCRIPTION
## Summary
- add Apache license headers to governance demo files

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails to install due to environment)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844e79bbd648333bdef9a4773e0bf9c