### PR TITLE
[alpha_factory] document new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,8 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py --loglevel info
 ```
 
+Adjust `alpha_factory_v1/demos/alpha_asi_world_model/config.yaml` to tune the world-model loop. Key options include `env_batch` (parallel environments), `hidden` (latent state size) and `mcts_simulations` (MCTS rollouts per action).
+
 
 ### Insight Browser Demo
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/config.yaml
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/config.yaml
@@ -10,9 +10,12 @@ general:
 
 training:
   buffer_limit: 50000   # 🧠 Replay-buffer size
+  env_batch: 2         # 🌐 Parallel environments
   train_batch: 128
   lr: 0.001
   max_steps: 100000     # ⏱️ Orchestrator loop iterations
+  hidden: 256          # 🤖 Latent state size
+  mcts_simulations: 16 # 🕵️ MCTS rollouts per action
   ui_tick: 100          # 📈 How often to broadcast stats (in steps)
 
 env:

--- a/tests/test_world_model_config.py
+++ b/tests/test_world_model_config.py
@@ -82,3 +82,29 @@ def test_config_seed_changes_env(monkeypatch, tmp_path, non_network: None) -> No
 
     assert first == second_same
     assert first != different
+
+
+def test_extended_cfg_fields(monkeypatch, tmp_path, non_network: None) -> None:
+    """Values from config.yaml should populate the Config dataclass."""
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "training:\n"
+        "  env_batch: 3\n"
+        "  hidden: 64\n"
+        "  mcts_simulations: 8\n"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NO_LLM", "1")
+    monkeypatch.setenv("ALPHA_ASI_SILENT", "1")
+    monkeypatch.setenv("ALPHA_ASI_MAX_STEPS", "1")
+
+    module = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+    if module in sys.modules:
+        del sys.modules[module]
+    mod = importlib.import_module(module)
+
+    assert mod.CFG.env_batch == 3
+    assert mod.CFG.hidden == 64
+    assert mod.CFG.mcts_simulations == 8


### PR DESCRIPTION
## Summary
- expose env_batch, hidden and mcts_simulations in world model config
- document these config options in the README quick-start
- test loading extended config values

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest tests/test_world_model_config.py::test_bool_env_override -q` *(fails: Ensuring baseline requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6847000749848333ab1c9293c47a98f1