### PR TITLE
[alpha_factory] Fix A2ABus publish lock timing

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -171,11 +171,12 @@ class A2ABus:
     @classmethod
     def publish(cls, topic: str, msg: dict):
         with cls._lock:
-            for cb in list(cls._subs.get(topic, [])):
-                try:
-                    cb(msg)
-                except Exception as exc:  # pragma: no cover
-                    LOG.error("[A2A] handler error on %s: %s", topic, exc)
+            callbacks = list(cls._subs.get(topic, []))
+        for cb in callbacks:
+            try:
+                cb(msg)
+            except Exception as exc:  # pragma: no cover
+                LOG.error("[A2A] handler error on %s: %s", topic, exc)
 
     @classmethod
     def subscribe(cls, topic: str, cb: Callable[[dict], None]):


### PR DESCRIPTION
## Summary
- ensure `A2ABus.publish` invokes callbacks outside the lock

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: Timed out installing baseline requirements)*
- `pytest -q tests/test_world_model_demo.py` *(fails: Timed out installing baseline requirements)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py` *(fails: mypy errors and proto verification issues)*

------
https://chatgpt.com/codex/tasks/task_e_684709b729a48333af748f9a6f18fea7