### PR TITLE
[alpha_factory] fix cross-industry demo references

### DIFF
--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -255,7 +255,7 @@ sequenceDiagram
 |4|`alpha_agi_business_3_v1`|📊|Financial forecasting & fundraising agent swarm.|Optimises capital stack for ROI alpha.|`./alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh`|
 |5|`alpha_agi_marketplace_v1`|🛒|Peer‑to‑peer agent marketplace simulating price discovery.|Validates micro‑alpha extraction via agent barter.|`docker compose -f demos/docker-compose.marketplace.yml up`|
 |6|`alpha_asi_world_model`|🌌|Scales MuZero‑style world‑model to an open‑ended grid‑world.|Stress‑tests anticipatory planning for ASI scenarios.|`docker compose -f demos/docker-compose.asi_world.yml up`|
-|7|`cross_industry_alpha_factory`|🌐|Full pipeline: ingest → plan → act across 4 verticals.|Proof that one orchestrator handles multi‑domain alpha.|`docker compose -f demos/docker-compose.cross_industry.yml up`|
+|7|`cross_industry_alpha_factory`|🌐|Full pipeline: ingest → plan → act across 4 verticals.|Proof that one orchestrator handles multi‑domain alpha.|`./alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh`|
 |8|`era_of_experience`|🏛|Lifelong RL stack blending real & synthetic experience streams.|Showcases sensor-motor tools, grounded rewards & non-human reasoning.|`cd alpha_factory_v1/demos/era_of_experience && ./run_experience_demo.sh`|
 |9|`finance_alpha`|💹|Live momentum + risk‑parity bot on Binance test‑net.|Generates real P&L; stress‑tested against CVaR.|`./alpha_factory_v1/demos/finance_alpha/deploy_alpha_factory_demo.sh`|
 |10|`macro_sentinel`|🌐|GPT‑RAG news scanner auto‑hedges with CTA futures.|Shields portfolios from macro shocks.|`docker compose -f demos/docker-compose.macro.yml up`|

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -27,7 +27,7 @@ Run examples
         python -m alpha_factory_v1.backend.orchestrator --dev
 
     # container
-    docker compose -f demos/docker-compose.cross_industry.yml up
+    ./alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- correct cross-industry demo instructions in `alpha_factory_v1/README.md`
- update orchestrator docstring to run the bootstrap script

## Testing
- `python scripts/check_python_deps.py` *(fails: missing packages)*
- `python check_env.py --auto-install` *(failed to finish)*
- `pytest -q` *(failed to finish)*
- `pre-commit` *(not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68479d27f86083339ad62d182b8353e9