### PR TITLE
[alpha_factory] bump openai-agents runtime

### DIFF
--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -87,7 +87,7 @@ RUN if [ -f /tmp/requirements-lock.txt ]; then \
     fi && \
     # ⬇ Explicitly ensure critical agent frameworks are present
     pip install --no-cache-dir \
-        openai-agents>=0.0.16 \   # OpenAI Agents SDK (beta)
+        openai-agents>=0.0.17 \   # OpenAI Agents SDK (beta)
         "google-adk @ git+https://github.com/google/adk-python@main#egg=google-adk" \
         anthropic>=0.21 \
         gunicorn rocketry prometheus-client && \

--- a/alpha_factory_v1/backend/requirements-lock.txt
+++ b/alpha_factory_v1/backend/requirements-lock.txt
@@ -30,7 +30,7 @@ gitpython==3.1.43
 
 # ────────── LLM / Agents stack ─────────────────────────────────────────
 openai==1.82.0
-openai-agents==0.0.16
+openai-agents==0.0.17
 anthropic==0.21.1
 litellm==1.31.6
 tiktoken==0.5.2

--- a/alpha_factory_v1/backend/requirements.txt
+++ b/alpha_factory_v1/backend/requirements.txt
@@ -31,7 +31,7 @@ gitpython~=3.1          # local PR simulation for self-healing demo
 
 # ─────────── LLM / Agents stack ────────────────────────────────────────
 openai>=1.82.0,<2.0       # GPT-4o & embeddings (sync with root)
-openai-agents>=0.0.16   # **critical** – official Agents SDK
+openai-agents>=0.0.17   # **critical** – official Agents SDK
 anthropic>=0.21         # Claude & MCP bridge
 litellm>=1.31           # local gateway / fallback router
 tiktoken>=0.5

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in
@@ -17,7 +17,7 @@ rocketry==2.5.1
 pytest==8.3.5
 gitpython==3.1.44
 openai==1.77.0
-openai-agents==0.0.16
+openai-agents==0.0.17
 anthropic==0.50.0
 litellm==1.67.5
 tiktoken==0.9.0

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -17,7 +17,7 @@ rocketry==2.5.1
 pytest==8.3.5
 gitpython==3.1.44
 openai==1.77.0
-openai-agents==0.0.16
+openai-agents==0.0.17
 anthropic==0.50.0
 litellm==1.67.5
 tiktoken==0.9.0

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
@@ -17,7 +17,7 @@ rocketry==2.5.1
 pytest==8.3.5
 gitpython==3.1.44
 openai==1.77.0
-openai-agents==0.0.16
+openai-agents==0.0.17
 anthropic==0.50.0
 litellm==1.67.5
 tiktoken==0.9.0

--- a/alpha_factory_v1/requirements-colab.lock
+++ b/alpha_factory_v1/requirements-colab.lock
@@ -6,7 +6,7 @@ k6-python
 subprocess-tee
 ray[default]==2.10.0
 openai>=1.82.0,<2.0
-openai-agents>=0.0.16
+openai-agents>=0.0.17
 anthropic>=0.21
 litellm>=1.31
 pytest~=8.2

--- a/alpha_factory_v1/requirements-colab.txt
+++ b/alpha_factory_v1/requirements-colab.txt
@@ -9,7 +9,7 @@ subprocess-tee
 # Ray version mirrors the Docker setup
 ray[default]==2.10.0
 openai>=1.82.0,<2.0
-openai-agents>=0.0.16
+openai-agents>=0.0.17
 anthropic>=0.21
 litellm>=1.31
 pytest~=8.2

--- a/alpha_factory_v1/requirements.lock
+++ b/alpha_factory_v1/requirements.lock
@@ -54,7 +54,7 @@ mypy_extensions==1.1.0
 nodeenv==1.9.1
 numpy==2.2.6
 openai==1.82.0
-openai-agents==0.0.16
+openai-agents==0.0.17
 opentelemetry-api==1.33.1
 opentelemetry-exporter-gcp-trace==1.9.0
 opentelemetry-resourcedetector-gcp==1.9.0a0

--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -41,7 +41,7 @@ playwright~=1.42
 
 # ─────────── LLM / Agents stack ────────────────────────────────────────
 openai>=1.82.0,<2.0       # GPT-4o & embeddings (sync with backend)
-openai-agents>=0.0.16   # **critical** – official Agents SDK
+openai-agents>=0.0.17   # **critical** – official Agents SDK
 anthropic>=0.21         # Claude & MCP bridge
 litellm>=1.31           # local gateway / fallback router
 tiktoken>=0.5


### PR DESCRIPTION
## Summary
- require `openai-agents>=0.0.17`
- update various lock files for the new version
- keep demo Dockerfile and docs in sync

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: Operation cancelled)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files alpha_factory_v1/requirements.txt alpha_factory_v1/requirements.lock alpha_factory_v1/requirements-colab.txt alpha_factory_v1/requirements-colab.lock alpha_factory_v1/backend/requirements.txt alpha_factory_v1/backend/requirements-lock.txt alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock alpha_factory_v1/Dockerfile` *(failed: command not found / cancelled)*


------
https://chatgpt.com/codex/tasks/task_e_684b007d66ec8333bfd2a0c9bd334c30