### PR TITLE
[alpha_factory] pin yq version

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
@@ -61,7 +61,8 @@ else
 fi
 
 # containerised yq / cosign / rekor-cli / k6 / locust when missing
-yq(){ docker run --rm -i -v "$PWD":/workdir ghcr.io/mikefarah/yq "$@"; }
+# yq pinned to 4.44.1 for reproducible builds
+yq(){ docker run --rm -i -v "$PWD":/workdir ghcr.io/mikefarah/yq:4.44.1 "$@"; }
 # Use explicit tool versions to ensure reproducible builds
 # cosign v2.5.0, rekor-cli v1.3.10, k6 0.52.0, locust 2.37.10
 cosign(){ docker run --rm -e COSIGN_EXPERIMENTAL=1 -v "$PWD":/workdir ghcr.io/sigstore/cosign/v2:v2.5.0 "$@"; }

--- a/tests/test_cross_industry_patch.py
+++ b/tests/test_cross_industry_patch.py
@@ -24,7 +24,7 @@ def _run_script(tmp_path: Path) -> dict:
         """#!/usr/bin/env bash
 if [ "$1" = "info" ] || [ "$1" = "compose" ]; then exit 0; fi
 if [ "$1" = "run" ]; then
-  while [ "$1" != "ghcr.io/mikefarah/yq" ] && [ $# -gt 0 ]; do shift; done
+  while [ "$1" != "ghcr.io/mikefarah/yq:4.44.1" ] && [ $# -gt 0 ]; do shift; done
   shift
   yq "$@"
   exit $?


### PR DESCRIPTION
# Summary
- use tagged container for yq helper in cross-industry demo
- update test stub for new yq tag

# Checks
- `pre-commit` *(failed: see logs)*
- `python check_env.py --auto-install` *(failed: see logs)*
- `pytest -q` *(failed: see logs)*

# Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed)*
- `pytest -q` *(failed)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh` *(failed)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6848b7308dc083338276f02f1306c4b5