### PR TITLE
[alpha_factory] gate auto-commit in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ PY
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/cross_industry_alpha_factory
+# Set AUTO_COMMIT=1 to save generated assets back to the repo
 ./deploy_alpha_factory_cross_industry_demo.sh
 ```
 

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
@@ -7,6 +7,7 @@
 ###############################################################################
 set -Eeuo pipefail
 IFS=$'\n\t'; shopt -s lastpipe
+# Set AUTO_COMMIT=1 to automatically commit generated assets.
 
 usage(){
   echo "Usage: $0 [--ci] [--skip-bench]" >&2
@@ -214,7 +215,7 @@ if [[ -z ${SKIP_BENCH:-} ]]; then
 fi
 
 ############# 10. AUTO-COMMIT GENERATED ASSETS ################################
-if [[ -z ${CI:-} ]]; then
+if [[ -z ${CI:-} && ${AUTO_COMMIT:-0} == 1 ]]; then
   git add "$CI_PATH" "$CONTINUAL_DIR" "$LOADTEST_DIR" "$ASSETS_DIR" || true
   git commit -m "auto: bootstrap cross-industry demo ($COMMIT_SHA)" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary
- note `AUTO_COMMIT` in the cross industry demo
- mention the variable in the README quick-start

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(interrupted)*
- `pytest -q` *(interrupted)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh README.md` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68478911c7b48333abf43278cc2e2ad1