### PR TITLE
[alpha_factory] require owner approval for expensive tests

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,10 +4,15 @@ on:
   schedule:
     - cron: '0 4 * * 0'
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
 
 jobs:
   replay-bench:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,11 @@ name: "🐳 Build & Test"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
 
 env:
   PYTHON_VERSION_MATRIX: "3.11,3.12"
@@ -9,7 +14,7 @@ env:
 
 jobs:
   build-test:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ on:
     tags: ["v*"]
   pull_request:
 
+  workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
+
 permissions:
   contents: read
   actions: read
@@ -26,6 +33,7 @@ env:
 
 jobs:
   lint-type:
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     name: "🧹 Ruff + 🏷️ Mypy"
     runs-on: ubuntu-latest
     environment: ci-on-demand        # ⇦ optional: add reviewers in repo Settings → Environments
@@ -50,7 +58,7 @@ jobs:
   tests:
     name: "✅ Pytest"
     needs: lint-type
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
@@ -143,7 +151,7 @@ PY
   docker:
     name: "🐳 Docker build"
     needs: tests
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
@@ -184,7 +192,7 @@ PY
 
   deploy:
     name: "📦 Deploy"
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes' && startsWith(github.ref, 'refs/tags/')
     needs: docker
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -2,10 +2,15 @@ name: "🚀 Deploy — Kind"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
 
 jobs:
   deploy-kind:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -4,10 +4,15 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
 
 jobs:
   load-test:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -4,10 +4,15 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
 
 jobs:
   transfer-matrix:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,11 @@ name: "🔒 Container Security"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
   release:
     types: [created]
 
@@ -15,7 +20,7 @@ permissions:
 
 jobs:
   sbom-scan-sign:
-    if: github.actor == github.repository_owner
+    if: (github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes') || (github.event_name == 'release' && github.actor == 'MontrealAI')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,12 +1,16 @@
 name: "📦 Browser Size"
 
 on:
-  pull_request:
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
 
 jobs:
   build-and-check:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,13 +2,18 @@ name: "🔥 Smoke Test"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_expensive_tests:
+        description: "Run costly tests"
+        required: false
+        default: "no"
 
 env:
   PYTHON_VERSION_MATRIX: "3.11,3.12"
 
 jobs:
   smoke:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'MontrealAI' && github.event.inputs.run_expensive_tests == 'yes'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -237,8 +237,8 @@ extraction for a brief walkthrough.
 
 A dedicated GitHub Actions workflow
 [`size-check.yml`](../../../../.github/workflows/size-check.yml) rebuilds the
-archive on each pull request and fails if `insight_browser.zip` grows beyond
-**3&nbsp;MiB**.
+archive when triggered manually by **MontrealAI** with the `run_expensive_tests`
+input set to `yes` and fails if `insight_browser.zip` grows beyond **3&nbsp;MiB**.
 
 ## Locale Support
 The interface automatically loads French, Spanish or Chinese translations based


### PR DESCRIPTION
## Summary
- guard Browser Size job with explicit run_expensive_tests input
- require MontrealAI confirmation before expensive workflows execute
- document how to trigger size-check workflow manually

## Testing
- `pre-commit` *(failed: command not found)*
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(failed: pip install interrupted)*
- `pytest -q` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845970f613c8333addd7b9042058d8c