### PR TITLE
[alpha_factory] docs: point Business 3 users to offline setup guide

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -22,6 +22,7 @@ of a real general intelligence. Use at your own risk.
 - [`openai-agents`](https://openai.github.io/openai-agents-python/) `==0.0.17` is mandatory for online mode.
 - [`llama-cpp-python`](https://pypi.org/project/llama-cpp-python/) and [`ctransformers`](https://pypi.org/project/ctransformers/) enable the offline fallback.
 - Run `python check_env.py --auto-install` to fetch missing packages, or supply `--wheelhouse <dir>` when installing offline.
+  See [alpha_factory_v1/scripts/README.md](../../scripts/README.md#offline-setup) for details on building and using a wheelhouse.
 
 ## 📚 Table of Contents
 0. [Executive Summary](#0)


### PR DESCRIPTION
## Summary
- mention wheelhouse instructions in the Business 3 README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: timeout/cancelled)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684b0d401e848333ba1cde9d3f98aff5