### PR TITLE
[alpha_factory] skip CI tests for non-owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
   tests:
     name: "✅ Pytest"
     needs: lint-type
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:


### PR DESCRIPTION
## Summary
- ensure CI tests only run when triggered by repo owner

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: process interrupted)*
- `pre-commit run --all-files` *(failed: initialization interrupted)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68458dd75df8833389161a3d2dfa5aef