### PR TITLE
[alpha_factory] graceful orchestrator shutdown

### DIFF
--- a/tests/test_world_model_demo.py
+++ b/tests/test_world_model_demo.py
@@ -44,9 +44,7 @@ def test_post_new_env(non_network: None) -> None:
     os.environ.setdefault("ALPHA_ASI_SILENT", "1")
     os.environ.setdefault("ALPHA_ASI_MAX_STEPS", "1")
 
-    mod = importlib.import_module(
-        "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
-    )
+    mod = importlib.import_module("alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo")
     client = TestClient(cast(Any, mod.app))
 
     resp = client.post("/command", json={"cmd": "new_env"})
@@ -61,9 +59,7 @@ def test_multi_env_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ALPHA_ASI_UI_TICK", "1")
     monkeypatch.setenv("ALPHA_ASI_ENV_BATCH", "2")
 
-    mod = importlib.import_module(
-        "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
-    )
+    mod = importlib.import_module("alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo")
 
     class DummyEnv:
         def __init__(self, reward: float) -> None:
@@ -103,3 +99,17 @@ def test_multi_env_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert msg["t"] == 0
     assert msg["r"] == pytest.approx(0.5)
     assert msg["loss"] == pytest.approx(0.3)
+
+
+def test_shutdown_stops_loop(non_network: None) -> None:
+    """The orchestrator loop thread should terminate on app shutdown."""
+    os.environ["NO_LLM"] = "1"
+    os.environ.setdefault("ALPHA_ASI_MAX_STEPS", "100000")
+
+    mod = importlib.import_module("alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo")
+
+    with TestClient(cast(Any, mod.app)) as client:
+        client.get("/agents")
+        loop = mod.loop_thread
+        assert loop is not None and loop.is_alive()
+    assert loop is not None and not loop.is_alive()


### PR DESCRIPTION
## Summary
- implement FastAPI shutdown handler in alpha_asi_world_model_demo
- stop orchestrator thread and join on exit
- test that shutdown terminates loop thread

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846e4c16b8c83339c1c5bbaab17fe94