### PR TITLE
[alpha_factory] handle auth error in governance summary

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
@@ -85,7 +85,10 @@ def summarise_with_agent(mean_coop: float, *, agents: int, rounds: int, delta: f
 
     try:  # optional dependency
         import openai
+    except Exception:
+        return base_msg
 
+    try:
         client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         completion = client.chat.completions.create(
             model="gpt-4o",
@@ -96,6 +99,8 @@ def summarise_with_agent(mean_coop: float, *, agents: int, rounds: int, delta: f
             max_tokens=60,
         )
         return cast(str, completion.choices[0].message.content).strip()
+    except openai.AuthenticationError:
+        return base_msg + " (OPENAI_API_KEY not set; using offline summary)"
     except Exception:
         return base_msg
 

--- a/tests/test_governance_sim.py
+++ b/tests/test_governance_sim.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from alpha_factory_v1.demos.solving_agi_governance import run_sim, summarise_with_agent
 
+
 class TestGovernanceSim(unittest.TestCase):
     def test_basic_convergence(self) -> None:
         coop = run_sim(agents=50, rounds=500, delta=0.85, stake=2.5, seed=1)
@@ -17,9 +18,7 @@ class TestGovernanceSim(unittest.TestCase):
         self.assertIn("mean cooperation", text)
 
     def test_summary_with_openai_mock(self) -> None:
-        completion = SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
-        )
+        completion = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
             with patch("openai.OpenAI") as mock_client:
                 mock_client.return_value.chat.completions.create.return_value = completion
@@ -31,6 +30,22 @@ class TestGovernanceSim(unittest.TestCase):
                     stake=1.0,
                 )
         self.assertEqual(text, "ok")
+
+    def test_summary_auth_error(self) -> None:
+        import openai
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            with patch("openai.OpenAI") as mock_client:
+                mock_client.return_value.chat.completions.create.side_effect = openai.AuthenticationError("bad key")
+                text = summarise_with_agent(
+                    0.5,
+                    agents=2,
+                    rounds=10,
+                    delta=0.9,
+                    stake=1.0,
+                )
+        self.assertIn("OPENAI_API_KEY not set", text)
+        self.assertIn("offline summary", text)
 
     def test_agents_must_be_positive(self) -> None:
         with self.assertRaises(ValueError):
@@ -53,6 +68,7 @@ class TestGovernanceSim(unittest.TestCase):
     def test_stake_must_not_be_negative(self) -> None:
         with self.assertRaises(ValueError):
             run_sim(agents=1, rounds=10, delta=0.5, stake=-0.1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- improve offline handling in `governance_sim.py`
- clarify message when OPENAI authentication fails
- test the new failure path

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: timed out installing packages)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845b6a9b27c833399df61fe76a3fb7b