### PR TITLE
[alpha_factory] replace open command in README

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -65,7 +65,7 @@ pip install -r requirements.txt        # torch, fastapi, uvicorn…
 # new CLI (after `pip install -e .` at repo root)
 alpha-asi-demo --demo        # same as `python -m alpha_asi_world_model_demo --demo`
 alpha-asi-demo --demo --no-llm   # force-disable the optional LLM planner
-open http://localhost:7860             # dashboard & Swagger
+python -m webbrowser http://localhost:7860  # dashboard & Swagger
 
 # ░ One-liner Docker
 python -m alpha_asi_world_model_demo --emit-docker


### PR DESCRIPTION
## Summary
- update cross-platform command in the alpha_asi_world_model demo README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/README.md` *(failed: environment setup took too long)*
- `python scripts/check_python_deps.py` *(failed: missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(failed: interrupted)*
- `pytest -q` *(failed: interrupted during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68474a33955083339680ea44e745f295