### PR TITLE
[alpha_factory] docs: update offline setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,10 @@ python check_env.py --auto-install  # verify & auto-install deps (10 min timeout
 pip install -r requirements.lock
 # (If this fails with a network error, create a wheelhouse and rerun
 #  with --wheelhouse <path> or place the wheels under ./wheels)
+# Build a wheelhouse if the machine has no internet access:
+#   mkdir -p /media/wheels
+#   pip wheel -r requirements.txt -w /media/wheels
+#   pip wheel -r requirements-dev.txt -w /media/wheels
 ./quickstart.sh               # creates venv, installs deps, launches
 # Use `--wheelhouse /path/to/wheels` to install offline packages when
 # the host has no internet access. The setup script automatically

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -13,13 +13,15 @@ python -m alpha_asi_world_model_demo --demo
 ### Wheelhouse Setup
 
 Build wheels using the same Python version as your virtual environment and
-verify packages from that directory:
+verify packages from that directory before running the tests:
 
 ```bash
 mkdir -p /media/wheels
 pip wheel -r requirements.txt -w /media/wheels
 pip wheel -r ../../../requirements-dev.txt -w /media/wheels
-python check_env.py --auto-install --wheelhouse /media/wheels
+WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
+  python check_env.py --auto-install --wheelhouse /media/wheels
+WHEELHOUSE=/media/wheels pytest -q
 ```
 
 Set `WHEELHOUSE=/media/wheels` when launching the demo offline:


### PR DESCRIPTION
## Summary
- mention building a wheelhouse in the root quick-start
- document running `check_env.py --auto-install --wheelhouse <dir>` before tests

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails to install packages)*
- `pytest -q` *(failed: KeyboardInterrupt during install)*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846eb7c71cc8333b9d8aae09379824d