### PR TITLE
[alpha_factory] add optional integration tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -13,8 +13,8 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    ```bash
    pip install -r requirements-demo.txt
    ```
-   This also installs `openai>=1.82.0,<2.0` and `openai-agents>=0.0.16` for
-   the OpenAI Agents tests.
+   This also installs `openai>=1.82.0,<2.0`, `openai-agents` and `google-adk` so
+   the optional integration tests can run.
    3. Verify the core dependencies are present:
    ```bash
    python scripts/check_python_deps.py
@@ -103,6 +103,9 @@ pytest -q
 ```bash
 OPENAI_API_KEY=dummy pytest tests/test_meta_agentic_tree_search_demo.py::test_bridge_online_mode
 ```
+- The optional integration checks in `test_external_integrations.py` exercise
+  the real `openai_agents` and `google_adk` packages. Install them via
+  `requirements-demo.txt` or they will be skipped automatically.
 - The meta-agentic tree search tests also rely on `numpy` and `pyyaml`. These packages are included in `requirements-dev.txt`, so running `pip install -r requirements-dev.txt` will install them.
 
 ## Troubleshooting

--- a/tests/test_external_integrations.py
+++ b/tests/test_external_integrations.py
@@ -1,0 +1,94 @@
+import importlib
+import types
+from unittest.mock import patch, AsyncMock
+import asyncio
+import os
+import pytest
+
+HAS_OAI = importlib.util.find_spec("openai_agents") or importlib.util.find_spec("agents")
+HAS_ADK = importlib.util.find_spec("google_adk") or importlib.util.find_spec("google.adk")
+
+
+@pytest.mark.skipif(not HAS_OAI, reason="openai_agents package not installed")
+def test_build_llm_missing_api_key(monkeypatch):
+    if importlib.util.find_spec("openai_agents"):
+        import openai_agents as oa
+    else:  # pragma: no cover - legacy package name
+        import agents as oa
+
+    captured = {}
+
+    class DummyAgent:
+        def __init__(self, *a, base_url=None, **kw):
+            captured['base_url'] = base_url
+
+    monkeypatch.setattr(oa, "OpenAIAgent", DummyAgent)
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://testserver")
+
+    import importlib as _imp
+    mod = _imp.reload(_imp.import_module("alpha_factory_v1.demos.aiga_meta_evolution.utils"))
+    llm = mod.build_llm()
+    assert isinstance(llm, DummyAgent)
+    assert captured.get('base_url') == "http://testserver"
+
+
+@pytest.mark.skipif(not HAS_ADK, reason="google_adk package not installed")
+def test_adk_auto_register(monkeypatch):
+    if importlib.util.find_spec("google_adk"):
+        import google_adk as gadk
+    else:  # pragma: no cover - alt module path
+        from google import adk as gadk
+
+    registered = []
+
+    class DummyRouter:
+        def __init__(self):
+            self.app = types.SimpleNamespace(middleware=lambda *_a, **_k: lambda f: f)
+
+        def register_agent(self, agent):
+            registered.append(agent)
+
+    monkeypatch.setattr(gadk, "Router", DummyRouter)
+    monkeypatch.setenv("ALPHA_FACTORY_ENABLE_ADK", "true")
+
+    import importlib as _imp
+    bridge = _imp.reload(_imp.import_module("alpha_factory_v1.backend.adk_bridge"))
+
+    class Dummy:
+        name = "dummy"
+        def run(self, prompt: str):
+            return "ok"
+
+    bridge.auto_register([Dummy()])
+    assert registered
+
+    called = {}
+    def fake_run(app, host, port, log_level="info", **kw):
+        called['host'] = host
+        called['port'] = port
+    monkeypatch.setattr("uvicorn.run", fake_run)
+
+    bridge.maybe_launch(host="127.0.0.1", port=1234)
+    assert called == {"host": "127.0.0.1", "port": 1234}
+
+
+@pytest.mark.skipif(not HAS_ADK, reason="google_adk package not installed")
+def test_adk_auto_register_disabled(monkeypatch):
+    if importlib.util.find_spec("google_adk"):
+        import google_adk as gadk
+    else:  # pragma: no cover
+        from google import adk as gadk
+
+    class DummyRouter:
+        def __init__(self):
+            self.app = types.SimpleNamespace(middleware=lambda *_a, **_k: lambda f: f)
+        def register_agent(self, agent):
+            raise AssertionError("should not register")
+
+    monkeypatch.setattr(gadk, "Router", DummyRouter)
+    monkeypatch.delenv("ALPHA_FACTORY_ENABLE_ADK", raising=False)
+
+    import importlib as _imp
+    bridge = _imp.reload(_imp.import_module("alpha_factory_v1.backend.adk_bridge"))
+    bridge.auto_register([object()])  # no error


### PR DESCRIPTION
## Summary
- add integration checks for openai_agents and google_adk when installed
- document optional integrations in test README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: pandas)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed to collect: torch required)*
- `pre-commit run --files tests/test_external_integrations.py tests/README.md` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68499fd9ce548333a28fe84c3b15b477