### PR TITLE
[alpha_factory] Document wheelhouse pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,12 @@ Follow these steps when working without internet access.
      python check_env.py --auto-install --wheelhouse /media/wheels
    pip check
    ```
-`check_env.py` uses the wheels under `/media/wheels`. Set
+   When network access is unavailable, install packages directly from the
+   wheelhouse:
+   ```bash
+   WHEELHOUSE=/media/wheels pip install --no-index --find-links "$WHEELHOUSE" -r requirements.txt
+   ```
+   `check_env.py` uses the wheels under `/media/wheels`. Set
 `WHEELHOUSE=/media/wheels` when running `pre-commit` or the tests so
 dependencies install from the local cache. See
 [Offline Setup](alpha_factory_v1/scripts/README.md#offline-setup) for more

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -36,6 +36,11 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": "When network access is unavailable, set `WHEELHOUSE` to your wheel cache and install dependencies from there:\n```bash\nWHEELHOUSE=/media/wheels pip install --no-index --find-links \"$WHEELHOUSE\" -r requirements.txt\n```"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 0 \u00b7 Runtime check"
    ]


### PR DESCRIPTION
## Summary
- update offline setup docs with `pip install --no-index --find-links`
- mention WHEELHOUSE in the business demo notebook

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --timeout 30` *(fails: timed out installing requirements)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb --hook-stage manual` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_684b328d87c483339af92594b80e4a43