### PR TITLE
[alpha_factory] Add concise quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Strategic Edge:
 * Strategically validated methodologies guarantee consistent economic leadership.
 
 ## Quick Start
+**Local:** `./quickstart.sh` &nbsp;&nbsp;|&nbsp;&nbsp; **Docker:** `docker compose up --build`
+
+An interactive Colab notebook demonstrates the same zero‑data Insight search loop. Open [colab_alpha_agi_insight_demo.ipynb](alpha_factory_v1/demos/alpha_agi_insight_v0/colab_alpha_agi_insight_demo.ipynb) in Google Colab to try it online.
+
 Clone the repository and run the helper script to start the Insight demo locally:
 
 ```bash


### PR DESCRIPTION
## Summary
- add one-line quick start tips for local and Docker execution
- highlight Colab notebook link for the Insight demo

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --timeout 5` *(fails: Timed out installing baseline requirements)*
- `pytest -q` *(fails: Skipped: torch required)*
- `pre-commit run --files README.md --hook-stage manual` *(fails: KeyboardInterrupt during environment init)*

------
https://chatgpt.com/codex/tasks/task_e_684ad005f4848333872755e82256fc87