### PR TITLE
[alpha_factory] add macro launcher tests

### DIFF
--- a/tests/test_macro_launcher.py
+++ b/tests/test_macro_launcher.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Macro-Sentinel Docker launcher."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(
+    "alpha_factory_v1/demos/macro_sentinel/macro_launcher.py"
+)
+
+
+@pytest.mark.skipif(
+    not SCRIPT.exists(), reason="script missing"
+)
+def test_macro_launcher_no_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`OPENAI_API_KEY` disables the offline profile."""
+    compose_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *a, **k) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["docker", "compose"]:
+            compose_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-key")
+
+    mod = __import__(
+        "alpha_factory_v1.demos.macro_sentinel.macro_launcher", fromlist=["main"]
+    )
+    mod.main([])
+
+    cmd_str = " ".join(" ".join(c) for c in compose_calls)
+    assert "--profile offline" not in cmd_str
+
+
+@pytest.mark.skipif(
+    not SCRIPT.exists(), reason="script missing"
+)
+def test_macro_launcher_health_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Health gate should hit the expected endpoint."""
+    curl_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *a, **k) -> subprocess.CompletedProcess[str]:
+        if cmd[0] == "curl":
+            curl_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-key")
+
+    mod = __import__(
+        "alpha_factory_v1.demos.macro_sentinel.macro_launcher", fromlist=["main"]
+    )
+    mod.main([])
+
+    urls = " ".join(" ".join(c) for c in curl_calls)
+    assert "http://localhost:7864/healthz" in urls


### PR DESCRIPTION
## Summary
- add new macro launcher tests that expect `OPENAI_API_KEY` to disable the offline compose profile
- assert the health endpoint requested by the launcher

## Testing
- `pre-commit run --files tests/test_macro_launcher.py` *(fails: could not install hook dependencies)*
- `pytest -q tests/test_macro_launcher.py` *(fails: skipped because torch is required)*

------
https://chatgpt.com/codex/tasks/task_e_684c36e15dac8333b6429c5572120675