### PR TITLE
[alpha_factory] fallback when openai-agents missing

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -178,8 +178,9 @@ The `OPENAI_API_KEY` variable must be set or the bridge cannot communicate with 
 
 The script registers a `GovernanceSimAgent` with the Agents runtime and, when
 `google-adk` is available, also exposes it over the A2A protocol. If either
-package is missing the bridge prints a warning and runs the local simulator
-only, so the demo remains fully offline capable.
+package is missing the bridge prints a warning and executes the local simulator
+instead. The offline fallback accepts the same parameters as `governance-sim`
+(`-N`, `-r`, `--delta`, `--stake`) so the demo remains fully offline capable.
 
 Specify a custom runtime port with `--port`:
 

--- a/tests/test_governance_bridge_offline.py
+++ b/tests/test_governance_bridge_offline.py
@@ -2,7 +2,9 @@
 """Offline mode test for the governance bridge."""
 
 import builtins
-import importlib
+import subprocess
+import sys
+
 import pytest
 
 
@@ -16,9 +18,18 @@ def test_governance_bridge_offline(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    with pytest.raises(SystemExit):
-        importlib.reload(
-            importlib.import_module(
-                "alpha_factory_v1.demos.solving_agi_governance.openai_agents_bridge"
-            )
-        )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "alpha_factory_v1.demos.solving_agi_governance.openai_agents_bridge",
+            "-N",
+            "10",
+            "-r",
+            "20",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "mean cooperation" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add offline mode to governance bridge when `openai-agents` isn't installed
- document bridge fallback in README
- update governance bridge offline test

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to finish due to missing dependencies)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845cc4bccd883339206252ae8a6eb90