### PR TITLE
[alpha_factory] enforce str cast for LLM content

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import random
 import os
+from typing import cast
 
 # Payoff matrix for a standard Prisoner's Dilemma (T > R > P > S)
 R, T, P, S = 3.0, 5.0, 1.0, 0.0
@@ -94,7 +95,7 @@ def summarise_with_agent(mean_coop: float, *, agents: int, rounds: int, delta: f
             ],
             max_tokens=60,
         )
-        return completion.choices[0].message.content.strip()
+        return cast(str, completion.choices[0].message.content).strip()
     except Exception:
         return base_msg
 


### PR DESCRIPTION
## Summary
- import `cast` in `governance_sim.py`
- cast LLM response before stripping

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails to install requirements)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/governance_sim.py` *(fails: interrupted during environment setup)*
- `mypy alpha_factory_v1/demos/solving_agi_governance/governance_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_6845811cbf3c8333bec16a229c1cfbc5