### PR TITLE
[alpha_factory] POSIX sed backup

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/deploy_alpha_factory_cross_industry_demo.sh
@@ -128,7 +128,7 @@ patch(){
 # offline Mixtral-8x7B if no API key
 if [[ -z ${OPENAI_API_KEY:-} ]]; then
   OPENAI_API_BASE="http://local-llm:11434/v1"
-  sed -i 's|^OPENAI_API_BASE=.*|OPENAI_API_BASE=http://local-llm:11434/v1|' alpha_factory_v1/.env
+  sed -i.bak 's|^OPENAI_API_BASE=.*|OPENAI_API_BASE=http://local-llm:11434/v1|' alpha_factory_v1/.env
   # Pin ollama 0.9.0 for reproducibility
   patch local-llm '.services += {"local-llm":{image:"ollama/ollama:0.9.0",ports:["11434:11434"],volumes:["ollama:/root/.ollama"],environment:{"OLLAMA_MODELS":"mixtral:8x7b-instruct"}}}'
 fi

--- a/tests/test_cross_industry_patch.py
+++ b/tests/test_cross_industry_patch.py
@@ -48,8 +48,13 @@ exit 0
     )
 
     subprocess.run(["bash", str(script)], check=True, env=env, timeout=10)
+    bak = tmp_path / "AGI-Alpha-Agent-v0" / "alpha_factory_v1" / ".env.bak"
+    if bak.exists():
+        bak.unlink()
     first = yaml.safe_load(compose.read_text())
     subprocess.run(["bash", str(script)], check=True, env=env, timeout=10)
+    if bak.exists():
+        bak.unlink()
     second = yaml.safe_load(compose.read_text())
     return {"first": first, "second": second}
 


### PR DESCRIPTION
## Summary
- use `sed -i.bak` in cross-industry deploy script
- cleanup backup in tests

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q tests/test_cross_industry_patch.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848de0a3d188333bff4a520770c77d2