### PR TITLE
[alpha_factory] handle missing demo server

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/openai_agents_bridge.py
@@ -24,18 +24,26 @@ except Exception:  # pragma: no cover - adk not installed
 
 @Tool(name="list_agents", description="List active orchestrator agents")
 async def list_agents() -> list[str]:
-    resp = requests.get("http://localhost:7860/agents", timeout=5)
-    resp.raise_for_status()
-    return resp.json()
+    try:
+        resp = requests.get("http://localhost:7860/agents", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException:
+        print("Demo server not running")
+        return []
 
 
 @Tool(name="new_env", description="Spawn a new demo environment")
 async def new_env() -> dict:
-    resp = requests.post(
-        "http://localhost:7860/command", json={"cmd": "new_env"}, timeout=5
-    )
-    resp.raise_for_status()
-    return resp.json()
+    try:
+        resp = requests.post(
+            "http://localhost:7860/command", json={"cmd": "new_env"}, timeout=5
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException:
+        print("Demo server not running")
+        return {}
 
 
 POLICY_MAP = {


### PR DESCRIPTION
## Summary
- add connection error handling to `openai_agents_bridge.py`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --wheelhouse wheels` *(fails: Could not find packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684599e1f16083339900b960553beaa0