### PR TITLE
[alpha_factory] add annotations for macro sentinel

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
+++ b/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
@@ -10,7 +10,7 @@ An Agentic pipeline that
 3. sizes a hedge,
 4. explains its reasoning in prose.
 
-OpenAI key present  → GPT-4o  
+OpenAI key present  → GPT-4o
 No key             → Mixtral via Ollama (offline)
 
 Deploy via Docker (run_macro_demo.sh) or directly:
@@ -26,6 +26,8 @@ import contextlib
 import json
 import os
 from urllib import request
+from typing import Any, AsyncIterator, Tuple, cast
+
 try:
     import pandas as pd
     import gradio as gr
@@ -50,9 +52,9 @@ def _check_ollama(url: str) -> None:
         request.urlopen(f"{base}/api/tags", timeout=3)
     except Exception as exc:  # pragma: no cover - network check
         raise RuntimeError(
-            f"Ollama not reachable at {base}. "
-            "Install it from https://ollama.com and run 'ollama serve'."
+            f"Ollama not reachable at {base}. " "Install it from https://ollama.com and run 'ollama serve'."
         ) from exc
+
 
 # ─────────────────────────── LLM bridge ─────────────────────────────
 if os.getenv("OPENAI_API_KEY"):
@@ -65,18 +67,19 @@ LLM = OpenAIAgent(
     model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
     api_key=os.getenv("OPENAI_API_KEY") or None,
     base_url=base_url,
-    temperature=float(os.getenv("TEMPERATURE", 0.15))
+    temperature=float(os.getenv("TEMPERATURE", 0.15)),
 )
 
 # ─────────────────────────── Globals ────────────────────────────────
-PORTFOLIO_USD = float(os.getenv("DEFAULT_PORTFOLIO_USD", "2000000"))
-LIVE_FEED     = bool(int(os.getenv("LIVE_FEED", "0")))
-simulator     = MonteCarloSimulator()
-event_iter    = stream_macro_events(live=LIVE_FEED)   # async generator
+PORTFOLIO_USD: float = float(os.getenv("DEFAULT_PORTFOLIO_USD", "2000000"))
+LIVE_FEED: bool = bool(int(os.getenv("LIVE_FEED", "0")))
+simulator: MonteCarloSimulator = MonteCarloSimulator()
+event_iter: AsyncIterator[dict[str, Any]] = stream_macro_events(live=LIVE_FEED)
+
 
 # ─────────────────────────── Tools ──────────────────────────────────
-@Tool("macro_event", "Stream the newest macro telemetry event.")
-async def macro_event() -> dict:
+@Tool("macro_event", "Stream the newest macro telemetry event.")  # type: ignore[misc]
+async def macro_event() -> dict[str, Any]:
     """Return the next macro event from the feed.
 
     Returns:
@@ -84,8 +87,9 @@ async def macro_event() -> dict:
     """
     return await anext(event_iter)
 
-@Tool("mc_risk", "Run Monte-Carlo risk. Returns hedge + scenario table.")
-async def mc_risk(event: dict, portfolio: float = PORTFOLIO_USD) -> dict:
+
+@Tool("mc_risk", "Run Monte-Carlo risk. Returns hedge + scenario table.")  # type: ignore[misc]
+async def mc_risk(event: dict[str, Any], portfolio: float = PORTFOLIO_USD) -> dict[str, Any]:
     """Run risk simulation and size a hedge.
 
     Args:
@@ -96,12 +100,13 @@ async def mc_risk(event: dict, portfolio: float = PORTFOLIO_USD) -> dict:
         Dictionary with hedging information and return scenarios.
     """
     factors = simulator.simulate(event)
-    hedge   = simulator.hedge(factors, portfolio)
-    scen    = simulator.scenario_table(factors).to_dict(orient="records")
+    hedge = simulator.hedge(factors, portfolio)
+    scen = simulator.scenario_table(factors).to_dict(orient="records")
     return {"hedge": hedge, "scenarios": scen}
 
-@Tool("order_stub", "Draft a JSON order for Micro-ES future.")
-async def order_stub(hedge: dict) -> dict:
+
+@Tool("order_stub", "Draft a JSON order for Micro-ES future.")  # type: ignore[misc]
+async def order_stub(hedge: dict[str, Any]) -> dict[str, Any]:
     """Create a stub futures order based on the hedge.
 
     Args:
@@ -111,12 +116,13 @@ async def order_stub(hedge: dict) -> dict:
         Order parameters for a market trade in Micro‑ES.
     """
     notional = hedge["es_notional"]
-    side     = "SELL" if notional > 0 else "BUY"
-    qty      = max(int(abs(notional)//50_000), 1)    # 50 k USD ≈ 1 MES
+    side = "SELL" if notional > 0 else "BUY"
+    qty = max(int(abs(notional) // 50_000), 1)  # 50 k USD ≈ 1 MES
     return {"symbol": "MES", "qty": qty, "side": side, "type": "MKT"}
 
-@Tool("explain", "Narrate risk & hedge for a PM.")
-async def explain(event: dict, hedge: dict) -> str:
+
+@Tool("explain", "Narrate risk & hedge for a PM.")  # type: ignore[misc]
+async def explain(event: dict[str, Any], hedge: dict[str, Any]) -> str:
     """Explain the hedge rationale in prose.
 
     Args:
@@ -132,22 +138,21 @@ async def explain(event: dict, hedge: dict) -> str:
         f"Event:\n```json\n{json.dumps(event, indent=2)}\n```\n"
         f"Hedge:\n```json\n{json.dumps(hedge, indent=2)}\n```"
     )
-    return LLM(prompt)
+    return cast(str, LLM(prompt))
+
 
 # ─────────────────────────── Agent ──────────────────────────────────
-sentinel = Agent(
-    name  = "Macro-Sentinel",
-    llm   = LLM,
-    tools = [macro_event, mc_risk, order_stub, explain]
-)
+sentinel = Agent(name="Macro-Sentinel", llm=LLM, tools=[macro_event, mc_risk, order_stub, explain])
 
 # Optionally expose via Google ADK (Agent-to-Agent federation)
 try:  # pragma: no cover - optional dependency
     from alpha_factory_v1.backend import adk_bridge
+
     adk_bridge.auto_register([sentinel])
     adk_bridge.maybe_launch()
 except Exception:
     pass
+
 
 # ─────────────────────────── Gradio UI ──────────────────────────────
 async def launch_ui() -> None:
@@ -155,44 +160,42 @@ async def launch_ui() -> None:
         gr.Markdown("## 📈 Macro-Sentinel — real-time macro risk radar")
 
         col1, col2 = gr.Row().children
-        event_box   = gr.Json(label="Latest macro event", elem_id="evt")
-        scen_df     = gr.Dataframe(label="Return scenarios (P50/P95/P99)")
+        event_box = gr.Json(label="Latest macro event", elem_id="evt")
+        scen_df = gr.Dataframe(label="Return scenarios (P50/P95/P99)")
 
-        metrics_md  = gr.Markdown()
-        story_md    = gr.Markdown()
-        run_btn     = gr.Button("🔄 Run Sentinel Cycle")
+        metrics_md = gr.Markdown()
+        story_md = gr.Markdown()
+        run_btn = gr.Button("🔄 Run Sentinel Cycle")
 
-        async def cycle():
-            event   = await macro_event()
-            risk    = await mc_risk(event, PORTFOLIO_USD)
-            hedge   = risk["hedge"]
-            story   = await explain(event, hedge)
+        async def cycle() -> Tuple[dict[str, Any], pd.DataFrame, str, str]:
+            event = await macro_event()
+            risk = await mc_risk(event, PORTFOLIO_USD)
+            hedge = risk["hedge"]
+            story = await explain(event, hedge)
             scen_df = pd.DataFrame(risk["scenarios"])
 
-            metric = (f"**VaR 5 %:** {hedge['metrics']['var']:.2%} &nbsp;&nbsp;"
-                      f"**CVaR 5 %:** {hedge['metrics']['cvar']:.2%} &nbsp;&nbsp;"
-                      f"**Skew:** {hedge['metrics']['skew']:.2f}<br>"
-                      f"**ES notional:** ${hedge['es_notional']:,.0f}  "
-                      f"(Micro-ES qty ≈ {abs(int(hedge['es_notional']//50_000))})")
+            metric = (
+                f"**VaR 5 %:** {hedge['metrics']['var']:.2%} &nbsp;&nbsp;"
+                f"**CVaR 5 %:** {hedge['metrics']['cvar']:.2%} &nbsp;&nbsp;"
+                f"**Skew:** {hedge['metrics']['skew']:.2f}<br>"
+                f"**ES notional:** ${hedge['es_notional']:,.0f}  "
+                f"(Micro-ES qty ≈ {abs(int(hedge['es_notional']//50_000))})"
+            )
 
             return event, scen_df, metric, story
 
-        run_btn.click(
-            cycle,
-            outputs=[event_box, scen_df, metrics_md, story_md]
-        )
+        run_btn.click(cycle, outputs=[event_box, scen_df, metrics_md, story_md])
 
     fast = FastAPI()
 
-    @fast.get("/healthz", response_class=PlainTextResponse, include_in_schema=False)
+    @fast.get("/healthz", response_class=PlainTextResponse, include_in_schema=False)  # type: ignore[misc]
     async def _health() -> str:  # noqa: D401
         return "ok"
 
     gr_app = gr.mount_gradio_app(fast, ui, path="/")
-    server = uvicorn.Server(
-        uvicorn.Config(gr_app, host="0.0.0.0", port=7864, loop="asyncio")
-    )
+    server = uvicorn.Server(uvicorn.Config(gr_app, host="0.0.0.0", port=7864, loop="asyncio"))
     await server.serve()
+
 
 # ─────────────────────────── Main ───────────────────────────────────
 if __name__ == "__main__":
@@ -201,6 +204,7 @@ if __name__ == "__main__":
     finally:
         # tidy aiohttp session if running outside Docker
         from data_feeds import aiohttp, _SESSION
+
         if (s := _SESSION) and isinstance(s, aiohttp.ClientSession):
             with contextlib.suppress(Exception):
                 asyncio.run(s.close())

--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -92,7 +92,8 @@ def _ensure_offline() -> None:
                 writer.writerow(row)
 
 
-def _csv(name: str) -> list[dict]:
+def _csv(name: str) -> list[dict[str, str]]:
+    """Return rows from an offline CSV file."""
     with open(_data_dir() / name, newline="") as f:
         return list(csv.DictReader(f))
 
@@ -140,7 +141,7 @@ async def _http_text(url: str) -> str:
     s = await _session()
     async with s.get(url) as r:
         r.raise_for_status()
-        return await r.text()
+        return str(await r.text())
 
 
 # ───────────────────────── Live fetchers ─────────────────────────────
@@ -158,7 +159,7 @@ async def _fred_latest(series: str) -> Optional[float]:
     return float(val) if val not in {"", "."} else None
 
 
-_CACHE_SPEECH = deque(maxlen=10)
+_CACHE_SPEECH: deque[str] = deque(maxlen=10)
 
 
 async def _latest_fed_speech() -> Optional[str]:
@@ -210,7 +211,7 @@ def _safe(f: Any, *a: Any, **kw: Any) -> None:
         pass
 
 
-def _push_db(evt: Dict[str, Any]):
+def _push_db(evt: Dict[str, Any]) -> None:
     """Persist ``evt`` to TimescaleDB when configured."""
     if not DB_URL:
         return
@@ -230,7 +231,7 @@ def _push_db(evt: Dict[str, Any]):
         )
 
 
-def _push_redis(evt: Dict[str, Any]):
+def _push_redis(evt: Dict[str, Any]) -> None:
     """Publish ``evt`` to a Redis stream when configured."""
     if not REDIS_URL:
         return
@@ -241,7 +242,7 @@ def _push_redis(evt: Dict[str, Any]):
     r.xadd("macro_stream", {"json": _j.dumps(evt)}, maxlen=10000)
 
 
-def _push_qdrant(evt: Dict[str, Any]):
+def _push_qdrant(evt: Dict[str, Any]) -> None:
     """Insert ``evt`` into a Qdrant collection when configured."""
     if not VEC_URL:
         return


### PR DESCRIPTION
## Summary
- add return type hints for push helpers in data_feeds
- annotate tool functions and global variables in Macro-Sentinel demo
- format with black

## Testing
- `ruff check alpha_factory_v1/demos/macro_sentinel/data_feeds.py alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py`
- `black --check alpha_factory_v1/demos/macro_sentinel/data_feeds.py alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py`
- `python -m mypy alpha_factory_v1/demos/macro_sentinel/*.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Skipped due to environment check)*

------
https://chatgpt.com/codex/tasks/task_e_684cd1d4138c8333bf617ec5ec1b8da5