### PR TITLE
[alpha_factory] Document business 3 demo packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ notebooks install PyTorch from the [PyTorch wheel index](https://download.pytorc
 and pin Ray to the same version for compatibility.
 
 * [Solving AGI Governance](alpha_factory_v1/demos/solving_agi_governance/README.md) — Monte‑Carlo governance simulation with optional OpenAI‑Agents/ADK integration. [Colab](alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb)
+* **Note:** The `alpha_agi_business_3_v1` demo is intentionally left out of the published package. Clone this repository to run it from source.
 
 | `USE_GPU` | PyTorch wheel URL |
 |:--------:|-------------------------------------------------|


### PR DESCRIPTION
## Summary
- mention that `alpha_agi_business_3_v1` is omitted from the published package

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: interrupted)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files README.md` *(fails: initialization interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6849f4e2bd00833386b20b21289d6746