### PR TITLE
[alpha_factory] document demo env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,8 @@ template). The sample file now lists every variable with its default value.
 | `ALPHA_ASI_PORT` | FastAPI port for the demo | `7860` |
 | `ALPHA_ASI_LLM_MODEL` | Planner model used by the world model demo | `gpt-4o-mini` |
 | `PROOF_THRESHOLD` | Minimum score to generate SNARK proof | `0.5` |
+| `CROSS_ALPHA_LEDGER` | Output ledger file for the cross‑industry alpha demo | `cross_alpha_log.json` |
+| `CROSS_ALPHA_MODEL` | OpenAI model for the discovery tool when `OPENAI_API_KEY` is set | `gpt-4o-mini` |
 
 ## Coding Style
 - Use Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**) and include type hints for public APIs.


### PR DESCRIPTION
## Summary
- document CROSS_ALPHA_LEDGER and CROSS_ALPHA_MODEL in the env table

## Testing
- `python tools/check_env_table.py` *(fails: Missing from AGENTS.md: ALPHA_ASI_HIDDEN, GOOGLE_VERTEX_SA_KEY, NO_LLM; Missing from .env.sample files: CROSS_ALPHA_LEDGER, CROSS_ALPHA_MODEL)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684865d2d31483338be39ff8f5c11a27