### PR TITLE
[alpha_factory] fix run_tests docs

### DIFF
--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -428,7 +428,7 @@ falls back to Python's built-in `unittest` discovery when `pytest` is not
 available.
 
 ```bash
-./scripts/run_tests.py
+python -m alpha_factory_v1.scripts.run_tests
 ```
 ---
 

--- a/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
+++ b/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
@@ -153,7 +153,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "!python AGI-Alpha-Agent-v0/alpha_factory_v1/scripts/run_tests.py"
+    "!python -m alpha_factory_v1.scripts.run_tests"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- fix run_tests command in `alpha_factory_v1/README.md`
- update the Colab demo to match the correct invocation

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Missing numpy, yaml, pandas)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `pre-commit run --files alpha_factory_v1/README.md alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb` *(failed to fully run due to KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6845af6e2e2083338666b7203c39608e