### PR TITLE
[alpha_factory] add offline setup reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ Follow these steps when working without internet access.
 `WHEELHOUSE=/media/wheels` when running `pre-commit` or the tests so
 dependencies install from the local cache. See
 [Offline Setup](alpha_factory_v1/scripts/README.md#offline-setup) for more
-details. If package installation hangs for more than ten minutes,
+details. A short reference lives in
+[docs/OFFLINE_SETUP.md](docs/OFFLINE_SETUP.md). If package installation hangs
+for more than ten minutes,
 `check_env.py` will time out and suggest using `--wheelhouse` for
 offline installs.
 

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -49,6 +49,7 @@ Opens **http://localhost:7860** with a Gradio portal to every demo. Works on ma
 
 Advanced workflows like the OpenAI Agents bridge require the `openai-agents`
 package and `OPENAI_API_KEY` set.
+For air‑gapped installs see [docs/OFFLINE_SETUP.md](../../docs/OFFLINE_SETUP.md).
 
 ---
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -133,6 +133,8 @@ Follow these steps when working **air‑gapped**:
 
 See [scripts/README.md](../../scripts/README.md#offline-setup) for details on
 creating the wheelhouse.
+Consult [docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for a brief
+overview.
 
 ### Installing the OpenAI Agents SDK
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -285,6 +285,8 @@ these local wheels. Use the same variable when running `pre-commit` or tests:
 ```bash
 python check_env.py --auto-install --wheelhouse /media/wheels
 ```
+For a concise reference see
+[docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md).
 
 ### 🎛️ Local Gradio Dashboard
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -540,6 +540,8 @@ WHEELHOUSE=/media/wheels pytest -q
 
 `playwright` and other heavy packages must exist in the wheelhouse for tests to
 pass offline.
+See [docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for a concise
+summary.
 
 ### Troubleshooting
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -115,6 +115,8 @@ WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
 WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
   python check_env.py --auto-install --wheelhouse /media/wheels
 ```
+See [docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for a short
+reference.
 
 Set `NO_LLM=1` to disable the planning agent when no API key is available. The
 `deploy_alpha_asi_world_model_demo.sh` helper exports this variable

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -68,6 +68,8 @@ Customize variables like `OPENAI_API_KEY`, `AGENTS_ENABLED`, `PROM_PORT` or
 python scripts/check_python_deps.py
 python check_env.py --auto-install  # add --wheelhouse <dir> when offline
 ```
+See [docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for wheelhouse
+instructions.
 
 #### Pre-download Mixtral weights
 Pull the 8×7B model once and mount it during deployment:

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -168,7 +168,8 @@ WHEELHOUSE=/tmp/wheels pip install -r requirements.txt
 
 The repository's setup script automatically uses a `wheels/` directory
 in the project root when present, so placing your pre-built wheels there
-also works.
+also works. See
+[docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for a summary.
 
 ### Environment variables
 The demo consults a few environment variables when choosing a rewrite strategy

--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -22,6 +22,7 @@ pip install --no-index --find-links /path/to/wheels -r requirements.txt
 
 Ensure `pytest` and `prometheus_client` are present so the built-in tests and
 metrics exporter function correctly.
+See [docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for more details.
 
 ### Running Tests
 

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -137,7 +137,8 @@ def check_network(host: str = "pypi.org", timeout: float = 2.0) -> bool:
         socket.gethostbyname(host)
     except Exception:
         banner(
-            f"WARNING: Unable to resolve {host}. Use --wheelhouse for offline installs.",
+            f"WARNING: Unable to resolve {host}. Use --wheelhouse for offline installs."
+            " See docs/OFFLINE_SETUP.md for guidance.",
             "YELLOW",
         )
         return False

--- a/check_env.py
+++ b/check_env.py
@@ -125,7 +125,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         except subprocess.TimeoutExpired:
             print(
                 "Timed out installing baseline requirements. "
-                "Re-run with '--wheelhouse <path>' to install offline packages."
+                "Re-run with '--wheelhouse <path>' to install offline packages. "
+                "See docs/OFFLINE_SETUP.md."
             )
             return 1
         except subprocess.CalledProcessError as exc:
@@ -134,7 +135,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             if any(kw in stderr.lower() for kw in ["connection", "temporary failure", "network", "resolve"]):
                 print(
                     "Network failure detected. Re-run with '--wheelhouse <path>' "
-                    "or set WHEELHOUSE to install offline packages."
+                    "or set WHEELHOUSE to install offline packages. "
+                    "See docs/OFFLINE_SETUP.md."
                 )
             return exc.returncode
 
@@ -167,7 +169,8 @@ def main(argv: Optional[List[str]] = None) -> int:
                 result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)
             except subprocess.TimeoutExpired:
                 print(
-                    "Timed out installing packages. Re-run with '--wheelhouse <path>' " "to install from local wheels."
+                    "Timed out installing packages. Re-run with '--wheelhouse <path>' " "to install from local wheels. "
+                    "See docs/OFFLINE_SETUP.md."
                 )
                 return 1
             except subprocess.CalledProcessError as exc:
@@ -176,7 +179,8 @@ def main(argv: Optional[List[str]] = None) -> int:
                 if any(kw in stderr.lower() for kw in ["connection", "temporary failure", "network", "resolve"]):
                     print(
                         "Network failure detected. Re-run with '--wheelhouse <path>' "
-                        "or set WHEELHOUSE to install offline packages."
+                        "or set WHEELHOUSE to install offline packages. "
+                        "See docs/OFFLINE_SETUP.md."
                     )
                 return 1
             else:

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -1,0 +1,36 @@
+# Offline Setup Reference
+
+This document summarises how to install the project without internet access.
+
+## Build a wheelhouse
+Run these commands on a machine with connectivity:
+
+```bash
+mkdir -p /media/wheels
+pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r requirements-dev.txt -w /media/wheels
+```
+
+Copy the directory to the offline host.
+
+## Environment variables
+Set these before running the helper scripts:
+
+```bash
+export WHEELHOUSE=/media/wheels
+export AUTO_INSTALL_MISSING=1
+```
+
+`check_env.py` reads them to install packages from the wheelhouse when the network is unavailable.
+
+## Verify packages
+Use the scripts below to confirm all requirements are satisfied:
+
+```bash
+python scripts/check_python_deps.py
+python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+```
+
+Run `pytest -q` once the check succeeds.
+
+See [tests/README.md](../tests/README.md#offline-install) and [AGENTS.md](../AGENTS.md#offline-setup) for the full instructions.


### PR DESCRIPTION
## Summary
- document offline install commands in docs/OFFLINE_SETUP.md
- reference the new doc from README and demo guides
- warn about docs/OFFLINE_SETUP.md in preflight and check_env helpers

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: Timed out installing baseline requirements)*
- `pytest -q tests/test_imports.py` *(failed: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_6849aaac65f48333b69bded1b99e0d24