### PR TITLE
[alpha_factory] clarify A2A_HOST setting

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -319,6 +319,7 @@ $ python alpha_agi_business_3_v1.py --cycles 1 --loglevel info
 - Run `python check_env.py --auto-install` after sourcing so optional dependencies install correctly.
 - `ADK_HOST` – optional. URL of the ADK gateway to forward cycle summaries.
 - `A2A_PORT` – enable gRPC A2A messages when set to a port number.
+- `A2A_HOST` – host for the A2A gRPC server. Defaults to `localhost`.
 
 #### Offline Usage
 


### PR DESCRIPTION
## Summary
- mention `A2A_HOST` environment variable alongside `A2A_PORT` in the Business 3 demo README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md` *(fails: Makefile missing for proto verify)*
- `python scripts/check_python_deps.py` *(fails: numpy, pandas missing)*
- `python check_env.py --auto-install` *(fails: operation cancelled)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684b113b757883338fb49b4f6425d756