### PR TITLE
[alpha_factory] remove offline flag

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -266,8 +266,10 @@ helm install omega-lattice omega/omega-lattice \
 ```bash
 python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
-python -m alpha_factory_v1.demos.alpha_agi_business_3_v1 --offline
+python -m alpha_factory_v1.demos.alpha_agi_business_3_v1
 ```
+
+Offline mode activates automatically when `OPENAI_API_KEY` is unset.
 
 ### 8.4 Colab Notebook
 


### PR DESCRIPTION
## Summary
- update bare-metal command for alpha_agi_business_3 demo
- document automatic offline mode when OPENAI_API_KEY is unset

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md` *(fails: proto-verify hook requires Makefile)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --timeout 60` *(interrupted)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684b167b06cc8333949abaf34868b589