### PR TITLE
[alpha_factory] add SPDX headers

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 alpha_factory_v1.backend.agents
 ================================

--- a/alpha_factory_v1/backend/agents/aiga_evolver_agent.py
+++ b/alpha_factory_v1/backend/agents/aiga_evolver_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """AIGA Evolver Agent – wraps the meta-evolution demo as a domain agent.
 
 This lightweight agent bridges :mod:`aiga_meta_evolution.meta_evolver`

--- a/alpha_factory_v1/backend/agents/base.py
+++ b/alpha_factory_v1/backend/agents/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 alpha_factory_v1.backend.agents.base
 ====================================

--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 backend.agents.biotech_agent
 ====================================================================

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.climate_risk_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.cyber_threat_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.drug_design_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.energy_agent
 ===================================================================
 Alpha-Factory v1 👁️✨ — Multi-Agent AGENTIC α-AGI

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.manufacturing_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/market_analysis_agent.py
+++ b/alpha_factory_v1/backend/agents/market_analysis_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from .base import AgentBase

--- a/alpha_factory_v1/backend/agents/memory_agent.py
+++ b/alpha_factory_v1/backend/agents/memory_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from .base import AgentBase

--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 alpha_factory_v1.backend.agents.ping_agent
 ==========================================

--- a/alpha_factory_v1/backend/agents/planning_agent.py
+++ b/alpha_factory_v1/backend/agents/planning_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from .base import AgentBase

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.policy_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/research_agent.py
+++ b/alpha_factory_v1/backend/agents/research_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from .base import AgentBase

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.retail_demand_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/safety_agent.py
+++ b/alpha_factory_v1/backend/agents/safety_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from .base import AgentBase

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.smart_contract_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/strategy_agent.py
+++ b/alpha_factory_v1/backend/agents/strategy_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from .base import AgentBase

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.supply_chain_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """backend.agents.talent_matcht_agent
 ===================================================================
 Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI

--- a/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 ╭──────────────────────────────────────────────────────────────────────────────╮
 │  Alpha-Factory v1 👁️✨ — Multi-Agent AGENTIC α-AGI World-Model Demo          │

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # alpha_asi_world_model_demo.py – Alpha‑Factory v1 👁
 # =============================================================================
 # Production‑grade α‑ASI world‑model demo.

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v1.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v1.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # alpha_asi_world_model_demo.py ▒ Alpha-Factory v1 👁️✨   2025-04-25
 # ============================================================================#
 # Fully-agentic α-AGI demo: POET-style open-ended curriculum × MuZero learner #

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v2.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v2.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # alpha_asi_world_model_demo.py ─ Alpha-Factory v1 👁️✨ (2025-04-25)
 # ============================================================================
 # Fully-agentic α-AGI demo:

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v3.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v3.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
 # alpha_asi_world_model_demo.py – Alpha-Factory v1 👁️✨
 # ============================================================================
 # Fully-agentic α-AGI demo: POET-style curriculum × MuZero-lite learner

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v4.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v4.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # alpha_asi_world_model_demo.py – Alpha‑Factory v1 👁️✨  (auto‑generated 2025‑04‑25)
 # =============================================================================
 # Fully‑agentic α‑AGI demo: POET‑style curriculum × MuZero learner with light


### PR DESCRIPTION
## Summary
- add Apache headers in alpha_asi_world_model demo code
- add Apache headers in backend agents

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails to install dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844ea5964d483339cbf73b973afbe79