### PR TITLE
[alpha_factory] pass compose profiles separately

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -133,17 +133,19 @@ has_gpu && profiles+=(gpu)
 [[ -z "${OPENAI_API_KEY:-}" ]] && profiles+=(offline)
 (( LIVE )) && profiles+=(live-feed)
 export LIVE_FEED=${LIVE}
-profile_arg=""
-[[ ${#profiles[@]} -gt 0 ]] && profile_arg="--profile $(IFS=,;echo "${profiles[*]}")"
+profile_arg=()
+for p in "${profiles[@]}"; do
+  profile_arg+=(--profile "$p")
+done
 
 # ───────────────────────── Docker build ───────────────────────
 say "🚢 Building images (profiles: ${profiles[*]:-none})"
-docker compose -f "$compose_file" $profile_arg pull --quiet || true
-docker compose -f "$compose_file" $profile_arg build --pull
+docker compose -f "$compose_file" "${profile_arg[@]}" pull --quiet || true
+docker compose -f "$compose_file" "${profile_arg[@]}" build --pull
 
 # ───────────────────────── stack up ───────────────────────────
 say "🔄 Starting containers"
-docker compose --project-name alpha_macro -f "$compose_file" $profile_arg up -d
+docker compose --project-name alpha_macro -f "$compose_file" "${profile_arg[@]}" up -d
 
 # ─────────────────────── health gate & trap ───────────────────
 trap 'docker compose -p alpha_macro stop; exit 0' INT

--- a/tests/test_macro_compose_config.py
+++ b/tests/test_macro_compose_config.py
@@ -76,3 +76,58 @@ def test_run_macro_demo_offline_not_selected(tmp_path: Path) -> None:
     assert docker_log.exists()
     log = docker_log.read_text()
     assert "--profile offline" not in log
+
+
+def test_run_macro_demo_multiple_profiles(tmp_path: Path) -> None:
+    """Offline and live profiles should be passed separately."""
+    config = RUN_SCRIPT.parent / "config.env"
+    docker_log = tmp_path / "docker.log"
+    curl_log = tmp_path / "curl.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo \"$@\" >> \"$DOCKER_LOG\"\n"
+        "if [ \"$1\" = \"info\" ]; then echo \"{}\"; fi\n"
+        "if [ \"$1\" = \"version\" ]; then echo \"24.0.0\"; fi\n"
+        "exit 0\n"
+    )
+    docker_stub.chmod(0o755)
+
+    curl_stub = bin_dir / "curl"
+    curl_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo \"$@\" >> \"$CURL_LOG\"\n"
+        "out=\"\"\n"
+        "for ((i=1;i<=$#;i++)); do\n"
+        "  if [ \"${!i}\" = \"-o\" ]; then\n"
+        "    j=$((i+1))\n"
+        "    out=${!j}\n"
+        "  fi\n"
+        "done\n"
+        "if [ -n \"$out\" ]; then echo sample > \"$out\"; fi\n"
+        "echo OK\n"
+    )
+    curl_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "DOCKER_LOG": str(docker_log),
+        "CURL_LOG": str(curl_log),
+    })
+    env.pop("OPENAI_API_KEY", None)
+
+    try:
+        result = subprocess.run([f"./{RUN_SCRIPT.name}", "--live"], cwd=RUN_SCRIPT.parent, env=env, capture_output=True, text=True)
+    finally:
+        if config.exists():
+            config.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert docker_log.exists()
+    log = docker_log.read_text()
+    assert "--profile offline" in log
+    assert "--profile live-feed" in log


### PR DESCRIPTION
## Summary
- build docker compose arguments as separate `--profile` flags
- adapt compose commands to expand the array
- ensure tests check that multiple profiles are passed separately

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(failed to install packages)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'google', 106 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c5807dde88333a790ecf7b1f140a6