### PR TITLE
[alpha_factory] remove unused typing imports

### DIFF
--- a/tests/test_world_model_config.py
+++ b/tests/test_world_model_config.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import importlib
-import os
 import sys
-from typing import Any
 
 
 def test_bool_env_override(monkeypatch, non_network: None) -> None:

--- a/tests/test_world_model_safety.py
+++ b/tests/test_world_model_safety.py
@@ -5,8 +5,6 @@ from pathlib import Path
 import subprocess
 import contextlib
 
-from typing import Any
-
 import numpy as np  # ensure numpy optional dependency is present
 import pytest
 
@@ -18,6 +16,7 @@ def _reload_module(monkeypatch=None):
         del sys.modules[MODULE]
     if monkeypatch:
         import types
+
         fake = types.ModuleType("torch")
         fake.__path__ = []  # mark as package
         fake.manual_seed = lambda *_a, **_k: None
@@ -105,16 +104,14 @@ def _write_executable(path: Path, content: str) -> None:
 
 
 def _run_deploy_script(tmp_path: Path, env_vars: dict[str, str]) -> str:
-    script = Path(
-        "alpha_factory_v1/demos/alpha_asi_world_model/deploy_alpha_asi_world_model_demo.sh"
-    )
+    script = Path("alpha_factory_v1/demos/alpha_asi_world_model/deploy_alpha_asi_world_model_demo.sh")
     assert script.exists(), script
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     capture = tmp_path / "env.txt"
     _write_executable(
         bin_dir / "python",
-        "#!/usr/bin/env bash\nprintenv > \"$CAPTURE\"\n",
+        '#!/usr/bin/env bash\nprintenv > "$CAPTURE"\n',
     )
     env = os.environ.copy()
     env.update(env_vars)


### PR DESCRIPTION
## Summary
- clean up unused `typing.Any` imports in world model tests
- verify ruff passes on updated tests

## Testing
- `ruff check tests/test_world_model_config.py tests/test_world_model_safety.py`
- `pytest -q tests/test_world_model_config.py tests/test_world_model_safety.py` *(fails: KeyboardInterrupt)*
- `pre-commit run --files tests/test_world_model_config.py tests/test_world_model_safety.py` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6846f5aafbd48333a6a01eb2f730ef20