### PR TITLE
[alpha_factory] add config override test

### DIFF
--- a/tests/test_world_model_config.py
+++ b/tests/test_world_model_config.py
@@ -21,3 +21,19 @@ def test_bool_env_override(monkeypatch, non_network: None) -> None:
         del sys.modules[module]
     mod = importlib.import_module(module)
     assert mod.CFG.log_json is False
+
+
+def test_host_port_override(monkeypatch, non_network: None) -> None:
+    """ALPHA_ASI_HOST and ALPHA_ASI_PORT should override defaults."""
+    monkeypatch.setenv("ALPHA_ASI_HOST", "8.8.8.8")
+    monkeypatch.setenv("ALPHA_ASI_PORT", "12345")
+    monkeypatch.setenv("NO_LLM", "1")
+    monkeypatch.setenv("ALPHA_ASI_SILENT", "1")
+    monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+
+    module = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+    if module in sys.modules:
+        del sys.modules[module]
+    mod = importlib.import_module(module)
+    assert mod.CFG.host == "8.8.8.8"
+    assert mod.CFG.port == 12345


### PR DESCRIPTION
## Summary
- add regression test ensuring `ALPHA_ASI_HOST` and `ALPHA_ASI_PORT` override defaults

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install --wheelhouse /tmp/wheels_empty` *(fails: could not install baseline requirements)*
- `pytest -q tests/test_world_model_config.py::test_host_port_override` *(fails: attempt aborted during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_684604ad70bc8333926c7d56df90993b