### PR TITLE
[alpha_factory] pin openai-agents in demo Dockerfile

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # Install demo dependencies
 COPY ../../../../requirements-demo.txt /tmp/requirements-demo.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-demo.txt \
-    && pip install --no-cache-dir openai-agents \
+    && pip install --no-cache-dir openai-agents==0.0.16 \
     && rm /tmp/requirements-demo.txt
 
 # Copy only the demo package


### PR DESCRIPTION
## Summary
- pin `openai-agents` in the alpha_agi_business_3_v1 demo Dockerfile

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile` *(failed: proto-verify hook)*
- `python scripts/check_python_deps.py` *(failed: numpy, pandas missing)*
- `python check_env.py --auto-install` *(failed: operation cancelled)*
- `pytest -q` *(failed: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684a3a3dd6648333bf6b19283e2276b1