### PR TITLE
[alpha_factory] remove scheduled triggers

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,13 +1,11 @@
 name: "📈 Replay Bench"
 
 on:
-  schedule:
-    - cron: '0 4 * * 0'
   workflow_dispatch:
 
 jobs:
   replay-bench:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -1,13 +1,11 @@
 name: "🌩 Load Test"
 
 on:
-  schedule:
-    - cron: '0 5 * * *'
   workflow_dispatch:
 
 jobs:
   load-test:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -1,13 +1,11 @@
 name: "📊 Transfer Matrix"
 
 on:
-  schedule:
-    - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:
   transfer-matrix:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- remove schedule triggers from bench/loadtest/nightly workflows
- lock manual dispatch to repo owner

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(failed to finish)*
- `pytest -q` *(failed: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6882bb083338352d3af0361e11c