### PR TITLE
[alpha_factory] Remove world model demo from Ruff exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ exclude = [
     "alpha_factory_v1/demos/alpha_agi_insight_v0/*",
     "alpha_factory_v1/demos/alpha_agi_insight_v1/*",
     "alpha_factory_v1/demos/alpha_agi_marketplace_v1/*",
-    "alpha_factory_v1/demos/alpha_asi_world_model/*",
     "alpha_factory_v1/demos/cross_industry_alpha_factory/*",
     "alpha_factory_v1/demos/era_of_experience/*",
     "alpha_factory_v1/demos/finance_alpha/*",


### PR DESCRIPTION
## Summary
- enable linting for `alpha_asi_world_model_demo`

## Testing
- `SKIP=mypy,proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-mats-demo-lock,verify-mats-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,env-check,eslint-insight-browser pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_6846138383a083338fd0af9bb3fd9ef0