### PR TITLE
[alpha_factory] add Macro-Sentinel doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,3 +40,10 @@ To launch a job:
 Each workflow checks that the person triggering it matches
 `github.repository_owner`, so it executes only when the owner initiates the
 run.
+
+## Macro-Sentinel Demo
+
+A self-healing macro risk radar powered by multi-agent α‑AGI. The stack ingests
+macro telemetry, runs Monte-Carlo simulations and exposes a Gradio dashboard.
+See the [alpha_factory_v1/demos/macro_sentinel/README.md](../alpha_factory_v1/demos/macro_sentinel/README.md)
+for full instructions.


### PR DESCRIPTION
## Summary
- document Macro-Sentinel demo in docs README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --timeout 1` *(fails: timed out installing baseline requirements)*
- `pytest -q` *(fails: ModuleNotFoundError: google)*
- `pre-commit run --files docs/README.md` *(fails: interrupted during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684c591e48ec83338eb9f6f6f30b0645