### PR TITLE
[alpha_factory] update .env when OPENAI_API_KEY missing

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
@@ -127,6 +127,7 @@ patch(){
 # offline Mixtral-8x7B if no API key
 if [[ -z ${OPENAI_API_KEY:-} ]]; then
   OPENAI_API_BASE="http://local-llm:11434/v1"
+  sed -i 's|^OPENAI_API_BASE=.*|OPENAI_API_BASE=http://local-llm:11434/v1|' alpha_factory_v1/.env
   # Pin ollama 0.9.0 for reproducibility
   patch local-llm '.services += {"local-llm":{image:"ollama/ollama:0.9.0",ports:["11434:11434"],volumes:["ollama:/root/.ollama"],environment:{"OLLAMA_MODELS":"mixtral:8x7b-instruct"}}}'
 fi


### PR DESCRIPTION
## Summary
- set local LLM URL in `.env` when no OPENAI_API_KEY is present

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: installation interrupted)*
- `pytest -q` *(failed: KeyboardInterrupt during setup)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5601e9c83339049d2565cce8c7d