### PR TITLE
[alpha_factory] dynamic signals for omega-lattice demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -302,7 +302,7 @@ You can also run the Dockerised version:
 
 ```bash
 $ python alpha_agi_business_3_v1.py --cycles 1 --loglevel info
-2025-06-11 17:16:10 INFO     | ΔH=0.04 ΔS=0.01 β=1.0 → ΔG=0.03
+2025-06-11 17:16:10 INFO     | ΔH=0.027 ΔS=0.008 β=1.04 → ΔG=0.019
 2025-06-11 17:16:10 INFO     | LLM: LLM offline
 2025-06-11 17:16:10 INFO     | [Model] New weights committed (Gödel-proof verified)
 ```


### PR DESCRIPTION
## Summary
- add randomness to `alpha_agi_business_3_v1` demo
- update sample output in demo README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --timeout 1` *(fails: timed out installing baseline requirements)*
- `pytest -q` *(fails: Skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684b214e362083338533bd9e8de9a8cf