### PR TITLE
[alpha_factory] seed CUDA on GPU

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -80,6 +80,8 @@ def _set_seed(val: int) -> None:
     random.seed(val)
     np.random.seed(val)
     torch.manual_seed(val)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(val)
 
 
 # =============================================================================

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project are documented in this file.
   dashboard.
 - Documented `ALPHA_ASI_*` demo variables in README and AGENTS.md.
 - Removed outdated `alpha_asi_world_model_demo_v1.py` script.
+- `_set_seed` in `alpha_asi_world_model_demo.py` now sets CUDA seeds when
+  a GPU is available.
 
 ## [1.1.0] - 2025-07-15
 ### Added


### PR DESCRIPTION
## Summary
- ensure `_set_seed` sets CUDA seeds when a GPU is available
- note the new behavior in the changelog

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to complete: KeyboardInterrupt)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py docs/CHANGELOG.md` *(failed to complete: KeyboardInterrupt)*
- `pytest -q` *(failed to complete: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68472dc1ed1c8333841cf44e733706cd