### PR TITLE
[alpha_factory] simplify prompt string

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -96,7 +96,7 @@ def discover_alpha(
         random.seed(seed)
     picks: List[Dict[str, str]] = []
     if "openai" in globals() and os.getenv("OPENAI_API_KEY"):
-        prompt = "List " f"{num} short cross-industry investment opportunities as JSON"
+        prompt = f"List {num} short cross-industry investment opportunities as JSON"
         try:
             if hasattr(openai, "chat") and hasattr(openai.chat, "completions"):
                 create = openai.chat.completions.create


### PR DESCRIPTION
## Summary
- replace concatenated prompt with a single f-string

## Testing
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py` *(with several hooks skipped)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(failed: Operation cancelled)*
- `pytest -q` *(failed: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68490035aeb48333b45bc507eb186e16