### PR TITLE
[alpha_factory] deduplicate requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ Follow these steps when installing without internet access:
   ```bash
   pip-compile --generate-hashes --output-file requirements.lock requirements.txt
   ```
+  Run this command whenever you edit `requirements*.txt` so the lock file stays
+  in sync. The `verify-requirements-lock` hook checks for mismatches during
+  `pre-commit`.
 
 - Install from the lock file to reproduce identical environments:
   ```bash

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -4,6 +4,4 @@ torch>=2.2
 gymnasium[classic-control]>=0.29
 gradio>=4.35
 filelock>=3.13
-openai>=1.82.0,<2.0
-openai-agents>=0.0.16
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,18 +1,10 @@
 -r requirements.txt
-pytest
 pytest-benchmark
-prometheus_client
 mypy
-fastapi
-opentelemetry-api
-cryptography
 hypothesis
 grpcio-tools
 pytest-httpx
 pre-commit
-
-numpy
-PyYAML
 types-PyYAML
 types-requests
 papermill


### PR DESCRIPTION
## Summary
- remove runtime packages from `requirements-dev.txt`
- drop duplicates from `requirements-demo.txt`
- document regenerating requirements.lock in AGENTS

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: operation cancelled)*
- `pytest -q` *(fails: torch required)*


------
https://chatgpt.com/codex/tasks/task_e_68499981ebf08333a8ad8d98aacaeb6f