### PR TITLE
[alpha_factory] require manual trigger for browser size check

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,12 +1,11 @@
 name: "📦 Browser Size"
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:
   build-and-check:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -237,7 +237,7 @@ extraction for a brief walkthrough.
 
 A dedicated GitHub Actions workflow
 [`size-check.yml`](../../../../.github/workflows/size-check.yml) rebuilds the
-archive on each pull request and fails if `insight_browser.zip` grows beyond
+archive when triggered manually and fails if `insight_browser.zip` grows beyond
 **3&nbsp;MiB**.
 
 ## Locale Support


### PR DESCRIPTION
## Summary
- restrict Browser Size workflow so it only runs when manually triggered by the repo owner
- document that `size-check.yml` runs on demand instead of every pull request

## Testing
- `pre-commit` *(fails: proto-verify missing)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6845970f613c8333addd7b9042058d8c