### PR TITLE
[alpha_factory] replace prints with logging

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -44,8 +44,10 @@ class Orchestrator:
     def post_alpha_job(self, bundle_id: int, delta_g: float) -> None:
         """Broadcast a new job for agents when ``delta_g`` is favourable."""
 
-        print(
-            f"[Orchestrator] Posting alpha job for bundle {bundle_id} with ΔG={delta_g:.6f}"
+        log.info(
+            "[Orchestrator] Posting alpha job for bundle %s with ΔG=%.6f",
+            bundle_id,
+            delta_g,
         )
 
 
@@ -104,9 +106,7 @@ async def _llm_comment(delta_g: float) -> str:
         base_url=(None if os.getenv("OPENAI_API_KEY") else "http://ollama:11434/v1"),
     )
     try:
-        return await agent(
-            f"In one sentence, comment on ΔG={delta_g:.4f} for the business."
-        )
+        return await agent(f"In one sentence, comment on ΔG={delta_g:.4f} for the business.")
     except Exception as exc:  # pragma: no cover - network failures
         log.warning("LLM comment failed: %s", exc)
         return "LLM error"
@@ -119,7 +119,7 @@ class Model:
     def commit(self, weight_update: Dict[str, Any]) -> None:
         """Commit the supplied weights after verification."""
 
-        print("[Model] New weights committed (Gödel-proof verified)")
+        log.info("[Model] New weights committed (Gödel-proof verified)")
 
 
 async def run_cycle_async(
@@ -166,17 +166,9 @@ def run_cycle(
     """Execute one evaluation + commitment cycle, creating an event loop if needed."""
 
     if loop is None:
-        asyncio.run(
-            run_cycle_async(
-                orchestrator, fin_agent, res_agent, ene_agent, gdl_agent, model
-            )
-        )
+        asyncio.run(run_cycle_async(orchestrator, fin_agent, res_agent, ene_agent, gdl_agent, model))
     else:
-        loop.run_until_complete(
-            run_cycle_async(
-                orchestrator, fin_agent, res_agent, ene_agent, gdl_agent, model
-            )
-        )
+        loop.run_until_complete(run_cycle_async(orchestrator, fin_agent, res_agent, ene_agent, gdl_agent, model))
 
 
 async def main(argv: list[str] | None = None) -> None:
@@ -213,9 +205,7 @@ async def main(argv: list[str] | None = None) -> None:
 
     cycle = 0
     while True:
-        await run_cycle_async(
-            orchestrator, fin_agent, res_agent, ene_agent, gdl_agent, model
-        )
+        await run_cycle_async(orchestrator, fin_agent, res_agent, ene_agent, gdl_agent, model)
         cycle += 1
         if args.cycles and cycle >= args.cycles:
             break

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -18,7 +18,8 @@ class DummyModel(demo.Model):
 
 
 @pytest.mark.asyncio
-async def test_run_cycle_commits() -> None:
+async def test_run_cycle_commits(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level("INFO")
     model = DummyModel()
     await demo.run_cycle_async(
         demo.Orchestrator(),
@@ -29,9 +30,15 @@ async def test_run_cycle_commits() -> None:
         model,
     )
     assert model.committed
+    assert any("New weights committed" in record.message for record in caplog.records)
+
 
 @pytest.mark.asyncio
-async def test_run_cycle_negative_delta_g_posts_job() -> None:
+async def test_run_cycle_negative_delta_g_posts_job(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("INFO")
+
     class LowFin(demo.AgentFin):
         def latent_work(self, bundle):
             return 0.0
@@ -53,6 +60,8 @@ async def test_run_cycle_negative_delta_g_posts_job() -> None:
         DummyModel(),
     )
     assert orch.called
+    assert any("Posting alpha job" in record.message for record in caplog.records)
+
 
 def test_cli_execution() -> None:
     result = subprocess.run(
@@ -69,6 +78,7 @@ def test_cli_execution() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
 
 @pytest.mark.asyncio
 async def test_llm_comment_offline() -> None:


### PR DESCRIPTION
## Summary
- log events in Orchestrator.post_alpha_job and Model.commit
- create log-based assertions in demo tests

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py tests/test_alpha_agi_business_3_v1.py` *(fails: mypy errors, proto-verify failure)*
- `pytest -q` *(fails: Skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_6849aea2450c8333ad87a3828f5df86a