### PR TITLE
[alpha_factory] add unsubscribe and reload test

### DIFF
--- a/tests/test_world_model_reload.py
+++ b/tests/test_world_model_reload.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure reloading the world model demo does not duplicate bus callbacks."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+MODULE = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+
+
+def _load():
+    if MODULE in sys.modules:
+        return importlib.reload(sys.modules[MODULE])
+    return importlib.import_module(MODULE)
+
+
+def test_module_reload_no_duplicate_callbacks(monkeypatch) -> None:
+    monkeypatch.setenv("NO_LLM", "1")
+    monkeypatch.setenv("ALPHA_ASI_SILENT", "1")
+    monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+
+    mod = _load()
+    counts = {k: len(v) for k, v in mod.A2ABus._subs.items()}
+
+    for agent in mod.AGENTS.values():
+        agent.close()
+
+    mod = importlib.reload(mod)
+    counts2 = {k: len(v) for k, v in mod.A2ABus._subs.items()}
+
+    assert counts2 == counts

--- a/tests/test_world_model_safety.py
+++ b/tests/test_world_model_safety.py
@@ -58,6 +58,7 @@ def test_safety_agent_halts_on_nan(monkeypatch):
     mod.A2ABus.subscribe("orch", lambda m: msgs.append(m))
     safety.handle({"loss": np.nan})
     assert {"cmd": "stop"} in msgs
+    safety.close()
 
 
 def test_safety_agent_halts_on_large_loss(monkeypatch):
@@ -72,6 +73,7 @@ def test_safety_agent_halts_on_large_loss(monkeypatch):
     mod.A2ABus.subscribe("orch", lambda m: msgs.append(m))
     safety.handle({"loss": 5000.0})
     assert {"cmd": "stop"} in msgs
+    safety.close()
 
 
 def test_llm_planner_activates_with_key(monkeypatch):


### PR DESCRIPTION
## Summary
- add thread-safe A2ABus.unsubscribe and Agent.close
- call close in world model safety tests
- add reload regression test

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt / package install)*
- `pytest tests/test_world_model_reload.py::test_module_reload_no_duplicate_callbacks -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845c8fced308333a36f8c657ee73891