### PR TITLE
[alpha_factory] Governance demo bridge

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+#!/usr/bin/env python3
+"""OpenAI Agents SDK bridge for the solving_agi_governance demo."""
+from __future__ import annotations
+
+import argparse
+import logging
+
+from .governance_sim import run_sim
+
+logger = logging.getLogger(__name__)
+
+try:
+    from openai_agents import Agent, AgentRuntime, Tool
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+    raise SystemExit(
+        "openai-agents package is missing. Install with `pip install openai-agents`"
+    ) from exc
+
+
+@Tool(name="run_sim", description="Run governance simulation")
+async def run_sim_tool(
+    agents: int = 100,
+    rounds: int = 1000,
+    delta: float = 0.8,
+    stake: float = 2.5,
+) -> float:
+    return run_sim(agents=agents, rounds=rounds, delta=delta, stake=stake)
+
+
+class GovernanceSimAgent(Agent):
+    """Agent exposing the governance simulation."""
+
+    name = "governance_sim"
+    tools = [run_sim_tool]
+
+    async def policy(self, obs, ctx):  # type: ignore[override]
+        if isinstance(obs, dict):
+            return await self.tools.run_sim(
+                int(obs.get("agents", 100)),
+                int(obs.get("rounds", 1000)),
+                float(obs.get("delta", 0.8)),
+                float(obs.get("stake", 2.5)),
+            )
+        return await self.tools.run_sim()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description="Expose the governance simulation via OpenAI Agents runtime"
+    )
+    ap.add_argument(
+        "--enable-adk",
+        action="store_true",
+        help="Expose agent via ADK gateway",
+    )
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    runtime = AgentRuntime(api_key=None)
+    agent = GovernanceSimAgent()
+    runtime.register(agent)
+    if args.enable_adk:
+        try:
+            from alpha_factory_v1.backend.adk_bridge import auto_register, maybe_launch
+
+            auto_register([agent])
+            maybe_launch()
+        except Exception as exc:  # pragma: no cover - ADK optional
+            logger.warning(f"ADK bridge unavailable: {exc}")
+    logger.info("Registered GovernanceSimAgent with runtime")
+    runtime.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ aii = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli:main"
 verify-wheel-sig = "alpha_factory_v1.scripts.verify_wheel_sig:main"
 mats-demo = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo:main"
 mats-bridge = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge:main"
+governance-bridge = "alpha_factory_v1.demos.solving_agi_governance.openai_agents_bridge:main"
 
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here

--- a/tests/test_governance_bridge_offline.py
+++ b/tests/test_governance_bridge_offline.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline mode test for the governance bridge."""
+
+import builtins
+import importlib
+import pytest
+
+
+def test_governance_bridge_offline(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "openai_agents":
+            raise ModuleNotFoundError(name)
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(SystemExit):
+        importlib.reload(
+            importlib.import_module(
+                "alpha_factory_v1.demos.solving_agi_governance.openai_agents_bridge"
+            )
+        )


### PR DESCRIPTION
## Summary
- expose solving_agi_governance demo via new `openai_agents_bridge` module
- add optional ADK gateway support via `--enable-adk`
- register script under `governance-bridge`
- verify missing `openai_agents` raises SystemExit

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: timeout during pip install)*
- `pytest -q` *(failed: 103 errors during collection)*
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py tests/test_governance_bridge_offline.py pyproject.toml` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844f12cff4c833389520ff08294c050