### PR TITLE
[alpha_factory] aggregate world model stats

### DIFF
--- a/tests/test_world_model_demo.py
+++ b/tests/test_world_model_demo.py
@@ -52,3 +52,54 @@ def test_post_new_env(non_network: None) -> None:
     resp = client.post("/command", json={"cmd": "new_env"})
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+
+
+def test_multi_env_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Aggregated metrics should reflect all environments."""
+    monkeypatch.setenv("NO_LLM", "1")
+    monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+    monkeypatch.setenv("ALPHA_ASI_UI_TICK", "1")
+    monkeypatch.setenv("ALPHA_ASI_ENV_BATCH", "2")
+
+    mod = importlib.import_module(
+        "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+    )
+
+    class DummyEnv:
+        def __init__(self, reward: float) -> None:
+            self.reward = reward
+
+        def reset(self):
+            return None
+
+        def step(self, _a: int):
+            return None, self.reward, True, {}
+
+    class DummyLearner:
+        def __init__(self, loss: float) -> None:
+            self.loss = loss
+
+        def act(self, _obs):
+            return 0
+
+        def remember(self, _obs, _reward) -> None:
+            pass
+
+        def train_once(self) -> float:
+            return self.loss
+
+    mod.A2ABus._subs = {}
+    orch = mod.Orchestrator()
+    orch.envs = [DummyEnv(1.0), DummyEnv(0.0)]
+    orch.learners = [DummyLearner(0.2), DummyLearner(0.4)]
+
+    msgs: list[dict] = []
+    mod.A2ABus.subscribe("ui", lambda m: msgs.append(m))
+
+    orch.loop()
+
+    assert msgs
+    msg = msgs[-1]
+    assert msg["t"] == 0
+    assert msg["r"] == pytest.approx(0.5)
+    assert msg["loss"] == pytest.approx(0.3)


### PR DESCRIPTION
## Summary
- average reward and loss across environments in `alpha_asi_world_model_demo`
- test aggregated reporting from the orchestrator

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to complete in CI)*
- `pytest -q` *(failed to complete in CI)*

------
https://chatgpt.com/codex/tasks/task_e_6846d96953148333b7aa2377635e4e53