### PR TITLE
[alpha_factory] add DEFAULT_PORTFOLIO_USD config row

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -97,6 +97,7 @@ fully offline.
 | `TW_BEARER_TOKEN` | *(blank)* | Twitter/X API bearer token for Fed speech stream |
 | `PG_PASSWORD` | `alpha` | TimescaleDB superuser password |
 | `LIVE_FEED` | `0` | 1 uses live FRED/Etherscan feeds |
+| `DEFAULT_PORTFOLIO_USD` | `2000000` | Portfolio USD notional for Monte‑Carlo hedge sizing |
 | `ALPHA_FACTORY_ENABLE_ADK` | `0` | 1 exposes ADK gateway on port 9000 |
 | `PROMETHEUS_SCRAPE_INTERVAL` | `15s` | Metrics polling frequency |
 | `GRAFANA_ADMIN_PASSWORD` | `alpha` | Grafana admin password |


### PR DESCRIPTION
## Summary
- document DEFAULT_PORTFOLIO_USD in the Macro-Sentinel configuration table

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: KeyboardInterrupt during pip install)*
- `pytest -q` *(fails: torch required)*
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/README.md` *(fails: KeyboardInterrupt during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684c41cc5230833393affc8c6c9f08dd