### PR TITLE
[alpha_factory] add CLI emit test

### DIFF
--- a/tests/test_world_model_cli.py
+++ b/tests/test_world_model_cli.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI regression test for ``alpha_asi_world_model_demo`` helpers."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+
+import pytest
+
+pytest.importorskip("nbformat")
+
+
+def test_cli_emit_helpers() -> None:
+    """Ensure emit flags generate expected files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        for flag in ["--emit-docker", "--emit-helm", "--emit-notebook"]:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo",
+                    flag,
+                ],
+                cwd=tmp,
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, result.stderr
+
+        assert (tmp / "Dockerfile").exists()
+        assert (tmp / "helm_chart" / "values.yaml").exists()
+        assert (tmp / "alpha_asi_world_model_demo.ipynb").exists()
+
+    assert not Path(tmpdir).exists()


### PR DESCRIPTION
## Summary
- test world model CLI emit helpers

## Testing
- `pre-commit run --files tests/test_world_model_cli.py` *(failed: command not found / network)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(interrupted due to network/time)*
- `pytest -q tests/test_world_model_cli.py` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6846e28bf1388333a1e540ce49391d7b