### PR TITLE
[alpha_factory] clarify discovery extras

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
@@ -23,9 +23,11 @@ user -> orchestrator (FastAPI)
 ## Typical Workflow
 
 1. Run `deploy_alpha_factory_cross_industry_demo.sh` or open the Colab notebook to launch the stack.
-2. (Optional) Start `openai_agents_bridge.py` to drive the discovery stub via the Agents SDK or ADK.
-3. Interact with the REST API or Grafana dashboards to monitor agent activity.
-4. The PPO trainer periodically updates each agent using rewards defined in `continual/rubric.json`.
+2. Install `requirements-demo.txt` if you want to use `cross_alpha_discovery_stub.py`
+   or the OpenAI Agents bridge.
+3. (Optional) Start `openai_agents_bridge.py` to drive the discovery stub via the Agents SDK or ADK.
+4. Interact with the REST API or Grafana dashboards to monitor agent activity.
+5. The PPO trainer periodically updates each agent using rewards defined in `continual/rubric.json`.
 
 The shipped agents are lightweight but illustrate how more sophisticated domain logic can plug into the orchestrator. Each agent subclass resides in `cross_industry_alpha_factory` and can be swapped for a production implementation.
 

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -45,6 +45,9 @@ The notebook installs dependencies from `../requirements-colab.lock` for a quick
 Both flows autodetect `OPENAI_API_KEY`; when absent they inject a **Mixtral 8×7B**
 local LLM container so the demo works **fully offline**.
 
+Install the extras from `requirements-demo.txt` if you plan to run
+`cross_alpha_discovery_stub.py` or `openai_agents_bridge.py`.
+
 > **Prerequisite**: Docker 24+ with the `docker compose` plugin (or the
 > legacy `docker-compose` binary) must be installed.
 


### PR DESCRIPTION
## Summary
- show which extras enable cross-alpha discovery
- remind in the conceptual doc about requirements-demo.txt

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/README.md alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848f81806788333bc75af70d95888e4