### PR TITLE
[alpha_factory] fix mypy stubs for business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -33,15 +33,15 @@ except ImportError:  # pragma: no cover - offline fallback
         OpenAIAgent = None
 
 try:  # optional Google ADK client
-    from google_adk import Client as ADKClient  # type: ignore
+    from google_adk import Client as ADKClient
 except Exception:  # pragma: no cover - offline fallback
     try:
-        from google.adk import Client as ADKClient  # type: ignore
+        from google.adk import Client as ADKClient
     except Exception:
-        ADKClient = None  # type: ignore[misc]
+        ADKClient = None
 
 try:  # optional A2A message socket
-    from a2a import A2ASocket  # type: ignore
+    from a2a import A2ASocket
     _port = int(os.getenv("A2A_PORT", "0"))
     if _port > 0:
         _A2A = A2ASocket(
@@ -52,7 +52,7 @@ try:  # optional A2A message socket
     else:
         _A2A = None
 except Exception:  # pragma: no cover - missing dependency
-    A2ASocket = None  # type: ignore
+    A2ASocket = None
     _A2A = None
 
 
@@ -130,7 +130,12 @@ async def _llm_comment(delta_g: float) -> str:
     # ``alpha_factory_v1.backend`` exposes a non-callable placeholder.
     # Guard against that scenario as well so offline tests succeed.
     if OpenAIAgent is None or not callable(OpenAIAgent):
-        return local_llm.chat(f"In one sentence, comment on ΔG={delta_g:.4f} for the business.")
+        return cast(
+            str,
+            local_llm.chat(
+                f"In one sentence, comment on ΔG={delta_g:.4f} for the business."
+            ),
+        )
 
     agent = OpenAIAgent(
         model=os.getenv("MODEL_NAME", "gpt-4o-mini"),


### PR DESCRIPTION
## Summary
- remove unnecessary type ignore comments for optional imports
- adjust `_llm_comment` return for mypy

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --timeout 60` *(failed: Timed out installing baseline requirements)*
- `mypy alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py`
- `pytest -q` *(failed: missing torch)*

------
https://chatgpt.com/codex/tasks/task_e_684b8967cac883339e05aefa969c35c3