### PR TITLE
[alpha_factory] catch more openai errors

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
@@ -101,6 +101,10 @@ def summarise_with_agent(mean_coop: float, *, agents: int, rounds: int, delta: f
         return cast(str, completion.choices[0].message.content).strip()
     except openai.AuthenticationError:
         return base_msg + " (OPENAI_API_KEY not set; using offline summary)"
+    except openai.APIConnectionError:
+        return base_msg + " (OpenAI connection error; using offline summary)"
+    except openai.RateLimitError:
+        return base_msg + " (OpenAI rate limit exceeded; using offline summary)"
     except Exception:
         return base_msg
 


### PR DESCRIPTION
## Summary
- handle `openai.APIConnectionError` and `openai.RateLimitError`
- test offline summary for these errors in `tests/test_governance_sim.py`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails to install requirements)*
- `pytest -k governance_sim -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/governance_sim.py tests/test_governance_sim.py` *(failed: interrupted during environment install)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb5820ec8333a47d096525544153