### PR TITLE
[alpha_factory] add env check to macro sentinel demo

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -72,6 +72,11 @@ env_file="$demo_dir/config.env"
 offline_dir="$demo_dir/offline_samples"
 cd "$root_dir"
 
+# ─────────────────────── dependency check ─────────────────────
+if ! python "$demo_dir/../../../check_env.py" --demo macro_sentinel --auto-install; then
+  die "Environment check failed. Run 'python ../../check_env.py --demo macro_sentinel --auto-install' and resolve any issues."
+fi
+
 # ──────────────────────── prerequisites ───────────────────────
 need docker
 docker compose version &>/dev/null || die "Docker Compose plug-in missing"


### PR DESCRIPTION
## Summary
- call `check_env.py` when running `run_macro_demo.sh`
- exit if the environment check fails

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --timeout 1` *(fails to install baseline requirements)*
- `pytest -q` *(fails to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c839d4fb4833393840a7fcf7c9f38