### PR TITLE
[alpha_factory] guard optional heavy packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,6 +922,9 @@ Run `python check_env.py --auto-install` again before executing `pytest` to
 ensure optional dependencies are present. In offline setups pass
 `--wheelhouse <dir>` (or set `WHEELHOUSE`) so packages install from the local
 wheel cache.
+The full test suite relies on optional packages including `numpy`, `torch`,
+`pandas`, `prometheus_client`, `gymnasium`, `playwright`, `httpx`, `uvicorn`,
+`git` and `hypothesis`.
 
 #### Test Runtime
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,11 +19,14 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    ```
 4. Install any missing optional packages:
    ```bash
-   python check_env.py --auto-install
-   ```
-   These commands download packages from PyPI, so ensure you have either
-   internet connectivity or a wheelhouse available via `--wheelhouse <dir>`
-   (or the `WHEELHOUSE` environment variable).
+    python check_env.py --auto-install
+    ```
+    These commands download packages from PyPI, so ensure you have either
+    internet connectivity or a wheelhouse available via `--wheelhouse <dir>`
+    (or the `WHEELHOUSE` environment variable).
+    The full suite exercises features that depend on optional packages such as
+    `numpy`, `torch`, `pandas`, `prometheus_client`, `gymnasium`, `playwright`,
+    `httpx`, `uvicorn`, `git` and `hypothesis`.
 5. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 6. Execute `pytest -q`.
 

--- a/tests/test_embedding_orthogonaliser.py
+++ b/tests/test_embedding_orthogonaliser.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import random
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from src.agents.guards.embedding_orthogonaliser import EmbeddingOrthogonaliser
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -7,6 +7,10 @@ from unittest import mock
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config
 
+import pytest
+
+np = pytest.importorskip("numpy")
+
 
 def test_concurrent_experiments(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("ARCHIVE_PATH", str(tmp_path / "arch.db"))
@@ -14,8 +18,6 @@ def test_concurrent_experiments(tmp_path, monkeypatch) -> None:
     settings = config.Settings(bus_port=0)
     with mock.patch.object(orchestrator.Orchestrator, "_init_agents", lambda self: []):
         orch = orchestrator.Orchestrator(settings)
-
-    import numpy as np
 
     monkeypatch.setattr("src.evaluators.novelty.embed", lambda _t: np.zeros((1, 1), dtype="float32"))
     monkeypatch.setattr("src.simulation.surrogate_fitness.aggregate", lambda vals, **kw: [0.0 for _ in vals])

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 import unittest
+import pytest
+
+pytest.importorskip("prometheus_client")
+
 from prometheus_client import CollectorRegistry
 import prometheus_client
 import importlib

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from src.archive.selector import select_parent
 

--- a/tests/test_selector_v2.py
+++ b/tests/test_selector_v2.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from src.archive.selector import select_parent
 

--- a/tests/test_self_improver.py
+++ b/tests/test_self_improver.py
@@ -6,6 +6,8 @@ import pytest
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src import self_improver
 from typing import Any
 
+pytest.importorskip("prometheus_client")
+
 git = pytest.importorskip("git")
 
 

--- a/tests/test_world_model_demo.py
+++ b/tests/test_world_model_demo.py
@@ -9,6 +9,8 @@ from typing import Any, cast
 
 import pytest
 
+pytest.importorskip("numpy")
+
 pytest.importorskip("torch")
 from fastapi.testclient import TestClient  # noqa: E402
 


### PR DESCRIPTION
## Summary
- skip `tests/test_world_model_demo.py` if numpy isn't present
- guard numpy-dependent tests
- guard prometheus_client tests
- document heavy optional dependencies for tests

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt during pip install)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684581a92b708333b22c19cd755213a4