### PR TITLE
[alpha_factory] Document failed test run

### DIFF
--- a/testing_notes.md
+++ b/testing_notes.md
@@ -1,0 +1,2 @@
+Attempted to run `pytest -q` after installing missing packages via `python check_env.py --auto-install`. Installation timed out due to heavy dependencies, and running `pytest` was interrupted. Pre-commit hooks also failed to complete because required tools weren't available.
+


### PR DESCRIPTION
## Summary
- add testing notes documenting failure to run tests

## Checks
- [ ] I ran `pre-commit run --files testing_notes.md`
- [ ] I ran `python check_env.py --auto-install`
- [ ] I ran `pytest -q` and documented any failures below

## Testing
- `pre-commit run --files tests/README.md` *(failed: Missing tools)*
- `python check_env.py --auto-install` *(failed: Timed out installing baseline requirements)*
- `pytest -q` *(failed: installation timed out / KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846475ffaf08333af0466161ec39325