### PR TITLE
[alpha_factory] remove shell open cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ pip install google-adk mcp
 # Requires Python 3.11–3.12 (<3.13)
 ./quickstart.sh
 Run `pre-commit run --all-files` after the dependencies finish installing.
-python -m webbrowser http://localhost:8000/docs
+# Open http://localhost:8000/docs in your browser
 ```
 The adapters initialise automatically when these optional packages are present.
 
@@ -750,8 +750,7 @@ pip install -r requirements.lock
 #   python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 #   WHEELHOUSE=$WHEELHOUSE ./quickstart.sh
 #   WHEELHOUSE=$WHEELHOUSE pytest -q
-# open the docs in your browser
-python -m webbrowser http://localhost:8000/docs
+# Open http://localhost:8000/docs in your browser
 # Alternatively, ``python alpha_factory_v1/quickstart.py`` provides the same
 # workflow on Windows and other systems without Bash.
 


### PR DESCRIPTION
## Summary
- replace the `python -m webbrowser` lines in the README with a plain instruction to open the docs URL

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install --wheelhouse /tmp/wheels` *(fails to install baseline requirements)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eb1e88c48333808d1de2efeaf1c8