### PR TITLE
[alpha_factory] add json response format

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -88,6 +88,7 @@ def discover_alpha(
             resp = openai.ChatCompletion.create(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
             )
             picks = json.loads(resp.choices[0].message.content)
             if isinstance(picks, dict):

--- a/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
@@ -37,6 +37,7 @@ SAMPLE_ALPHA: List[Dict[str, str]] = [
 
 DEFAULT_LEDGER = Path(__file__).with_name("omni_alpha_log.json")
 
+
 def _ledger_path(path: str | os.PathLike | None) -> Path:
     if path:
         return Path(path).expanduser().resolve()
@@ -61,14 +62,12 @@ def discover_alpha(
         random.seed(seed)
     picks: List[Dict[str, str]] = []
     if "openai" in globals() and os.getenv("OPENAI_API_KEY"):
-        prompt = (
-            "List "
-            f"{num} short cross-industry investment opportunities as JSON"
-        )
+        prompt = "List " f"{num} short cross-industry investment opportunities as JSON"
         try:
             resp = openai.ChatCompletion.create(
                 model="gpt-4o-mini",
                 messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
             )
             picks = json.loads(resp.choices[0].message.content)  # type: ignore[index]
             if isinstance(picks, dict):


### PR DESCRIPTION
## Summary
- use `response_format={"type": "json_object"}` when calling OpenAI in `discover_alpha`
- test that the OpenAI call includes the new parameter

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py tests/test_cross_alpha_discovery.py` *(failed: KeyboardInterrupt)*
- `pytest -q tests/test_cross_alpha_discovery.py::TestCrossAlphaDiscoveryStub::test_openai_response_format` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68479822f0a08333ba4e28d1f6c1b77c