### PR TITLE
[alpha_factory] Allow disabling planner via NO_LLM

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@
 # Copy to `.env` and adjust the values before running docker compose or Helm
 
 OPENAI_API_KEY=
+NO_LLM=0
 # Database password for Neo4j
 NEO4J_PASSWORD=REPLACE_ME
 # Launch mode: api | cli | web

--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ for instructions and example volume mounts.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `OPENAI_API_KEY` | _(empty)_ | API key for hosted models. Offline mode is used when empty. |
+| `NO_LLM` | `0` | Set to `1` to skip the LLM planner even when `OPENAI_API_KEY` is provided. |
 | `NEO4J_PASSWORD` | `REPLACE_ME` | Database password required by the orchestrator. |
 | `RUN_MODE` | `api` | Launch mode for Compose or Helm (`api`, `cli`, `web`). |
 | `PORT` | `8000` | REST API port. |

--- a/alpha_factory_v1/demos/alpha_asi_world_model/.env.sample
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/.env.sample
@@ -13,6 +13,7 @@ ALPHA_ASI_MAX_GRID=64          # Safety clamp on generated mazes
 
 # ▶️  Optional cloud keys (leave blank for fully-offline mode)
 OPENAI_API_KEY=                # Enables LLM planner 🧠
+NO_LLM=0                       # Set to 1 to disable the planner even with a key
 ANTHROPIC_API_KEY=             # Future MCP tools
 GOOGLE_VERTEX_SA_KEY=          # For ADK micro-services on GCP
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -160,7 +160,7 @@ bus liveness even on a clean clone.)*
 | 🐳 **Docker** | Auto-generated `Dockerfile` (<100 MB slim). GPU builds: swap base for `nvidia/cuda:runtime-12.4`. |
 | ☸️ **Kubernetes** | Run `--emit-helm`; edit values (`replicaCount`, `resources.limits`). Works on GKE, AKS, EKS, k3d. |
 | 🐍 **Pure Python** | No Docker needed; just `pip install -r requirements.txt`. |
-| 🔒 **Air-gapped** | Offline wheels; set env `NO_LLM=1` or omit API keys. |
+| 🔒 **Air-gapped** | Offline wheels; set `NO_LLM=1` to disable the planner or omit API keys. |
 | 🔑 **Cloud LLM mode** | Export `OPENAI_API_KEY` → PlanningAgent & ResearchAgent auto-upgrade to LLM assistants. |
 
 ---
@@ -211,6 +211,7 @@ Need help? Open an issue → **@MontrealAI/alpha-factory-core**.
 - Launch via `./deploy_alpha_asi_world_model_demo.sh` and visit `http://localhost:7860`.
 - The script sets `NO_LLM=1` automatically when `OPENAI_API_KEY` is unset.
 - Provide an `OPENAI_API_KEY` to unlock planner features.
+- Set `NO_LLM=1` to skip the LLM planner even when a key is provided.
 
 ---
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -354,7 +354,7 @@ BasicSafetyAgent()
 # =============================================================================
 # 9. Optional LLM planner
 # =============================================================================
-if os.getenv("OPENAI_API_KEY"):
+if os.getenv("OPENAI_API_KEY") and not os.getenv("NO_LLM"):
     try:
         import openai, functools, concurrent.futures, contextlib
         class LLMPlanner(Agent):


### PR DESCRIPTION
## Summary
- let `NO_LLM=1` disable the LLM planner even when `OPENAI_API_KEY` is set
- document the `NO_LLM` variable in README and environment samples

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, pandas)*
- `python check_env.py --auto-install --wheelhouse /tmp/none` *(fails: Could not find dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files .env.sample README.md alpha_factory_v1/demos/alpha_asi_world_model/.env.sample alpha_factory_v1/demos/alpha_asi_world_model/README.md alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py` *(fails: mypy errors and proto-verify hook)*


------
https://chatgpt.com/codex/tasks/task_e_6844eb6d33d48333a0655a76ef326497