### PR TITLE
[alpha_factory] docs: add prototype disclaimer

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
@@ -1,7 +1,12 @@
 
+## Disclaimer
+This demo is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
+
 # Alpha‑Factory v1 👁️✨ — α‑ASI World‑Model Demo Documentation
 
-Welcome to the documentation bundle for the **α‑ASI World‑Model demo**.  
+Welcome to the documentation bundle for the **α‑ASI World‑Model demo**.
 This archive contains all the user‑facing docs needed to understand, deploy, and extend the demo:
 
 | File | Purpose |

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
@@ -1,3 +1,8 @@
+## Disclaimer
+This demo is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
+
 ### Agents
 - PlanningAgent: high‑level goal decomposition
 - ResearchAgent: literature & data mining

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
@@ -1,3 +1,8 @@
+## Disclaimer
+This demo is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
+
 ### REST Endpoints
 - `/agents` : list agents
 - `/command` : POST a JSON command `{cmd: ...}`

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -1,5 +1,10 @@
 ## Quick‑Start
 
+## Disclaimer
+This demo is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
+
 ```bash
 pip install -r requirements.txt
 python -m alpha_asi_world_model_demo --demo


### PR DESCRIPTION
## Summary
- clarify AGI limitations for the α‑ASI world-model docs

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: missing core packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845d0b2b53083338ea04ce66bf64be5