### PR TITLE
[alpha_factory] clarify OPENAI_API_KEY usage

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -55,6 +55,11 @@ python ../../check_env.py    # verify optional dependencies
                               # (--live exports LIVE_FEED=1)
 ```
 
+Export `OPENAI_API_KEY` in your shell (or define it in `config.env`) before
+launching. If the variable is absent, the script runs in offline mode. With the
+previous issue resolved, the launcher now reads `config.env` automatically when
+present.
+
 Offline sample data is fetched automatically the first time you run the
 launcher—no manual downloads required.
 


### PR DESCRIPTION
## Summary
- clarify that `OPENAI_API_KEY` must be exported before running the macro demo
- note that `config.env` is automatically read once the issue is fixed

## Testing
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/README.md` *(fails: proto-verify missing make dependency)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails due to network)*
- `pytest -q` *(fails: torch required)*

------
https://chatgpt.com/codex/tasks/task_e_684c30d1547c8333b6bb5a6b006d5369