### PR TITLE
[alpha_factory] add open-endedness gating

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/config.yaml
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/config.yaml
@@ -19,6 +19,9 @@ env:
   min_size: 5           # 🌍 Smallest grid size
   max_size: 10          # 🌍 Largest grid size
   obstacle_density: 0.15  # 🚧 % of cells turned into obstacles
+  mc_min: 0.2           # 🔎 Reject envs solved < mc_min return
+  mc_max: 0.8           # 🔎 Reject envs scoring > mc_max return
+  mc_episodes: 3        # 🎲 Episodes to estimate average return
 
 agents:                 # 🤖 Agent modules to auto-load
   required:

--- a/tests/test_world_model_open_endedness.py
+++ b/tests/test_world_model_open_endedness.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""POETGenerator acceptance thresholds."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from typing import Any
+
+import pytest
+
+
+def test_trivial_maze_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Generator should reject easy mazes when thresholds active."""
+    monkeypatch.setenv("NO_LLM", "1")
+    monkeypatch.setenv("ALPHA_ASI_SILENT", "1")
+    monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+    monkeypatch.setenv("ALPHA_ASI_MC_MIN", "0.2")
+    monkeypatch.setenv("ALPHA_ASI_MC_MAX", "0.8")
+    module = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+    if module in sys.modules:
+        del sys.modules[module]
+    mod = importlib.import_module(module)
+
+    calls: list[float] = [1.0, 0.5]
+
+    def fake_eval(self, env, policy, episodes):
+        return calls.pop(0)
+
+    monkeypatch.setattr(mod.POETGenerator, "_mc_eval", fake_eval)
+
+    gen = mod.POETGenerator()
+    env = gen.propose()
+    assert env in gen.pool
+    assert not calls  # second env accepted


### PR DESCRIPTION
## Summary
- run MC evaluation inside `POETGenerator.propose`
- reject worlds outside `mc_min`/`mc_max`
- allow config of MC thresholds
- test rejection of trivial mazes

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to complete)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py alpha_factory_v1/demos/alpha_asi_world_model/config.yaml tests/test_world_model_open_endedness.py` *(failed: KeyboardInterrupt)*
- `pytest tests/test_world_model_open_endedness.py -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846dea6b3488333981c863d4f0e95bf