### PR TITLE
[alpha_factory] sync business 3 demo docker usage

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -233,7 +233,7 @@ Offline mode → `ene_agent` resorts to GARCH / Kalman to estimate β.
 ### 8.1 Docker One‑liner
 
 ```bash
-docker run -p 7860:7860 ghcr.io/montrealai/omega-lattice:latest
+docker run alpha_business_v3:latest
 ```
 You can also build the demo locally using the provided Dockerfile:
 ```bash

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
@@ -13,5 +13,5 @@ command -v docker >/dev/null 2>&1 || { echo "❌ Docker is required"; exit 1; }
 image="alpha_business_v3:latest"
 
 docker build -t "$image" -f alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile .
-docker run --rm -it -p 7860:7860 -e OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
+docker run --rm -it -e OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
   "$image" python -m alpha_factory_v1.demos.alpha_agi_business_3_v1


### PR DESCRIPTION
## Summary
- make README Docker example use `alpha_business_v3:latest`
- drop unused port mapping

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Missing core packages)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c81ea1a48333adc850081809993b