### PR TITLE
[alpha_factory] Update demo Dockerfile path

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install demo dependencies
-COPY ../../../../requirements-demo.txt /tmp/requirements-demo.txt
+COPY ../../../requirements-demo.txt /tmp/requirements-demo.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-demo.txt \
     && pip install --no-cache-dir openai-agents==0.0.16 \
     && rm /tmp/requirements-demo.txt


### PR DESCRIPTION
## Summary
- point to `requirements-demo.txt` from the correct relative path in the Business demo Dockerfile

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: torch required)*
- `docker build -t alpha_business_v3:latest -f alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae198e2e0833384403e185ff445c9