### PR TITLE
[alpha_factory] add ADK helm flag

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
@@ -64,6 +64,7 @@ xdg-open http://localhost:7860      # or just paste in browser
 | `service.type` | `ClusterIP` | Switch to `LoadBalancer` or `Ingress` for public clouds. |
 | `resources.requests.cpu` | `250m` | Tweak for on-prem GPU nodes (see docs). |
 | `env.ALHPA_ASI_MAX_STEPS` | `100000` | Faster demo? Set to `20000`. |
+| `enableADK` | `false` | Set to `true` to expose the Google ADK gateway. |
 | `secretKeys.openai` | *(unset)* | Will be mounted to `OPENAI_API_KEY`. |
 
 ```yaml

--- a/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/templates/deployment.yaml
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         - name: {{ $k }}   # noqa: yaml-anchor-lint
           value: "{{ $v }}"
         {{- end }}
+        {{- if .Values.enableADK }}
+        - name: ALPHA_FACTORY_ENABLE_ADK
+          value: "true"
+        {{- end }}
         resources: {{- toYaml .Values.resources | nindent 10 }}
         livenessProbe:
           httpGet: { path: /agents, port: 7860 }

--- a/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/values.yaml
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/values.yaml
@@ -19,6 +19,7 @@ resources:                      # sensible defaults; tweak per cluster
     memory: 512Mi
 
 # You can set OPENAI_API_KEY here (or via secret) to enable the LLM planner:
+enableADK: false               # true ⇒ expose Google ADK gateway
 env: {}
   # OPENAI_API_KEY: "sk-..."
 


### PR DESCRIPTION
## Summary
- add `enableADK` flag in `helm_chart/values.yaml`
- inject `ALPHA_FACTORY_ENABLE_ADK` when enabled
- document ADK option in the chart README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to complete)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684594d506f083338764c4665bfc82d0