### PR TITLE
[alpha_factory] restrict workflow tests to owner

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   replay-bench:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   build-test:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   deploy-kind:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   load-test:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   transfer-matrix:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   sbom-scan-sign:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-check:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   smoke:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:


### PR DESCRIPTION
## Summary
- only run heavy test workflows when triggered by repo owner

## Testing
- `pre-commit` *(fails: proto-verify: Makefile:26 missing separator)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt during pip install)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*


------
https://chatgpt.com/codex/tasks/task_e_6845907287a48333a35b1e6c6dddfa60