### PR TITLE
[alpha_factory] install openai_agents in business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /app
 
 # Install demo dependencies
 COPY ../../../../requirements-demo.txt /tmp/requirements-demo.txt
-RUN pip install --no-cache-dir -r /tmp/requirements-demo.txt && rm /tmp/requirements-demo.txt
+RUN pip install --no-cache-dir -r /tmp/requirements-demo.txt \
+    && pip install --no-cache-dir openai-agents \
+    && rm /tmp/requirements-demo.txt
 
 # Copy only the demo package
 RUN mkdir -p alpha_factory_v1/demos

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -298,11 +298,9 @@ $ python alpha_agi_business_3_v1.py --cycles 1 --loglevel info
 
 - `OPENAI_API_KEY` – optional. When set, the demo uses OpenAI Agents to
   generate a short LLM comment. Leave it unset to run in fully offline mode.
-- Python ≥3.11 with packages from `requirements.txt` installed.
-  The helper script `run_business_3_demo.sh` builds a Docker image with the demo
-  dependencies preinstalled **except** for `openai_agents`. Install it manually
-  with `pip install openai_agents` or add it to the Dockerfile if you need OpenAI
-  Agents integration.
+- Python ≥3.11 with packages from `requirements.txt` installed. The
+  `run_business_3_demo.sh` helper now builds a Docker image that includes
+  `openai_agents` by default.
 
 ---
 

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -21,7 +21,10 @@ from typing import Any, cast
 try:  # optional OpenAI Agents integration
     from openai_agents import OpenAIAgent
 except Exception:  # pragma: no cover - offline fallback
-    OpenAIAgent = None
+    try:  # fall back to the new package name
+        from agents import OpenAIAgent
+    except Exception:
+        OpenAIAgent = None
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- install `openai_agents` inside the Business v3 demo Dockerfile
- fall back to the `agents` package when importing in `alpha_agi_business_3_v1.py`
- remove manual install note from the demo README

## Testing
- `python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py --cycles 1 --loglevel info`
- `OPENAI_API_KEY=dummy python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py --cycles 1 --loglevel info`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py` *(fails: Verify protobuf files are up to date)*
- `pytest tests/test_alpha_agi_business_3_v1.py -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_6849cceb17e48333aa6422cd0191c831