### PR TITLE
[alpha_factory] add curl dependency check

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -85,6 +85,7 @@ fi
 
 # ──────────────────────── prerequisites ───────────────────────
 need docker
+need curl
 docker compose version &>/dev/null || die "Docker Compose plug-in missing"
 CHECK_URL="${CONNECTIVITY_CHECK_URL:-https://pypi.org}"
 curl -fsSL "$CHECK_URL" &>/dev/null || warn "No outbound HTTPS — live mode may fail"


### PR DESCRIPTION
## Summary
- check for `curl` in Macro-Sentinel launcher
- skip if curl missing in tests

## Testing
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh tests/test_macro_launcher.py --hook-stage manual`

------
https://chatgpt.com/codex/tasks/task_e_684cd6efccf08333915f31d5783f11e8