### PR TITLE
[alpha_factory] improve offline install docs

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -83,6 +83,17 @@ python agent_macro_entrypoint.py
 The entry point pulls minimal CSV snapshots if they are missing so you can run
 fully offline.
 
+### Preparing a wheelhouse
+
+Build wheels on a machine with internet access so the demo can be installed
+offline:
+
+```bash
+pip wheel -r requirements.txt -w /path/to/wheels
+```
+
+Pass `--wheelhouse /path/to/wheels` to `check_env.py` as shown below.
+
 ### Offline installation
 
 ```bash

--- a/alpha_factory_v1/scripts/build_macro_wheelhouse.sh
+++ b/alpha_factory_v1/scripts/build_macro_wheelhouse.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# build_macro_wheelhouse.sh -- build wheels for the Macro-Sentinel demo
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/.." && pwd)"
+WHEEL_DIR=${1:-$ROOT/../wheels}
+mkdir -p "$WHEEL_DIR"
+pip wheel -r "$ROOT/demos/macro_sentinel/requirements.txt" -w "$WHEEL_DIR"
+echo "Wheels written to $WHEEL_DIR"
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -150,6 +150,7 @@ Alternatively install the package first:
 pip install -e .
 pytest -q
 ```
+- Set PYTEST_NET_OFF=1 to skip tests that require outbound network access.
 - Playwright test `test_umap_fallback.py` ensures the simulator uses random UMAP coordinates when Pyodide is blocked.
 - The `test_bridge_online_mode` case in `test_meta_agentic_tree_search_demo.py` requires the `openai-agents` package. Set `OPENAI_API_KEY=dummy` and run:
 ```bash

--- a/tests/test_check_env_network.py
+++ b/tests/test_check_env_network.py
@@ -2,6 +2,7 @@
 """check_env network detection tests."""
 
 import pytest
+import subprocess
 import check_env
 
 
@@ -20,11 +21,16 @@ def test_offline_no_wheelhouse(monkeypatch: pytest.MonkeyPatch, capsys: pytest.C
     out = capsys.readouterr().out
     assert rc == 1
     assert "--wheelhouse <dir>" in out
+    assert "No network connectivity" in out
 
 
 def test_offline_with_wheelhouse(monkeypatch: pytest.MonkeyPatch) -> None:
     """Allow offline installs when --wheelhouse is provided."""
     _no_missing(monkeypatch)
     monkeypatch.setattr(check_env, "has_network", lambda: False)
+    def _fake_run(*_a, **_k):
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
     rc = check_env.main(["--auto-install", "--wheelhouse", "wheels"])
     assert rc == 0


### PR DESCRIPTION
## Summary
- refine network detection in `check_env.py`
- document wheelhouse preparation for Macro-Sentinel
- add helper script to build demo wheelhouse
- note skipping network tests in README
- update tests for new check_env messaging

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install --timeout 1`
- `pytest tests/test_check_env_network.py -q`
- `pre-commit run --files check_env.py alpha_factory_v1/demos/macro_sentinel/README.md alpha_factory_v1/scripts/build_macro_wheelhouse.sh tests/test_check_env_network.py tests/README.md` *(failed: network required)*

------
https://chatgpt.com/codex/tasks/task_e_684c8e6f2ae083338e0b5b3950f55743