### PR TITLE
[alpha_factory] add env example for cross-industry demo

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/.env.example
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/.env.example
@@ -1,0 +1,16 @@
+#======================================================================
+#  Cross-Industry Alpha-Factory demo — environment template
+#  Copy to `alpha_factory_v1/.env` and edit values before running the installer.
+#  Never commit real secrets to version control.
+#======================================================================
+
+ALPHA_FACTORY_MODE=cross_industry
+OPENAI_API_KEY=
+OPENAI_API_BASE=https://api.openai.com/v1
+AGENTS_ENABLED="finance_agent biotech_agent climate_agent manufacturing_agent policy_agent"
+PROM_PORT=9090
+RAY_PORT=8265
+PROJECT_SHA=
+PROMPT_SIGN_PUBKEY=
+COSIGN_PUBKEY=
+API_TOKEN=REPLACE_ME_TOKEN

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -50,10 +50,13 @@ local LLM container so the demo works **fully offline**.
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/cross_industry_alpha_factory
+cp .env.example ../../.env  # optional customization
 ./deploy_alpha_factory_cross_industry_demo.sh
 ```
 The installer writes a random `API_TOKEN` to `.env`; include it in the
 `Authorization` header when calling the REST API.
+Customize variables like `OPENAI_API_KEY`, `AGENTS_ENABLED`, `PROM_PORT` or
+`RAY_PORT` by editing `../../.env` before deployment.
 
 #### Colab Quick Start
 Click the badge above or run:


### PR DESCRIPTION
## Summary
- provide `.env.example` for the cross-industry alpha factory demo
- document copying and customizing the file before running the installer

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684882bd4e5083339361b39071f2b737