### PR TITLE
[alpha_factory] Rewrite safety notes

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
@@ -1,1 +1,12 @@
-This system monitors numeric instability, reward hacking, and policy divergence. It can pause training on anomalies and enforces role‑based agent scopes.
+## Disclaimer
+This demo is a conceptual research prototype. References to "AGI" and
+"superintelligence" describe aspirational goals and do not indicate the
+presence of a real general intelligence. Use at your own risk.
+
+# Safety Notes
+
+This system monitors numeric instability, reward hacking, and policy divergence. It can pause training when anomalies are detected and enforces role-based agent scopes.
+
+Monitoring numeric instability helps catch sudden spikes or NaN values that signal faulty gradients or diverging models. The training loop logs running statistics for rewards, activations, and losses, and halts when numbers move outside safe bounds.
+
+Policy divergence occurs when the agent's behavior drifts from its intended strategy. By periodically comparing actions against a baseline policy, the system can stop training if the divergence grows beyond a threshold.


### PR DESCRIPTION
## Summary
- rewrite safety_notes.md using ASCII text
- include monitoring description for numeric instability and policy divergence

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: Missing core packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460d75354c8333b096489dbb60770a