### PR TITLE
[alpha_factory] fix fed speech session

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -138,6 +138,7 @@ _CACHE_SPEECH = deque(maxlen=10)
 
 
 async def _latest_fed_speech() -> Optional[str]:
+    await _session()  # early check so RuntimeError propagates when aiohttp is missing
     try:
         xml = await _http_text(RSS_URL)
         title_start = xml.index("<title>") + 7
@@ -146,7 +147,7 @@ async def _latest_fed_speech() -> Optional[str]:
         if title not in _CACHE_SPEECH:
             _CACHE_SPEECH.append(title)
             return title
-    except Exception:
+    except (aiohttp.ClientError, ValueError):
         return None
     return None
 

--- a/tests/test_macro_sentinel.py
+++ b/tests/test_macro_sentinel.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 import unittest
 from typing import Any, Dict
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 from alpha_factory_v1.demos.macro_sentinel import data_feeds, simulation_core
 
@@ -46,8 +46,11 @@ class TestMacroSentinel(unittest.TestCase):
             orig = data_feeds.aiohttp  # type: ignore[attr-defined]
             data_feeds.aiohttp = None  # type: ignore[attr-defined]
             try:
-                it = data_feeds.stream_macro_events(live=True)
-                await anext(it)
+                with patch.object(data_feeds, "_fred_latest", new_callable=AsyncMock, return_value=None), \
+                     patch.object(data_feeds, "_latest_stable_flow", new_callable=AsyncMock, return_value=None), \
+                     patch.object(data_feeds, "_latest_cme_settle", new_callable=AsyncMock, return_value=None):
+                    it = data_feeds.stream_macro_events(live=True)
+                    await anext(it)
             finally:
                 data_feeds.aiohttp = orig  # type: ignore[attr-defined]
                 os.environ.pop("LIVE_FEED", None)


### PR DESCRIPTION
## Summary
- ensure `_session()` check occurs before network requests in `_latest_fed_speech`
- only swallow network/parsing errors
- adjust macro sentinel test to patch other fetchers

## Testing
- `pytest -q tests/test_macro_sentinel.py::TestMacroSentinel::test_live_feed_requires_aiohttp`
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/data_feeds.py tests/test_macro_sentinel.py` *(failed: KeyboardInterrupt)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684c62891d908333a760205b34e12972