### PR TITLE
[alpha_factory] Clarify macro-sentinel prototype

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -8,6 +8,8 @@
 
 > **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.
 
+This demonstration is a conceptual research prototype. Any references to AGI or superintelligence describe aspirational goals rather than current capabilities.
+
 ---
 
 ## ✨ Key capabilities


### PR DESCRIPTION
## Summary
- clarify that the Macro-Sentinel demo is a conceptual research prototype
- keep existing disclaimer text

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: numpy required)*
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/README.md` *(fails: could not initialize semgrep environment)*

------
https://chatgpt.com/codex/tasks/task_e_684c91a683c483338819ed44657ffeae