### PR TITLE
[alpha_factory] enhance governance demo docs

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -150,3 +150,26 @@ is self-contained and does not require network access once installed.
 
 ---
 
+### 11 · OpenAI Agents Bridge
+Install the optional packages to expose the simulator via the
+**OpenAI Agents SDK** and, when desired, the **Google ADK** federation layer:
+
+```bash
+pip install openai-agents google-adk
+```
+
+Launch the bridge with your API key set:
+
+```bash
+export OPENAI_API_KEY=sk-…
+export ALPHA_FACTORY_ENABLE_ADK=true  # optional
+governance-bridge --enable-adk
+```
+
+The script registers a `GovernanceSimAgent` with the Agents runtime and, when
+`google-adk` is available, also exposes it over the A2A protocol. If either
+package is missing the bridge prints a warning and runs the local simulator
+only, so the demo remains fully offline capable.
+
+---
+


### PR DESCRIPTION
## Summary
- document installing openai-agents and google-adk
- explain how to start the `governance-bridge` script
- describe fallback behaviour when packages are missing

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to complete in the environment)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844f557937483339c12edd582555010