### PR TITLE
[alpha_factory] enhance offline detection

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -124,7 +124,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if auto and not wheelhouse and not has_network():
         print(
-            "No network access detected. Re-run with '--wheelhouse <path>' "
+            "No network access detected. Re-run with '--wheelhouse <dir>' "
             "or set WHEELHOUSE to install packages from local wheels. "
             "See docs/OFFLINE_SETUP.md."
         )
@@ -163,7 +163,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         except subprocess.TimeoutExpired:
             print(
                 "Timed out installing baseline requirements. "
-                "Re-run with '--wheelhouse <path>' to install offline packages. "
+                "Re-run with '--wheelhouse <dir>' to install offline packages. "
                 "See docs/OFFLINE_SETUP.md.",
             )
             if not has_network() and not wheelhouse:
@@ -174,7 +174,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             print("Failed to install baseline requirements", exc.returncode)
             if any(kw in stderr.lower() for kw in ["connection", "temporary failure", "network", "resolve"]):
                 print(
-                    "Network failure detected. Re-run with '--wheelhouse <path>' "
+                    "Network failure detected. Re-run with '--wheelhouse <dir>' "
                     "or set WHEELHOUSE to install offline packages. "
                     "See docs/OFFLINE_SETUP.md."
                 )
@@ -219,7 +219,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 )
             except subprocess.TimeoutExpired:
                 print(
-                    "Timed out installing packages. Re-run with '--wheelhouse <path>' to install from local wheels. "
+                    "Timed out installing packages. Re-run with '--wheelhouse <dir>' to install from local wheels. "
                     "See docs/OFFLINE_SETUP.md.",
                 )
                 if not has_network() and not wheelhouse:
@@ -230,7 +230,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 print("Automatic install failed with code", exc.returncode)
                 if any(kw in stderr.lower() for kw in ["connection", "temporary failure", "network", "resolve"]):
                     print(
-                        "Network failure detected. Re-run with '--wheelhouse <path>' "
+                        "Network failure detected. Re-run with '--wheelhouse <dir>' "
                         "or set WHEELHOUSE to install offline packages. "
                         "See docs/OFFLINE_SETUP.md."
                     )

--- a/tests/test_check_env_network.py
+++ b/tests/test_check_env_network.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""check_env network detection tests."""
+
+import pytest
+import check_env
+
+
+def _no_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(check_env, "REQUIRED", [])
+    monkeypatch.setattr(check_env, "OPTIONAL", [])
+    monkeypatch.setattr(check_env, "warn_missing_core", lambda: [])
+
+
+def test_offline_no_wheelhouse(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Fail fast when offline without a wheelhouse."""
+    _no_missing(monkeypatch)
+    monkeypatch.setattr(check_env, "has_network", lambda: False)
+    monkeypatch.delenv("WHEELHOUSE", raising=False)
+    rc = check_env.main(["--auto-install"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "--wheelhouse <dir>" in out
+
+
+def test_offline_with_wheelhouse(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allow offline installs when --wheelhouse is provided."""
+    _no_missing(monkeypatch)
+    monkeypatch.setattr(check_env, "has_network", lambda: False)
+    rc = check_env.main(["--auto-install", "--wheelhouse", "wheels"])
+    assert rc == 0


### PR DESCRIPTION
## Summary
- detect missing network earlier in setup script and warn to use `--wheelhouse`
- tweak `check_env.py` messages
- test offline failure messaging

## Testing
- `pre-commit run --files check_env.py codex/setup.sh tests/test_check_env_network.py` *(failed: KeyboardInterrupt)*
- `python scripts/check_python_deps.py` *(failed: Missing packages)*
- `python check_env.py --auto-install` *(failed: Operation cancelled)*
- `pytest -q tests/test_check_env_network.py` *(failed: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684b361e14888333a12d9ed35c001050