### PR TITLE
[alpha_factory] async governance run

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import asyncio
 
 from .governance_sim import run_sim
 
@@ -13,9 +14,7 @@ logger = logging.getLogger(__name__)
 try:
     from openai_agents import Agent, AgentRuntime, Tool
 except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-    raise SystemExit(
-        "openai-agents package is missing. Install with `pip install openai-agents`"
-    ) from exc
+    raise SystemExit("openai-agents package is missing. Install with `pip install openai-agents`") from exc
 
 
 @Tool(name="run_sim", description="Run governance simulation")
@@ -25,7 +24,7 @@ async def run_sim_tool(
     delta: float = 0.8,
     stake: float = 2.5,
 ) -> float:
-    return run_sim(agents=agents, rounds=rounds, delta=delta, stake=stake)
+    return await asyncio.to_thread(run_sim, agents, rounds, delta, stake)
 
 
 class GovernanceSimAgent(Agent):
@@ -46,9 +45,7 @@ class GovernanceSimAgent(Agent):
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    ap = argparse.ArgumentParser(
-        description="Expose the governance simulation via OpenAI Agents runtime"
-    )
+    ap = argparse.ArgumentParser(description="Expose the governance simulation via OpenAI Agents runtime")
     ap.add_argument(
         "--enable-adk",
         action="store_true",


### PR DESCRIPTION
## Summary
- run governance sim in a background thread

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to complete)*
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py` *(failed to complete)*
- `pytest tests/test_governance_bridge_runtime.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684587eb7acc8333979c43aeb7fc78d5