### PR TITLE
[alpha_factory] pass env key to bridge

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -98,7 +98,7 @@ class CrossIndustryAgent(Agent):
 
 
 def main() -> None:
-    runtime = AgentRuntime(api_key=None)
+    runtime = AgentRuntime(api_key=os.getenv("OPENAI_API_KEY"))
     agent = CrossIndustryAgent()
     runtime.register(agent)
     try:

--- a/tests/test_cross_industry_bridge_runtime.py
+++ b/tests/test_cross_industry_bridge_runtime.py
@@ -4,6 +4,7 @@
 import asyncio
 import builtins
 import importlib
+import os
 import sys
 import types
 import unittest
@@ -58,6 +59,39 @@ class TestCrossIndustryBridgeRuntime(unittest.TestCase):
             runtime.register(agent)
             samples = asyncio.run(mod.list_samples())
             self.assertEqual(samples, mod.SAMPLE_ALPHA)
+
+    def test_main_uses_env_key(self) -> None:
+        stub = types.ModuleType("openai_agents")
+
+        runtime = MagicMock()
+
+        def _tool(*_a, **_k):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+        stub.Agent = object
+        stub.AgentRuntime = MagicMock(return_value=runtime)
+        stub.Tool = _tool
+
+        with (
+            patch.dict(sys.modules, {"openai_agents": stub}),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=False),
+            patch("alpha_factory_v1.backend.adk_bridge.auto_register") as auto_reg,
+            patch("alpha_factory_v1.backend.adk_bridge.maybe_launch") as maybe_launch,
+        ):
+            sys.modules.pop(
+                "alpha_factory_v1.demos.cross_industry_alpha_factory.openai_agents_bridge",
+                None,
+            )
+            mod = importlib.import_module("alpha_factory_v1.demos.cross_industry_alpha_factory.openai_agents_bridge")
+            mod.main()
+
+            stub.AgentRuntime.assert_called_once_with(api_key="key")
+            runtime.register.assert_called_once()
+            auto_reg.assert_called_once()
+            maybe_launch.assert_called_once()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual run


### PR DESCRIPTION
## Summary
- propagate OPENAI_API_KEY to `AgentRuntime`
- ensure the cross-industry bridge runtime uses the API key

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: Operation cancelled)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py tests/test_cross_industry_bridge_runtime.py` *(failed: proto-verify)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848a77fe9948333b091490fea440f24