### PR TITLE
[alpha_factory] add filelock optional dependency

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -72,6 +72,7 @@ Environment variables controlling `cross_alpha_discovery_stub`:
 - `CROSS_ALPHA_LEDGER` – output ledger file. Defaults to `cross_alpha_log.json`. Use `--ledger` to override.
 - `CROSS_ALPHA_MODEL` – OpenAI model used when an API key is available. Defaults to `gpt-4o-mini`. Use `--model` to override.
 - `OPENAI_API_KEY` – enables live suggestions. Without it the tool falls back to the offline samples.
+- Install `filelock` if multiple runs write to the same ledger to ensure atomic updates.
 
 ### 🤖 OpenAI Agents bridge
 Expose the discovery helper via the OpenAI Agents SDK:

--- a/alpha_factory_v1/requirements.lock
+++ b/alpha_factory_v1/requirements.lock
@@ -14,6 +14,7 @@ Deprecated==1.2.18
 distro==1.9.0
 docstring_parser==0.16
 fastapi==0.115.12
+filelock==3.18.0
 google-adk==1.1.1
 google-api-core==2.25.0rc1
 google-api-python-client==2.170.0

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -3,4 +3,5 @@
 torch>=2.2
 gymnasium[classic-control]>=0.29
 gradio>=4.35
+filelock>=3.13
 


### PR DESCRIPTION
## Summary
- update demo optional requirements
- pin filelock in lock file
- note optional filelock install in the cross-industry demo README

## Testing
- `python scripts/check_python_deps.py` *(fails: missing packages)*
- `python check_env.py --auto-install` *(fails: timed out installing baseline requirements)*
- `pytest -q` *(fails: 108 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68486a8515848333a37cb63a3c69c0b7