### PR TITLE
[alpha_factory] remove cross industry demo from lint excludes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,6 @@ exclude = \
     alpha_factory_v1/demos/alpha_agi_insight_v1/*,\
     alpha_factory_v1/demos/alpha_agi_marketplace_v1/*,\
     alpha_factory_v1/demos/alpha_asi_world_model/*,\
-    alpha_factory_v1/demos/cross_industry_alpha_factory/*,\
     alpha_factory_v1/demos/era_of_experience/*,\
     alpha_factory_v1/demos/finance_alpha/*,\
     alpha_factory_v1/demos/macro_sentinel/*,\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ exclude = [
     "alpha_factory_v1/demos/alpha_agi_insight_v0/*",
     "alpha_factory_v1/demos/alpha_agi_insight_v1/*",
     "alpha_factory_v1/demos/alpha_agi_marketplace_v1/*",
-    "alpha_factory_v1/demos/cross_industry_alpha_factory/*",
     "alpha_factory_v1/demos/era_of_experience/*",
     "alpha_factory_v1/demos/finance_alpha/*",
     "alpha_factory_v1/demos/macro_sentinel/*",


### PR DESCRIPTION
## Summary
- remove `cross_industry_alpha_factory` demo from `ruff` and `flake8` exclude lists

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: interrupted due to KeyboardInterrupt)*
- `pytest -q` *(failed: interrupted due to KeyboardInterrupt)*
- `pre-commit run --files pyproject.toml .flake8 alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py alpha_factory_v1/demos/cross_industry_alpha_factory/__init__.py` *(failed: interrupted due to KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_6848e40e2a78833388ab95896232adf3