### PR TITLE
[alpha_factory] allow governance bridge port

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -171,5 +171,11 @@ The script registers a `GovernanceSimAgent` with the Agents runtime and, when
 package is missing the bridge prints a warning and runs the local simulator
 only, so the demo remains fully offline capable.
 
+Specify a custom runtime port with `--port`:
+
+```bash
+governance-bridge --port 5005
+```
+
 ---
 

--- a/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
@@ -54,12 +54,20 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Expose agent via ADK gateway",
     )
+    ap.add_argument(
+        "--port",
+        type=int,
+        help="Custom port for the Agents runtime",
+    )
     return ap.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> None:
     args = _parse_args(argv)
-    runtime = AgentRuntime(api_key=None)
+    if args.port is not None:
+        runtime = AgentRuntime(port=args.port, api_key=None)
+    else:
+        runtime = AgentRuntime(api_key=None)
     agent = GovernanceSimAgent()
     runtime.register(agent)
     if args.enable_adk:

--- a/tests/test_governance_bridge_cli.py
+++ b/tests/test_governance_bridge_cli.py
@@ -21,3 +21,18 @@ def test_governance_bridge_help() -> None:
     )
     assert result.returncode == 0
     assert "usage" in result.stdout.lower()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("openai_agents") is None,
+    reason="openai_agents not installed",
+)
+def test_governance_bridge_port_arg() -> None:
+    """Verify the CLI accepts the --port option."""
+    result = subprocess.run(
+        ["governance-bridge", "--port", "1234", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add `--port` argument to solving_agi_governance bridge
- propagate the port to `AgentRuntime`
- document custom port usage in demo README
- test CLI option `--port`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Missing core packages)*
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py alpha_factory_v1/demos/solving_agi_governance/README.md tests/test_governance_bridge_cli.py` *(fails: environment setup interrupted)*
- `pytest tests/test_governance_bridge_cli.py::test_governance_bridge_port_arg -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684500a172948333aa0dc3957114d596