### PR TITLE
[alpha_factory] make macro demo connectivity check configurable

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -50,6 +50,9 @@ Usage: $(basename "$0") [--live] [--reset] [--help]
   --live    Enable live macro collectors (requires API keys in config.env)
   --reset   Stop & purge containers + volumes before new start
   --help    Show this message
+
+Environment variables:
+  CONNECTIVITY_CHECK_URL  Probe URL for outbound HTTPS check (default: https://pypi.org)
 EOF
 }
 
@@ -80,7 +83,8 @@ fi
 # ──────────────────────── prerequisites ───────────────────────
 need docker
 docker compose version &>/dev/null || die "Docker Compose plug-in missing"
-curl -fsSL https://google.com &>/dev/null || warn "No outbound HTTPS — live mode may fail"
+CHECK_URL="${CONNECTIVITY_CHECK_URL:-https://pypi.org}"
+curl -fsSL "$CHECK_URL" &>/dev/null || warn "No outbound HTTPS — live mode may fail"
 
 # Optional reset
 if (( RESET )); then


### PR DESCRIPTION
## Summary
- allow `CONNECTIVITY_CHECK_URL` to override the connectivity probe
- default to using `https://pypi.org`
- document the variable in `--help`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: numpy required)*
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c96013b248333a9012667e9c18e5f