### PR TITLE
[alpha_factory] secure env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ Build the demo containers locally:
 
 ```bash
 cp .env.sample .env  # fill in NEO4J_PASSWORD, API_TOKEN and optional PINNER_TOKEN
+chmod 600 alpha_factory_v1/.env
 cd infrastructure
 docker build -t alpha-demo .
 docker compose up -d

--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -345,6 +345,7 @@ cd AGI-Alpha-Agent-v0/alpha_factory_v1
 export ALPHA_KAFKA_BROKER=localhost:9092
 echo "PORT=8000" > .env
 echo "LOG_LEVEL=info" >> .env
+chmod 600 alpha_factory_v1/.env
 ./quickstart.sh  # automatically loads .env
 open http://localhost:8000/docs
 ```

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -139,7 +139,7 @@ Running `npm run build` or `python manual_build.py` copies this file to
 ## Manual Build
 Use `manual_build.py` for air‑gapped environments:
 
-1. `cp .env.sample .env` and edit the values if you haven't already.
+1. `cp .env.sample .env` and edit the values if you haven't already, then `chmod 600 .env`.
 2. `npm run fetch-assets` to fetch Pyodide and the GPT‑2 model.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.

--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -183,6 +183,7 @@ cd AGI-Alpha-Agent-v0
 # 2‒ Launch via Docker (recommended)
 cd alpha_factory_v1/demos/omni_factory_demo
 cp .env.sample .env  # optional – edit to customise
+chmod 600 .env
 docker compose up -d  # builds image on first run
 
 # 3‒ Open the dashboard

--- a/alpha_factory_v1/install_alpha_factory_pro.sh
+++ b/alpha_factory_v1/install_alpha_factory_pro.sh
@@ -115,6 +115,7 @@ fi
 if [[ ! -f .env ]]; then
   echo "→ creating .env (edit credentials later)"
   cp .env.sample .env
+  chmod 600 .env
 fi
 
 # 3. local model fallback

--- a/alpha_factory_v1/scripts/install_alpha_factory_pro.sh
+++ b/alpha_factory_v1/scripts/install_alpha_factory_pro.sh
@@ -121,6 +121,7 @@ fi
 if [[ ! -f .env ]]; then
   echo "→ creating .env (edit credentials later)"
   cp .env.sample .env
+  chmod 600 .env
 fi
 
 # 3. local model fallback


### PR DESCRIPTION
## Summary
- ensure `.env` gets restrictive permissions in install scripts
- update docs to `chmod 600 alpha_factory_v1/.env`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt)*
- `pytest -q tests/test_cross_industry_patch.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848762922f0833380fd65931dccbc0b