### PR TITLE
[alpha_factory] automate pre-commit setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,23 +41,18 @@ Python must report 3.11 or 3.12 and Docker Compose must be at least 2.5.
   python3 -m venv .venv
   source .venv/bin/activate
   pip install -U pip
-  pip install pre-commit
   ```
   On Windows PowerShell:
   ```powershell
   python -m venv .venv
   .\.venv\Scripts\Activate.ps1
   pip install -U pip
-  pip install pre-commit
   ```
 - The script `alpha_factory_v1/scripts/preflight.py` enforces this requirement.
 - It verifies the optional `openai_agents` package is at least version `0.0.14`
   when installed.
-- From the repository root, run `./codex/setup.sh` to install the project in editable mode
-  with minimal runtime dependencies. This ensures all relative paths resolve correctly.
+- Run `./codex/setup.sh` from the repository root to install the project in editable mode with minimal runtime dependencies. The script installs `pre-commit` and sets up the git hook automatically. Execute it before contributing so all relative paths resolve correctly.
 - After installation, run `pre-commit run --all-files` once to verify formatting and hooks.
-- If the `pre-commit` command is missing, run `pip install pre-commit` and then
-  `pre-commit install`; see [Troubleshooting](#troubleshooting).
 ### Offline Setup
 
 Follow these steps when installing without internet access:

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -207,6 +207,9 @@ def main(argv: list[str] | None = None) -> None:
     ok &= check_python()
     ok &= check_cmd("docker")
     ok &= check_cmd("git")
+    has_precommit = check_cmd("pre-commit")
+    if not has_precommit:
+        banner("Install pre-commit and run 'pre-commit install' to enable git hooks", "YELLOW")
     ok &= check_docker_daemon()
     ok &= check_docker_compose()
     if not args.offline:

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -38,6 +38,9 @@ $PYTHON -m pip install --quiet "${wheel_opts[@]}" --upgrade pip setuptools wheel
 # Install pip-compile (pip-tools) early so hooks can verify lock files
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" pip-tools
 
+# Install pre-commit for git hooks
+$PYTHON -m pip install --quiet "${wheel_opts[@]}" pre-commit
+
 # Install package in editable mode
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" -e .
 
@@ -165,4 +168,7 @@ if [[ "${FETCH_BROWSER_ASSETS:-1}" != "0" ]]; then
   echo "Fetching Insight browser assets..."
   $PYTHON scripts/fetch_assets.py
 fi
+
+# Set up pre-commit hooks
+pre-commit install
 


### PR DESCRIPTION
## Summary
- automate pre-commit installation in `codex/setup.sh`
- note the setup script in contributor docs
- warn when `pre-commit` is missing in preflight checks

## Testing
- `pre-commit run --files AGENTS.md codex/setup.sh alpha_factory_v1/scripts/preflight.py` *(fails: mypy and proto-verify)*
- `python scripts/check_python_deps.py` *(fails: missing numpy, pandas)*
- `python check_env.py --auto-install` *(failed: operation cancelled)*
- `pytest tests/test_preflight.py -q` *(errors: ModuleNotFoundError: pydantic_settings)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c349eb48333bdce0374f1c72e19