### PR TITLE
[alpha_factory] Avoid duplicate safety agent

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -449,7 +449,8 @@ class BasicSafetyAgent(Agent):
             self.emit("orch", {"cmd": "stop"})
 
 
-BasicSafetyAgent()
+if "safety" not in AGENTS:
+    BasicSafetyAgent()
 
 # =============================================================================
 # 9. Optional LLM planner

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v2.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v2.py
@@ -332,7 +332,8 @@ class BasicSafetyAgent(Agent):
             self.emit("orch", {"cmd": "stop"})
 
 
-BasicSafetyAgent()  # gets overridden if a richer SafetyAgent exists
+if "safety" not in AGENTS:
+    BasicSafetyAgent()  # gets overridden if a richer SafetyAgent exists
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 9.  OPTIONAL LLM PLANNER (OpenAI Agents SDK — only if API key provided)

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v4.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo_v4.py
@@ -397,7 +397,8 @@ class BasicSafetyAgent(Agent):
             self.emit("orch", {"cmd": "stop"})
 
 
-BasicSafetyAgent()
+if "safety" not in AGENTS:
+    BasicSafetyAgent()
 
 # =============================================================================
 # 9. Optional LLM planner

--- a/tests/test_world_model_safety.py
+++ b/tests/test_world_model_safety.py
@@ -92,6 +92,7 @@ def test_real_safety_agent_loaded(monkeypatch) -> None:
     mod = _reload_module(monkeypatch)
 
     assert "safety" in mod.AGENTS
+    assert list(mod.AGENTS).count("safety") == 1
     subs = mod.A2ABus._subs.get("safety") or []
     assert len(subs) == 1
 


### PR DESCRIPTION
## Summary
- guard BasicSafetyAgent instantiation
- check only one safety agent is registered

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: missing packages)*
- `pip install numpy PyYAML pandas`
- `pytest -q` *(fails: ModuleNotFoundError: google, cachetools, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845c594e3448333a1c170cd13d8443d