### PR TITLE
[alpha_factory] align macro sentinel base URL variable

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -66,7 +66,7 @@ Offline mode requires an [Ollama](https://ollama.com) server with the
 `mixtral:instruct` model available at `http://localhost:11434`. The Docker
 stack provisions this container automatically via the `offline` profile, but
 when running bare‑metal or inside Colab you must manually start `ollama serve`
-first.
+first. Set `OLLAMA_BASE_URL` if the server listens on a different host or port.
 
 Offline sample data is fetched automatically the first time you run the
 launcher—no manual downloads required. These CSV snapshots mirror
@@ -122,6 +122,7 @@ without internet access.
 | `OPENAI_API_KEY` | *(blank)* | Use GPT‑4o when provided; offline Mixtral otherwise |
 | `MODEL_NAME` | `gpt-4o-mini` | Any OpenAI completion model |
 | `TEMPERATURE` | `0.15` | LLM sampling temperature |
+| `OLLAMA_BASE_URL` | `http://ollama:11434/v1` | Offline LLM endpoint |
 | `FRED_API_KEY` | *(blank)* | Enables live yield‑curve collector |
 | `ETHERSCAN_API_KEY` | *(blank)* | Enables on‑chain stable‑flow collector |
 | `TW_BEARER_TOKEN` | *(blank)* | Twitter/X API bearer token for Fed speech stream |

--- a/alpha_factory_v1/demos/macro_sentinel/config.env.sample
+++ b/alpha_factory_v1/demos/macro_sentinel/config.env.sample
@@ -11,6 +11,7 @@
 OPENAI_API_KEY=            # leave blank to run fully offline (Mixtral via Ollama)
 MODEL_NAME=gpt-4o-mini     # any model supported by OpenAI Agents SDK
 TEMPERATURE=0.15           # generation creativity
+OLLAMA_BASE_URL=http://ollama:11434/v1  # custom LM endpoint when offline
 
 # ┌───────────────────────────
 # │  Database & cache

--- a/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
@@ -126,7 +126,7 @@ services:
       DATABASE_URL: "postgresql://alpha:${PG_PASSWORD:-alpha}@timescaledb:5432/macro_ticks"
       REDIS_URL: "redis://redis:6379"
       VECTOR_HOST: "qdrant:6333"
-      LLM_BASE_URL: "${LLM_BASE_URL:-http://ollama:11434/v1}"
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434/v1}"
     volumes:
       - ./:/app/demo:ro
     ports:

--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -121,6 +121,14 @@ if [[ -z "${OPENAI_API_KEY:-}" && -f "$env_file" ]]; then
   source "$env_file"
 fi
 
+# Propagate custom Ollama endpoint
+if [[ -n "${OLLAMA_BASE_URL:-}" ]]; then
+  export OLLAMA_BASE_URL
+elif [[ -f "$env_file" ]]; then
+  base_url=$(grep -E '^OLLAMA_BASE_URL=' "$env_file" | cut -d= -f2-)
+  [[ -n "$base_url" ]] && export OLLAMA_BASE_URL="$base_url"
+fi
+
 # ──────────────────────── offline data ────────────────────────
 say "Syncing offline CSV snapshots"
 mkdir -p "$offline_dir"

--- a/tests/test_macro_compose_config.py
+++ b/tests/test_macro_compose_config.py
@@ -131,3 +131,16 @@ def test_run_macro_demo_multiple_profiles(tmp_path: Path) -> None:
     log = docker_log.read_text()
     assert "--profile offline" in log
     assert "--profile live-feed" in log
+
+
+def test_compose_base_url_substitution() -> None:
+    env = os.environ.copy()
+    env["OLLAMA_BASE_URL"] = "http://example.com/v1"
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE_FILE), "config"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert "http://example.com/v1" in result.stdout


### PR DESCRIPTION
## Summary
- support `OLLAMA_BASE_URL` in the macro sentinel compose file
- provide a default in `config.env.sample` and docs
- export the variable in the launcher when set
- document offline server override in the README
- extend tests for the new variable

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ccc6570cc83338f0094308f700902