### PR TITLE
[alpha_factory] Ensure A2A socket optional

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -42,11 +42,15 @@ except Exception:  # pragma: no cover - offline fallback
 
 try:  # optional A2A message socket
     from a2a import A2ASocket  # type: ignore
-    _A2A = A2ASocket(
-        host=os.getenv("A2A_HOST", "localhost"),
-        port=int(os.getenv("A2A_PORT", "0")),
-        app_id="alpha_business_v3",
-    )
+    _port = int(os.getenv("A2A_PORT", "0"))
+    if _port > 0:
+        _A2A = A2ASocket(
+            host=os.getenv("A2A_HOST", "localhost"),
+            port=_port,
+            app_id="alpha_business_v3",
+        )
+    else:
+        _A2A = None
 except Exception:  # pragma: no cover - missing dependency
     A2ASocket = None  # type: ignore
     _A2A = None

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -22,6 +22,23 @@ def test_adk_client_import(monkeypatch):
     assert mod.ADKClient is Client
 
 
+def test_a2a_port_zero(monkeypatch):
+    """`_A2A` should remain ``None`` when ``A2A_PORT=0``."""
+    dummy = types.ModuleType("a2a")
+
+    class DummySocket:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - dummy
+            raise AssertionError("should not be instantiated")
+
+    dummy.A2ASocket = DummySocket
+    monkeypatch.setitem(sys.modules, "a2a", dummy)
+    monkeypatch.setenv("A2A_PORT", "0")
+    if MODULE in sys.modules:
+        del sys.modules[MODULE]
+    mod = importlib.import_module(MODULE)
+    assert mod._A2A is None
+
+
 def test_llm_comment_offline(monkeypatch):
     """`_llm_comment` should use local_llm when OpenAIAgent is unavailable."""
     mod = importlib.import_module(MODULE)


### PR DESCRIPTION
## Summary
- guard A2ASocket creation on A2A_PORT in business demo
- add regression test verifying socket disabled when port is zero

## Testing
- `pytest -q tests/test_alpha_agi_business_3_v1.py`


------
https://chatgpt.com/codex/tasks/task_e_684b474908208333860c63bc3bfca3cb