### PR TITLE
[alpha_factory] Add offline install steps

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -20,6 +20,7 @@ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team
 ## 0  Table of Contents  <!-- omit in toc -->
 1. [Why this demo matters](#1-why-this-demo-matters)
 2. [Quick-start 🥑](#2-quick-start-)
+   - [Offline setup](#offline-setup)
 3. [High-level architecture 🗺️](#3-high-level-architecture-️)
 4. [Meet the agents 🤖 (≥ 5)](#4-meet-the-agents-️-≥-5)
 5. [Runtime controls 🎮](#5-runtime-controls-)
@@ -89,6 +90,27 @@ ALPHA_FACTORY_ENABLE_ADK=true python openai_agents_bridge.py
 
 > **Tip 💡** Set `ALPHA_ASI_SEED=<int>` to reproduce identical curriculum runs.
 > **Tip 💡** Set `ALPHA_ASI_SILENT=1` to hide the startup banner.
+
+### Offline setup
+When working without internet access, first build a local wheelhouse:
+
+```bash
+mkdir -p /media/wheels
+pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r ../../../requirements-dev.txt -w /media/wheels
+```
+
+Install and verify using the wheelhouse from the repository root:
+
+```bash
+WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
+WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
+  python check_env.py --auto-install --wheelhouse /media/wheels
+```
+
+Set `NO_LLM=1` to disable the planning agent when no API key is available. The
+`deploy_alpha_asi_world_model_demo.sh` helper exports this variable
+automatically.
 
 ---
 


### PR DESCRIPTION
## Summary
- document offline installation for the world-model demo

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/README.md` *(fails: interrupted while fetching semgrep)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684503422dc48333beeeb23ffec2e2a5