### PR TITLE
[alpha_factory] Replace lambda policy with function

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -403,7 +403,9 @@ class POETGenerator:
         return float(np.mean(scores))
 
     def propose(self) -> MiniWorld:
-        policy = lambda _o: random.randint(0, 3)
+        def policy(_o: np.ndarray) -> int:
+            """Random baseline policy used for Monte Carlo evaluation."""
+            return random.randint(0, 3)
         attempts = 5
         env = None
         for _ in range(attempts):


### PR DESCRIPTION
## Summary
- minor API change: use a `policy` function instead of a lambda in the MuZero world model demo

## Testing
- `ruff check alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0971cdc8333a0711fc0f6cf6a5c