### PR TITLE
[alpha_factory] limit demo docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,14 @@ Dockerfile*
 *.md
 alpha_factory_v1/tests/
 requests/tests/
+
+# Restrict build context for demo images
+alpha_factory_v1/demos/*
+!alpha_factory_v1/demos/__init__.py
+!alpha_factory_v1/demos/alpha_agi_business_3_v1/
+!alpha_factory_v1/demos/alpha_agi_business_3_v1/**
+!alpha_factory_v1/demos/alpha_agi_insight_v1/
+!alpha_factory_v1/demos/alpha_agi_insight_v1/**
+!alpha_factory_v1/__init__.py
+!alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+!requirements-demo.txt

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -241,9 +241,12 @@ Offline mode → `ene_agent` resorts to GARCH / Kalman to estimate β.
 ```bash
 docker run alpha_business_v3:latest
 ```
-You can also build the demo locally using the provided Dockerfile:
+You can also build the demo locally using the provided Dockerfile.
+Run the command from the repository root so the `.dockerignore` rules
+trim the build context:
 ```bash
-docker build -t alpha_business_v3:latest -f Dockerfile .
+docker build -t alpha_business_v3:latest \
+    -f alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile .
 ```
 
 <a id="8.2"></a>


### PR DESCRIPTION
## Summary
- ignore all other demos except the business3 and insight demos so `docker build` only sees the needed files
- clarify the business demo Docker build command

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to finish due to network)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files .dockerignore alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md` *(failed: could not finish environment install)*

------
https://chatgpt.com/codex/tasks/task_e_684a33afe6e08333bf85e4c4871acf0a