### PR TITLE
[alpha_factory] clarify demo extras needed for tests

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -97,6 +97,14 @@ Python standard library.
 
 ---
 
+### Requirements
+* Python 3.11 or 3.12
+* Install the demo extras before running the tests:
+  ```bash
+  pip install -r requirements-demo.txt
+  ```
+  See [tests/README.md](../../../tests/README.md) for full instructions.
+
 ### 9 · Running the Demo
 The CLI simulator has **no third‑party dependencies**—use Python 3.11 or 3.12.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    ```bash
    pip install -r requirements-dev.txt
    ```
-2. Install the demo extras:
+2. Install the demo extras **required for the full suite**:
    ```bash
    pip install -r requirements-demo.txt
    ```
@@ -28,7 +28,7 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
     `numpy`, `torch`, `pandas`, `prometheus_client`, `gymnasium`, `playwright`,
     `httpx`, `uvicorn`, `git` and `hypothesis`.
 5. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
-6. Execute `pytest -q`.
+6. After installing **both** requirements files above, execute `pytest -q`.
 
 ### Offline install
 


### PR DESCRIPTION
## Summary
- clarify that the demo extras must be installed before running pytest
- point the governance demo README to root test instructions

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/test_alpha_discovery_stub.py::test_basic -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845c763910c8333bad9f36b23616328