### PR TITLE
[alpha_factory] add disclaimers to demos

### DIFF
--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -16,6 +16,11 @@ Global markets seep *USD ✧ trillions/yr* in latent opportunity — “alph
 
 Built atop **OpenAI Agents SDK**, **Google ADK**, **A2A protocol**, and Anthropic’s **Model Context Protocol**, the stack runs cloud‑native *or* air‑gapped, hot‑swapping between frontier LLMs and distilled local models.
 
+## Disclaimer
+This repository is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
+
 ---
 
 ## 📜 Table of Contents

--- a/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
@@ -5,6 +5,11 @@
 > **Alpha‑Factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.
 
 ---
+## Disclaimer
+This repository is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
+
 
 ## ⚡ TL;DR  
 

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -11,6 +11,11 @@ high‑stakes prod cluster right now.
 > **Definition**: An **α‑AGI Business** 👁️✨ (`<name>.a.agi.eth`) is an antifragile, self‑governing multi‑agent  👁️✨ (`<name>.a.agent.agi.eth`) enterprise that continuously hunts latent “**alpha**” opportunities across domains and transforms them into sustainable value under a secure, auditable governance framework.
 
 ---
+## Disclaimer
+This repository is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence
+of a real general intelligence. Use at your own risk.
+
 
 ## 📚 Table of Contents
 0. [Executive Summary](#0)

--- a/alpha_factory_v1/demos/solving_agi_governance/alpha_asi_governance_v13.tex
+++ b/alpha_factory_v1/demos/solving_agi_governance/alpha_asi_governance_v13.tex
@@ -61,6 +61,9 @@ Minimal Conditions for Stable, Antifragile Multi-Agent Order}
 
 \begin{document}
 \maketitle\vspace*{-1.2ex}
+\paragraph{Disclaimer.} This repository is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+
 
 % ---------- abstract ----------
 \begin{abstract}


### PR DESCRIPTION
## Summary
- add conceptual-use disclaimer to Alpha‑Factory README
- note demos are conceptual in business2 and business3 READMEs
- add disclaimer to alpha_asi_governance_v13.tex

## Testing
- `pre-commit run --files alpha_factory_v1/README.md alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md alpha_factory_v1/demos/solving_agi_governance/alpha_asi_governance_v13.tex` *(fails: proto-verify missing Makefile)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(failed: operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845d2a95b988333b572800fd6b2eb34