### PR TITLE
[alpha_factory] add env example for business 3 demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/.env.example
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/.env.example
@@ -1,0 +1,9 @@
+# Example settings for run_business_3_demo.sh
+# Copy to '.env' and edit as needed.
+
+OPENAI_API_KEY=
+LOCAL_LLM_URL=http://ollama:11434/v1
+ADK_HOST=http://localhost:9000
+A2A_HOST=localhost
+A2A_PORT=0
+LLAMA_MODEL_PATH=

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -313,6 +313,7 @@ $ python alpha_agi_business_3_v1.py --cycles 1 --loglevel info
 - Python ≥3.11 with packages from `requirements.txt` installed. The
   `run_business_3_demo.sh` helper now builds a Docker image that includes
   `openai_agents` by default.
+- Copy `.env.example` in this folder to `.env` and adjust the values before running.
 - `ADK_HOST` – optional. URL of the ADK gateway to forward cycle summaries.
 - `A2A_PORT` – enable gRPC A2A messages when set to a port number.
 


### PR DESCRIPTION
## Summary
- include `.env.example` next to `run_business_3_demo.sh`
- update business 3 README to reference the example env file

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to complete)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md alpha_factory_v1/demos/alpha_agi_business_3_v1/.env.example` *(failed to initialize)*

------
https://chatgpt.com/codex/tasks/task_e_684afccf5b5c833392d7a850d5076317