### PR TITLE
[alpha_factory] update python version requirement in world model demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -235,7 +235,7 @@ Need help? Open an issue → **@MontrealAI/alpha-factory-core**.
 
 ## 10  Production checklist ✅
 
-- Ensure `python3 --version` returns 3.10–3.12.
+- Ensure `python3 --version` returns 3.11–3.12.
 - Install dependencies: `pip install -r requirements.txt`.
 - Launch via `./deploy_alpha_asi_world_model_demo.sh` and visit `http://localhost:7860`.
 - The script sets `NO_LLM=1` automatically when `OPENAI_API_KEY` is unset.


### PR DESCRIPTION
## Summary
- fix Python version reference in `alpha_asi_world_model` production checklist

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: cancelled due to network)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845987a197483338a941e5ce5bf1fd4