### PR TITLE
[alpha_factory] add macro sentinel observability and collector

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/collector/collector.py
+++ b/alpha_factory_v1/demos/macro_sentinel/collector/collector.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live-feed collector sidecar for Macro-Sentinel."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from alpha_factory_v1.demos.macro_sentinel.data_feeds import stream_macro_events
+
+log = logging.getLogger("macro_collector")
+
+
+async def main() -> None:
+    """Poll live APIs and emit events via data_feeds."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    async for evt in stream_macro_events(live=True):
+        log.info("event=%s", json.dumps(evt))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/alpha_factory_v1/demos/macro_sentinel/observability/grafana_dashboard.json
+++ b/alpha_factory_v1/demos/macro_sentinel/observability/grafana_dashboard.json
@@ -1,0 +1,19 @@
+{
+  "id": null,
+  "title": "Macro-Sentinel",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "HTTP Latency p95",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))"}
+      ],
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 0}
+    }
+  ]
+}

--- a/alpha_factory_v1/demos/macro_sentinel/observability/grafana_datasource.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/observability/grafana_datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/alpha_factory_v1/demos/macro_sentinel/observability/prometheus.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/observability/prometheus.yml
@@ -1,0 +1,13 @@
+# Prometheus config for Macro-Sentinel demo
+# Scrapes orchestrator metrics and itself
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'macro_sentinel'
+    static_configs:
+      - targets: ['orchestrator:7864']
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/tests/test_macro_compose_config.py
+++ b/tests/test_macro_compose_config.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+COMPOSE_FILE = Path(__file__).resolve().parents[1] / "alpha_factory_v1" / "demos" / "macro_sentinel" / "docker-compose.macro.yml"
+
+if not shutil.which("docker"):
+    pytest.skip("docker not available", allow_module_level=True)
+
+
+def test_docker_compose_config() -> None:
+    subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "config"], check=True, capture_output=True)


### PR DESCRIPTION
## Summary
- add Prometheus and Grafana configs for the Macro‑Sentinel demo
- implement `collector.py` live-feed sidecar
- provide docker compose config smoke test

## Testing
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -k macro_sentinel -q` *(failed: torch required)*
- `docker compose -f alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml config` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1f80e66c8333b8c1c67c5f8f0c20