### PR TITLE
[alpha_factory] Document OLLAMA_BASE_URL for offline Macro-Sentinel

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -66,7 +66,7 @@ Offline mode requires an [Ollama](https://ollama.com) server with the
 `mixtral:instruct` model available at `http://localhost:11434`. The Docker
 stack provisions this container automatically via the `offline` profile, but
 when running bare‑metal or inside Colab you must manually start `ollama serve`
-first. Set `OLLAMA_BASE_URL` if the server listens on a different host or port.
+first. If the server isn't on `localhost`, set the `OLLAMA_BASE_URL` environment variable (or edit `config.env`) to its full HTTP endpoint, e.g.: `export OLLAMA_BASE_URL=http://192.168.1.10:11434/v1`.
 
 Offline sample data is fetched automatically the first time you run the
 launcher—no manual downloads required. These CSV snapshots mirror

--- a/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
+++ b/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
@@ -15,8 +15,8 @@
       "id": "768347ff",
       "metadata": {},
       "source": [
-        "# 🌐 Macro‑Sentinel · Colab Notebook\n",
-        "*Alpha‑Factory v1 👁️✨ — Cross‑asset macro risk radar*"
+        "# \ud83c\udf10\u00a0Macro\u2011Sentinel \u00b7 Colab Notebook\n",
+        "*Alpha\u2011Factory\u00a0v1\u00a0\ud83d\udc41\ufe0f\u2728\u00a0\u2014 Cross\u2011asset macro risk radar*"
       ]
     },
     {
@@ -26,13 +26,13 @@
       "source": [
         "### Why this notebook?\n",
         "\n",
-        "Run the full **Macro‑Sentinel** agent stack in <10 min without Docker.\n",
-        "Ideal for quick experimentation, hackathons, classrooms, or due‑diligence.\n",
+        "Run the full **Macro\u2011Sentinel** agent stack in <10\u202fmin without Docker.\n",
+        "Ideal for quick experimentation, hackathons, classrooms, or due\u2011diligence.\n",
         "\n",
         "| Mode | LLM | Data feeds |\n",
         "|------|-----|------------|\n",
-        "| **Offline** (default) | Mixtral‑8x7B (Ollama) | bundled CSV snapshots |\n",
-        "| **Online**            | GPT‑4o (OpenAI)       | FRED API, Fed RSS, on‑chain flows |\n",
+        "| **Offline** (default) | Mixtral\u20118x7B (Ollama) | bundled CSV snapshots |\n",
+        "| **Online**            | GPT\u20114o (OpenAI)       | FRED API, Fed RSS, on\u2011chain flows |\n",
         "\n",
         "---"
       ]
@@ -51,7 +51,7 @@
       "id": "541cda31",
       "metadata": {},
       "source": [
-        "## 0 · Runtime check"
+        "##\u00a00 \u00b7 Runtime check"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!nvidia-smi -L || echo '🔹 GPU not detected — running on CPU'"
+        "!nvidia-smi -L || echo '\ud83d\udd39 GPU not detected \u2014 running on CPU'"
       ]
     },
     {
@@ -69,8 +69,8 @@
       "id": "9721caf1",
       "metadata": {},
       "source": [
-        "## 1 · Clone repo & install Python deps\n",
-        "*(≈ 90 s; wheels cached by Colab)*"
+        "##\u00a01 \u00b7 Clone repo & install Python deps\n",
+        "*(\u2248\u202f90\u202fs; wheels cached by Colab)*"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "id": "ef4ee381",
       "metadata": {},
       "source": [
-        "### 🛜 Optional: pull Mixtral for offline mode (~4 GB)"
+        "###\u00a0\ud83d\udedc Optional: pull Mixtral for offline mode (~4\u202fGB)"
       ]
     },
     {
@@ -111,7 +111,7 @@
         "        subprocess.run([\"ollama\", \"serve\"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n",
         "        subprocess.run([\"ollama\", \"pull\", \"mixtral:instruct\"], check=True)\n",
         "    except FileNotFoundError:\n",
-        "        print(\"⚠️ Ollama not found; offline LLM will not work.\")\n",
+        "        print(\"\u26a0\ufe0f Ollama not found; offline LLM will not work.\")\n",
         "PY\n"
       ]
     },
@@ -120,7 +120,10 @@
       "id": "8a832ea8",
       "metadata": {},
       "source": [
-        "## 2 · Configure credentials & runtime flags"
+        "##\u00a02 \u00b7 Configure credentials & runtime flags\n",
+        "\n",
+        "Set `OPENAI_API_KEY` to use GPT-4o. Leave it blank to run Mixtral locally via Ollama.\n",
+        "If Ollama runs on another host, set `OLLAMA_BASE_URL` to its http endpoint.\n"
       ]
     },
     {
@@ -135,13 +138,14 @@
         "    if v is not None:\n",
         "        os.environ[k]=v\n",
         "\n",
-        "_set('OPENAI_API_KEY', getpass.getpass('🔑 OpenAI key (blank for offline): '))\n",
+        "_set('OPENAI_API_KEY', getpass.getpass('\ud83d\udd11 OpenAI key (blank for offline): '))\n",
         "_set('FRED_API_KEY',  '')\n",
         "_set('TW_BEARER_TOKEN', getpass.getpass('Twitter bearer token (optional): '))\n",
-        "_set('LIVE_FEED',     input('Real‑time feeds? (0/1) → ') or '0')\n",
+        "_set('LIVE_FEED',     input('Real\u2011time feeds? (0/1) \u2192 ') or '0')\n",
+        "_set('OLLAMA_BASE_URL', input('Ollama base URL (blank=local): ') or None)\n",
         "os.environ['DEFAULT_PORTFOLIO_USD'] = '2000000'\n",
         "\n",
-        "print(json.dumps({k:os.getenv(k,'') for k in ['OPENAI_API_KEY','FRED_API_KEY','TW_BEARER_TOKEN','LIVE_FEED']}, indent=2))\n"
+        "print(json.dumps({k:os.getenv(k,'') for k in ['OPENAI_API_KEY','OLLAMA_BASE_URL','FRED_API_KEY','TW_BEARER_TOKEN','LIVE_FEED']}, indent=2))\n"
       ]
     },
     {
@@ -149,7 +153,7 @@
       "id": "3f8da8c5",
       "metadata": {},
       "source": [
-        "## 3 · Launch Macro‑Sentinel dashboard"
+        "##\u00a03 \u00b7 Launch Macro\u2011Sentinel dashboard"
       ]
     },
     {
@@ -175,13 +179,13 @@
         "        if m: link_q.put(m.group(1))\n",
         "threading.Thread(target=_tail, daemon=True).start()\n",
         "\n",
-        "print('⏳ Waiting for Gradio tunnel...')\n",
+        "print('\u23f3 Waiting for Gradio tunnel...')\n",
         "try:\n",
         "    url = link_q.get(timeout=120)\n",
         "    from IPython.display import Markdown, display\n",
-        "    display(Markdown(f'### ✅ Dashboard ready: [Open ↗]({url})'))\n",
+        "    display(Markdown(f'### \u2705 Dashboard ready: [Open \u2197]({url})'))\n",
         "except queue.Empty:\n",
-        "    print('⚠️ Tunnel timeout')\n"
+        "    print('\u26a0\ufe0f Tunnel timeout')\n"
       ]
     },
     {
@@ -189,7 +193,7 @@
       "id": "c0c5419c",
       "metadata": {},
       "source": [
-        "## 4 · Programmatic agent call (optional)"
+        "##\u00a04 \u00b7 Programmatic agent call (optional)"
       ]
     },
     {
@@ -217,7 +221,7 @@
       "id": "600e950a",
       "metadata": {},
       "source": [
-        "## 5 · Chat over A2A protocol (bonus)"
+        "##\u00a05 \u00b7 Chat over A2A protocol (bonus)"
       ]
     },
     {
@@ -238,7 +242,7 @@
       "id": "3374dbcf",
       "metadata": {},
       "source": [
-        "## 6 · Graceful shutdown"
+        "##\u00a06 \u00b7 Graceful shutdown"
       ]
     },
     {
@@ -248,7 +252,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "proc.terminate(); print('✅ Sentinel stopped')"
+        "proc.terminate(); print('\u2705\u00a0Sentinel stopped')"
       ]
     },
     {
@@ -257,7 +261,7 @@
       "metadata": {},
       "source": [
         "---\n",
-        "© 2025 **MONTREAL.AI** • Apache-2.0 License"
+        "\u00a9\u00a02025 **MONTREAL.AI** \u2022 Apache-2.0 License"
       ]
     }
   ],

--- a/alpha_factory_v1/demos/macro_sentinel/config.env.sample
+++ b/alpha_factory_v1/demos/macro_sentinel/config.env.sample
@@ -11,7 +11,7 @@
 OPENAI_API_KEY=            # leave blank to run fully offline (Mixtral via Ollama)
 MODEL_NAME=gpt-4o-mini     # any model supported by OpenAI Agents SDK
 TEMPERATURE=0.15           # generation creativity
-OLLAMA_BASE_URL=http://ollama:11434/v1  # custom LM endpoint when offline
+OLLAMA_BASE_URL=http://ollama:11434/v1  # base URL for Ollama when OPENAI_API_KEY is unset
 
 # ┌───────────────────────────
 # │  Database & cache


### PR DESCRIPTION
## Summary
- document how to set `OLLAMA_BASE_URL` in Macro‑Sentinel demo
- note the variable in `config.env.sample`
- demonstrate usage in the Colab notebook

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install --wheelhouse wheels` *(fails: could not find numpy)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684cd2de88288333971027f5b33ec26c