### PR TITLE
[alpha_factory] docs: clarify business 3 Docker image

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -298,10 +298,11 @@ $ python alpha_agi_business_3_v1.py --cycles 1 --loglevel info
 
 - `OPENAI_API_KEY` – optional. When set, the demo uses OpenAI Agents to
   generate a short LLM comment. Leave it unset to run in fully offline mode.
-- Python ≥3.11 with packages from `requirements.txt` installed. Install the
-  optional `openai_agents` package if you want SDK integration. The helper
-  script `run_business_3_demo.sh` builds a Docker image with all dependencies
-  preinstalled.
+- Python ≥3.11 with packages from `requirements.txt` installed.
+  The helper script `run_business_3_demo.sh` builds a Docker image with the demo
+  dependencies preinstalled **except** for `openai_agents`. Install it manually
+  with `pip install openai_agents` or add it to the Dockerfile if you need OpenAI
+  Agents integration.
 
 ---
 


### PR DESCRIPTION
## Summary
- note missing openai_agents in Business 3 demo image

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_6849c98504048333931c7227f3be0e64