### PR TITLE
[alpha_factory] add world model command test

### DIFF
--- a/tests/test_world_model_demo.py
+++ b/tests/test_world_model_demo.py
@@ -34,3 +34,19 @@ def test_agents_list_offline(non_network: None) -> None:
         "SafetyAgent",
     }
     assert expected.issubset(set(agents))
+
+
+def test_post_new_env(non_network: None) -> None:
+    """Force a new environment via /command."""
+    os.environ["NO_LLM"] = "1"
+    os.environ.setdefault("ALPHA_ASI_SILENT", "1")
+    os.environ.setdefault("ALPHA_ASI_MAX_STEPS", "1")
+
+    mod = importlib.import_module(
+        "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+    )
+    client = TestClient(cast(Any, mod.app))
+
+    resp = client.post("/command", json={"cmd": "new_env"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}


### PR DESCRIPTION
## Summary
- test posting `{cmd: new_env}` to `/command`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install --wheelhouse wheels` *(fails: No matching distribution)*
- `pre-commit run --files tests/test_world_model_demo.py` *(fails: pre-commit not found)*
- `pytest -q tests/test_world_model_demo.py` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684500b6a4c08333a7b2c450378d7470