### PR TITLE
[alpha_factory] bump openai-agents version

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ The adapters initialise automatically when these optional packages are present.
 Install these extras to unlock additional features:
 
 - `pip install gradio` – enables the MuZero planning dashboard.
-- `pip install openai-agents` – activates the official Agents runtime used for commentary.
+- `pip install openai-agents==0.0.17` – activates the official Agents runtime used for commentary.
 - `pip install google-adk` and set `ALPHA_FACTORY_ENABLE_ADK=true` – starts the Google ADK gateway for cross‑organisation agent exchange.
 
 To regenerate `requirements.lock` from `requirements.txt` with hashes, run:

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -4,5 +4,5 @@ torch>=2.2
 gymnasium[classic-control]>=0.29
 gradio>=4.35
 filelock>=3.13
-openai-agents>=0.0.16
+openai-agents==0.0.17
 


### PR DESCRIPTION
## Summary
- pin `openai-agents` to 0.0.17 in `requirements-demo.txt`
- document the version in the README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files requirements-demo.txt README.md` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684af736bc1883338d2df91ba0d4fd1b