### PR TITLE
[alpha_factory] verify check_env in Business 3 demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 
 # Verify the Ω‑Lattice demo locally
 python alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py --loglevel info
+# The entrypoint automatically verifies dependencies via `check_env.py`.
 ```
 
 Adjust `alpha_factory_v1/demos/alpha_asi_world_model/config.yaml` to tune the world-model loop. Key options include `env_batch` (parallel environments), `hidden` (latent state size) and `mcts_simulations` (MCTS rollouts per action).

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -270,6 +270,17 @@ def run_cycle(
 async def main(argv: list[str] | None = None) -> None:
     """Entry point for command line execution."""
 
+    try:  # auto-verify environment when available
+        import importlib
+        _check_env = importlib.import_module("check_env")
+    except Exception:  # pragma: no cover - optional dependency
+        _check_env = None
+    if _check_env and hasattr(_check_env, "main"):
+        try:
+            _check_env.main([])
+        except Exception:  # pragma: no cover - best effort
+            log.warning("check_env.main failed", exc_info=True)
+
     ap = argparse.ArgumentParser(description="Run the Ω‑Lattice business demo")
     ap.add_argument("--loglevel", default="INFO", help="Logging level")
     ap.add_argument(

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -95,10 +95,13 @@ def test_run_cycle_async_logs_delta_g(monkeypatch, caplog):
     assert any("ΔG" in r.getMessage() for r in caplog.records)
 
 
-def test_main_subprocess() -> None:
+def test_main_subprocess(tmp_path) -> None:
     """Running the demo via ``python -m`` should output the ΔG message."""
+    stub = tmp_path / "check_env.py"
+    stub.write_text("def main(args=None):\n    pass\n")
     env = os.environ.copy()
     env["OPENAI_API_KEY"] = "dummy"
+    env["PYTHONPATH"] = f"{tmp_path}:{env.get('PYTHONPATH', '')}"
     result = subprocess.run(
         [
             sys.executable,
@@ -115,10 +118,13 @@ def test_main_subprocess() -> None:
     assert "ΔG" in (result.stdout + result.stderr)
 
 
-def test_cli_entrypoint() -> None:
+def test_cli_entrypoint(tmp_path) -> None:
     """Running the ``alpha-agi-business-3-v1`` script should output the ΔG message."""
+    stub = tmp_path / "check_env.py"
+    stub.write_text("def main(args=None):\n    pass\n")
     env = os.environ.copy()
     env["OPENAI_API_KEY"] = "dummy"
+    env["PYTHONPATH"] = f"{tmp_path}:{env.get('PYTHONPATH', '')}"
     result = subprocess.run(
         ["alpha-agi-business-3-v1", "--cycles", "1"],
         capture_output=True,
@@ -151,6 +157,7 @@ def test_main_stops_a2a(monkeypatch) -> None:
 
     monkeypatch.setattr(mod, "_A2A", dummy)
     monkeypatch.setattr(mod, "ADKClient", None)
+    monkeypatch.setattr(mod, "check_env", types.SimpleNamespace(main=lambda *_a, **_k: None), raising=False)
 
     async def _llm(_: float) -> str:
         return "ok"


### PR DESCRIPTION
## Summary
- call `check_env.main([])` at the start of the Omega‑Lattice Business 3 demo
- explain the automatic environment check in the README
- mock `check_env.main` in Business 3 tests

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --timeout 1` *(fails to install requirements)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684b5614866883338e2ca7a6a1019be6