### PR TITLE
[alpha_factory] ensure stub raises when called

### DIFF
--- a/alpha_factory_v1/backend/__init__.py
+++ b/alpha_factory_v1/backend/__init__.py
@@ -49,6 +49,12 @@ except ModuleNotFoundError:  # SDK not installed
                 "Please install it with:  pip install openai-agents"
             )
 
+        def __call__(self, *args, **kwargs):  # noqa: D401
+            raise ModuleNotFoundError(
+                "The OpenAI Agents SDK is required for this operation. "
+                "Please install it with:  pip install openai-agents"
+            )
+
     # Expose typical top-level symbols so `from openai_agents import Agent`
     # fails with an informative message *at call-time* rather than import-time.
     for _name in (

--- a/tests/test_adk_gateway_startup.py
+++ b/tests/test_adk_gateway_startup.py
@@ -35,6 +35,7 @@ def test_maybe_launch_starts_uvicorn(stub_adk, monkeypatch):
     """maybe_launch should call uvicorn.run when ADK is enabled."""
     uvicorn = pytest.importorskip("uvicorn")
     from alpha_factory_v1.backend import adk_bridge as module
+
     module = importlib.reload(module)
 
     called = {}
@@ -57,3 +58,15 @@ def test_maybe_launch_starts_uvicorn(stub_adk, monkeypatch):
 
     module.maybe_launch(host="1.2.3.4", port=1234)
     assert called == {"app": module._ensure_router().app, "host": "1.2.3.4", "port": 1234}
+
+
+def test_openai_agents_stub_call(monkeypatch):
+    """Calling Agent from the shim should raise ModuleNotFoundError."""
+    sys.modules.pop("openai_agents", None)
+    sys.modules.pop("agents", None)
+    importlib.reload(importlib.import_module("alpha_factory_v1.backend"))
+
+    from openai_agents import Agent
+
+    with pytest.raises(ModuleNotFoundError, match="OpenAI Agents SDK is required"):
+        Agent()


### PR DESCRIPTION
## Summary
- extend `_MissingSDK` with `__call__` to raise ModuleNotFoundError
- add regression test for the openai_agents shim

## Testing
- `pytest -q tests/test_adk_gateway_startup.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5307002c8333ac83a8fbde8f4fdf