### PR TITLE
[alpha_factory] document openai extras in demo requirements

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -93,6 +93,8 @@ Install them all at once with:
 ```bash
 pip install -r requirements-demo.txt
 ```
+The `requirements-demo.txt` file installs these extras, including
+`openai>=1.82.0,<2.0` and `openai-agents>=0.0.16`.
 
 or install the packages individually.
 

--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -116,6 +116,8 @@ Python standard library.
   ```bash
   pip install -r requirements-demo.txt
   ```
+  This installs optional packages like `openai>=1.82.0,<2.0` and
+  `openai-agents>=0.0.16` used by the Agents bridge.
   See [tests/README.md](../../../tests/README.md) for full instructions.
 
 ### 9 · Running the Demo

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -4,4 +4,6 @@ torch>=2.2
 gymnasium[classic-control]>=0.29
 gradio>=4.35
 filelock>=3.13
+openai>=1.82.0,<2.0
+openai-agents>=0.0.16
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,9 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    ```bash
    pip install -r requirements-demo.txt
    ```
-3. Verify the core dependencies are present:
+   This also installs `openai>=1.82.0,<2.0` and `openai-agents>=0.0.16` for
+   the OpenAI Agents tests.
+   3. Verify the core dependencies are present:
    ```bash
    python scripts/check_python_deps.py
    ```


### PR DESCRIPTION
## Summary
- add `openai` and `openai-agents` pins to `requirements-demo.txt`
- document the extras in the cross-industry demo README
- note the pinned versions in the governance demo and test READMEs

## Testing
- `python scripts/check_python_deps.py`
- ❌ `pre-commit run --files requirements-demo.txt alpha_factory_v1/demos/cross_industry_alpha_factory/README.md alpha_factory_v1/demos/solving_agi_governance/README.md tests/README.md` *(fails: Missing packages: numpy, pandas)*
- ❌ `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848e01e14848333b870cf6f84d6a40c