### PR TITLE
[alpha_factory] Auto install missing packages in tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -26,7 +26,13 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
     (or the `WHEELHOUSE` environment variable).
     The full suite exercises features that depend on optional packages such as
     `numpy`, `torch`, `pandas`, `prometheus_client`, `gymnasium`, `playwright`,
-    `httpx`, `uvicorn`, `git` and `hypothesis`.
+   `httpx`, `uvicorn`, `git` and `hypothesis`.
+   
+   The test suite automatically attempts to install missing packages at
+   session start when `numpy` or `torch` are unavailable by invoking
+   `check_env.py --auto-install`.  Set the `WHEELHOUSE` environment
+   variable to point to a local wheel directory when running offline so
+   these installs can succeed without contacting PyPI.
 5. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 6. After installing **both** requirements files above, execute `pytest -q`.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 import sys
 import types
+import importlib.util
 from src.simulation import replay
 
 rocketry_stub = types.ModuleType("rocketry")
@@ -11,6 +12,18 @@ conds_mod.every = lambda *_: None
 rocketry_stub.conds = conds_mod
 sys.modules.setdefault("rocketry", rocketry_stub)
 sys.modules.setdefault("rocketry.conds", conds_mod)
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Ensure core packages are installed at session start."""
+    missing = [name for name in ("numpy", "torch") if importlib.util.find_spec(name) is None]
+    if missing:
+        try:
+            import check_env
+        except Exception as exc:  # pragma: no cover - fallback just prints
+            print(f"check_env unavailable: {exc}")
+        else:
+            check_env.main(["--auto-install"])
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- ensure missing packages auto-install on test session start
- mention automatic install and WHEELHOUSE in test docs

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: Timed out / interrupted)*
- `pytest -q tests/test_no_network.py` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files tests/conftest.py tests/README.md` *(failed: Interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_6845d265bb308333934628f5303eafd8