### PR TITLE
[alpha_factory] support no-log option in cross alpha stub

### DIFF
--- a/tests/test_cross_alpha_discovery.py
+++ b/tests/test_cross_alpha_discovery.py
@@ -99,6 +99,29 @@ class TestCrossAlphaDiscoveryStub(unittest.TestCase):
             self.assertIsInstance(data, list)
             self.assertEqual(len(data), 1)
 
+    def test_no_log_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = Path(tmp) / "no_log.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    STUB,
+                    "-n",
+                    "1",
+                    "--seed",
+                    "4",
+                    "--ledger",
+                    str(ledger),
+                    "--no-log",
+                    "--model",
+                    "gpt-4o-mini",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(ledger.exists())
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- handle `--no-log` in cross_alpha_discovery_stub by passing ledger=None
- skip ledger writes when `discover_alpha` receives `ledger=None`
- test that `--no-log` does not create a ledger file

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt while installing dependencies)*
- `pytest -q` *(fails: KeyboardInterrupt while ensuring baseline requirements)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py tests/test_cross_alpha_discovery.py` *(fails: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684791f2dcac83339b776366fef190a9