### PR TITLE
[alpha_factory] add docstrings for public methods

### DIFF
--- a/src/agents/meta_refinement_agent.py
+++ b/src/agents/meta_refinement_agent.py
@@ -62,18 +62,17 @@ class MetaRefinementAgent:
             except Exception:
                 current = 0
             new_val = current + 1
-            diff = (
-                "--- a/metric.txt\n"
-                "+++ b/metric.txt\n"
-                "@@\n"
-                f"-{current}\n"
-                f"+{new_val}\n"
-            )
+            diff = "--- a/metric.txt\n" "+++ b/metric.txt\n" "@@\n" f"-{current}\n" f"+{new_val}\n"
             return diff
         return propose_diff(str(metric), goal)
 
     # ------------------------------------------------------------------
     def refine(self) -> bool:
+        """Generate and apply a patch addressing the detected bottleneck.
+
+        Returns:
+            bool: ``True`` if the patch was merged, ``False`` otherwise.
+        """
         logs = self._load_logs()
         bottleneck = self._detect_bottleneck(logs)
         if not bottleneck:

--- a/src/agents/self_improver_agent.py
+++ b/src/agents/self_improver_agent.py
@@ -59,6 +59,7 @@ class SelfImproverAgent(BaseAgent):
         self.allowed = list(allowed or ["**"])
 
     async def handle(self, _env: object) -> None:  # pragma: no cover - no messaging
+        """Ignore messages since this agent only operates locally."""
         return None
 
     def _check_allowed(self, diff: str) -> None:
@@ -68,6 +69,7 @@ class SelfImproverAgent(BaseAgent):
                 raise ValueError(f"file '{f}' not allowed")
 
     async def run_cycle(self) -> None:
+        """Apply the proposed patch if valid and update the metric file."""
         if git is None:
             raise RuntimeError("GitPython is required")
         diff = self.patch_file.read_text()

--- a/src/analysis/chaos_monkey.py
+++ b/src/analysis/chaos_monkey.py
@@ -24,6 +24,7 @@ class ChaosMonkey:
         ]
 
     def mutate(self, text: str, case: str) -> str:
+        """Return ``text`` modified according to the specified ``case``."""
         match case:
             case "contradiction":
                 return text + " although the opposite is true"

--- a/src/archive/__init__.py
+++ b/src/archive/__init__.py
@@ -52,16 +52,19 @@ class Archive:
         metrics.dgm_lineage_depth.set(len(records))
 
     def add(self, meta: dict[str, Any], score: float) -> None:
+        """Insert an agent entry and update archive metrics."""
         with sqlite3.connect(self.path) as cx:
             cx.execute("INSERT INTO agents(meta, score) VALUES (?, ?)", (json.dumps(meta), score))
         self._update_metrics()
 
     def all(self) -> List[Agent]:
+        """Return all archived agents sorted by insertion order."""
         with sqlite3.connect(self.path) as cx:
             rows = list(cx.execute("SELECT id, meta, score FROM agents ORDER BY id"))
         return [Agent(id=r[0], meta=json.loads(r[1]), score=float(r[2])) for r in rows]
 
     def sample(self, k: int, *, lam: float = 10.0, alpha0: float = 0.5) -> List[Agent]:
+        """Draw ``k`` agents using a logistic ranking scheme."""
         agents = self.all()
         if not agents:
             return []

--- a/src/archive/db.py
+++ b/src/archive/db.py
@@ -83,11 +83,13 @@ class ArchiveDB:
             session.commit()
 
     def add(self, entry: ArchiveEntry) -> None:
+        """Insert or update ``entry`` in the database."""
         with Session(self.engine) as session:
             session.merge(_ArchiveRow(**dataclasses.asdict(entry)))
             session.commit()
 
     def get(self, h: str) -> ArchiveEntry | None:
+        """Return the entry matching ``h`` or ``None`` if missing."""
         with Session(self.engine) as session:
             row = session.get(_ArchiveRow, h)
             if row is None:
@@ -102,6 +104,7 @@ class ArchiveDB:
             )
 
     def history(self, start_hash: str) -> Iterator[ArchiveEntry]:
+        """Yield ancestral lineage starting from ``start_hash``."""
         current = self.get(start_hash)
         while current is not None:
             yield current

--- a/src/archive/solution_archive.py
+++ b/src/archive/solution_archive.py
@@ -57,6 +57,7 @@ class SolutionArchive:
         return int(score // 10)
 
     def add(self, sector: str, approach: str, score: float, data: Mapping[str, Any]) -> None:
+        """Insert a solution entry grouped by sector and approach."""
         band = self._band(score)
         self.conn.execute(
             "INSERT INTO solutions(sector, approach, score, band, data, ts) VALUES (?,?,?,?,?,?)",
@@ -71,6 +72,7 @@ class SolutionArchive:
         approach: str | None = None,
         band: int | None = None,
     ) -> list[Solution]:
+        """Return solutions matching the provided filters."""
         clauses: list[str] = []
         params: list[Any] = []
         if sector is not None:
@@ -100,11 +102,13 @@ class SolutionArchive:
         return result
 
     def diversity_histogram(self) -> dict[tuple[str, str], int]:
+        """Return entry counts keyed by ``(sector, approach)``."""
         cur = self.conn.execute("SELECT sector, approach, COUNT(*) FROM solutions GROUP BY sector, approach")
         rows = cur.fetchall()
         return {(r[0], r[1]): int(r[2]) for r in rows}
 
     def close(self) -> None:
+        """Close the underlying connection."""
         if self.conn:
             self.conn.close()
             self.conn = None

--- a/src/critics/dual_critic_service.py
+++ b/src/critics/dual_critic_service.py
@@ -22,6 +22,7 @@ except Exception:  # pragma: no cover - optional
     JSONResponse = None  # type: ignore
 
 if FastAPI is not None:
+
     class CritiqueRequest(BaseModel):
         context: str
         response: str
@@ -79,6 +80,7 @@ class DualCriticService:
         return score, citations
 
     def score(self, context: str, response: str) -> Dict[str, Any]:
+        """Return logic and feasibility scores for ``response`` given ``context``."""
         logic = self.logic_score(context, response)
         feas, cites = self.feasibility_score(response)
         reasons = []
@@ -97,6 +99,7 @@ class DualCriticService:
 
     # ------------------------------------------------------------------
     def create_app(self) -> "FastAPI":
+        """Return a minimal FastAPI app exposing the ``/critique`` endpoint."""
         if FastAPI is None:
             raise RuntimeError("FastAPI not installed")
 
@@ -118,6 +121,7 @@ class DualCriticService:
         return json.dumps(result).encode()
 
     async def start_grpc(self, port: int) -> None:
+        """Launch a gRPC server listening on ``port``."""
         if grpc is None:
             raise RuntimeError("grpc not installed")
         server = grpc.aio.server()
@@ -133,12 +137,14 @@ class DualCriticService:
         self._server = server
 
     async def stop_grpc(self) -> None:
+        """Stop the running gRPC server if one exists."""
         if self._server:
             await self._server.stop(0)
             self._server = None
 
 
 # ─────────────────────────── FastAPI helper ─────────────────────────────
+
 
 def create_app(service: DualCriticService) -> "FastAPI":
     return service.create_app()

--- a/src/evaluators/feasibility_critic.py
+++ b/src/evaluators/feasibility_critic.py
@@ -33,6 +33,7 @@ class FeasibilityCritic:
         return len(sa & sb) / len(sa | sb)
 
     def score(self, genome: str | Iterable[float]) -> float:
+        """Return a feasibility score based on Jaccard overlap."""
         tokens = str(genome).lower().split()
         best = 0.0
         for ex in self.examples:

--- a/src/evaluators/logic_critic.py
+++ b/src/evaluators/logic_critic.py
@@ -29,6 +29,7 @@ class LogicCritic:
         self.scale = max(len(self.examples) - 1, 1)
 
     def score(self, genome: str | Iterable[float]) -> float:
+        """Return a heuristic logic score for ``genome``."""
         key = str(genome).lower()
         pos = self.index.get(key, -1)
         base = (pos + 1) / (self.scale + 1) if pos >= 0 else 0.0

--- a/src/evaluators/novelty.py
+++ b/src/evaluators/novelty.py
@@ -52,6 +52,7 @@ class NoveltyIndex:
         self.count = 0
 
     def add(self, text: str) -> None:
+        """Index the embedding of ``text`` and update the mean vector."""
         vec = embed(text)
         if self.index is not None:
             self.index.add(vec)
@@ -59,6 +60,7 @@ class NoveltyIndex:
         self.count += 1
 
     def divergence(self, text: str) -> float:
+        """Return the KL divergence between ``text`` and the index mean."""
         vec = embed(text)
         if self.count == 0:
             return 1.0

--- a/src/evolve.py
+++ b/src/evolve.py
@@ -50,9 +50,11 @@ class InMemoryArchive:
         metrics.dgm_lineage_depth.set(len(self._items))
 
     def all(self) -> Sequence[Candidate]:
+        """Return a copy of all archived candidates."""
         return list(self._items)
 
     async def accept(self, cand: Candidate) -> None:
+        """Add ``cand`` to the archive and update metrics."""
         self._items.append(cand)
         self._update_metrics()
 

--- a/src/self_edit/tools.py
+++ b/src/self_edit/tools.py
@@ -269,6 +269,7 @@ class FileToolsADK(adk.Agent):
         ),
     )
     def view_task(self, *, path: str, start: int = 0, end: Optional[int] = None) -> dict[str, str]:
+        """Return file contents between ``start`` and ``end``."""
         return {"text": view(path, start, end)}
 
     @adk.task(
@@ -289,6 +290,7 @@ class FileToolsADK(adk.Agent):
         output_schema=adk.JsonSchema({"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}),
     )
     def edit_task(self, *, path: str, start: int, end: Optional[int] = None, new_code: str) -> dict[str, bool]:
+        """Replace a range of lines in ``path`` with ``new_code``."""
         edit(path, start, end, new_code)
         return {"ok": True}
 
@@ -311,6 +313,7 @@ class FileToolsADK(adk.Agent):
         ),
     )
     def replace_task(self, *, path: str, pattern: str, repl: str) -> dict[str, int]:
+        """Perform a regex replacement in ``path``."""
         return {"count": replace(path, pattern, repl)}
 
     @adk.task(
@@ -332,6 +335,7 @@ class FileToolsADK(adk.Agent):
         ),
     )
     def view_lines_task(self, *, path: str, start: int, end: Optional[int] = None) -> dict[str, str]:
+        """Return inclusive line range from ``path``."""
         return {"text": view_lines(path, start, end)}
 
     @adk.task(
@@ -353,6 +357,7 @@ class FileToolsADK(adk.Agent):
         ),
     )
     def replace_str_task(self, *, path: str, old: str, new: str) -> dict[str, int]:
+        """Replace occurrences of ``old`` with ``new`` in ``path``."""
         return {"count": replace_str(path, old, new)}
 
     @adk.task(
@@ -372,6 +377,7 @@ class FileToolsADK(adk.Agent):
         output_schema=adk.JsonSchema({"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}),
     )
     def insert_after_task(self, *, path: str, anchor: str, code: str) -> dict[str, bool]:
+        """Insert ``code`` after ``anchor`` in ``path``."""
         insert_after(path, anchor, code)
         return {"ok": True}
 
@@ -382,4 +388,5 @@ class FileToolsADK(adk.Agent):
         output_schema=adk.JsonSchema({"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}),
     )
     def undo_task(self) -> dict[str, bool]:
+        """Undo the last edit applied via this tool."""
         return {"ok": undo_last_edit()}

--- a/src/simulation/mats_ops.py
+++ b/src/simulation/mats_ops.py
@@ -26,6 +26,7 @@ class GaussianParam:
         self.rng = rng or random.Random()
 
     def __call__(self, genome: List[float]) -> List[float]:
+        """Return ``genome`` perturbed by Gaussian noise within bounds."""
         low, high = self.bounds
         return [min(high, max(low, g + self.rng.gauss(0.0, self.std))) for g in genome]
 
@@ -38,6 +39,7 @@ class PromptRewrite:
         self.synonyms = {"improve": "enhance", "quick": "fast", "test": "trial"}
 
     def __call__(self, text: str) -> str:
+        """Replace a random word in ``text`` with a simple synonym."""
         words = text.split()
         if not words:
             return text
@@ -51,6 +53,7 @@ class CodePatch:
     """Return code with a small comment appended."""
 
     def __call__(self, code: str) -> str:
+        """Append a ``# patched`` comment to ``code``."""
         suffix = "# patched"
         if not code.endswith("\n"):
             code += "\n"
@@ -88,6 +91,7 @@ class SelfRewriteOperator:
         self._op = PromptRewrite(rng=self.rng)
 
     def __call__(self, text: str) -> str:
+        """Return ``text`` after applying a series of rewrites."""
         for _ in range(self.steps):
             if self.templates and self.rng.random() < self.reuse_rate:
                 text = self.rng.choice(self.templates)
@@ -122,11 +126,7 @@ class SelfRewriteOperator:
         import tempfile
 
         try:
-            root = (
-                Path(
-                    subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
-                )
-            )
+            root = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
         except subprocess.CalledProcessError:
             return False
 


### PR DESCRIPTION
## Summary
- document refine cycle in MetaRefinementAgent
- describe SelfImproverAgent lifecycle helpers
- clarify ChaosMonkey, HashArchive and ArchiveService routines
- document archive helper methods and novelty evaluators
- add docstrings to self-edit tools and simulation operators

## Testing
- `ruff check src`
- `mypy --strict src/agents/meta_refinement_agent.py src/agents/self_improver_agent.py src/analysis/chaos_monkey.py src/archive/__init__.py src/archive/db.py src/archive/hash_archive.py src/archive/service.py src/archive/solution_archive.py src/critics/dual_critic_service.py src/evaluators/feasibility_critic.py src/evaluators/logic_critic.py src/evaluators/novelty.py src/evolve.py src/self_edit/tools.py src/simulation/mats_ops.py` *(fails: unused ignore comments and type errors)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed: Operation cancelled by user)*
- `pytest -q` *(fails: torch required)*


------
https://chatgpt.com/codex/tasks/task_e_684b30763a108333a8c3184d30813a1e