### PR TITLE
[alpha_factory] standardize Twitter token

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -87,7 +87,7 @@ fully offline.
 | `TEMPERATURE` | `0.15` | LLM sampling temperature |
 | `FRED_API_KEY` | *(blank)* | Enables live yield‑curve collector |
 | `ETHERSCAN_API_KEY` | *(blank)* | Enables on‑chain stable‑flow collector |
-| `TW_BEARER_TOKEN` | *(blank)* | Enables Fed speech Twitter stream |
+| `TW_BEARER_TOKEN` | *(blank)* | Twitter/X API bearer token for Fed speech stream |
 | `PG_PASSWORD` | `alpha` | TimescaleDB superuser password |
 | `LIVE_FEED` | `0` | 1 uses live FRED/Etherscan feeds |
 | `ALPHA_FACTORY_ENABLE_ADK` | `0` | 1 exposes ADK gateway on port 9000 |

--- a/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
+++ b/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
@@ -127,10 +127,11 @@
     "\n",
     "_set('OPENAI_API_KEY', getpass.getpass('\ud83d\udd11 OpenAI key (blank for offline): '))\n",
     "_set('FRED_API_KEY',  '')\n",
+    "_set('TW_BEARER_TOKEN', getpass.getpass('Twitter bearer token (optional): '))\n",
     "_set('LIVE_FEED',     input('Real\u2011time feeds? (0/1) \u2192 ') or '0')\n",
     "os.environ['DEFAULT_PORTFOLIO_USD'] = '2000000'\n",
     "\n",
-    "print(json.dumps({k:os.getenv(k,'') for k in ['OPENAI_API_KEY','FRED_API_KEY','LIVE_FEED']}, indent=2))\n"
+    "print(json.dumps({k:os.getenv(k,'') for k in ['OPENAI_API_KEY','FRED_API_KEY','TW_BEARER_TOKEN','LIVE_FEED']}, indent=2))\n"
    ]
   },
   {

--- a/alpha_factory_v1/demos/macro_sentinel/config.env.sample
+++ b/alpha_factory_v1/demos/macro_sentinel/config.env.sample
@@ -28,9 +28,6 @@ LIVE_FEED=0                # 1 → pull live APIs instead of offline CSVs
 # ┌───────────────────────────
 # │  Hedge execution venue
 # └───────────────────────────
-HEDGE_BROKER_URL=https://paper-api.alpaca.markets
-HEDGE_BROKER_KEY=
-HEDGE_BROKER_SECRET=
 DEFAULT_PORTFOLIO_USD=2000000  # notional used for VaR → hedge sizing
 
 # ┌───────────────────────────

--- a/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
@@ -152,7 +152,7 @@ services:
       <<: *common-env
       REDIS_URL: "redis://redis:6379"
       FRED_API_KEY: "${FRED_API_KEY:-}"
-      TWITTER_BEARER_TOKEN: "${TW_BEARER_TOKEN:-}"
+      TW_BEARER_TOKEN: "${TW_BEARER_TOKEN:-}"
     volumes:
       - ./collector:/collector:ro
     command: python /collector/collector.py


### PR DESCRIPTION
## Summary
- remove unused hedge broker variables from macro demo
- update docker compose to use `TW_BEARER_TOKEN`
- clarify Twitter token name in README
- set the token in the Colab notebook

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install --timeout 1` *(fails: Timed out installing baseline requirements)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684c21d849908333b96c445169c609ee