### PR TITLE
[alpha_factory] add semgrep python rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     hooks:
       - id: semgrep
         args: ["--config", "semgrep.yml"]
+        types: [python]
   - repo: local
     hooks:
       - id: proto-verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,8 @@ pre-commit run --files <paths>   # before each commit
     to regenerate and verify protobuf sources.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using
     `mypy.ini`.
+  - Semgrep scans Python files with the official `p/python` ruleset to enforce
+    security and style best practices.
   - Hooks `verify-requirements-lock`, `verify-alpha-requirements-lock` and
     `verify-backend-requirements-lock` ensure each `requirements-lock` file
     matches its `requirements.txt`. They rely on `pip-tools`.

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -1,3 +1,5 @@
+imports:
+  - p/python
 rules:
   - id: solidity-tx-origin
     languages: [solidity]


### PR DESCRIPTION
## Summary
- add official Python semgrep rules
- limit semgrep pre-commit hook to Python files
- document semgrep in AGENTS guide

## Testing
- `pre-commit run --files semgrep.yml .pre-commit-config.yaml AGENTS.md` *(fails: proto-verify hook)*

------
https://chatgpt.com/codex/tasks/task_e_6845e705f0f48333accd982142e9831b