### PR TITLE
[alpha_factory] handle missing ledger directory

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -112,6 +112,7 @@ def discover_alpha(
         existing = []
 
     existing.extend(picks if num != 1 else [picks[0]])
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(existing, indent=2))
     return picks
 

--- a/tests/test_cross_alpha_discovery.py
+++ b/tests/test_cross_alpha_discovery.py
@@ -41,6 +41,29 @@ class TestCrossAlphaDiscoveryStub(unittest.TestCase):
             self.assertIsInstance(logged, list)
             self.assertEqual(len(logged), 2)
 
+    def test_nested_ledger_path(self) -> None:
+        """Ledger directory is created when missing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = Path(tmp) / 'nested' / 'log.json'
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    STUB,
+                    '-n',
+                    '1',
+                    '--seed',
+                    '1',
+                    '--ledger',
+                    str(ledger),
+                    '--model',
+                    'gpt-4o-mini',
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(ledger.exists())
+            
     def test_accumulate_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             ledger = Path(tmp) / 'log.json'


### PR DESCRIPTION
## Summary
- ensure ledger directory is created in `discover_alpha`
- add regression test for nested ledger path

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q tests/test_cross_alpha_discovery.py` *(fails: KeyboardInterrupt while installing requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6847815b63a88333abbaa547564f9da2