### PR TITLE
[alpha_factory] check Agents runtime version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Python must report 3.11 or 3.12 and Docker Compose must be at least 2.5.
   pip install pre-commit
   ```
 - The script `alpha_factory_v1/scripts/preflight.py` enforces this requirement.
+- It verifies the optional `openai_agents` package is at least version `0.0.14`
+  when installed.
 - From the repository root, run `./codex/setup.sh` to install the project in editable mode
   with minimal runtime dependencies. This ensures all relative paths resolve correctly.
 - After installation, run `pre-commit run --all-files` once to verify formatting and hooks.

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -35,6 +35,7 @@ else:
 MIN_PY = (3, 11)
 MAX_PY = (3, 13)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
+MIN_OPENAI_AGENTS_VERSION = "0.0.14"
 
 COLORS = {
     "RED": "\033[31m",
@@ -149,7 +150,7 @@ def check_network(host: str = "pypi.org", timeout: float = 2.0) -> bool:
     return True
 
 
-def check_openai_agents_version(min_version: str = "0.0.14") -> bool:
+def check_openai_agents_version(min_version: str = MIN_OPENAI_AGENTS_VERSION) -> bool:
     """Verify the installed Agents runtime is new enough.
 
     This checks both the ``openai_agents`` and ``agents`` packages.
@@ -165,7 +166,13 @@ def check_openai_agents_version(min_version: str = "0.0.14") -> bool:
             return True
 
     mod = importlib.import_module(module_name)
-    version = getattr(mod, "__version__", "0")
+    if not hasattr(mod, "__version__"):
+        banner(
+            f"{module_name} missing __version__; >={min_version} required",
+            "RED",
+        )
+        return False
+    version = mod.__version__
     if _version_lt(version, min_version):
         banner(
             f"{module_name} {version} detected; >={min_version} required",

--- a/tests/test_preflight_openai_agents_version.py
+++ b/tests/test_preflight_openai_agents_version.py
@@ -9,8 +9,10 @@ from alpha_factory_v1.scripts import preflight
 
 
 class TestPreflightOpenAIAgentsVersion(unittest.TestCase):
-    def _run_check(self, module_name: str, version: str) -> bool:
-        fake_mod = types.SimpleNamespace(__version__=version)
+    def _run_check(self, module_name: str, version: str | None) -> bool:
+        fake_mod = types.SimpleNamespace()
+        if version is not None:
+            fake_mod.__version__ = version
         orig_import_module = importlib.import_module
         orig_find_spec = importlib.util.find_spec
 
@@ -41,6 +43,11 @@ class TestPreflightOpenAIAgentsVersion(unittest.TestCase):
         for name in ("openai_agents", "agents"):
             with self.subTest(module=name):
                 self.assertTrue(self._run_check(name, "0.0.15"))
+
+    def test_missing_version_fails(self) -> None:
+        for name in ("openai_agents", "agents"):
+            with self.subTest(module=name):
+                self.assertFalse(self._run_check(name, None))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- require openai_agents >= 0.0.14 during preflight
- handle missing `__version__` attribute in preflight check
- document the new requirement in AGENTS.md
- test missing version handling

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --timeout 1` *(fails: Timed out installing baseline requirements)*
- `pytest -q tests/test_preflight_openai_agents_version.py` *(fails: Skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684af279e5288333ab335c1e053b6f0a