### PR TITLE
[alpha_factory] Add CLI entry for business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -266,7 +266,7 @@ helm install omega-lattice omega/omega-lattice \
 ```bash
 python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
-python -m alpha_factory_v1.demos.alpha_agi_business_3_v1
+alpha-agi-business-3-v1
 ```
 
 Offline mode activates automatically when `OPENAI_API_KEY` is unset.
@@ -288,7 +288,7 @@ example **Llama‑3‑8B.gguf** – to enable offline inference.
 Run the standalone script directly to simulate one Ω‑Lattice cycle:
 
 ```bash
-python alpha_agi_business_3_v1.py --loglevel info
+alpha-agi-business-3-v1 --loglevel info
 ```
 If the **OpenAI Agents SDK** is installed, each cycle emits a concise LLM
 comment on the computed ΔG. Without it the demo uses an offline placeholder.
@@ -301,7 +301,7 @@ You can also run the Dockerised version:
 #### Example Session
 
 ```bash
-$ python alpha_agi_business_3_v1.py --cycles 1 --loglevel info
+$ alpha-agi-business-3-v1 --cycles 1 --loglevel info
 2025-06-11 17:16:10 INFO     | ΔH=0.027 ΔS=0.008 β=1.04 → ΔG=0.019
 2025-06-11 17:16:10 INFO     | LLM: LLM offline
 2025-06-11 17:16:10 INFO     | [Model] New weights committed (Gödel-proof verified)
@@ -331,7 +331,7 @@ Set `LLAMA_MODEL_PATH` to a local `.gguf` model and install either
 without internet access.
 
 ```bash
-LLAMA_MODEL_PATH=/path/model.gguf python alpha_agi_business_3_v1.py
+LLAMA_MODEL_PATH=/path/model.gguf alpha-agi-business-3-v1
 ```
 
 ---

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/cli.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Console entry point for the α‑AGI Business v3 demo."""
+from __future__ import annotations
+
+import asyncio
+
+from .alpha_agi_business_3_v1 import main as _main
+
+
+def main() -> None:
+    """Run the asynchronous ``_main`` function via ``asyncio.run``."""
+    asyncio.run(_main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ alpha-agi-insight-production = "alpha_factory_v1.demos.alpha_agi_insight_v0.offi
 alpha-agi-insight-offline = "alpha_factory_v1.demos.alpha_agi_insight_v0.official_demo_zero_data:main"
 alpha-agi-insight-api = "alpha_factory_v1.demos.alpha_agi_insight_v0.api_server:main"
 alpha-agi-insight-dashboard = "alpha_factory_v1.demos.alpha_agi_insight_v0.insight_dashboard:main"
+alpha-agi-business-3-v1 = "alpha_factory_v1.demos.alpha_agi_business_3_v1.cli:main"
 alpha-agi-insight-v1 = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli:main"
 alpha-agi-insight-v1-api = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server:main"
 aii = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli:main"

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -115,6 +115,20 @@ def test_main_subprocess() -> None:
     assert "ΔG" in (result.stdout + result.stderr)
 
 
+def test_cli_entrypoint() -> None:
+    """Running the ``alpha-agi-business-3-v1`` script should output the ΔG message."""
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "dummy"
+    result = subprocess.run(
+        ["alpha-agi-business-3-v1", "--cycles", "1"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ΔG" in (result.stdout + result.stderr)
+
+
 def test_main_stops_a2a(monkeypatch) -> None:
     """`_A2A.stop()` should be called when the loop exits."""
     mod = importlib.import_module(MODULE)


### PR DESCRIPTION
## Summary
- expose `alpha-agi-business-3-v1` console command
- document the new command in demo README
- support running business demo via new CLI
- verify CLI entry via new test

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed: operation cancelled)*
- `pytest -k "cli_entrypoint" -q` *(fails: missing `torch` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684b525e2bc88333ba80ccaf7656ca79