### PR TITLE
[alpha_factory] add Apache license comment

### DIFF
--- a/af_requests/__init__.py
+++ b/af_requests/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Compatibility wrapper for the optional :mod:`requests` dependency.
 
 The package exposes the real :mod:`requests` library when installed.


### PR DESCRIPTION
## Summary
- insert SPDX identifier in `af_requests/__init__.py`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt)*
- `pre-commit run --files af_requests/__init__.py` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684747eb4f388333b0304426e5b0c3e1