### PR TITLE
[alpha_factory] add offline model references

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ section of the α‑ASI world-model quickstart for a concise summary.
      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-GGUF/resolve/main/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf
    export LLAMA_MODEL_PATH=~/.cache/llama/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf
    ```
+   Common weights and typical CPU throughput:
+
+   | Model | Size | ~tokens/s |
+   |-------|------|-----------|
+   | TinyLlama‑1.1B‑Chat Q4_K_M | 380 MB | ~20 |
+   | Llama‑3‑8B‑Instruct Q4_K_M | 4 GB | ~5 |
+   | Mixtral‑8×7B‑Instruct Q4_0 | 7 GB | ~3 |
+
+   Install `llama-cpp-python` or `ctransformers` to enable offline inference.
 
 4. **Fetch and build the browser assets** (requires **Node.js**) to run the Insight demo fully offline:
    ```bash
@@ -209,7 +218,8 @@ section of the α‑ASI world-model quickstart for a concise summary.
    ```
 
 6. **Enable offline inference** by setting ``AGI_INSIGHT_OFFLINE=1`` in
-   ``.env`` or the environment.
+   ``.env`` or the environment (ensure `llama-cpp-python` or `ctransformers`
+   is installed).
 
 7. **Disable broadcasting** to avoid network calls:
    ```bash

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb
@@ -1,288 +1,297 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "This notebook is a conceptual research prototype. References to ‘AGI’ or ‘superintelligence’ describe aspirational goals and do not indicate the presence of real general intelligence. Use at your own risk.\n\n# 👁️‍🗨️ Alpha-Factory v1 – Cross-Industry AGENTIC α-AGI  \n## _(Google Colab, self-contained)_\n\n**What you get in < 10 minutes**\n\n* 🪄 Five domain agents (finance, biotech, climate, mfg, policy) orchestrated by `backend/orchestrator.py`\n* 🏋 Continual PPO trainer self-improves agents\n* 🔐 Guard-rails (MCP), ed25519 prompt signing, policy deny-list\n* 📊 Prometheus **9090** & Grafana **3000** exposed through public *ngrok* URLs\n* ⚡ 30-second k6 load-test to prove antifragility\n* 📴 Works offline (Mixtral-8×7B GGML) or online (OpenAI key)\n\n> **Paste an `OPENAI_API_KEY` below for better quality,** or leave blank to run fully offline.\nThe script will also generate a random `API_TOKEN` in `.env` for authenticated requests."
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "env"
-      },
-      "source": [
-        "OPENAI_API_KEY = \"\"  # ← 🔑  put your key here or leave empty"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Optional offline mode",
-        "",
-        "Download a `.gguf` weight and set `LLAMA_MODEL_PATH` before running the setup cell. Install `openai-agents`, `llama-cpp-python` and `ctransformers` for local inference:",
-        "",
-        "```bash",
-        "pip install openai-agents llama-cpp-python ctransformers",
-        "```",
-        "When `LLAMA_MODEL_PATH` is defined the orchestrator loads the weight instead of calling OpenAI."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "01-setup"
-      },
-      "source": [
-        "%%bash\n",
-        "set -euo pipefail\n",
-        "REPO=AGI-Alpha-Agent-v0\n",
-        "if [ ! -d \"$REPO/.git\" ]; then\n",
-        "  echo '📥 cloning repo …'\n",
-        "  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git $REPO\n",
-        "fi\n",
-        "cd $REPO\n",
-        "\n",
-        "echo '🔧 installing Python deps …'\n",
-        "pip install -q -r alpha_factory_v1/requirements-colab.txt  # lightweight agent deps\n",
-        "pip install -q ray[default]==2.10.0 uvicorn fastapi pyngrok ctransformers==0.2.27 k6-python subprocess-tee\n",
-        "\n",
-        "# ─── runtime artefacts ──────────────────────────────────────────────────\n",
-        "mkdir -p alpha_factory_v1/{keys,policies,continual,adapters}\n",
-        "\n",
-        "ssh-keygen -t ed25519 -N '' -q -f alpha_factory_v1/keys/agent_key <<<y || true\n",
-        "PUB=$(cat alpha_factory_v1/keys/agent_key.pub)\n",
-        "\n",
-        "cat > alpha_factory_v1/.env <<EOF\n",
-        "ALPHA_FACTORY_MODE=cross_industry\n",
-        "OPENAI_API_KEY=${OPENAI_API_KEY}\n",
-        "OPENAI_API_BASE=${OPENAI_API_BASE:-https://api.openai.com/v1}\n",
-        "AGENTS_ENABLED=finance_agent biotech_agent climate_agent manufacturing_agent policy_agent\n",
-        "PROMPT_SIGN_PUBKEY=${PUB}\n",
-        "EOF\n",
-        "\n",
-        "cat > alpha_factory_v1/policies/redteam.json <<'JSON'\n",
-        "{\"id\":\"af_v1_guard\",\"patterns_deny\":[\"(?i)breakout\",\"(?i)leak\",\"(?i)privileged\"],\"max_tokens\":2048}\n",
-        "JSON\n",
-        "\n",
-        "# ─── offline LLM (Mixtral) if no key ───────────────────────────────────\n",
-        "if [ -z \"${OPENAI_API_KEY}\" ]; then\n",
-        "  pip install -q sentencepiece\n",
-        "  python - <<'PY'\n",
-        "from ctransformers import AutoModelForCausalLM\n",
-        "AutoModelForCausalLM.from_pretrained(\n",
-        "  \"TheBloke/Mixtral-8x7B-Instruct-GGML\",\n",
-        "  model_file=\"mixtral-8x7b-instruct.ggmlv3.q4_K_M.bin\",\n",
-        "  local_files_only=False)\n",
-        "PY\n",
-        "fi"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## ⚙️ Patch orchestrator: add `/update_model` hot-reload endpoint"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "02-patch"
-      },
-      "source": [
-        "%%bash\n",
-        "apply_patch() {\n",
-        "python - <<'PY'\n",
-        "import importlib, textwrap, pathlib, inspect\n",
-        "src = pathlib.Path('AGI-Alpha-Agent-v0/alpha_factory_v1/backend/orchestrator.py')\n",
-        "code = src.read_text()\n",
-        "if 'update_model' in code:\n",
-        "    print('✅ update_model already present'); raise SystemExit\n",
-        "insertion = textwrap.dedent('''\\n@router.post(\"/agent/{agent_id}/update_model\")\\nasync def update_model(agent_id: str, file: bytes = File(...)):\\n    if agent_id not in AGENT_REGISTRY:\\n        raise HTTPException(status_code=404, detail=\"agent not found\")\\n    import tempfile, zipfile, io\\n    with tempfile.TemporaryDirectory() as td:\\n        zf = zipfile.ZipFile(io.BytesIO(file)); zf.extractall(td)\\n        AGENT_REGISTRY[agent_id].load_weights(td)\\n    return {\"status\":\"ok\"}\\n''')\n",
-        "marker = '# === ROUTES ==='\n",
-        "idx = code.index(marker) + len(marker)\n",
-        "new_code = code[:idx] + insertion + code[idx:]\n",
-        "src.write_text(new_code)\n",
-        "print('🚀 patched orchestrator with hot-reload endpoint')\n",
-        "PY\n",
-        "}\n",
-        "apply_patch"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 🚀 Launch orchestrator, agents, Ray & mock adapters (background)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "03-launch"
-      },
-      "source": [
-        "%%bash --bg\n",
-        "cd AGI-Alpha-Agent-v0/alpha_factory_v1\n",
-        "ray start --head --dashboard-host 0.0.0.0 --port 6379 --dashboard-port 8265 &>/dev/null &\n",
-        "uvicorn backend.orchestrator:app --host 0.0.0.0 --port 8000 &>/dev/null &\n",
-        "\n",
-        "# tiny PubMed & Carbon adapters\n",
-        "python - <<'PY' &>/dev/null &\n",
-        "from fastapi import FastAPI; import uvicorn, random\n",
-        "app=FastAPI(); @app.get('/')\n",
-        "def root(): return {\"msg\":\"ok\"}\n",
-        "uvicorn.run(app,host='0.0.0.0',port=8005)\n",
-        "PY\n",
-        "python - <<'PY' &>/dev/null &\n",
-        "from fastapi import FastAPI; import uvicorn\n",
-        "app=FastAPI(); @app.get('/co2')\n",
-        "def co2(): return {\"ppm\":420.42}\n",
-        "uvicorn.run(app,host='0.0.0.0',port=8010)\n",
-        "PY"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 🔗 Expose Grafana & Prometheus with `pyngrok`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "04-ngrok"
-      },
-      "source": [
-        "from pyngrok import ngrok, conf\n",
-        "conf.get_default().region = 'us'\n",
-        "import os\n",
-        "port = int(os.getenv('DASH_PORT', 9000))\n",
-        "grafana = ngrok.connect(port, 'http'); prom = ngrok.connect(9090, 'http')\n",
-        "print('Grafana  →', grafana.public_url)\n",
-        "print('Prometheus →', prom.public_url)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 🏋️ Quick k6 load-test (20 VUs × 30 s)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "05-k6"
-      },
-      "source": [
-        "%%bash\nset -euo pipefail\n",
-        "cat > k6.js <<'JS'\n",
-        "import http from 'k6/http'; import {sleep} from 'k6';\n",
-        "export let options = {vus:20,duration:'30s'};\n",
-        "const A=['finance_agent','biotech_agent','climate_agent','manufacturing_agent','policy_agent'];\n",
-        "export default function(){\n",
-        "  const a=A[Math.floor(Math.random()*A.length)];\n",
-        "  http.post(`http://127.0.0.1:8000/agent/${a}/skill_test`,JSON.stringify({ping:Math.random()}),{headers:{'Content-Type':'application/json'}});\n",
-        "  sleep(0.05);\n",
-        "}\n",
-        "JS\n",
-        "k6 run k6.js"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## ♻️ Continuous PPO trainer (runs async)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "06-trainer"
-      },
-      "source": [
-        "%%bash --bg\n",
-        "python AGI-Alpha-Agent-v0/alpha_factory_v1/continual/ppo_trainer.py"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## ✅ Smoke-probe orchestrator + sample agent call"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "07-health"
-      },
-      "source": [
-        "import requests, time, pprint, json, os\n",
-        "for _ in range(20):\n",
-        "  try:\n",
-        "    if requests.get('http://127.0.0.1:8000/healthz').status_code==200:\n",
-        "      print('orchestrator healthy'); break\n",
-        "  except: pass; time.sleep(2)\n",
-        "resp=requests.post('http://127.0.0.1:8000/agent/finance_agent/skill_test',json={'ping':123}).json()\n",
-        "pprint.pp(resp)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "---\n",
-        "### 🎉 All set!\n",
-        "\n",
-        "* Use the **Grafana** link above (`admin / admin`) to explore dashboards (import JSON if blank)\n",
-        "* Rewards tune automatically; edit `rubric.json` in `continual/` and rerun the trainer cell\n",
-        "* Adapt this notebook to plug in your own domain adapters or extra agents\n",
-        "* When finished, run `docker compose down -v` (or `./teardown_alpha_factory_cross_industry_demo.sh`) to clean up"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Troubleshooting",
-        "",
-        "The demo typically completes setup in under 10 minutes. A code cell prints the detected GPU via `nvidia-smi -L` and falls back to the CPU when no GPU is present.",
-        "Long waits often indicate missing GPU acceleration or network stalls."
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": ""
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "This notebook is a conceptual research prototype. References to \u2018AGI\u2019 or \u2018superintelligence\u2019 describe aspirational goals and do not indicate the presence of real general intelligence. Use at your own risk.\n\n# \ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f Alpha-Factory v1 \u2013 Cross-Industry AGENTIC \u03b1-AGI  \n## _(Google Colab, self-contained)_\n\n**What you get in < 10 minutes**\n\n* \ud83e\ude84 Five domain agents (finance, biotech, climate, mfg, policy) orchestrated by `backend/orchestrator.py`\n* \ud83c\udfcb Continual PPO trainer self-improves agents\n* \ud83d\udd10 Guard-rails (MCP), ed25519 prompt signing, policy deny-list\n* \ud83d\udcca Prometheus **9090** & Grafana **3000** exposed through public *ngrok* URLs\n* \u26a1 30-second k6 load-test to prove antifragility\n* \ud83d\udcf4 Works offline (Mixtral-8\u00d77B GGML) or online (OpenAI key)\n\n> **Paste an `OPENAI_API_KEY` below for better quality,** or leave blank to run fully offline.\nThe script will also generate a random `API_TOKEN` in `.env` for authenticated requests."
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "env"
+   },
+   "source": [
+    "OPENAI_API_KEY = \"\"  # \u2190 \ud83d\udd11  put your key here or leave empty"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Optional offline mode\n",
+    "\n",
+    "Download a `.gguf` weight and set `LLAMA_MODEL_PATH` before running the setup cell. `llama-cpp-python` or `ctransformers` must be installed for local inference:\n",
+    "\n",
+    "```bash\n",
+    "pip install openai-agents llama-cpp-python ctransformers\n",
+    "```\n",
+    "\n",
+    "Example weights and rough CPU throughput:\n",
+    "\n",
+    "| Model | Size | ~tokens/s |\n",
+    "|-------|------|-----------|\n",
+    "| TinyLlama-1.1B-Chat Q4_K_M | 380 MB | ~20 |\n",
+    "| Llama-3-8B-Instruct Q4_K_M | 4 GB | ~5 |\n",
+    "| Mixtral-8x7B-Instruct Q4_0 | 7 GB | ~3 |\n",
+    "\n",
+    "When `LLAMA_MODEL_PATH` is defined the orchestrator loads the weight instead of calling OpenAI.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "01-setup"
+   },
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "REPO=AGI-Alpha-Agent-v0\n",
+    "if [ ! -d \"$REPO/.git\" ]; then\n",
+    "  echo '\ud83d\udce5 cloning repo \u2026'\n",
+    "  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git $REPO\n",
+    "fi\n",
+    "cd $REPO\n",
+    "\n",
+    "echo '\ud83d\udd27 installing Python deps \u2026'\n",
+    "pip install -q -r alpha_factory_v1/requirements-colab.txt  # lightweight agent deps\n",
+    "pip install -q ray[default]==2.10.0 uvicorn fastapi pyngrok ctransformers==0.2.27 k6-python subprocess-tee\n",
+    "\n",
+    "# \u2500\u2500\u2500 runtime artefacts \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
+    "mkdir -p alpha_factory_v1/{keys,policies,continual,adapters}\n",
+    "\n",
+    "ssh-keygen -t ed25519 -N '' -q -f alpha_factory_v1/keys/agent_key <<<y || true\n",
+    "PUB=$(cat alpha_factory_v1/keys/agent_key.pub)\n",
+    "\n",
+    "cat > alpha_factory_v1/.env <<EOF\n",
+    "ALPHA_FACTORY_MODE=cross_industry\n",
+    "OPENAI_API_KEY=${OPENAI_API_KEY}\n",
+    "OPENAI_API_BASE=${OPENAI_API_BASE:-https://api.openai.com/v1}\n",
+    "AGENTS_ENABLED=finance_agent biotech_agent climate_agent manufacturing_agent policy_agent\n",
+    "PROMPT_SIGN_PUBKEY=${PUB}\n",
+    "EOF\n",
+    "\n",
+    "cat > alpha_factory_v1/policies/redteam.json <<'JSON'\n",
+    "{\"id\":\"af_v1_guard\",\"patterns_deny\":[\"(?i)breakout\",\"(?i)leak\",\"(?i)privileged\"],\"max_tokens\":2048}\n",
+    "JSON\n",
+    "\n",
+    "# \u2500\u2500\u2500 offline LLM (Mixtral) if no key \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
+    "if [ -z \"${OPENAI_API_KEY}\" ]; then\n",
+    "  pip install -q sentencepiece\n",
+    "  python - <<'PY'\n",
+    "from ctransformers import AutoModelForCausalLM\n",
+    "AutoModelForCausalLM.from_pretrained(\n",
+    "  \"TheBloke/Mixtral-8x7B-Instruct-GGML\",\n",
+    "  model_file=\"mixtral-8x7b-instruct.ggmlv3.q4_K_M.bin\",\n",
+    "  local_files_only=False)\n",
+    "PY\n",
+    "fi"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \u2699\ufe0f Patch orchestrator: add `/update_model` hot-reload endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "02-patch"
+   },
+   "source": [
+    "%%bash\n",
+    "apply_patch() {\n",
+    "python - <<'PY'\n",
+    "import importlib, textwrap, pathlib, inspect\n",
+    "src = pathlib.Path('AGI-Alpha-Agent-v0/alpha_factory_v1/backend/orchestrator.py')\n",
+    "code = src.read_text()\n",
+    "if 'update_model' in code:\n",
+    "    print('\u2705 update_model already present'); raise SystemExit\n",
+    "insertion = textwrap.dedent('''\\n@router.post(\"/agent/{agent_id}/update_model\")\\nasync def update_model(agent_id: str, file: bytes = File(...)):\\n    if agent_id not in AGENT_REGISTRY:\\n        raise HTTPException(status_code=404, detail=\"agent not found\")\\n    import tempfile, zipfile, io\\n    with tempfile.TemporaryDirectory() as td:\\n        zf = zipfile.ZipFile(io.BytesIO(file)); zf.extractall(td)\\n        AGENT_REGISTRY[agent_id].load_weights(td)\\n    return {\"status\":\"ok\"}\\n''')\n",
+    "marker = '# === ROUTES ==='\n",
+    "idx = code.index(marker) + len(marker)\n",
+    "new_code = code[:idx] + insertion + code[idx:]\n",
+    "src.write_text(new_code)\n",
+    "print('\ud83d\ude80 patched orchestrator with hot-reload endpoint')\n",
+    "PY\n",
+    "}\n",
+    "apply_patch"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \ud83d\ude80 Launch orchestrator, agents, Ray & mock adapters (background)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "03-launch"
+   },
+   "source": [
+    "%%bash --bg\n",
+    "cd AGI-Alpha-Agent-v0/alpha_factory_v1\n",
+    "ray start --head --dashboard-host 0.0.0.0 --port 6379 --dashboard-port 8265 &>/dev/null &\n",
+    "uvicorn backend.orchestrator:app --host 0.0.0.0 --port 8000 &>/dev/null &\n",
+    "\n",
+    "# tiny PubMed & Carbon adapters\n",
+    "python - <<'PY' &>/dev/null &\n",
+    "from fastapi import FastAPI; import uvicorn, random\n",
+    "app=FastAPI(); @app.get('/')\n",
+    "def root(): return {\"msg\":\"ok\"}\n",
+    "uvicorn.run(app,host='0.0.0.0',port=8005)\n",
+    "PY\n",
+    "python - <<'PY' &>/dev/null &\n",
+    "from fastapi import FastAPI; import uvicorn\n",
+    "app=FastAPI(); @app.get('/co2')\n",
+    "def co2(): return {\"ppm\":420.42}\n",
+    "uvicorn.run(app,host='0.0.0.0',port=8010)\n",
+    "PY"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \ud83d\udd17 Expose Grafana & Prometheus with `pyngrok`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "04-ngrok"
+   },
+   "source": [
+    "from pyngrok import ngrok, conf\n",
+    "conf.get_default().region = 'us'\n",
+    "import os\n",
+    "port = int(os.getenv('DASH_PORT', 9000))\n",
+    "grafana = ngrok.connect(port, 'http'); prom = ngrok.connect(9090, 'http')\n",
+    "print('Grafana  \u2192', grafana.public_url)\n",
+    "print('Prometheus \u2192', prom.public_url)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \ud83c\udfcb\ufe0f Quick k6 load-test (20 VUs \u00d7 30 s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "05-k6"
+   },
+   "source": [
+    "%%bash\nset -euo pipefail\n",
+    "cat > k6.js <<'JS'\n",
+    "import http from 'k6/http'; import {sleep} from 'k6';\n",
+    "export let options = {vus:20,duration:'30s'};\n",
+    "const A=['finance_agent','biotech_agent','climate_agent','manufacturing_agent','policy_agent'];\n",
+    "export default function(){\n",
+    "  const a=A[Math.floor(Math.random()*A.length)];\n",
+    "  http.post(`http://127.0.0.1:8000/agent/${a}/skill_test`,JSON.stringify({ping:Math.random()}),{headers:{'Content-Type':'application/json'}});\n",
+    "  sleep(0.05);\n",
+    "}\n",
+    "JS\n",
+    "k6 run k6.js"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \u267b\ufe0f Continuous PPO trainer (runs async)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "06-trainer"
+   },
+   "source": [
+    "%%bash --bg\n",
+    "python AGI-Alpha-Agent-v0/alpha_factory_v1/continual/ppo_trainer.py"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \u2705 Smoke-probe orchestrator + sample agent call"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "07-health"
+   },
+   "source": [
+    "import requests, time, pprint, json, os\n",
+    "for _ in range(20):\n",
+    "  try:\n",
+    "    if requests.get('http://127.0.0.1:8000/healthz').status_code==200:\n",
+    "      print('orchestrator healthy'); break\n",
+    "  except: pass; time.sleep(2)\n",
+    "resp=requests.post('http://127.0.0.1:8000/agent/finance_agent/skill_test',json={'ping':123}).json()\n",
+    "pprint.pp(resp)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "### \ud83c\udf89 All set!\n",
+    "\n",
+    "* Use the **Grafana** link above (`admin / admin`) to explore dashboards (import JSON if blank)\n",
+    "* Rewards tune automatically; edit `rubric.json` in `continual/` and rerun the trainer cell\n",
+    "* Adapt this notebook to plug in your own domain adapters or extra agents\n",
+    "* When finished, run `docker compose down -v` (or `./teardown_alpha_factory_cross_industry_demo.sh`) to clean up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Troubleshooting",
+    "",
+    "The demo typically completes setup in under 10 minutes. A code cell prints the detected GPU via `nvidia-smi -L` and falls back to the CPU when no GPU is present.",
+    "Long waits often indicate missing GPU acceleration or network stalls."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- document example GGUF weights and performance
- clarify that llama-cpp-python or ctransformers is required for offline mode

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: torch required)*
- `pre-commit run --files README.md alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb` *(failed: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_684ad23df0508333a4682937bd4d5553