### PR TITLE
[alpha_factory] Add governance demo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,8 @@ The official Docker image bundles **PyTorch&nbsp;2.2.x** and **Ray&nbsp;2.10.0**
 notebooks install PyTorch from the [PyTorch wheel index](https://download.pytorch.org/whl)
 and pin Ray to the same version for compatibility.
 
+* [Solving AGI Governance](alpha_factory_v1/demos/solving_agi_governance/README.md) — Monte‑Carlo governance simulation with optional OpenAI‑Agents/ADK integration. [Colab](alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb)
+
 | `USE_GPU` | PyTorch wheel URL |
 |:--------:|-------------------------------------------------|
 | `True`   | <https://download.pytorch.org/whl/cu118> |


### PR DESCRIPTION
## Summary
- link the Solving AGI Governance demo and Colab under Demo Showcase

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: Missing packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844fad9bcf083339dae5f3f0adfe920