### PR TITLE
[alpha_factory] remove unused import

### DIFF
--- a/src/archive/service.py
+++ b/src/archive/service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 import os


### PR DESCRIPTION
## Summary
- delete the unused `contextlib` import from `src/archive/service.py`

## Testing
- `pre-commit run --files src/archive/service.py` *(fails: mypy, proto-verify)*
- `python scripts/check_python_deps.py` *(fails: missing numpy, pandas)*
- `python check_env.py --auto-install` *(fails: keyboard interrupt during pip install)*
- `pytest -q` *(fails: torch required)*


------
https://chatgpt.com/codex/tasks/task_e_684b288651788333a319a9e54394a4ae