### PR TITLE
[alpha_factory] fix openai import errors

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -23,10 +23,10 @@ from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import local_llm
 
 try:  # optional OpenAI Agents integration
     from openai_agents import OpenAIAgent
-except Exception:  # pragma: no cover - offline fallback
+except ImportError:  # pragma: no cover - offline fallback
     try:  # fall back to the new package name
         from agents import OpenAIAgent
-    except Exception:
+    except ImportError:
         OpenAIAgent = None
 
 
@@ -104,9 +104,7 @@ async def _llm_comment(delta_g: float) -> str:
     # ``alpha_factory_v1.backend`` exposes a non-callable placeholder.
     # Guard against that scenario as well so offline tests succeed.
     if OpenAIAgent is None or not callable(OpenAIAgent):
-        return local_llm.chat(
-            f"In one sentence, comment on ΔG={delta_g:.4f} for the business."
-        )
+        return local_llm.chat(f"In one sentence, comment on ΔG={delta_g:.4f} for the business.")
 
     agent = OpenAIAgent(
         model=os.getenv("MODEL_NAME", "gpt-4o-mini"),


### PR DESCRIPTION
## Summary
- adjust imports in business demo to only catch ImportError

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: timed out during pip install)*
- `pytest -q tests/test_alpha_agi_business_3_v1.py` *(skipped: torch required)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py tests/test_alpha_agi_business_3_v1.py` *(failed: proto-verify hook)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ba37e4c833385288e24b3e3191f