### PR TITLE
[alpha_factory] docs: update troubleshooting instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,10 +319,15 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
 ### Troubleshooting
 - If the stack fails to start, verify Docker and Docker Compose are running.
 - Setup errors usually mean Python is older than 3.11. Use Python 3.11 or 3.12 (>=3.11,<3.13).
- - Missing optional packages can cause test failures; first run
+- Missing optional packages can cause test failures; first run
   `python scripts/check_python_deps.py` and then
   `python check_env.py --auto-install` (pass `--wheelhouse <path>` when offline)
   if required.
+- Always execute `python check_env.py --auto-install` before running the tests
+  or `pre-commit` so optional dependencies install correctly. When offline,
+  provide `--wheelhouse <dir>` or set `WHEELHOUSE` to your wheel cache.
+- If `pre-commit` reports "command not found", install it manually with
+  `pip install pre-commit` and run `pre-commit install` once.
 
 For detailed troubleshooting steps, see [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md).
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ everything is formatted correctly. These commands mirror the steps in
 [AGENTS.md](AGENTS.md) and keep commits consistent.
 Before opening a pull request, run `pre-commit run --all-files` to ensure
 all hooks succeed.
+Run `python check_env.py --auto-install` before invoking these commands so
+optional hook dependencies are installed. When working offline, pass
+`--wheelhouse <dir>` or set `WHEELHOUSE` to install from a local cache. If
+`pre-commit` isn't found, install it with `pip install pre-commit`.
 
 When editing the web UI, preserve existing ARIA labels so the interface
 remains accessible.


### PR DESCRIPTION
## Summary
- emphasize running `python check_env.py --auto-install` before tests or `pre-commit`
- mention manual `pre-commit` install in Troubleshooting and README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: could not install packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files AGENTS.md README.md` *(fails: proto-verify hook)*

------
https://chatgpt.com/codex/tasks/task_e_6845084884988333aa9a2ddf9cc5a6b8