### PR TITLE
[alpha_factory] fix: robust boot for step-based agents

### DIFF
--- a/tests/test_world_model_safety.py
+++ b/tests/test_world_model_safety.py
@@ -84,6 +84,18 @@ def test_llm_planner_activates_with_key(monkeypatch):
     assert "llm_planner" in mod.A2ABus._subs
 
 
+def test_real_safety_agent_loaded(monkeypatch) -> None:
+    monkeypatch.setenv("NO_LLM", "1")
+    monkeypatch.setenv("ALPHA_ASI_SILENT", "1")
+    monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+
+    mod = _reload_module(monkeypatch)
+
+    assert "safety" in mod.AGENTS
+    subs = mod.A2ABus._subs.get("safety") or []
+    assert len(subs) == 1
+
+
 def _write_executable(path: Path, content: str) -> None:
     path.write_text(content)
     path.chmod(0o755)


### PR DESCRIPTION
## Summary
- improve `_boot()` for step-only agents, deriving names and auto-adapting `step()`
- ensure AGENTS uses the new name
- test SafetyAgent loading to avoid duplicate subscribers

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py tests/test_world_model_safety.py` *(fails: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c3d1af0883338b974a46dd469b73