### PR TITLE
[alpha_factory] add macro_sentinel requirements

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -77,7 +77,7 @@ repository and cover roughly March–April 2024 activity.
 ### Bare‑metal (advanced)
 
 ```bash
-pip install -U openai_agents gradio aiohttp psycopg2-binary qdrant-client
+pip install -r requirements.txt
 python agent_macro_entrypoint.py
 ```
 The entry point pulls minimal CSV snapshots if they are missing so you can run

--- a/alpha_factory_v1/demos/macro_sentinel/requirements.txt
+++ b/alpha_factory_v1/demos/macro_sentinel/requirements.txt
@@ -1,0 +1,8 @@
+# Macro-Sentinel demo dependencies
+# Reuse the main project requirements and add demo extras
+-r ../../requirements.txt
+openai-agents
+gradio
+aiohttp
+psycopg2-binary
+qdrant-client


### PR DESCRIPTION
## Summary
- add `requirements.txt` for Macro-Sentinel demo
- update bare-metal instructions to install from this file

## Testing
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/README.md alpha_factory_v1/demos/macro_sentinel/requirements.txt` *(fails: Makefile:26: *** missing separator)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(partial output)*
- `pytest -q` *(fails: 106 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c888315948333bb2d2101e4898cda