### PR TITLE
[alpha_factory] add LOCAL_LLM_URL

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -305,6 +305,8 @@ $ python alpha_agi_business_3_v1.py --cycles 1 --loglevel info
 
 - `OPENAI_API_KEY` – optional. When set, the demo uses OpenAI Agents to
   generate a short LLM comment. Leave it unset to run in fully offline mode.
+- `LOCAL_LLM_URL` – optional. Base URL for the local fallback model.
+  Defaults to `http://ollama:11434/v1`.
 - Python ≥3.11 with packages from `requirements.txt` installed. The
   `run_business_3_demo.sh` helper now builds a Docker image that includes
   `openai_agents` by default.

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -109,7 +109,11 @@ async def _llm_comment(delta_g: float) -> str:
     agent = OpenAIAgent(
         model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
         api_key=os.getenv("OPENAI_API_KEY"),
-        base_url=(None if os.getenv("OPENAI_API_KEY") else "http://ollama:11434/v1"),
+        base_url=(
+            None
+            if os.getenv("OPENAI_API_KEY")
+            else os.getenv("LOCAL_LLM_URL", "http://ollama:11434/v1")
+        ),
     )
     try:
         return cast(

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -3,6 +3,7 @@ import asyncio
 import subprocess
 import sys
 import hashlib
+import os
 
 import pytest
 
@@ -86,7 +87,8 @@ def test_cli_execution() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[misc]
-async def test_llm_comment_offline() -> None:
+async def test_llm_comment_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_LLM_URL", "http://example.com/v1")
     msg = await demo._llm_comment(-0.1)
     assert isinstance(msg, str)
 
@@ -101,6 +103,7 @@ async def test_llm_comment_uses_local_model(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(demo, "OpenAIAgent", None)
     monkeypatch.setattr(demo.local_llm, "chat", fake_chat)
+    monkeypatch.setenv("LOCAL_LLM_URL", "http://example.com/v1")
 
     out = await demo._llm_comment(0.1234)
 
@@ -120,6 +123,7 @@ async def test_llm_comment_no_openai(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     removed = sys.modules.pop("openai_agents", None)
     monkeypatch.setattr(demo.local_llm, "chat", fake_chat)
+    monkeypatch.setenv("LOCAL_LLM_URL", "http://example.com/v1")
 
     try:
         out = await demo._llm_comment(-0.42)


### PR DESCRIPTION
## Summary
- allow `LOCAL_LLM_URL` environment variable in demo
- document `LOCAL_LLM_URL`
- set `LOCAL_LLM_URL` in offline tests

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: Timed out installing baseline requirements)*
- `pytest -q` *(fails: Skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684a2f6818ac83338cfe16e8bd385003