### PR TITLE
[alpha_factory] Add environment checks

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -60,6 +60,12 @@ The installer writes a random `API_TOKEN` to `.env`; include it in the
 Customize variables like `OPENAI_API_KEY`, `AGENTS_ENABLED`, `PROM_PORT` or
 `RAY_PORT` by editing `../../.env` before deployment.
 
+> **Run this check before launching** the deploy script or Colab notebook:
+```bash
+python scripts/check_python_deps.py
+python check_env.py --auto-install  # add --wheelhouse <dir> when offline
+```
+
 #### Colab Quick Start
 Click the badge above or run:
 ```bash


### PR DESCRIPTION
## Summary
- emphasize running `scripts/check_python_deps.py` and `check_env.py` before using the cross‑industry demo

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848e6b7158c83338e96b8714100d087