### PR TITLE
[alpha_factory] add macro demo compose test

### DIFF
--- a/tests/test_macro_compose_config.py
+++ b/tests/test_macro_compose_config.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import pytest
 
-COMPOSE_FILE = Path(__file__).resolve().parents[1] / "alpha_factory_v1" / "demos" / "macro_sentinel" / "docker-compose.macro.yml"
+BASE_DIR = Path(__file__).resolve().parents[1] / "alpha_factory_v1" / "demos" / "macro_sentinel"
+COMPOSE_FILE = BASE_DIR / "docker-compose.macro.yml"
+RUN_SCRIPT = BASE_DIR / "run_macro_demo.sh"
 
 if not shutil.which("docker"):
     pytest.skip("docker not available", allow_module_level=True)
@@ -13,3 +15,8 @@ if not shutil.which("docker"):
 
 def test_docker_compose_config() -> None:
     subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "config"], check=True, capture_output=True)
+
+
+def test_run_macro_demo_help() -> None:
+    """`run_macro_demo.sh --help` should exit successfully."""
+    subprocess.run([str(RUN_SCRIPT), "--help"], check=True, capture_output=True)


### PR DESCRIPTION
## Summary
- ensure macro_sentinel compose file resolves
- verify run_macro_demo.sh prints help

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails to install packages due to network restrictions)*
- `pytest -q tests/test_macro_compose_config.py::test_run_macro_demo_help -s` *(skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684c23345d7883338f43d7b445fa58e6