### PR TITLE
[alpha_factory] Add disclaimer to AGI governance notebook

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
+++ b/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
@@ -2,6 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3d1d9f72",
+   "metadata": {},
+   "source": [
+    "## Disclaimer\n",
+    "This repository is a conceptual research prototype. References to \"AGI\" and\n",
+    "\"superintelligence\" describe aspirational goals and do not indicate the presence\n",
+    "of a real general intelligence. Use at your own risk."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b8740ea6",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- add the README disclaimer to the top of the governance Colab notebook

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to complete in environment)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684505462ce08333a00bebfcc03b2207