### PR TITLE
[alpha_factory] add SPDX headers

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Light-weight dependency check for demos and tests.
 
 This helper validates that the Python packages required by the

--- a/edge_runner.py
+++ b/edge_runner.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 """Wrapper script forwarding to :mod:`alpha_factory_v1.edge_runner`."""
 from alpha_factory_v1.edge_runner import main

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Top level utilities used by the small demo interface package."""

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Agent utilities."""
 
 from .meta_refinement_agent import MetaRefinementAgent

--- a/src/agents/guards/__init__.py
+++ b/src/agents/guards/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/src/interface/web_client/staking/__init__.py
+++ b/src/interface/web_client/staking/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/test_agent_muzero_entrypoint.py
+++ b/tests/test_agent_muzero_entrypoint.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import builtins
 import sys

--- a/tests/test_cross_industry_patch.py
+++ b/tests/test_cross_industry_patch.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import os

--- a/tests/test_experience_launcher.py
+++ b/tests/test_experience_launcher.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 from pathlib import Path

--- a/tests/test_external_integrations.py
+++ b/tests/test_external_integrations.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import types
 from unittest.mock import patch, AsyncMock

--- a/tests/test_inspector_bridge.py
+++ b/tests/test_inspector_bridge.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # ruff: noqa: E402
 import asyncio
 import sys

--- a/tests/test_mats_bridge_entrypoint.py
+++ b/tests/test_mats_bridge_entrypoint.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib.metadata as im
 import unittest
 

--- a/tests/test_skill_test_route.py
+++ b/tests/test_skill_test_route.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 
 pytest = __import__("pytest")

--- a/tests/test_world_model_safety.py
+++ b/tests/test_world_model_safety.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import os
 import sys


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to scripts, package inits and tests

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed to run due to missing `torch`)*

------
https://chatgpt.com/codex/tasks/task_e_684a1fb8768c83339275c839e2cd40cc