### PR TITLE
[alpha_factory] support new OpenAI chat API

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -98,7 +98,12 @@ def discover_alpha(
     if "openai" in globals() and os.getenv("OPENAI_API_KEY"):
         prompt = "List " f"{num} short cross-industry investment opportunities as JSON"
         try:
-            resp = openai.ChatCompletion.create(
+            if hasattr(openai, "chat") and hasattr(openai.chat, "completions"):
+                create = openai.chat.completions.create
+            else:
+                create = openai.ChatCompletion.create
+
+            resp = create(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
                 response_format={"type": "json_object"},

--- a/tests/test_cross_alpha_discovery.py
+++ b/tests/test_cross_alpha_discovery.py
@@ -169,6 +169,24 @@ class TestCrossAlphaDiscoveryStub(unittest.TestCase):
         kwargs = openai_mock.ChatCompletion.create.call_args.kwargs
         self.assertEqual(kwargs.get("response_format"), {"type": "json_object"})
 
+    def test_openai_v1_response_format(self) -> None:
+        from alpha_factory_v1.demos.cross_industry_alpha_factory import (
+            cross_alpha_discovery_stub as stub,
+        )
+
+        resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="[]"))])
+        openai_mock = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=Mock(return_value=resp)))
+        )
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "x"}):
+            with patch.object(stub, "openai", openai_mock):
+                stub.discover_alpha(num=1, ledger=None, model="gpt-4o-mini")
+
+        openai_mock.chat.completions.create.assert_called_once()
+        kwargs = openai_mock.chat.completions.create.call_args.kwargs
+        self.assertEqual(kwargs.get("response_format"), {"type": "json_object"})
+
     def test_concurrent_writes(self) -> None:
         from alpha_factory_v1.demos.cross_industry_alpha_factory import (
             cross_alpha_discovery_stub as stub,


### PR DESCRIPTION
## Summary
- support both `openai.ChatCompletion` and `openai.chat.completions` in cross-alpha demo
- add regression test for new OpenAI client

## Testing
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py tests/test_cross_alpha_discovery.py` *(fails: Makefile missing separator)*
- `pytest -q` *(failed to run due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6848daac13f88333b7d71c6d215ff1e3