### PR TITLE
[alpha_factory] handle missing aiohttp for Macro-Sentinel live mode

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -31,35 +31,34 @@ from urllib.request import urlopen
 # ───────────────────────── Config from env ──────────────────────────
 DATA_DIR = pathlib.Path(__file__).parent / "offline_samples"
 
-FRED_KEY      = os.getenv("FRED_API_KEY")
+FRED_KEY = os.getenv("FRED_API_KEY")
 ETHERSCAN_KEY = os.getenv("ETHERSCAN_API_KEY")
-RSS_URL       = os.getenv("FED_RSS_URL",
-                          "https://www.federalreserve.gov/feeds/press_speeches.htm")
-FRED_3M       = os.getenv("FRED_SERIES_3M",  "DTB3")
-FRED_10Y      = os.getenv("FRED_SERIES_10Y", "DGS10")
-STABLE_TOKEN  = os.getenv("STABLE_TOKEN",
-                          "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606e48")   # USDC
-CME_SYMBOL    = os.getenv("CME_SYMBOL", "ES")     # S&P 500 futures
+RSS_URL = os.getenv("FED_RSS_URL", "https://www.federalreserve.gov/feeds/press_speeches.htm")
+FRED_3M = os.getenv("FRED_SERIES_3M", "DTB3")
+FRED_10Y = os.getenv("FRED_SERIES_10Y", "DGS10")
+STABLE_TOKEN = os.getenv("STABLE_TOKEN", "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606e48")  # USDC
+CME_SYMBOL = os.getenv("CME_SYMBOL", "ES")  # S&P 500 futures
 
 # optional sinks
-DB_URL    = os.getenv("DATABASE_URL")   # Timescale/Postgres
+DB_URL = os.getenv("DATABASE_URL")  # Timescale/Postgres
 REDIS_URL = os.getenv("REDIS_URL")
-VEC_URL   = os.getenv("VECTOR_HOST")    # Qdrant
+VEC_URL = os.getenv("VECTOR_HOST")  # Qdrant
 
 # ───────────────────────── Helpers / offline CSV ────────────────────
 OFFLINE_URLS = {
     "fed_speeches.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/fed_speeches.csv",
-    "yield_curve.csv":  "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/yield_curve.csv",
+    "yield_curve.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/yield_curve.csv",
     "stable_flows.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/stable_flows.csv",
-    "cme_settles.csv":  "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/cme_settles.csv",
+    "cme_settles.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/cme_settles.csv",
 }
 
 _DEFAULT_ROWS = {
     "fed_speeches.csv": {"text": "No speech"},
-    "yield_curve.csv":  {"3m": "4.5", "10y": "4.4"},
+    "yield_curve.csv": {"3m": "4.5", "10y": "4.4"},
     "stable_flows.csv": {"usd_mn": "25"},
-    "cme_settles.csv":  {"settle": "5000"},
+    "cme_settles.csv": {"settle": "5000"},
 }
+
 
 def _ensure_offline():
     DATA_DIR.mkdir(exist_ok=True)
@@ -77,24 +76,34 @@ def _ensure_offline():
                 writer.writeheader()
                 writer.writerow(row)
 
+
 def _csv(name: str) -> list[dict]:
     with open(DATA_DIR / name, newline="") as f:
         return list(csv.DictReader(f))
 
+
 _ensure_offline()
 
-OFF_FED    = _csv("fed_speeches.csv")
-OFF_YIELD  = _csv("yield_curve.csv")
-OFF_FLOW   = _csv("stable_flows.csv")
-OFF_CME    = _csv("cme_settles.csv")  # snapshot of ES settles
+OFF_FED = _csv("fed_speeches.csv")
+OFF_YIELD = _csv("yield_curve.csv")
+OFF_FLOW = _csv("stable_flows.csv")
+OFF_CME = _csv("cme_settles.csv")  # snapshot of ES settles
 
 # ───────────────────────── Async HTTP helpers ───────────────────────
 _SESSION: Optional[aiohttp.ClientSession] = None
+
+
 async def _session() -> aiohttp.ClientSession:
+    """Return a shared aiohttp session or raise when unavailable."""
     global _SESSION
+    if aiohttp is None:
+        if os.getenv("LIVE_FEED", "0") == "1":
+            raise RuntimeError("LIVE_FEED=1 requires the aiohttp package")
+        raise RuntimeError("aiohttp is required for live mode")
     if _SESSION is None:
         _SESSION = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5))
     return _SESSION
+
 
 async def _http_json(url: str) -> Any:
     s = await _session()
@@ -102,29 +111,36 @@ async def _http_json(url: str) -> Any:
         r.raise_for_status()
         return await r.json()
 
+
 async def _http_text(url: str) -> str:
     s = await _session()
     async with s.get(url) as r:
         r.raise_for_status()
         return await r.text()
 
+
 # ───────────────────────── Live fetchers ─────────────────────────────
 async def _fred_latest(series: str) -> Optional[float]:
     if not FRED_KEY:
         return None
-    url = ("https://api.stlouisfed.org/fred/series/observations"
-           f"?series_id={series}&api_key={FRED_KEY}&file_type=json"
-           "&sort_order=desc&limit=1")
+    url = (
+        "https://api.stlouisfed.org/fred/series/observations"
+        f"?series_id={series}&api_key={FRED_KEY}&file_type=json"
+        "&sort_order=desc&limit=1"
+    )
     j = await _http_json(url)
     val = j["observations"][0]["value"]
     return float(val) if val not in {"", "."} else None
 
+
 _CACHE_SPEECH = deque(maxlen=10)
+
+
 async def _latest_fed_speech() -> Optional[str]:
     try:
         xml = await _http_text(RSS_URL)
         title_start = xml.index("<title>") + 7
-        title_end   = xml.index("</title>", title_start)
+        title_end = xml.index("</title>", title_start)
         title = xml[title_start:title_end]
         if title not in _CACHE_SPEECH:
             _CACHE_SPEECH.append(title)
@@ -133,91 +149,104 @@ async def _latest_fed_speech() -> Optional[str]:
         return None
     return None
 
+
 async def _latest_stable_flow() -> Optional[float]:
     if not ETHERSCAN_KEY:
         return None
-    url = (f"https://api.etherscan.io/api?module=account&action=tokentx"
-           f"&contractaddress={STABLE_TOKEN}&page=1&offset=1&sort=desc"
-           f"&apikey={ETHERSCAN_KEY}")
+    url = (
+        f"https://api.etherscan.io/api?module=account&action=tokentx"
+        f"&contractaddress={STABLE_TOKEN}&page=1&offset=1&sort=desc"
+        f"&apikey={ETHERSCAN_KEY}"
+    )
     j = await _http_json(url)
     val = j["result"][0]["value"]
     return float(val) / 1e6
+
 
 async def _latest_cme_settle() -> Optional[float]:
     # Deribit free endpoint as CME fallback
     try:
         url = f"https://www.deribit.com/api/v2/public/ticker?instrument_name={CME_SYMBOL}-PERPETUAL"
-        j   = await _http_json(url)
+        j = await _http_json(url)
         return float(j["result"]["last_price"])
     except Exception:
         return None
 
+
 # ───────────────────────── Optional fan-out sinks ────────────────────
-def _safe(f, *a, **kw):
+def _safe(f: Any, *a: Any, **kw: Any) -> None:
     try:
         f(*a, **kw)
     except Exception:
         pass
 
+
 def _push_db(evt: Dict[str, Any]):
     if not DB_URL:
         return
     import psycopg2
+
     with psycopg2.connect(DB_URL) as conn, conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO macro_events "
-            "(ts,speech,y10y,y3m,stable_flow,es_settle)"
-            "VALUES (%s,%s,%s,%s,%s,%s)",
-            (evt["timestamp"], evt["fed_speech"], evt["yield_10y"],
-             evt["yield_3m"], evt["stable_flow"], evt["es_settle"])
+            "INSERT INTO macro_events " "(ts,speech,y10y,y3m,stable_flow,es_settle)" "VALUES (%s,%s,%s,%s,%s,%s)",
+            (
+                evt["timestamp"],
+                evt["fed_speech"],
+                evt["yield_10y"],
+                evt["yield_3m"],
+                evt["stable_flow"],
+                evt["es_settle"],
+            ),
         )
+
 
 def _push_redis(evt: Dict[str, Any]):
     if not REDIS_URL:
         return
     import redis, json as _j
+
     r = redis.from_url(REDIS_URL)
     r.xadd("macro_stream", {"json": _j.dumps(evt)}, maxlen=10000)
+
 
 def _push_qdrant(evt: Dict[str, Any]):
     if not VEC_URL:
         return
     import af_requests as requests, hashlib, json as _j
-    vec = hashlib.sha256(evt["fed_speech"].encode()).digest()[:8]
-    payload = {"points":[{"id":evt["timestamp"],"vector":list(vec),"payload":evt}]}
-    requests.put(f"http://{VEC_URL}/collections/macro/points",
-                 data=_j.dumps(payload),
-                 headers={"Content-Type":"application/json"})
 
-def _fanout(evt: Dict[str, Any]):
-    _safe(_push_db,   evt)
-    _safe(_push_redis,evt)
-    _safe(_push_qdrant,evt)
+    vec = hashlib.sha256(evt["fed_speech"].encode()).digest()[:8]
+    payload = {"points": [{"id": evt["timestamp"], "vector": list(vec), "payload": evt}]}
+    requests.put(
+        f"http://{VEC_URL}/collections/macro/points",
+        data=_j.dumps(payload),
+        headers={"Content-Type": "application/json"},
+    )
+
+
+def _fanout(evt: Dict[str, Any]) -> None:
+    _safe(_push_db, evt)
+    _safe(_push_redis, evt)
+    _safe(_push_qdrant, evt)
+
 
 # ───────────────────────── Main async generator ──────────────────────
 async def stream_macro_events(live: bool = False) -> AsyncIterator[Dict[str, Any]]:
     idx = 0
     while True:
-        evt = {"timestamp": dt.datetime.now(dt.timezone.utc).isoformat()}
+        evt: Dict[str, Any] = {"timestamp": dt.datetime.now(dt.timezone.utc).isoformat()}
         if live:
             speech = await _latest_fed_speech() or OFF_FED[idx]["text"]
-            y10    = await _fred_latest(FRED_10Y)  or float(OFF_YIELD[idx]["10y"])
-            y3     = await _fred_latest(FRED_3M)   or float(OFF_YIELD[idx]["3m"])
-            flow   = await _latest_stable_flow()   or float(OFF_FLOW[idx]["usd_mn"])
-            es     = await _latest_cme_settle()    or float(OFF_CME[idx]["settle"])
+            y10 = await _fred_latest(FRED_10Y) or float(OFF_YIELD[idx]["10y"])
+            y3 = await _fred_latest(FRED_3M) or float(OFF_YIELD[idx]["3m"])
+            flow = await _latest_stable_flow() or float(OFF_FLOW[idx]["usd_mn"])
+            es = await _latest_cme_settle() or float(OFF_CME[idx]["settle"])
         else:
             speech = OFF_FED[idx]["text"]
             y10, y3 = float(OFF_YIELD[idx]["10y"]), float(OFF_YIELD[idx]["3m"])
             flow = float(OFF_FLOW[idx]["usd_mn"])
-            es   = float(OFF_CME[idx]["settle"])
+            es = float(OFF_CME[idx]["settle"])
 
-        evt.update({
-            "fed_speech":  speech,
-            "yield_10y":   y10,
-            "yield_3m":    y3,
-            "stable_flow": flow,
-            "es_settle":   es
-        })
+        evt.update({"fed_speech": speech, "yield_10y": y10, "yield_3m": y3, "stable_flow": flow, "es_settle": es})
         _fanout(evt)
         yield evt
         idx = (idx + 1) % len(OFF_FED)

--- a/tests/test_macro_sentinel.py
+++ b/tests/test_macro_sentinel.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
+import os
 import unittest
+from typing import Any, Dict
 
 from alpha_factory_v1.demos.macro_sentinel import data_feeds, simulation_core
 
 
 class TestMacroSentinel(unittest.TestCase):
-    def test_stream_macro_events_offline(self):
-        async def get_one():
+    def test_stream_macro_events_offline(self) -> None:
+        async def get_one() -> Dict[str, Any]:
             it = data_feeds.stream_macro_events(live=False)
             return await anext(it)
 
@@ -18,19 +20,36 @@ class TestMacroSentinel(unittest.TestCase):
         self.assertIn("stable_flow", evt)
         self.assertIn("es_settle", evt)
 
-    def test_montecarlo_hedge_basic(self):
+    def test_montecarlo_hedge_basic(self) -> None:
         sim = simulation_core.MonteCarloSimulator(n_paths=500, horizon=5)
-        factors = sim.simulate({
-            "yield_10y": 4.0,
-            "yield_3m": 4.5,
-            "stable_flow": 10.0,
-            "es_settle": 5000.0,
-        })
+        factors = sim.simulate(
+            {
+                "yield_10y": 4.0,
+                "yield_3m": 4.5,
+                "stable_flow": 10.0,
+                "es_settle": 5000.0,
+            }
+        )
         hedge = sim.hedge(factors, 1_000_000)
         self.assertIn("es_notional", hedge)
         self.assertIn("dv01_usd", hedge)
         self.assertIn("metrics", hedge)
         self.assertEqual(len(sim.scenario_table(factors)), 3)
+
+    def test_live_feed_requires_aiohttp(self) -> None:
+        async def run_live() -> None:
+            os.environ["LIVE_FEED"] = "1"
+            orig = data_feeds.aiohttp  # type: ignore[attr-defined]
+            data_feeds.aiohttp = None  # type: ignore[attr-defined]
+            try:
+                it = data_feeds.stream_macro_events(live=True)
+                await anext(it)
+            finally:
+                data_feeds.aiohttp = orig  # type: ignore[attr-defined]
+                os.environ.pop("LIVE_FEED", None)
+
+        with self.assertRaises(RuntimeError):
+            asyncio.run(run_live())
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- handle missing `aiohttp` in `macro_sentinel` data feeds
- add regression test for live mode without `aiohttp`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --timeout 120` *(failed to finish)*
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/data_feeds.py tests/test_macro_sentinel.py` *(failed to run hooks)*
- `pytest -q tests/test_macro_sentinel.py` *(skipped: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684c2cde8a488333884b3b9b3a545ece