### PR TITLE
[alpha_factory] restrict tests to repo owner

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   replay-bench:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   build-test:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   load-test:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   transfer-matrix:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   smoke:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:


### PR DESCRIPTION
# Summary
Updated several GitHub workflow jobs so test or benchmark steps only run when the workflow is triggered by the repository owner.

# Checks
- [ ] I ran `pre-commit run --files <paths>` *(failed: proto-verify)*
- [ ] I ran `python check_env.py --auto-install` *(failed: missing packages)*
- [ ] I ran `pytest -q` *(failed: ModuleNotFoundError: numpy)*

# Testing
See logs for the attempted commands. Pre‑commit aborted due to a proto verification error, `check_env.py` required network installs, and pytest failed because `numpy` was not available.

------
https://chatgpt.com/codex/tasks/task_e_68459174b4288333938eb1d6b2be0d18