### PR TITLE
[alpha_factory] add ADK gateway example to notebook

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
+++ b/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
@@ -16,8 +16,8 @@
    "id": "b8740ea6",
    "metadata": {},
    "source": [
-    "# 🕊️ Governance Simulation · Colab Notebook\n",
-    "*Alpha-Factory v1 👁*"
+    "# \ud83d\udd4a\ufe0f Governance Simulation \u00b7 Colab Notebook\n",
+    "*Alpha-Factory\u00a0v1 \ud83d\udc41*"
    ]
   },
   {
@@ -35,7 +35,7 @@
    "id": "4f25f593",
    "metadata": {},
    "source": [
-    "## 0 · Runtime check"
+    "##\u00a00 \u00b7 Runtime check"
    ]
   },
   {
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!nvidia-smi -L || echo '🔹 GPU not detected — running on CPU'"
+    "!nvidia-smi -L || echo '\ud83d\udd39 GPU not detected \u2014 running on CPU'"
    ]
   },
   {
@@ -53,8 +53,8 @@
    "id": "dbcaaa8b",
    "metadata": {},
    "source": [
-    "## 1 · Install demo package\n",
-    "*(≈ 10 s; wheels cached by Colab)*"
+    "##\u00a01 \u00b7 Install demo package\n",
+    "*(\u2248\u00a010\u202fs; wheels cached by Colab)*"
    ]
   },
   {
@@ -79,7 +79,7 @@
    "id": "06d70f5a",
    "metadata": {},
    "source": [
-    "## 2 · Quick simulation"
+    "##\u00a02 \u00b7 Quick simulation"
    ]
   },
   {
@@ -91,7 +91,7 @@
    "source": [
     "from alpha_factory_v1.demos.solving_agi_governance import run_sim\n",
     "coop = run_sim(agents=500, rounds=3000, delta=0.8, stake=2.5, seed=42)\n",
-    "print(f'mean cooperation ≈ {coop:.3f}')"
+    "print(f'mean cooperation \u2248 {coop:.3f}')"
    ]
   },
   {
@@ -105,7 +105,7 @@
     "import ipywidgets as widgets\n",
     "from IPython.display import display\n",
     "\n",
-    "delta = widgets.FloatSlider(value=0.8, min=0.5, max=0.99, step=0.01, description='δ')\n",
+    "delta = widgets.FloatSlider(value=0.8, min=0.5, max=0.99, step=0.01, description='\u03b4')\n",
     "button = widgets.Button(description='Run simulation')\n",
     "output = widgets.Output()\n",
     "\n",
@@ -113,7 +113,7 @@
     "    with output:\n",
     "        output.clear_output()\n",
     "        coop = run_sim(agents=500, rounds=3000, delta=delta.value, stake=2.5, seed=42)\n",
-    "        print(f'mean cooperation ≈ {coop:.3f}')\n",
+    "        print(f'mean cooperation \u2248 {coop:.3f}')\n",
     "\n",
     "button.on_click(_run)\n",
     "display(delta, button, output)\n"
@@ -124,7 +124,7 @@
    "id": "806dd8e9",
    "metadata": {},
    "source": [
-    "## 3 · Explore δ sensitivity"
+    "##\u00a03 \u00b7 Explore \u03b4 sensitivity"
    ]
   },
   {
@@ -140,7 +140,7 @@
     "deltas = np.linspace(0.6, 0.95, 8)\n",
     "coops = [run_sim(agents=200, rounds=2000, delta=d, stake=2.5, seed=0) for d in deltas]\n",
     "plt.plot(deltas, coops, marker='o')\n",
-    "plt.xlabel('Discount factor δ')\n",
+    "plt.xlabel('Discount factor \u03b4')\n",
     "plt.ylabel('Mean cooperation')\n",
     "plt.grid(True)\n",
     "plt.show()"
@@ -164,11 +164,38 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 \u00b7 ADK Gateway (experimental)\n",
+    "The **Google Agent Development Kit (ADK)** lets agents collaborate over the A2A protocol. ",
+    "When `google-adk` is installed and the `ALPHA_FACTORY_ENABLE_ADK` environment variable is set,\n",
+    "the bridge exposes an A2A endpoint so remote agents can delegate tasks.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, subprocess\n",
+    "try:\n",
+    "    import google_adk  # type: ignore\n",
+    "    if os.getenv(\"ALPHA_FACTORY_ENABLE_ADK\", \"false\").lower() == \"true\":\n",
+    "        subprocess.run([\"governance-bridge\", \"--enable-adk\", \"--help\"], check=True)\n",
+    "    else:\n",
+    "        print(\"Set ALPHA_FACTORY_ENABLE_ADK=true to start the ADK gateway.\")\n",
+    "except ModuleNotFoundError:\n",
+    "    print(\"google-adk not installed; skipping ADK gateway demo.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b045ee16",
    "metadata": {},
    "source": [
     "---\n",
-    "© 2025 **MONTREAL.AI** • Apache-2.0 License"
+    "\u00a9\u00a02025 **MONTREAL.AI** \u2022 Apache-2.0 License"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- extend `colab_solving_agi_governance.ipynb` with a markdown note and code cell
  showing how to launch `governance-bridge --enable-adk`
- handle the case where `google-adk` isn't installed

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: Timed out installing baseline requirements)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684594b7bac08333be5d8f0faea03b91