### PR TITLE
[alpha_factory] bump openai-agents in insight demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in
@@ -17,7 +17,7 @@ rocketry==2.5.1
 pytest==8.3.5
 gitpython==3.1.44
 openai==1.77.0
-openai-agents==0.0.14
+openai-agents==0.0.16
 anthropic==0.50.0
 litellm==1.67.5
 tiktoken==0.9.0

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -17,7 +17,7 @@ rocketry==2.5.1
 pytest==8.3.5
 gitpython==3.1.44
 openai==1.77.0
-openai-agents==0.0.14
+openai-agents==0.0.16
 anthropic==0.50.0
 litellm==1.67.5
 tiktoken==0.9.0

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
@@ -17,7 +17,7 @@ rocketry==2.5.1
 pytest==8.3.5
 gitpython==3.1.44
 openai==1.77.0
-openai-agents==0.0.14
+openai-agents==0.0.16
 anthropic==0.50.0
 litellm==1.67.5
 tiktoken==0.9.0


### PR DESCRIPTION
## Summary
- use `openai-agents==0.0.16` for the Insight demo

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt` *(fails: `proto-verify`)*
- `pytest` *(fails: `Skipped: torch required`)*


------
https://chatgpt.com/codex/tasks/task_e_684989b74914833388c11f581e5eb4fc