### PR TITLE
[alpha_factory] improve CI extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
+          pip install -r requirements-demo.txt
           pip install pytest pytest-cov pytest-benchmark mutmut
       - name: Verify environment
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ Follow these steps when installing without internet access:
 - The unit tests rely on `fastapi`, `opentelemetry-api`, `openai-agents` and `google-adk`. `./codex/setup.sh` installs these packages automatically. When skipping the setup script, run
   `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no
   missing packages before running `pytest`.
+  Install `requirements-demo.txt` as well when running tests that depend on
+  heavy extras such as `numpy` and `torch`.
 - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes.
   If failures remain, document them in the PR description.
 - When running tests directly from the repository without installation, set `PYTHONPATH`


### PR DESCRIPTION
## Summary
- mention heavy extras in contributor docs so tests don't silently fail
- install demo extras during CI

## Testing
- `python scripts/check_python_deps.py` *(fails: missing numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: network timeout)*
- `pytest -q` *(fails: torch missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b1bb209a8833398f822e586bfbc60