### PR TITLE
[alpha_factory] fix path in business demo script

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
-root_dir="${script_dir%/*/*}"
+root_dir="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || echo "${script_dir%/*/*/*}")"
 
 cd "$root_dir"
 


### PR DESCRIPTION
## Summary
- fix root directory detection in `run_business_3_demo.sh`

## Testing
- `python scripts/check_python_deps.py` *(fails: missing numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: could not install packages)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af483b6948333862852cd200ea0df