### PR TITLE
[alpha_factory] move logger declaration

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -9,9 +9,9 @@ import logging
 from pathlib import Path
 from typing import List, Dict
 
-logger = logging.getLogger(__name__)
-
 from .cross_alpha_discovery_stub import SAMPLE_ALPHA, discover_alpha, _ledger_path
+
+logger = logging.getLogger(__name__)
 
 try:
     from openai_agents import Agent, AgentRuntime, Tool


### PR DESCRIPTION
# Summary
- reorder logging initialization to follow local imports

# Checks
- `pre-commit` *(failed: initialization interrupted)*
- `python check_env.py --auto-install` *(failed: command timed out)*
- `pytest -q` *(failed: KeyboardInterrupt)*

# Testing
- `ruff check alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py` *(failed with many errors)*

------
https://chatgpt.com/codex/tasks/task_e_68476356dd3483339829219603c6b646