### PR TITLE
[alpha_factory] add ipywidgets governance demo

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
+++ b/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
@@ -2,14 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "b8740ea6",
    "metadata": {},
    "source": [
-    "# \ud83d\udd4a\ufe0f Governance Simulation \u00b7 Colab Notebook\n",
-    "*Alpha-Factory\u00a0v1 \ud83d\dc41*"
+    "# 🕊️ Governance Simulation · Colab Notebook\n",
+    "*Alpha-Factory v1 👁*"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "af949a37",
    "metadata": {},
    "source": [
     "### Why this notebook?\n",
@@ -19,31 +21,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4f25f593",
    "metadata": {},
    "source": [
-    "##\u00a00 \u00b7 Runtime check"
+    "## 0 · Runtime check"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "53b1cb83",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!nvidia-smi -L || echo '\ud83d\udd39 GPU not detected \u2014 running on CPU'"
+    "!nvidia-smi -L || echo '🔹 GPU not detected — running on CPU'"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "dbcaaa8b",
    "metadata": {},
    "source": [
-    "##\u00a01 \u00b7 Install demo package\n",
-    "*(\u2248\u00a010\u202fs; wheels cached by Colab)*"
+    "## 1 · Install demo package\n",
+    "*(≈ 10 s; wheels cached by Colab)*"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7ee2c88f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,32 +65,61 @@
   },
   {
    "cell_type": "markdown",
+   "id": "06d70f5a",
    "metadata": {},
    "source": [
-    "##\u00a02 \u00b7 Quick simulation"
+    "## 2 · Quick simulation"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7b675b1d",
    "metadata": {},
    "outputs": [],
    "source": [
     "from alpha_factory_v1.demos.solving_agi_governance import run_sim\n",
     "coop = run_sim(agents=500, rounds=3000, delta=0.8, stake=2.5, seed=42)\n",
-    "print(f'mean cooperation \u2248 {coop:.3f}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "##\u00a03 \u00b7 Explore \u03b4 sensitivity"
+    "print(f'mean cooperation ≈ {coop:.3f}')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "19221dbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "delta = widgets.FloatSlider(value=0.8, min=0.5, max=0.99, step=0.01, description='δ')\n",
+    "button = widgets.Button(description='Run simulation')\n",
+    "output = widgets.Output()\n",
+    "\n",
+    "def _run(_):\n",
+    "    with output:\n",
+    "        output.clear_output()\n",
+    "        coop = run_sim(agents=500, rounds=3000, delta=delta.value, stake=2.5, seed=42)\n",
+    "        print(f'mean cooperation ≈ {coop:.3f}')\n",
+    "\n",
+    "button.on_click(_run)\n",
+    "display(delta, button, output)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "806dd8e9",
+   "metadata": {},
+   "source": [
+    "## 3 · Explore δ sensitivity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bfe7ae3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,18 +129,35 @@
     "deltas = np.linspace(0.6, 0.95, 8)\n",
     "coops = [run_sim(agents=200, rounds=2000, delta=d, stake=2.5, seed=0) for d in deltas]\n",
     "plt.plot(deltas, coops, marker='o')\n",
-    "plt.xlabel('Discount factor \u03b4')\n",
+    "plt.xlabel('Discount factor δ')\n",
     "plt.ylabel('Mean cooperation')\n",
     "plt.grid(True)\n",
     "plt.show()"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9e5c980",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "try:\n",
+    "    import openai_agents  # type: ignore\n",
+    "    import subprocess\n",
+    "    subprocess.run(['governance-bridge', '--help'], check=True)\n",
+    "except ModuleNotFoundError:\n",
+    "    print('openai-agents not installed; skipping governance-bridge demo.')\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
+   "id": "b045ee16",
    "metadata": {},
    "source": [
     "---\n",
-    "\u00a9\u00a02025 **MONTREAL.AI** \u2022 Apache-2.0 License"
+    "© 2025 **MONTREAL.AI** • Apache-2.0 License"
    ]
   }
  ],

--- a/alpha_factory_v1/requirements-colab.txt
+++ b/alpha_factory_v1/requirements-colab.txt
@@ -14,3 +14,4 @@ anthropic>=0.21
 litellm>=1.31
 pytest~=8.2
 prometheus-client~=0.19
+ipywidgets~=8.1


### PR DESCRIPTION
## Summary
- add ipywidgets slider and run button in the governance Colab
- demo governance-bridge only when `openai-agents` is installed
- include `ipywidgets` in Colab requirements

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: Timed out installing baseline requirements)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844f6b9155c8333aaae565e56f1a13d