### PR TITLE
[alpha_factory] update cross alpha ledger defaults

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 try:
     from filelock import FileLock
 except Exception:  # pragma: no cover - optional dependency
-    FileLock = None  # type: ignore
+    FileLock = None
 
 with contextlib.suppress(ModuleNotFoundError):
     import openai
@@ -52,16 +52,20 @@ SAMPLE_ALPHA: List[Dict[str, str]] = [
     {"sector": "Telecom", "opportunity": "Lease dark fiber to data-intensive startups"},
 ]
 
-DEFAULT_LEDGER = Path(__file__).with_name("cross_alpha_log.json")
+DEFAULT_LEDGER = Path.home() / ".alpha_factory" / "cross_alpha_log.json"
 
 
 def _ledger_path(path: str | os.PathLike[str] | None) -> Path:
     if path:
-        return Path(path).expanduser().resolve()
-    env = os.getenv("CROSS_ALPHA_LEDGER")
-    if env:
-        return Path(env).expanduser().resolve()
-    return DEFAULT_LEDGER
+        resolved = Path(path).expanduser().resolve()
+    else:
+        env = os.getenv("CROSS_ALPHA_LEDGER")
+        if env:
+            resolved = Path(env).expanduser().resolve()
+        else:
+            resolved = DEFAULT_LEDGER.expanduser().resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return resolved
 
 
 def discover_alpha(


### PR DESCRIPTION
## Summary
- default cross alpha discovery ledger to `~/.alpha_factory/cross_alpha_log.json`
- create ledger directory automatically
- update tests for new path and directory creation

## Testing
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py tests/test_cross_alpha_discovery.py` *(fails: proto-verify, requirements.lock)*
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68489d45d8a88333a5e0ccf8d91bf743