### PR TITLE
[alpha_factory] avoid duplicate offline samples

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -95,7 +95,7 @@ def discover_alpha(
         except Exception:
             picks = []
     if not picks:
-        picks = [random.choice(SAMPLE_ALPHA) for _ in range(max(1, num))]
+        picks = random.sample(SAMPLE_ALPHA, k=min(num, len(SAMPLE_ALPHA)))
 
     if ledger is not None:
         path = _ledger_path(ledger)

--- a/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
@@ -76,7 +76,7 @@ def discover_alpha(
         except Exception:
             picks = []
     if not picks:
-        picks = [random.choice(SAMPLE_ALPHA) for _ in range(max(1, num))]
+        picks = random.sample(SAMPLE_ALPHA, k=min(num, len(SAMPLE_ALPHA)))
 
     (_ledger_path(ledger) if ledger else DEFAULT_LEDGER).write_text(
         json.dumps(picks[0] if num == 1 else picks, indent=2)

--- a/tests/test_alpha_discovery_stub.py
+++ b/tests/test_alpha_discovery_stub.py
@@ -30,6 +30,7 @@ class TestAlphaDiscoveryStub(unittest.TestCase):
             logged = json.loads(ledger.read_text())
             self.assertIsInstance(logged, list)
             self.assertEqual(len(logged), 2)
+            self.assertEqual(len(logged), len({json.dumps(i, sort_keys=True) for i in logged}))
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_cross_alpha_discovery.py
+++ b/tests/test_cross_alpha_discovery.py
@@ -42,6 +42,7 @@ class TestCrossAlphaDiscoveryStub(unittest.TestCase):
             logged = json.loads(ledger.read_text())
             self.assertIsInstance(logged, list)
             self.assertEqual(len(logged), 2)
+            self.assertEqual(len(logged), len({json.dumps(i, sort_keys=True) for i in logged}))
 
     def test_accumulate_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- prevent duplicate opportunities in discovery stubs
- update tests for deterministic unique sampling

## Testing
- `python check_env.py --auto-install` *(fails: Could not complete installation)*
- `pytest -q tests/test_alpha_discovery_stub.py tests/test_cross_alpha_discovery.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6847939a8e388333a1ca156d5c25d521