### PR TITLE
[alpha_factory] update demo pinned version

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # Install demo dependencies
 COPY ../../../requirements-demo.txt /tmp/requirements-demo.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-demo.txt \
-    && pip install --no-cache-dir openai-agents==0.0.16 \
+    && pip install --no-cache-dir openai-agents==0.0.17 \
     && rm /tmp/requirements-demo.txt
 
 # Copy only the demo package

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -19,7 +19,7 @@ of a real general intelligence. Use at your own risk.
 ## 🛠 Requirements
 
 - **Python ≥3.11**
-- [`openai-agents`](https://openai.github.io/openai-agents-python/) `>=0.0.16` is mandatory for online mode.
+- [`openai-agents`](https://openai.github.io/openai-agents-python/) `==0.0.17` is mandatory for online mode.
 - [`llama-cpp-python`](https://pypi.org/project/llama-cpp-python/) and [`ctransformers`](https://pypi.org/project/ctransformers/) enable the offline fallback.
 - Run `python check_env.py --auto-install` to fetch missing packages, or supply `--wheelhouse <dir>` when installing offline.
 


### PR DESCRIPTION
# Summary
- pin OpenAI agents version in business demo docs and Dockerfile

# Checks
- `pre-commit run --files requirements-demo.lock alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md alpha_factory_v1/demos/alpha_agi_business_3_v1/Dockerfile` *(failed: semgrep install hung)*
- `python check_env.py --auto-install` *(failed: pip install timed out)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aecc12c4c8333821d1368321df724