### PR TITLE
[alpha_factory] fix imports in macro sentinel demos

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
+++ b/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
@@ -20,7 +20,11 @@ This research prototype provides no financial advice.
 """
 
 from __future__ import annotations
-import os, json, asyncio, contextlib
+
+import asyncio
+import contextlib
+import json
+import os
 from urllib import request
 try:
     import pandas as pd

--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -18,7 +18,12 @@ Highlights
 """
 
 from __future__ import annotations
-import os, csv, json, asyncio, datetime as dt, pathlib, random
+
+import asyncio
+import csv
+import os
+import pathlib
+import datetime as dt
 
 try:  # aiohttp optional at test time
     import aiohttp
@@ -229,7 +234,8 @@ def _push_redis(evt: Dict[str, Any]):
     """Publish ``evt`` to a Redis stream when configured."""
     if not REDIS_URL:
         return
-    import redis, json as _j
+    import redis
+    import json as _j
 
     r = redis.from_url(REDIS_URL)
     r.xadd("macro_stream", {"json": _j.dumps(evt)}, maxlen=10000)
@@ -239,7 +245,9 @@ def _push_qdrant(evt: Dict[str, Any]):
     """Insert ``evt`` into a Qdrant collection when configured."""
     if not VEC_URL:
         return
-    import af_requests as requests, hashlib, json as _j
+    import af_requests as requests
+    import hashlib
+    import json as _j
 
     vec = hashlib.sha256(evt["fed_speech"].encode()).digest()[:8]
     payload = {"points": [{"id": evt["timestamp"], "vector": list(vec), "payload": evt}]}

--- a/alpha_factory_v1/demos/macro_sentinel/simulation_core.py
+++ b/alpha_factory_v1/demos/macro_sentinel/simulation_core.py
@@ -17,7 +17,8 @@ New in this revision
 """
 
 from __future__ import annotations
-import functools, datetime as dt, random
+
+import random
 
 try:  # optional deps
     import numpy as np


### PR DESCRIPTION
## Summary
- split up multi-import lines in macro sentinel demo files
- remove unused imports
- clean up per ruff suggestions

## Testing
- `ruff check alpha_factory_v1/demos/macro_sentinel/*.py`
- `python scripts/check_python_deps.py` *(fails: numpy, yaml, pandas missing)*
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684cd101b92c8333830c297e6151f003