### PR TITLE
[alpha_factory] test colab notebook and doc

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -79,7 +79,12 @@ helm install alpha-asi ./helm_chart
 python -m alpha_asi_world_model_demo --emit-notebook
 jupyter lab alpha_asi_world_model_demo.ipynb
 # ░ Colab
-Open `alpha_asi_world_model_colab.ipynb` in Google Colab for an end-to-end guided setup
+Open `alpha_asi_world_model_colab.ipynb` in Google Colab for an end-to-end guided setup.
+Non‑technical users can run it step by step:
+1. Visit the notebook on GitHub and click **Open in Colab**.
+2. Wait for the environment to start then choose **Runtime → Run all** (or run each cell manually).
+3. The notebook installs requirements and launches the demo. When no API key is provided it automatically sets `NO_LLM=1`.
+4. Interact with the dashboard in the new browser tab and run the final **Shut down** cell when done.
 # ░ Shell helper
 ./deploy_alpha_asi_world_model_demo.sh
 # ░ OpenAI Agents bridge

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ numpy
 PyYAML
 types-PyYAML
 types-requests
+papermill

--- a/tests/test_world_model_notebook_exec.py
+++ b/tests/test_world_model_notebook_exec.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Execute the alpha_asi_world_model_colab notebook in --no-llm mode."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import nbformat
+import papermill as pm
+
+
+def test_notebook_runs(tmp_path: Path) -> None:
+    nb_path = Path("alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_colab.ipynb")
+    assert nb_path.exists(), nb_path
+    nb = nbformat.read(nb_path, as_version=4)
+
+    skip = {2, 4, 8, 15, 17, 19}
+    for idx in skip:
+        nb.cells[idx].source = "print('skipped')"
+
+    mod = tmp_path / "mod.ipynb"
+    nbformat.write(nb, mod)
+
+    os.environ["NO_LLM"] = "1"
+    os.environ.setdefault("ALPHA_ASI_SILENT", "1")
+
+    pm.execute_notebook(str(mod), str(tmp_path / "out.ipynb"), kernel_name="python3")


### PR DESCRIPTION
## Summary
- verify `alpha_asi_world_model_colab.ipynb` can run with papermill
- show non‑technical users how to open the notebook step by step
- include papermill in dev requirements

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py` *(fails: Missing packages)*
- `pytest -q` *(fails: ModuleNotFoundError: google)*
- `pre-commit run --files requirements-dev.txt tests/test_world_model_notebook_exec.py alpha_factory_v1/demos/alpha_asi_world_model/README.md` *(fails: pre-commit environment init)*

------
https://chatgpt.com/codex/tasks/task_e_68459088347c833388e76377a42d435c