### PR TITLE
[alpha_factory] support custom macro sentinel data dir

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -29,7 +29,15 @@ from collections import deque
 from urllib.request import urlopen
 
 # ───────────────────────── Config from env ──────────────────────────
-DATA_DIR = pathlib.Path(__file__).parent / "offline_samples"
+_DEFAULT_DATA_DIR = pathlib.Path(__file__).parent / "offline_samples"
+
+
+def _data_dir() -> pathlib.Path:
+    """Return offline CSV directory from env or default."""
+    return pathlib.Path(os.getenv("OFFLINE_DATA_DIR", str(_DEFAULT_DATA_DIR)))
+
+
+DATA_DIR = _data_dir()
 
 FRED_KEY = os.getenv("FRED_API_KEY")
 ETHERSCAN_KEY = os.getenv("ETHERSCAN_API_KEY")
@@ -60,10 +68,11 @@ _DEFAULT_ROWS = {
 }
 
 
-def _ensure_offline():
-    DATA_DIR.mkdir(exist_ok=True)
+def _ensure_offline() -> None:
+    offline_dir = _data_dir()
+    offline_dir.mkdir(parents=True, exist_ok=True)
     for name, url in OFFLINE_URLS.items():
-        path = DATA_DIR / name
+        path = offline_dir / name
         if path.exists():
             continue
         try:
@@ -79,7 +88,7 @@ def _ensure_offline():
 
 
 def _csv(name: str) -> list[dict]:
-    with open(DATA_DIR / name, newline="") as f:
+    with open(_data_dir() / name, newline="") as f:
         return list(csv.DictReader(f))
 
 

--- a/tests/test_macro_sentinel.py
+++ b/tests/test_macro_sentinel.py
@@ -46,9 +46,11 @@ class TestMacroSentinel(unittest.TestCase):
             orig = data_feeds.aiohttp
             data_feeds.aiohttp = None
             try:
-                with patch.object(data_feeds, "_fred_latest", new_callable=AsyncMock, return_value=None), patch.object(
-                    data_feeds, "_latest_stable_flow", new_callable=AsyncMock, return_value=None
-                ), patch.object(data_feeds, "_latest_cme_settle", new_callable=AsyncMock, return_value=None):
+                with (
+                    patch.object(data_feeds, "_fred_latest", new_callable=AsyncMock, return_value=None),
+                    patch.object(data_feeds, "_latest_stable_flow", new_callable=AsyncMock, return_value=None),
+                    patch.object(data_feeds, "_latest_cme_settle", new_callable=AsyncMock, return_value=None),
+                ):
                     it = data_feeds.stream_macro_events(live=True)
                     await anext(it)
             finally:
@@ -62,8 +64,9 @@ class TestMacroSentinel(unittest.TestCase):
         """_ensure_offline should write one row when downloads fail."""
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
-            with patch.object(data_feeds, "DATA_DIR", tmp), patch(
-                "alpha_factory_v1.demos.macro_sentinel.data_feeds.urlopen", side_effect=Exception
+            with (
+                patch.dict(os.environ, {"OFFLINE_DATA_DIR": tmpdir}),
+                patch("alpha_factory_v1.demos.macro_sentinel.data_feeds.urlopen", side_effect=Exception),
             ):
                 data_feeds._ensure_offline()
                 for name in data_feeds.OFFLINE_URLS:


### PR DESCRIPTION
## Summary
- add `_data_dir()` helper to lookup `OFFLINE_DATA_DIR`
- write and read offline csvs from the env path
- update tests for new environment variable

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: numpy required)*

------
https://chatgpt.com/codex/tasks/task_e_684c936ae94c8333878e075e3ba22cfd