### PR TITLE
[alpha_factory] fix: add license header to business v3 tests

### DIFF
--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 import types


### PR DESCRIPTION
## Summary
- add Apache license header to tests/test_alpha_agi_business_3_v1.py

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `WHEELHOUSE=wheels python check_env.py --auto-install` *(fails: No matching distribution for fastapi)*
- `pytest -q` *(fails: Skipped: torch required)*
- `pre-commit run --files tests/test_alpha_agi_business_3_v1.py` *(fails: interrupted during semgrep env setup)*

------
https://chatgpt.com/codex/tasks/task_e_684b0b9432588333b8b8948be5d35930