### PR TITLE
[alpha_factory] ensure numpy and metrics deps

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,8 +24,9 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    ```bash
    python check_env.py --auto-install
    ```
-4. Ensure `numpy`, `pyyaml` and `pandas` are installed. They ship with
-   `requirements-dev.txt` but might be missing in minimal setups.
+4. Ensure `numpy`, `pyyaml`, `pandas` and `prometheus_client` are installed.
+   They ship with `requirements-dev.txt` but might be missing in minimal
+   setups.
 5. Install any missing optional packages:
    ```bash
    python check_env.py --auto-install
@@ -37,7 +38,8 @@ The full suite exercises features that depend on optional packages such as
 `numpy`, `torch`, `pandas`, `prometheus_client`, `gymnasium`, `playwright`,
 `httpx`, `uvicorn`, `git` and `hypothesis`.
 
-Tests are skipped when `numpy` or `torch` are missing. Pre-install them with
+Tests are skipped when `numpy`, `prometheus_client` or `torch` are missing.
+Pre-install them with
 `python check_env.py --auto-install`. Set the `WHEELHOUSE` environment
 variable to point to a local wheel directory when running offline so this
 command succeeds without contacting PyPI. `torch` in particular is heavy and


### PR DESCRIPTION
## Summary
- install numpy and prometheus_client automatically in `check_env.py`
- document these dependencies in the test README

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy, yaml, pandas missing)*
- `python check_env.py --auto-install` *(fails: timed out installing baseline requirements)*
- `pytest -q` *(fails: torch missing)*
- `pre-commit run --files check_env.py tests/README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5a3bdbf883338791194a7c1a07d4