### PR TITLE
[alpha_factory] Add host and port configuration

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/.env.sample
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/.env.sample
@@ -19,8 +19,8 @@ ANTHROPIC_API_KEY=             # Future MCP tools
 GOOGLE_VERTEX_SA_KEY=          # For ADK micro-services on GCP
 
 # ▶️  UI / network
-ALPHA_ASI_HOST=0.0.0.0       # (unused)
-ALPHA_ASI_PORT=7860          # (unused)
+ALPHA_ASI_HOST=0.0.0.0       # FastAPI bind address
+ALPHA_ASI_PORT=7860          # FastAPI port
 
 #######################################################################
 #   💡 Tips

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -86,6 +86,8 @@ class Config:
     mcts_simulations: int = 16
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
     log_json: bool = False
+    host: str = "127.0.0.1"
+    port: int = 7860
 
     def update(self, **kw):
         for k, v in kw.items():
@@ -543,8 +545,8 @@ def _main():
     p.add_argument("--emit-docker", action="store_true")
     p.add_argument("--emit-helm", action="store_true")
     p.add_argument("--emit-notebook", action="store_true")
-    p.add_argument("--host", default="127.0.0.1")
-    p.add_argument("--port", type=int, default=7860)
+    p.add_argument("--host", default=CFG.host)
+    p.add_argument("--port", type=int, default=CFG.port)
     args = p.parse_args()
     if args.emit_docker:
         emit_docker()


### PR DESCRIPTION
## Summary
- allow configuring FastAPI host and port via `ALPHA_ASI_HOST` and `ALPHA_ASI_PORT`
- update `.env.sample` accordingly

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: pip install requires network)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py alpha_factory_v1/demos/alpha_asi_world_model/.env.sample` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845b63dc06c833389912652db3b301d