### PR TITLE
[alpha_factory] add offline wheelhouse instructions

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -83,6 +83,17 @@ python agent_macro_entrypoint.py
 The entry point pulls minimal CSV snapshots if they are missing so you can run
 fully offline.
 
+### Offline installation
+
+```bash
+pip wheel -r requirements.txt -w /media/wheels
+WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
+  python ../../check_env.py --auto-install --wheelhouse /media/wheels
+```
+
+This mirrors the repository's offline setup instructions so the demo works
+without internet access.
+
 ---
 
 ## ⚙️ Configuration


### PR DESCRIPTION
## Summary
- document building a wheelhouse in macro sentinel README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/README.md` *(failed: network timeout)*
- `python scripts/check_python_deps.py` *(fails: numpy, pandas missing)*
- `python check_env.py --auto-install` *(failed: operation cancelled)*
- `pytest -q` *(fails: 106 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d228a988333ac545e0ecc67cc2b