### PR TITLE
[alpha_factory] focus mypy on demo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,14 @@ Thank you for considering a contribution to this project. For the complete contr
 All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Please read **AGENTS.md** carefully before opening issues or submitting pull requests.
+
+## Type Checking the Demo
+
+Run mypy only on the demo package while iterating:
+
+```bash
+mypy --config-file mypy.ini alpha_factory_v1/demos/alpha_agi_insight_v1
+```
+
+Replace the path with your demo directory as needed. The configuration excludes
+other modules so checks remain fast.

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,6 @@
 python_version = 3.11
 strict = True
 ignore_missing_imports = True
+follow_imports = skip
+files = alpha_factory_v1/demos/alpha_agi_insight_v1/src
+exclude = (^af_requests/|^src/|^tests/|^alpha_factory_v1/backend/|^alpha_factory_v1/tests/|^alpha_factory_v1/demos/(?!alpha_agi_insight_v1).*)


### PR DESCRIPTION
## Summary
- limit mypy to the Insight demo sources
- explain how to run mypy on a demo in CONTRIBUTING

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to run - cancelled)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files mypy.ini CONTRIBUTING.md` *(failed to finish during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684ac2bd3e6c8333b465451fe8feffbb