### PR TITLE
[alpha_factory] update offline llm fallback

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -268,7 +268,8 @@ https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main
 ```
 
 
-No `OPENAI_API_KEY`? It auto‑switches to **Llama‑3‑8B.gguf**.
+No `OPENAI_API_KEY`? Set `LLAMA_MODEL_PATH` to a local `.gguf` weight – for
+example **Llama‑3‑8B.gguf** – to enable offline inference.
 
 #### Quick Local Demo
 

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -19,6 +19,8 @@ import os
 import hashlib
 from typing import Any, cast
 
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import local_llm
+
 try:  # optional OpenAI Agents integration
     from openai_agents import OpenAIAgent
 except Exception:  # pragma: no cover - offline fallback
@@ -102,7 +104,9 @@ async def _llm_comment(delta_g: float) -> str:
     # ``alpha_factory_v1.backend`` exposes a non-callable placeholder.
     # Guard against that scenario as well so offline tests succeed.
     if OpenAIAgent is None or not callable(OpenAIAgent):
-        return "LLM offline"
+        return local_llm.chat(
+            f"In one sentence, comment on ΔG={delta_g:.4f} for the business."
+        )
 
     agent = OpenAIAgent(
         model=os.getenv("MODEL_NAME", "gpt-4o-mini"),

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -91,6 +91,23 @@ async def test_llm_comment_offline() -> None:
     assert isinstance(msg, str)
 
 
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_llm_comment_uses_local_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+
+    def fake_chat(prompt: str, cfg: object | None = None) -> str:
+        called["prompt"] = prompt
+        return "local"
+
+    monkeypatch.setattr(demo, "OpenAIAgent", None)
+    monkeypatch.setattr(demo.local_llm, "chat", fake_chat)
+
+    out = await demo._llm_comment(0.1234)
+
+    assert out == "local"
+    assert called["prompt"].startswith("In one sentence, comment on ΔG=0.1234")
+
+
 def test_run_cycle_sync_commits() -> None:
     model = DummyModel()
     demo.run_cycle(


### PR DESCRIPTION
## Summary
- use local LLM when OpenAI Agents unavailable
- clarify README offline instructions
- test that the local model is invoked

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py` *(fails: Missing packages)*
- `pytest -q tests/test_alpha_agi_business_3_v1.py` *(errors: ModuleNotFoundError pydantic_settings)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md tests/test_alpha_agi_business_3_v1.py` *(failed to install hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6849e927c9508333974fdf9e5414bf9e