### PR TITLE
[alpha_factory] remove unused tempfile import

### DIFF
--- a/scripts/gen_proto.py
+++ b/scripts/gen_proto.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 import shutil
-import tempfile
 
 try:  # optional dependency
     import grpc_tools.protoc  # noqa: F401


### PR DESCRIPTION
## Summary
- clean up unused import in `scripts/gen_proto.py`

## Testing
- `ruff check scripts/gen_proto.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt installing dependencies)*
- `pre-commit run --files scripts/gen_proto.py` *(failed: KeyboardInterrupt initializing environment)*

------
https://chatgpt.com/codex/tasks/task_e_6846f35fd48483338d12d4913001e3a6