### PR TITLE
[alpha_factory] limit CI tests to owner manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
   tests:
     name: "✅ Pytest"
     needs: lint-type
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
@@ -143,6 +143,7 @@ PY
   docker:
     name: "🐳 Docker build"
     needs: tests
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
@@ -183,7 +184,7 @@ PY
 
   deploy:
     name: "📦 Deploy"
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner && startsWith(github.ref, 'refs/tags/')
     needs: docker
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- restrict `ci.yml` tests to run only on `workflow_dispatch` by repository owner
- skip subsequent Docker and deploy steps unless manually triggered

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: interrupted due to long execution)*
- `pytest -q` *(failed: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68459550484483339e7b69bf126d6dec