### PR TITLE
[alpha_factory] clarify offline test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
           pip install pytest pytest-cov pytest-benchmark mutmut
+      - name: Verify environment
+        run: |
+          python scripts/check_python_deps.py
+          python check_env.py --auto-install
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/README.md
+++ b/README.md
@@ -958,6 +958,7 @@ Install the optional test dependencies with:
 
 ```bash
 pip install -r requirements-dev.txt
+pip install -r requirements-demo.txt  # adds numpy, torch and extras
 ```
 
 Install the project in editable mode so tests resolve imports:
@@ -966,9 +967,9 @@ pip install -e .
 python check_env.py --auto-install  # times out after 10 minutes
 ```
 Run `python check_env.py --auto-install` again before executing `pytest` to
-ensure optional dependencies are present. In offline setups pass
-`--wheelhouse <dir>` (or set `WHEELHOUSE`) so packages install from the local
-wheel cache.
+ensure optional dependencies are present. When offline, set `WHEELHOUSE` or pass
+`--wheelhouse <dir>` so packages install from the local wheel cache. The
+repository ships with a `wheels/` directory that can be used as this cache.
 The full test suite relies on optional packages including `numpy`, `torch`,
 `pandas`, `prometheus_client`, `gymnasium`, `playwright`, `httpx`, `uvicorn`,
 `git` and `hypothesis`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,11 +32,10 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    `numpy`, `torch`, `pandas`, `prometheus_client`, `gymnasium`, `playwright`,
    `httpx`, `uvicorn`, `git` and `hypothesis`.
    
-   The test suite automatically attempts to install missing packages at
-   session start when `numpy` or `torch` are unavailable by invoking
-   `check_env.py --auto-install`.  Set the `WHEELHOUSE` environment
-   variable to point to a local wheel directory when running offline so
-   these installs can succeed without contacting PyPI.
+   Tests are skipped when `numpy` or `torch` are missing. Pre-install them with
+   `python check_env.py --auto-install`. Set the `WHEELHOUSE` environment
+   variable to point to a local wheel directory when running offline so this
+   command succeeds without contacting PyPI.
 6. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 7. Before running the tests, execute `python check_env.py --auto-install` once
    more (add `--wheelhouse <dir>` when offline), then run `pytest -q`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,17 +24,8 @@ rocketry_stub.conds = conds_mod
 sys.modules.setdefault("rocketry", rocketry_stub)
 sys.modules.setdefault("rocketry.conds", conds_mod)
 
-
-def pytest_sessionstart(session: pytest.Session) -> None:
-    """Ensure core packages are installed at session start."""
-    missing = [name for name in ("numpy", "torch") if importlib.util.find_spec(name) is None]
-    if missing:
-        try:
-            import check_env
-        except Exception as exc:  # pragma: no cover - fallback just prints
-            print(f"check_env unavailable: {exc}")
-        else:
-            check_env.main(["--auto-install"])
+pytest.importorskip("numpy", reason="numpy required")
+pytest.importorskip("torch", reason="torch required")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- skip tests when numpy/torch are absent instead of installing them
- mention `requirements-demo.txt` and wheel cache in README
- explain skip behaviour in `tests/README.md`
- make CI run the environment checks before pytest

## Testing
- `pre-commit run --files tests/conftest.py README.md tests/README.md .github/workflows/ci.yml` *(fails: proto-verify)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt installing numpy/pandas)*
- `pytest -q` *(fails: Skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_68497fcebc748333b97602f7929a9a93