### PR TITLE
[alpha_factory] add tests extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ mats-demo = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo:main"
 mats-bridge = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge:main"
 governance-bridge = "alpha_factory_v1.demos.solving_agi_governance.openai_agents_bridge:main"
 
+[project.optional-dependencies]
+tests = [
+    "pytest",
+]
+
 [project.entry-points."alpha_factory.agents"]
 # custom agents can be registered here
 


### PR DESCRIPTION
## Summary
- add `[project.optional-dependencies] tests = ["pytest"]`

## Testing
- `pre-commit run --files pyproject.toml` *(skipped heavy hooks)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, pandas)*
- `python check_env.py --auto-install` *(timed out)*
- `pip install -e .[tests]`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845b0fb0dbc8333bd793078fd679c6f