### PR TITLE
[alpha_factory] update torch skip logic

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -38,8 +38,10 @@ The full suite exercises features that depend on optional packages such as
 `numpy`, `torch`, `pandas`, `prometheus_client`, `gymnasium`, `playwright`,
 `httpx`, `uvicorn`, `git` and `hypothesis`.
 
-Tests are skipped when `numpy`, `prometheus_client` or `torch` are missing.
-Pre-install them with
+Tests are skipped when `numpy` or `prometheus_client` are missing. The
+`tests/conftest.py` helper checks for `torch` with `importlib.util.find_spec`
+and registers a `requires_torch` marker. Tests using this marker are skipped
+automatically when `torch` is absent. Pre-install these heavy dependencies with
 `python check_env.py --auto-install`. Set the `WHEELHOUSE` environment
 variable to point to a local wheel directory when running offline so this
 command succeeds without contacting PyPI. `torch` in particular is heavy and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,19 @@ import importlib.util
 
 # Skip early when heavy optional deps are missing to avoid stack traces
 pytest.importorskip("numpy", reason="numpy required")
-pytest.importorskip("torch", reason="torch required")
+
+_HAS_TORCH = importlib.util.find_spec("torch") is not None
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_torch: mark test that depends on the torch package",
+    )
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if "requires_torch" in item.keywords and not _HAS_TORCH:
+        pytest.skip("torch required", allow_module_level=True)
 
 try:  # skip all tests if the simulation module fails to import
     from src.simulation import replay


### PR DESCRIPTION
## Summary
- skip tests requiring torch when missing
- document torch skip behavior in the test README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: timed out installing baseline requirements)*
- `pytest -q` *(fails: 106 errors, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684c463a73ac8333a7f539c734170593