### PR TITLE
[alpha_factory] load API key from config env

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -103,6 +103,12 @@ ALPHA_FACTORY_ENABLE_ADK=0
 EOF
 fi
 
+# Load OPENAI_API_KEY from config.env if not already set
+if [[ -z "${OPENAI_API_KEY:-}" && -f "$env_file" ]]; then
+  # shellcheck disable=SC1090
+  source "$env_file"
+fi
+
 # ──────────────────────── offline data ────────────────────────
 say "Syncing offline CSV snapshots"
 mkdir -p "$offline_dir"

--- a/tests/test_macro_compose_config.py
+++ b/tests/test_macro_compose_config.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -20,3 +21,58 @@ def test_docker_compose_config() -> None:
 def test_run_macro_demo_help() -> None:
     """`run_macro_demo.sh --help` should exit successfully."""
     subprocess.run([str(RUN_SCRIPT), "--help"], check=True, capture_output=True)
+
+
+def test_run_macro_demo_offline_not_selected(tmp_path: Path) -> None:
+    """An API key in config.env should disable the offline profile."""
+    config = RUN_SCRIPT.parent / "config.env"
+    docker_log = tmp_path / "docker.log"
+    curl_log = tmp_path / "curl.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo \"$@\" >> \"$DOCKER_LOG\"\n"
+        "if [ \"$1\" = \"info\" ]; then echo \"{}\"; fi\n"
+        "if [ \"$1\" = \"version\" ]; then echo \"24.0.0\"; fi\n"
+        "exit 0\n"
+    )
+    docker_stub.chmod(0o755)
+
+    curl_stub = bin_dir / "curl"
+    curl_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo \"$@\" >> \"$CURL_LOG\"\n"
+        "out=\"\"\n"
+        "for ((i=1;i<=$#;i++)); do\n"
+        "  if [ \"${!i}\" = \"-o\" ]; then\n"
+        "    j=$((i+1))\n"
+        "    out=${!j}\n"
+        "  fi\n"
+        "done\n"
+        "if [ -n \"$out\" ]; then echo sample > \"$out\"; fi\n"
+        "echo OK\n"
+    )
+    curl_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "DOCKER_LOG": str(docker_log),
+        "CURL_LOG": str(curl_log),
+    })
+    env.pop("OPENAI_API_KEY", None)
+
+    config.write_text("OPENAI_API_KEY=test-key\n")
+    try:
+        result = subprocess.run([f"./{RUN_SCRIPT.name}"], cwd=RUN_SCRIPT.parent, env=env, capture_output=True, text=True)
+    finally:
+        if config.exists():
+            config.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert docker_log.exists()
+    log = docker_log.read_text()
+    assert "--profile offline" not in log


### PR DESCRIPTION
## Summary
- load OPENAI_API_KEY from `config.env` when running the macro demo
- only select the offline profile when no API key exists in the env or file
- test that an API key in `config.env` disables the offline profile

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: pip install timed out)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a8d8c7c83338108a0c8f7811b94