### PR TITLE
[alpha_factory] Update Colab notes for torch and ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,15 @@ sequenceDiagram
 
 > **Colab?** Each folder ships an `*.ipynb` that mirrors the Docker flow with free GPUs.
 
+The official Docker image bundles **PyTorch&nbsp;2.2.x** and **Ray&nbsp;2.10.0**. The
+notebooks install PyTorch from the [PyTorch wheel index](https://download.pytorch.org/whl)
+and pin Ray to the same version for compatibility.
+
+| `USE_GPU` | PyTorch wheel URL |
+|:--------:|-------------------------------------------------|
+| `True`   | <https://download.pytorch.org/whl/cu118> |
+| `False`  | <https://download.pytorch.org/whl/cpu> |
+
 ### 4.1 · [α-ASI World-Model Demo 👁️✨](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/tree/main/alpha_factory_v1/demos/alpha_asi_world_model)
 
 Paper: [Multi-Agent AGENTIC α-AGI World-Model Demo 🥑](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_asi_world_model/Alpha_ASI_World_Model.pdf)

--- a/alpha_factory_v1/requirements-colab.txt
+++ b/alpha_factory_v1/requirements-colab.txt
@@ -1,9 +1,12 @@
+# Minimal Colab dependencies. PyTorch 2.2.* is installed separately from
+# https://download.pytorch.org/whl and Ray is pinned to match the Docker image.
 fastapi>=0.111,<1.0
 uvicorn[standard]~=0.34
 pyngrok
 ctransformers==0.2.27
 k6-python
 subprocess-tee
+# Ray version mirrors the Docker setup
 ray[default]==2.10.0
 openai>=1.82.0,<2.0
 openai-agents>=0.0.16


### PR DESCRIPTION
## Summary
- document torch and ray versions that match the Docker environment
- mention `USE_GPU` wheel index mapping

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: interrupted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/requirements-colab.txt README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e7af2b5883338997da47b764d306