### PR TITLE
[alpha_factory] add governance ADK runtime test

### DIFF
--- a/tests/test_governance_bridge_adk_runtime.py
+++ b/tests/test_governance_bridge_adk_runtime.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("openai_agents") is None,
+    reason="openai_agents not installed",
+)
+def test_governance_bridge_adk_runtime(tmp_path: Path) -> None:
+    """Launch governance-bridge with ADK enabled and verify logs."""
+    stub = tmp_path / "google_adk.py"
+    stub.write_text(
+        """
+class Router:
+    def __init__(self):
+        self.app = type('app', (), {'middleware': lambda *a, **k: lambda f: f})()
+    def register_agent(self, agent):
+        pass
+class Agent: ...
+class AgentException(Exception):
+    pass
+"""
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{tmp_path}:{env.get('PYTHONPATH', '')}"
+    env["ALPHA_FACTORY_ENABLE_ADK"] = "true"
+
+    proc = subprocess.Popen(
+        ["governance-bridge", "--enable-adk", "--port", "0"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+    )
+    try:
+        time.sleep(2)
+        proc.terminate()
+        out, _ = proc.communicate(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    assert "Registered GovernanceSimAgent" in out
+    assert "ADK" in out


### PR DESCRIPTION
## Summary
- cover governance-bridge with `--enable-adk` flag
- ensure ADK stub module allows the CLI to start

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pip install numpy pyyaml pandas`
- `pytest -q` *(fails: 106 errors during collection)*
- `pytest tests/test_governance_bridge_adk_runtime.py::test_governance_bridge_adk_runtime -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b437d2508333a26ac03793c334f8