### PR TITLE
[alpha_factory] stop A2A socket

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -308,20 +308,27 @@ async def main(argv: list[str] | None = None) -> None:
     adk_client = ADKClient(os.getenv("ADK_HOST", "http://localhost:9000")) if ADKClient else None
 
     cycle = 0
-    while True:
-        await run_cycle_async(
-            orchestrator,
-            fin_agent,
-            res_agent,
-            ene_agent,
-            gdl_agent,
-            model,
-            adk_client,
-        )
-        cycle += 1
-        if args.cycles and cycle >= args.cycles:
-            break
-        await asyncio.sleep(args.interval)
+    try:
+        while True:
+            await run_cycle_async(
+                orchestrator,
+                fin_agent,
+                res_agent,
+                ene_agent,
+                gdl_agent,
+                model,
+                adk_client,
+            )
+            cycle += 1
+            if args.cycles and cycle >= args.cycles:
+                break
+            await asyncio.sleep(args.interval)
+    finally:
+        if _A2A:
+            try:
+                _A2A.stop()
+            except Exception:  # pragma: no cover - best effort
+                log.warning("Failed to stop A2A socket", exc_info=True)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- ensure the Alpha Business demo stops its A2A socket
- test that `_A2A.stop()` is invoked

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --timeout 30` *(fails: Timed out installing baseline requirements)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py tests/test_alpha_agi_business_3_v1.py` *(fails: interrupted during environment install)*

------
https://chatgpt.com/codex/tasks/task_e_684b4d2c18d48333bcf549fed482be2f