### PR TITLE
[alpha_factory] add --no-llm flag for world model

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -64,6 +64,7 @@ pip install -r requirements.txt        # torch, fastapi, uvicorn…
 
 # new CLI (after `pip install -e .` at repo root)
 alpha-asi-demo --demo        # same as `python -m alpha_asi_world_model_demo --demo`
+alpha-asi-demo --demo --no-llm   # force-disable the optional LLM planner
 open http://localhost:7860             # dashboard & Swagger
 
 # ░ One-liner Docker

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -605,6 +605,11 @@ def _main():
     p.add_argument("--emit-docker", action="store_true")
     p.add_argument("--emit-helm", action="store_true")
     p.add_argument("--emit-notebook", action="store_true")
+    p.add_argument(
+        "--no-llm",
+        action="store_true",
+        help="Disable the optional LLM planner regardless of OPENAI_API_KEY",
+    )
     p.add_argument("--host", default=CFG.host)
     p.add_argument("--port", type=int, default=CFG.port)
     args = p.parse_args()
@@ -615,6 +620,8 @@ def _main():
     elif args.emit_notebook:
         emit_notebook()
     elif args.demo:
+        if args.no_llm:
+            os.environ["NO_LLM"] = "1"
         uvicorn.run(
             "alpha_asi_world_model_demo:app",
             host=args.host,


### PR DESCRIPTION
## Summary
- add `--no-llm` option to alpha_asi_world_model_demo CLI
- document new flag in the demo README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails to install due to network)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845e1386f1083338dd7066a2d15c381