### PR TITLE
[alpha_factory] add Dockerfile for business 3 demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install demo dependencies
+COPY ../../../../requirements-demo.txt /tmp/requirements-demo.txt
+RUN pip install --no-cache-dir -r /tmp/requirements-demo.txt && rm /tmp/requirements-demo.txt
+
+# Copy only the demo package
+RUN mkdir -p alpha_factory_v1/demos
+COPY ../../__init__.py alpha_factory_v1/__init__.py
+COPY ../../demos/__init__.py alpha_factory_v1/demos/__init__.py
+COPY . alpha_factory_v1/demos/alpha_agi_business_3_v1
+
+# Switch to non-root user
+RUN useradd --uid 1001 --create-home appuser && chown -R appuser:appuser /app
+USER appuser
+
+CMD ["python", "-m", "alpha_factory_v1.demos.alpha_agi_business_3_v1"]

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -235,6 +235,10 @@ Offline mode → `ene_agent` resorts to GARCH / Kalman to estimate β.
 ```bash
 docker run -p 7860:7860 ghcr.io/montrealai/omega-lattice:latest
 ```
+You can also build the demo locally using the provided Dockerfile:
+```bash
+docker build -t alpha_business_v3:latest -f Dockerfile .
+```
 
 <a id="8.2"></a>
 ### 8.2 Helm / K8s
@@ -278,6 +282,7 @@ comment on the computed ΔG. Without it the demo uses an offline placeholder.
 You can also run the Dockerised version:
 ```bash
 ./run_business_3_demo.sh
+# builds `alpha_business_v3:latest` using `Dockerfile` in this folder
 ```
 
 ---

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
@@ -12,6 +12,6 @@ command -v docker >/dev/null 2>&1 || { echo "❌ Docker is required"; exit 1; }
 
 image="alpha_business_v3:latest"
 
-docker build -t "$image" -f alpha_factory_v1/Dockerfile .
+docker build -t "$image" -f alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile .
 docker run --rm -it -p 7860:7860 -e OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
   "$image" python -m alpha_factory_v1.demos.alpha_agi_business_3_v1


### PR DESCRIPTION
## Summary
- create Dockerfile for `alpha_agi_business_3_v1`
- build this image from `run_business_3_demo.sh`
- document local Docker build in the README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md` *(fails: Makefile:26: *** missing separator.  Stop.)*
- `pytest tests/test_alpha_agi_business_3_v1.py -q` *(fails: Skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_68498c5439f483338719a6073120f281