### PR TITLE
[alpha_factory] clarify wheelhouse usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ python check_env.py --auto-install  # verify runtime and install extras (10 min 
 Run `pre-commit run --all-files` after the dependencies finish installing.
 ```
 
+Offline example using a local wheelhouse:
+
+```bash
+WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./quickstart.sh
+```
+
 Or launch the full stack with Docker:
 
 ```bash

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -4,3 +4,15 @@
 pip install -r requirements.txt
 python -m alpha_asi_world_model_demo --demo
 ```
+
+To run without internet access, build wheels on a connected machine and
+install from a local wheelhouse:
+
+```bash
+mkdir -p /media/wheels
+pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r ../../../requirements-dev.txt -w /media/wheels
+WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
+  python check_env.py --auto-install --wheelhouse /media/wheels
+WHEELHOUSE=/media/wheels alpha-asi-demo --demo
+```

--- a/check_env.py
+++ b/check_env.py
@@ -115,7 +115,13 @@ def main(argv: Optional[List[str]] = None) -> int:
             )
             return 1
         except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
             print("Failed to install baseline requirements", exc.returncode)
+            if any(kw in stderr.lower() for kw in ["connection", "temporary failure", "network", "resolve"]):
+                print(
+                    "Network failure detected. Re-run with '--wheelhouse <path>' "
+                    "or set WHEELHOUSE to install offline packages."
+                )
             return exc.returncode
 
     missing_required: list[str] = []


### PR DESCRIPTION
## Summary
- document the wheelhouse method in README and world model quickstart
- warn about network failures in `check_env.py`

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md check_env.py` *(fails: Makefile:26: missing separator)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --wheelhouse /tmp/wheels` *(fails: Could not find a version that satisfies the requirement fastapi<1.0,>=0.111)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845080c6f188333848e97415ab79f60