### PR TITLE
[alpha_factory] honor seed config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,7 @@ template). The sample file now lists every variable with its default value.
 | `ARCHIVE_PATH` | Darwin‑Archive SQLite file | `archive.db` |
 | `ARCHIVE_DB` | API server results database | `archive.db` |
 | `SOLUTION_ARCHIVE_PATH` | Path to solution archive | `solutions.duckdb` |
-| `ALPHA_ASI_SEED` | Deterministic RNG seed for the world model demo | `42` |
+| `ALPHA_ASI_SEED` | Deterministic RNG seed for the world model demo (or `general.seed` in `config.yaml`) | `42` |
 | `ALPHA_ASI_MAX_STEPS` | Learner steps before auto-stop | `100000` |
 | `ALPHA_ASI_BUFFER_LIMIT` | Replay-buffer length | `50000` |
 | `ALPHA_ASI_TRAIN_BATCH` | SGD mini-batch size | `128` |

--- a/README.md
+++ b/README.md
@@ -878,7 +878,7 @@ for instructions and example volume mounts.
 | `OPENAI_API_KEY` | _(empty)_ | API key for hosted models. Offline mode is used when empty. |
 | `NO_LLM` | `0` | Set to `1` to skip the LLM planner even when `OPENAI_API_KEY` is provided. |
 | `ALPHA_ASI_LLM_MODEL` | `gpt-4o-mini` | Planner model name used by the world model demo. |
-| `ALPHA_ASI_SEED` | `42` | Deterministic RNG seed for the demo. |
+| `ALPHA_ASI_SEED` | `42` | Deterministic RNG seed for the demo (can also be set via `general.seed` in `config.yaml`). |
 | `ALPHA_ASI_MAX_STEPS` | `100000` | Learner steps before auto-stop. |
 | `ALPHA_ASI_BUFFER_LIMIT` | `50000` | Replay-buffer length. |
 | `ALPHA_ASI_TRAIN_BATCH` | `128` | SGD mini-batch size. |

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -94,7 +94,7 @@ python openai_agents_bridge.py
 ALPHA_FACTORY_ENABLE_ADK=true python openai_agents_bridge.py
 ```
 
-> **Tip 💡** Set `ALPHA_ASI_SEED=<int>` to reproduce identical curriculum runs.
+> **Tip 💡** Set `ALPHA_ASI_SEED=<int>` or `general.seed` in `config.yaml` to reproduce identical curriculum runs.
 > **Tip 💡** Set `ALPHA_ASI_SILENT=1` to hide the startup banner.
 
 ### Offline setup

--- a/tests/test_world_model_config.py
+++ b/tests/test_world_model_config.py
@@ -56,3 +56,29 @@ def test_auto_device_from_config(monkeypatch, tmp_path, non_network: None) -> No
 
     expected = "cuda" if torch.cuda.is_available() else "cpu"
     assert mod.CFG.device == expected
+
+
+def test_config_seed_changes_env(monkeypatch, tmp_path, non_network: None) -> None:
+    """`general.seed` should control RNG seeding."""
+
+    module = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+
+    def load_env(seed: int):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"general:\n  seed: {seed}\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("NO_LLM", "1")
+        monkeypatch.setenv("ALPHA_ASI_SILENT", "1")
+        monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+        if module in sys.modules:
+            del sys.modules[module]
+        mod = importlib.import_module(module)
+        env = mod.Orchestrator().envs[0]
+        return env.size, sorted(env.obstacles)
+
+    first = load_env(123)
+    second_same = load_env(123)
+    different = load_env(456)
+
+    assert first == second_same
+    assert first != different


### PR DESCRIPTION
## Summary
- read `general.seed` from config.yaml to set RNG
- document seed option in README and docs
- test deterministic seeding with custom config

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: KeyboardInterrupt)*
- `pre-commit run --files AGENTS.md README.md alpha_factory_v1/demos/alpha_asi_world_model/README.md alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py tests/test_world_model_config.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846fde2d4e0833380e94b55fdb2b4b8