### PR TITLE
[alpha_factory] update docs with ALPHA_ASI env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,14 @@ template). The sample file now lists every variable with its default value.
 | `ARCHIVE_PATH` | Darwin‑Archive SQLite file | `archive.db` |
 | `ARCHIVE_DB` | API server results database | `archive.db` |
 | `SOLUTION_ARCHIVE_PATH` | Path to solution archive | `solutions.duckdb` |
+| `ALPHA_ASI_SEED` | Deterministic RNG seed for the world model demo | `42` |
+| `ALPHA_ASI_MAX_STEPS` | Learner steps before auto-stop | `100000` |
+| `ALPHA_ASI_BUFFER_LIMIT` | Replay-buffer length | `50000` |
+| `ALPHA_ASI_TRAIN_BATCH` | SGD mini-batch size | `128` |
+| `ALPHA_ASI_MAX_GRID` | Safety clamp on generated mazes | `64` |
+| `ALPHA_ASI_HOST` | FastAPI bind address for the demo | `0.0.0.0` |
+| `ALPHA_ASI_PORT` | FastAPI port for the demo | `7860` |
+| `ALPHA_ASI_LLM_MODEL` | Planner model used by the world model demo | `gpt-4o-mini` |
 | `PROOF_THRESHOLD` | Minimum score to generate SNARK proof | `0.5` |
 
 ## Coding Style

--- a/README.md
+++ b/README.md
@@ -842,7 +842,14 @@ for instructions and example volume mounts.
 |----------|---------|---------|
 | `OPENAI_API_KEY` | _(empty)_ | API key for hosted models. Offline mode is used when empty. |
 | `NO_LLM` | `0` | Set to `1` to skip the LLM planner even when `OPENAI_API_KEY` is provided. |
-| `ALPHA_ASI_LLM_MODEL` | `gpt-4o-mini` | Model used by the world model planner. |
+| `ALPHA_ASI_LLM_MODEL` | `gpt-4o-mini` | Planner model name used by the world model demo. |
+| `ALPHA_ASI_SEED` | `42` | Deterministic RNG seed for the demo. |
+| `ALPHA_ASI_MAX_STEPS` | `100000` | Learner steps before auto-stop. |
+| `ALPHA_ASI_BUFFER_LIMIT` | `50000` | Replay-buffer length. |
+| `ALPHA_ASI_TRAIN_BATCH` | `128` | SGD mini-batch size. |
+| `ALPHA_ASI_MAX_GRID` | `64` | Safety clamp on generated mazes. |
+| `ALPHA_ASI_HOST` | `0.0.0.0` | FastAPI bind address for the demo. |
+| `ALPHA_ASI_PORT` | `7860` | FastAPI port for the demo. |
 | `NEO4J_PASSWORD` | `REPLACE_ME` | Database password required by the orchestrator. |
 | `RUN_MODE` | `api` | Launch mode for Compose or Helm (`api`, `cli`, `web`). |
 | `PORT` | `8000` | REST API port. |

--- a/alpha_factory_v1/.env.sample
+++ b/alpha_factory_v1/.env.sample
@@ -73,3 +73,13 @@ ARCHIVE_PATH=archive.db            # Darwin-Archive database
 ARCHIVE_DB=archive.db              # API server results DB
 SOLUTION_ARCHIVE_PATH=solutions.duckdb  # solution archive path
 PROOF_THRESHOLD=0.5                # SNARK proof score threshold
+
+# ─── Alpha ASI World Model Demo ─────────────────────────────────────
+ALPHA_ASI_SEED=42              # deterministic RNG seed
+ALPHA_ASI_MAX_STEPS=100000     # learner steps before auto-stop
+ALPHA_ASI_BUFFER_LIMIT=50000   # replay-buffer length
+ALPHA_ASI_TRAIN_BATCH=128      # SGD mini-batch size
+ALPHA_ASI_MAX_GRID=64          # safety clamp on generated mazes
+ALPHA_ASI_HOST=0.0.0.0         # demo FastAPI bind address
+ALPHA_ASI_PORT=7860            # demo FastAPI port
+ALPHA_ASI_LLM_MODEL=gpt-4o-mini  # planner model name

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
   automated image deployment on tags and rollback on failure. Metrics are
   exported via OpenTelemetry and can be viewed in Grafana or the Streamlit
   dashboard.
+- Documented `ALPHA_ASI_*` demo variables in README and AGENTS.md.
 
 ## [1.1.0] - 2025-07-15
 ### Added


### PR DESCRIPTION
## Summary
- document ALPHA_ASI demo variables in README and AGENTS guide
- add the variables to the main `.env.sample`
- mention docs update in CHANGELOG

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to complete: Timed out during requirements installation)*
- `pre-commit run --files README.md AGENTS.md docs/CHANGELOG.md alpha_factory_v1/.env.sample` *(failed: KeyboardInterrupt during environment setup)*
- `pytest -q` *(failed to run tests: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845f7cf11448333814af402fdfe8878