### PR TITLE
[alpha_factory] unify orchestrator service name

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/infra/prometheus.yml
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/infra/prometheus.yml
@@ -5,9 +5,9 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: 'alphafactory'
+  - job_name: 'orchestrator'
     static_configs:
-      - targets: ['alphafactory:8000']
+      - targets: ['orchestrator:8000']
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']

--- a/alpha_factory_v1/docker-compose.override.yml
+++ b/alpha_factory_v1/docker-compose.override.yml
@@ -17,9 +17,9 @@ services:
   ###########################################################################
   # 1️⃣  FastAPI back‑end – auto‑reload on source edits                      #
   ###########################################################################
-  alphafactory:
+  orchestrator:
     <<: *restart_policy
-    container_name: alphafactory-dev
+    container_name: orchestrator-dev
     # Re-use the multi-stage Dockerfile but build only the *runtime* stage
     build:
       context: .

--- a/alpha_factory_v1/docker-compose.yml
+++ b/alpha_factory_v1/docker-compose.yml
@@ -14,9 +14,9 @@ x-healthcheck: &default_healthcheck
 services:
 
   # ──────────────────────────── Core agents API ──────────────────────────── #
-  alphafactory:
+  orchestrator:
     <<: *restart_policy
-    container_name: alphafactory
+    container_name: orchestrator
     build:
       context: .
       dockerfile: Dockerfile            # multi‑stage (UI pre‑built)
@@ -71,7 +71,7 @@ services:
     networks:
       - af-net
     depends_on:
-      alphafactory:
+      orchestrator:
         condition: service_healthy
     healthcheck:
       <<: *default_healthcheck

--- a/alpha_factory_v1/docs/prometheus.yml
+++ b/alpha_factory_v1/docs/prometheus.yml
@@ -5,9 +5,9 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: 'alphafactory'
+  - job_name: 'orchestrator'
     static_configs:
-      - targets: ['alphafactory:8000']
+      - targets: ['orchestrator:8000']
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- rename `alphafactory` service to `orchestrator`
- adjust docker-compose override
- update Prometheus configs

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(incomplete due to network/timeout)*
- `pytest -q` *(interrupted: KeyboardInterrupt)*
- `pre-commit run --files alpha_factory_v1/docker-compose.yml alpha_factory_v1/docker-compose.override.yml alpha_factory_v1/docs/prometheus.yml alpha_factory_v1/demos/aiga_meta_evolution/infra/prometheus.yml` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68485ec2d7548333a9fb740322b319f1