### PR TITLE
[alpha_factory] handle invalid seed

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -154,7 +154,12 @@ def _load_cfg() -> Config:
     # map 'auto' → 'cuda' if available else 'cpu'
     if isinstance(cfg.device, str) and cfg.device.lower() == "auto":
         cfg.device = "cuda" if torch.cuda.is_available() else "cpu"
-    _set_seed(int(seed_raw))
+    try:
+        seed = int(seed_raw)
+    except Exception:  # pragma: no cover - rarely triggered
+        LOG.warning("Invalid seed %r; falling back to default", seed_raw)
+        seed = 42
+    _set_seed(seed)
     return cfg
 
 

--- a/tests/test_world_model_demo.py
+++ b/tests/test_world_model_demo.py
@@ -113,3 +113,15 @@ def test_shutdown_stops_loop(non_network: None) -> None:
         loop = mod.loop_thread
         assert loop is not None and loop.is_alive()
     assert loop is not None and not loop.is_alive()
+
+
+def test_invalid_seed_fallback(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Invalid ALPHA_ASI_SEED should trigger fallback to default."""
+    module = "alpha_factory_v1.demos.alpha_asi_world_model.alpha_asi_world_model_demo"
+    mod = importlib.import_module(module)
+    monkeypatch.setenv("ALPHA_ASI_SEED", "bad")
+    caplog.set_level("WARNING")
+    cfg = mod._load_cfg()
+    assert mod._SEED == 42
+    assert any("Invalid seed" in rec.message for rec in caplog.records)
+    assert isinstance(cfg, mod.Config)


### PR DESCRIPTION
## Summary
- guard ALPHA_ASI_SEED parsing
- test invalid seed via environment variable

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684713e9b9dc83339ed064ea176e09b5