### PR TITLE
[alpha_factory] add governance bridge CLI test

### DIFF
--- a/tests/test_governance_bridge_cli.py
+++ b/tests/test_governance_bridge_cli.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure the governance-bridge CLI is available."""
+
+import importlib.util
+import subprocess
+
+import pytest
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("openai_agents") is None,
+    reason="openai_agents not installed",
+)
+def test_governance_bridge_help() -> None:
+    """Verify the console script prints usage information."""
+    result = subprocess.run(
+        ["governance-bridge", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- test governance-bridge CLI help output

## Testing
- `pre-commit run --files tests/test_governance_bridge_cli.py` *(all hooks skipped)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(failed: missing packages)*
- `pytest -q tests/test_governance_bridge_cli.py` *(failed: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6844fc16662c83338cf98d31cca41e71