### PR TITLE
[alpha_factory] correct env bool parsing

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -95,6 +95,11 @@ class Config:
                 setattr(self, k, v)
 
 
+def _str_to_bool(v: str) -> bool:
+    """Return True for truthy strings."""
+    return v.lower() in {"1", "true", "yes", "on"}
+
+
 def _load_cfg() -> Config:
     cfg = Config()
     # yaml config file optional
@@ -111,10 +116,14 @@ def _load_cfg() -> Config:
         env_key = "ALPHA_ASI_" + k.upper()
         if env_key in os.environ:
             val = os.environ[env_key]
-            try:
-                val = type(getattr(cfg, k))(val)
-            except Exception:
-                pass
+            default = getattr(cfg, k)
+            if isinstance(default, bool):
+                val = _str_to_bool(val)
+            else:
+                try:
+                    val = type(default)(val)
+                except Exception:
+                    pass
             setattr(cfg, k, val)
     return cfg
 

--- a/tests/test_world_model_config.py
+++ b/tests/test_world_model_config.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration parsing tests for alpha_asi_world_model_demo."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from typing import Any
+
+
+def test_bool_env_override(monkeypatch, non_network: None) -> None:
+    """ALPHA_ASI_LOG_JSON=false should disable JSON logging."""
+    monkeypatch.setenv("ALPHA_ASI_LOG_JSON", "false")
+    monkeypatch.setenv("NO_LLM", "1")
+    monkeypatch.setenv("ALPHA_ASI_SILENT", "1")
+    monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+
+    module = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+    if module in sys.modules:
+        del sys.modules[module]
+    mod = importlib.import_module(module)
+    assert mod.CFG.log_json is False


### PR DESCRIPTION
# Summary
- fix boolean env var parsing in alpha_asi_world_model_demo
- add test for ALPHA_ASI_LOG_JSON=false

# Checks
- `pre-commit` *(failed: interrupted during environment setup)*
- `python check_env.py --auto-install` *(failed: interrupted during package install)*
- `pytest -q tests/test_world_model_config.py` *(failed: missing numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6845c21b0c2083339a062018891e0881