### PR TITLE
[alpha_factory] add offline wheelhouse summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ python check_env.py --auto-install --wheelhouse /media/wheels
 This mirrors the instructions in
 [alpha_factory_v1/scripts/README.md](alpha_factory_v1/scripts/README.md#offline-setup).
 
+See the [Wheelhouse Setup](alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md#wheelhouse-setup)
+section of the α‑ASI world-model quickstart for a concise summary.
+
 3. **Download a `.gguf` weight** and set ``LLAMA_MODEL_PATH``:
    ```bash
    mkdir -p ~/.cache/llama

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -10,15 +10,21 @@ pip install -r requirements.txt
 python -m alpha_asi_world_model_demo --demo
 ```
 
-To run without internet access, build wheels on a connected machine and
-install from a local wheelhouse:
+### Wheelhouse Setup
+
+Build wheels using the same Python version as your virtual environment and
+verify packages from that directory:
 
 ```bash
 mkdir -p /media/wheels
 pip wheel -r requirements.txt -w /media/wheels
 pip wheel -r ../../../requirements-dev.txt -w /media/wheels
-WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
-  python check_env.py --auto-install --wheelhouse /media/wheels
+python check_env.py --auto-install --wheelhouse /media/wheels
+```
+
+Set `WHEELHOUSE=/media/wheels` when launching the demo offline:
+
+```bash
 WHEELHOUSE=/media/wheels alpha-asi-demo --demo
 ```
 


### PR DESCRIPTION
## Summary
- document building a wheelhouse in world-model quickstart
- link README offline section to the new wheelhouse setup

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(interrupted: KeyboardInterrupt)*
- `pytest -q` *(interrupted: KeyboardInterrupt)*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684652c05ecc833393dbb5884085c2d2