### PR TITLE
[alpha_factory] warn on missing OpenAI Agents

### DIFF
--- a/tests/test_cross_industry_bridge_runtime.py
+++ b/tests/test_cross_industry_bridge_runtime.py
@@ -2,6 +2,7 @@
 """Verify runtime registration for the cross-industry demo bridge."""
 
 import asyncio
+import builtins
 import importlib
 import sys
 import types
@@ -28,14 +29,33 @@ class TestCrossIndustryBridgeRuntime(unittest.TestCase):
                 "alpha_factory_v1.demos.cross_industry_alpha_factory.openai_agents_bridge",
                 None,
             )
-            mod = importlib.import_module(
-                "alpha_factory_v1.demos.cross_industry_alpha_factory.openai_agents_bridge"
-            )
+            mod = importlib.import_module("alpha_factory_v1.demos.cross_industry_alpha_factory.openai_agents_bridge")
             agent = mod.CrossIndustryAgent()
             runtime = mod.AgentRuntime(api_key=None)
             runtime.register(agent)
             runtime.register.assert_called_once_with(agent)
 
+            samples = asyncio.run(mod.list_samples())
+        self.assertEqual(samples, mod.SAMPLE_ALPHA)
+
+    def test_missing_agents_module(self) -> None:
+        orig_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "openai_agents":
+                raise ModuleNotFoundError(name)
+            return orig_import(name, globals, locals, fromlist, level)
+
+        with patch.object(builtins, "__import__", fake_import):
+            sys.modules.pop(
+                "alpha_factory_v1.demos.cross_industry_alpha_factory.openai_agents_bridge",
+                None,
+            )
+            mod = importlib.import_module("alpha_factory_v1.demos.cross_industry_alpha_factory.openai_agents_bridge")
+            self.assertFalse(mod._OPENAI_AGENTS_AVAILABLE)
+            agent = mod.CrossIndustryAgent()
+            runtime = mod.AgentRuntime(api_key=None)
+            runtime.register(agent)
             samples = asyncio.run(mod.list_samples())
             self.assertEqual(samples, mod.SAMPLE_ALPHA)
 


### PR DESCRIPTION
## Summary
- detect missing `openai_agents` or API key in cross-industry bridge
- provide stub runtime with sample data when offline
- add regression test for fallback mode

## Testing
- `ruff format alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py tests/test_cross_industry_bridge_runtime.py`
- `ruff check alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py tests/test_cross_industry_bridge_runtime.py`
- `flake8 alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py tests/test_cross_industry_bridge_runtime.py`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py tests/test_cross_industry_bridge_runtime.py` *(failed: many unrelated errors)*
- `pytest -q` *(failed: dependency installation interrupted)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py tests/test_cross_industry_bridge_runtime.py` *(failed: environment setup interrupted)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847840b9b9c8333893d1947a899e4d4