### PR TITLE
[alpha_factory] add env-check hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,11 @@ repos:
         entry: python scripts/dp_scrubber.py
         language: python
         pass_filenames: false
+      - id: env-check
+        name: Verify required Python packages are installed
+        entry: scripts/env_check.sh
+        language: system
+        pass_filenames: false
       - id: eslint-insight-browser
         name: Lint Insight Browser with ESLint
         entry: scripts/run_eslint.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,8 @@ pre-commit run --files <paths>   # before each commit
   - Hook `eslint-insight-browser` lints the Insight browser demo. It runs `npm ci`
     in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` before
     invoking `eslint`.
+  - Hook `env-check` verifies Python packages are installed by running
+    `scripts/check_python_deps.py` and `check_env.py --auto-install`.
 
 #### Pre-commit in Air-Gapped Setups
 

--- a/scripts/env_check.sh
+++ b/scripts/env_check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python scripts/check_python_deps.py
+python check_env.py --auto-install


### PR DESCRIPTION
## Summary
- add new `env-check` pre-commit hook that runs `scripts/check_python_deps.py` and `check_env.py --auto-install`
- document the new hook in `AGENTS.md`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: interrupted)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `pre-commit run --files .pre-commit-config.yaml AGENTS.md scripts/env_check.sh` *(failed: environment installation interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_6845beed37488333b3d04fa2109dbf82