### PR TITLE
[alpha_factory] update docs

### DIFF
--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -47,6 +47,9 @@ make demo-run        # RUN_MODE=web for dashboard
 ```
 Opens **http://localhost:7860** with a Gradio portal to every demo. Works on macOS, Linux, WSL 2 and Colab.
 
+Advanced workflows like the OpenAI Agents bridge require the `openai-agents`
+package and `OPENAI_API_KEY` set.
+
 ---
 
 ## 2 • Demo Showcase 🎮

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -4,7 +4,8 @@
 """OpenAI Agents SDK bridge for the cross-industry Alpha-Factory demo.
 
 Warning: The agent outputs are illustrative only and do not constitute
-financial advice.
+financial advice. Tool registration is skipped when the Agents SDK is
+missing.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- mention Agents SDK fallback in cross-industry bridge
- note that advanced demo workflows need `openai-agents` and an API key

## Testing
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py alpha_factory_v1/demos/README.md` *(fails: mypy & proto-verify)*
- `python scripts/check_python_deps.py` *(fails: numpy, pandas missing)*
- `python check_env.py --auto-install` *(failed to finish)*
- `pytest -q` *(failed to finish)*


------
https://chatgpt.com/codex/tasks/task_e_6849781bc71c8333a9b3f7b8c7aa5886