### PR TITLE
[alpha_factory] fix A2A port parsing

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -42,15 +42,20 @@ except Exception:  # pragma: no cover - offline fallback
 
 try:  # optional A2A message socket
     from a2a import A2ASocket
-    _port = int(os.getenv("A2A_PORT", "0"))
-    if _port > 0:
-        _A2A = A2ASocket(
-            host=os.getenv("A2A_HOST", "localhost"),
-            port=_port,
-            app_id="alpha_business_v3",
-        )
-    else:
+    try:
+        _port = int(os.getenv("A2A_PORT", "0"))
+    except ValueError:  # pragma: no cover - invalid env var
+        log.warning("Invalid A2A_PORT=%r", os.getenv("A2A_PORT"))
         _A2A = None
+    else:
+        if _port > 0:
+            _A2A = A2ASocket(
+                host=os.getenv("A2A_HOST", "localhost"),
+                port=_port,
+                app_id="alpha_business_v3",
+            )
+        else:
+            _A2A = None
 except Exception:  # pragma: no cover - missing dependency
     A2ASocket = None
     _A2A = None

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -39,6 +39,23 @@ def test_a2a_port_zero(monkeypatch):
     assert mod._A2A is None
 
 
+def test_a2a_port_invalid(monkeypatch):
+    """Invalid ``A2A_PORT`` values should not crash the import."""
+    dummy = types.ModuleType("a2a")
+
+    class DummySocket:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - dummy
+            raise AssertionError("should not be instantiated")
+
+    dummy.A2ASocket = DummySocket
+    monkeypatch.setitem(sys.modules, "a2a", dummy)
+    monkeypatch.setenv("A2A_PORT", "abc")
+    if MODULE in sys.modules:
+        del sys.modules[MODULE]
+    mod = importlib.import_module(MODULE)
+    assert mod._A2A is None
+
+
 def test_llm_comment_offline(monkeypatch):
     """`_llm_comment` should use local_llm when OpenAIAgent is unavailable."""
     mod = importlib.import_module(MODULE)


### PR DESCRIPTION
## Summary
- avoid ValueError when parsing `A2A_PORT`
- warn and keep `_A2A` unset when the port envvar is invalid
- test invalid `A2A_PORT` handling

## Testing
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(fails: pip install timed out)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684b92d8e3fc833388d44ea1c163ef0f