### PR TITLE
[alpha_factory] improve test skip docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,11 @@ a lightweight smoke check via:
 ```bash
 pytest -m 'not e2e'
 ```
+Running without a GPU is fully supported. The world model and evolution tests
+fall back to CPU execution and are automatically skipped when `torch` is
+absent. Other optional packages behave the same way—tests relying on
+`fastapi`, `playwright` or `httpx` use `pytest.importorskip()` so the suite
+continues even in minimal environments.
 6. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 7. Before running the tests, execute `python check_env.py --auto-install` once
    more (add `--wheelhouse <dir>` when offline), then run `pytest -q`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,10 @@ import sys
 import types
 import importlib.util
 
+# Skip early when heavy optional deps are missing to avoid stack traces
+pytest.importorskip("numpy", reason="numpy required")
+pytest.importorskip("torch", reason="torch required")
+
 try:  # skip all tests if the simulation module fails to import
     from src.simulation import replay
 except Exception as exc:  # pragma: no cover - environment issue
@@ -23,9 +27,6 @@ conds_mod.every = lambda *_: None
 rocketry_stub.conds = conds_mod
 sys.modules.setdefault("rocketry", rocketry_stub)
 sys.modules.setdefault("rocketry.conds", conds_mod)
-
-pytest.importorskip("numpy", reason="numpy required")
-pytest.importorskip("torch", reason="torch required")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- handle heavy optional deps earlier in `tests/conftest.py`
- explain skipping behaviour and GPU fallback in `tests/README.md`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684ad637239083338df97a8ddcdecea7