### PR TITLE
[alpha_factory] docs: describe stub environment vars

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -66,6 +66,11 @@ python cross_alpha_discovery_stub.py --list
 Use `-n 3 --seed 42` to log three deterministic picks to
 `cross_alpha_log.json`. If `OPENAI_API_KEY` is set, the tool queries an LLM for fresh ideas. The model may be overridden with `--model` (default `gpt-4o-mini`).
 
+Environment variables controlling `cross_alpha_discovery_stub`:
+- `CROSS_ALPHA_LEDGER` – output ledger file. Defaults to `cross_alpha_log.json`. Use `--ledger` to override.
+- `CROSS_ALPHA_MODEL` – OpenAI model used when an API key is available. Defaults to `gpt-4o-mini`. Use `--model` to override.
+- `OPENAI_API_KEY` – enables live suggestions. Without it the tool falls back to the offline samples.
+
 ### 🤖 OpenAI Agents bridge
 Expose the discovery helper via the OpenAI Agents SDK:
 ```bash


### PR DESCRIPTION
## Summary
- explain CROSS_ALPHA_LEDGER, CROSS_ALPHA_MODEL and OPENAI_API_KEY in the discovery stub section

## Testing
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/README.md` *(failed: proto-verify missing separator)*
- `python scripts/check_python_deps.py` *(reports missing numpy and pandas)*
- `python check_env.py --auto-install` *(failed to install deps)*
- `pytest -q` *(failed: KeyboardInterrupt during install)*


------
https://chatgpt.com/codex/tasks/task_e_6847792008488333a40205046f845385