### PR TITLE
[alpha_factory] add macro-sentinel console script

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -80,7 +80,7 @@ repository and cover roughly March–April 2024 activity.
 
 ```bash
 pip install -r requirements.txt
-python agent_macro_entrypoint.py
+macro-sentinel  # or `python agent_macro_entrypoint.py`
 ```
 The entry point pulls minimal CSV snapshots if they are missing so you can run
 fully offline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ verify-wheel-sig = "alpha_factory_v1.scripts.verify_wheel_sig:main"
 mats-demo = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo:main"
 mats-bridge = "alpha_factory_v1.demos.meta_agentic_tree_search_v0.openai_agents_bridge:main"
 governance-bridge = "alpha_factory_v1.demos.solving_agi_governance.openai_agents_bridge:main"
+macro-sentinel = "alpha_factory_v1.demos.macro_sentinel.agent_macro_entrypoint:launch_ui"
 
 [project.optional-dependencies]
 tests = [


### PR DESCRIPTION
## Summary
- expose `macro-sentinel` entry point in `pyproject.toml`
- document usage of the new command in the Macro-Sentinel README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: import errors during collection)*
- `pre-commit run --files pyproject.toml alpha_factory_v1/demos/macro_sentinel/README.md` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_684c9850a1948333a00846c44aea55ac