### PR TITLE
[alpha_factory] align agent versions in Dockerfile

### DIFF
--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -86,9 +86,9 @@ RUN if [ -f /tmp/requirements-lock.txt ]; then \
     fi && \
     # ⬇ Explicitly ensure critical agent frameworks are present
     pip install --no-cache-dir \
-        openai-agents~=0.5 \   # OpenAI Agents SDK (beta)
+        openai-agents>=0.0.16 \   # OpenAI Agents SDK (beta)
         "google-adk @ git+https://github.com/google/adk-python@main#egg=google-adk" \
-        anthropic~=0.19 \
+        anthropic>=0.21 \
         gunicorn rocketry prometheus-client && \
     rm -rf /tmp/requirements-lock.txt /tmp/requirements.txt
 


### PR DESCRIPTION
## Summary
- keep Docker agent versions consistent with requirements

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt while installing packages)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `docker build -t alpha-factory-test -f alpha_factory_v1/Dockerfile alpha_factory_v1` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_68459a2787548333a550eed2c8e1e510