### PR TITLE
[alpha_factory] extend env check for macro_sentinel

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -50,7 +50,7 @@ flowchart LR
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/macro_sentinel
-python ../../check_env.py    # verify optional dependencies
+python ../../check_env.py --demo macro_sentinel    # verify optional dependencies
 ./run_macro_demo.sh           # add --live for real‑time collectors
                               # (--live exports LIVE_FEED=1)
 ```
@@ -88,7 +88,7 @@ fully offline.
 ```bash
 pip wheel -r requirements.txt -w /media/wheels
 WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
-  python ../../check_env.py --auto-install --wheelhouse /media/wheels
+  python ../../check_env.py --demo macro_sentinel --auto-install --wheelhouse /media/wheels
 ```
 
 This mirrors the repository's offline setup instructions so the demo works


### PR DESCRIPTION
## Summary
- allow check_env.py to verify demo specific requirements
- check `gradio`, `aiohttp` and `qdrant-client` for macro_sentinel
- document the new flag in the macro_sentinel README

## Testing
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(interrupted: pip install timed out)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_684c6fa7a2748333bc1fe76ccbc401c9