### PR TITLE
[alpha_factory] update world model quickstart

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -16,3 +16,17 @@ WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
   python check_env.py --auto-install --wheelhouse /media/wheels
 WHEELHOUSE=/media/wheels alpha-asi-demo --demo
 ```
+
+### Running `check_env.py` offline
+
+When network access is unavailable, pass `--wheelhouse <dir>` so `pip`
+installs missing packages from your local cache instead of PyPI:
+
+```bash
+python check_env.py --auto-install --wheelhouse /media/wheels
+```
+
+Run `python scripts/check_python_deps.py` first; if it reports any
+missing packages they **must** be installed from the wheelhouse using
+the command above. Set `NO_LLM=1` when no `OPENAI_API_KEY` is supplied
+to skip the external planner and run entirely with local models.


### PR DESCRIPTION
## Summary
- document offline run of `check_env.py --auto-install --wheelhouse <dir>`
- clarify `NO_LLM=1` when `OPENAI_API_KEY` is not set
- note installing missing deps via the wheelhouse

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md` *(fails: KeyboardInterrupt during environment init)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt during pip install)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845cca2ff948333ad30762e3632cb86