### PR TITLE
[alpha_factory] enable basic logging for governance bridge

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py
@@ -60,6 +60,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO)
     args = _parse_args(argv)
     if args.port is not None:
         runtime = AgentRuntime(port=args.port, api_key=None)


### PR DESCRIPTION
## Summary
- configure logging when launching the governance bridge

## Testing
- `ruff check alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py`
- `black alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py`
- `flake8 alpha_factory_v1/demos/solving_agi_governance/openai_agents_bridge.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `python check_env.py --auto-install` *(fails: Timed out or interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6845907d871c83338824543373779edc