### PR TITLE
[alpha_factory] fix logger init order

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -24,6 +24,8 @@ from typing import Any, cast
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import local_llm
 
+log = logging.getLogger(__name__)
+
 try:  # optional OpenAI Agents integration
     from openai_agents import OpenAIAgent
 except ImportError:  # pragma: no cover - offline fallback
@@ -59,10 +61,6 @@ try:  # optional A2A message socket
 except Exception:  # pragma: no cover - missing dependency
     A2ASocket = None
     _A2A = None
-
-
-log = logging.getLogger(__name__)
-
 
 @dataclass(slots=True)
 class Orchestrator:


### PR DESCRIPTION
## Summary
- initialize logger before parsing `A2A_PORT` in the demo

## Testing
- `python check_env.py --auto-install --wheelhouse wheels` *(fails: could not find wheels)*
- `pytest -q` *(fails: torch missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b997e69bc833395079c51eedabba4