### PR TITLE
[alpha_factory] add logging to discovery stub

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -21,9 +21,12 @@ import json
 import random
 import os
 import contextlib
+import logging
 from pathlib import Path
 from typing import List, Dict
 from tempfile import NamedTemporaryFile
+
+logger = logging.getLogger(__name__)
 
 try:
     from filelock import FileLock
@@ -99,7 +102,8 @@ def discover_alpha(
             picks = json.loads(resp.choices[0].message.content)
             if isinstance(picks, dict):
                 picks = [picks]
-        except Exception:
+        except Exception as exc:
+            logger.warning("OpenAI request failed: %s", exc)
             picks = []
     if not picks:
         picks = random.sample(SAMPLE_ALPHA, k=min(num, len(SAMPLE_ALPHA)))


### PR DESCRIPTION
## Summary
- log OpenAI request failures in `cross_alpha_discovery_stub`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: interrupted during install)*
- `pytest -q tests/test_cross_alpha_discovery.py` *(fails: interrupted during pip install)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py tests/test_cross_alpha_discovery.py` *(fails: interrupted during environment init)*

------
https://chatgpt.com/codex/tasks/task_e_684873e6e8548333b828ef13b46403d9