### PR TITLE
[alpha_factory] Clarify API key for OpenAI Agents bridge

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -166,6 +166,8 @@ export ALPHA_FACTORY_ENABLE_ADK=true  # optional
 governance-bridge --enable-adk
 ```
 
+The `OPENAI_API_KEY` variable must be set or the bridge cannot communicate with OpenAI.
+
 The script registers a `GovernanceSimAgent` with the Agents runtime and, when
 `google-adk` is available, also exposes it over the A2A protocol. If either
 package is missing the bridge prints a warning and runs the local simulator


### PR DESCRIPTION
## Summary
- document that OPENAI_API_KEY must be set for the bridge

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Missing core packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68458476d8b483339653c082e6098031