### PR TITLE
[alpha_factory] add governance-sim CLI test

### DIFF
--- a/tests/test_governance_sim_cli.py
+++ b/tests/test_governance_sim_cli.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure the governance-sim CLI runs."""
+
+import sys
+import subprocess
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="governance-sim not supported on Windows")
+def test_governance_sim_cli() -> None:
+    """Verify the console script prints a result."""
+    result = subprocess.run(
+        ["governance-sim", "-N", "10", "-r", "20"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "mean cooperation" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add `tests/test_governance_sim_cli.py` to ensure the governance simulator CLI works

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q tests/test_governance_sim_cli.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844fe4eb968833383b25ac6dc8f1261