### PR TITLE
[alpha_factory] pin demo-assets revision

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -74,6 +74,10 @@ launcher—no manual downloads required. These CSV snapshots mirror
 public data from the [demo‑assets](https://github.com/MontrealAI/demo-assets)
 repository and cover roughly March–April 2024 activity.
 
+These CSVs are pinned at revision `90fe9b623b3a0ae5475cf4fa8693d43cb5ba9ac5` of
+the demo-assets repo. Set `DEMO_ASSETS_REV=<sha>` to override when refreshing
+the snapshots.
+
 To reuse existing CSV snapshots or share them across projects,
 set `OFFLINE_DATA_DIR=/path/to/csvs` in your shell or `config.env`.
 

--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -33,6 +33,11 @@ from typing import AsyncIterator, Dict, Any, Optional
 from collections import deque
 from urllib.request import urlopen
 
+# Source snapshot revision for offline CSVs
+# Update to match `DEMO_ASSETS_REV` in run_macro_demo.sh when refreshing
+# offline samples.
+DEMO_ASSETS_REV = os.getenv("DEMO_ASSETS_REV", "90fe9b623b3a0ae5475cf4fa8693d43cb5ba9ac5")
+
 # ───────────────────────── Config from env ──────────────────────────
 _DEFAULT_DATA_DIR = pathlib.Path(__file__).parent / "offline_samples"
 
@@ -59,10 +64,10 @@ VEC_URL = os.getenv("VECTOR_HOST")  # Qdrant
 
 # ───────────────────────── Helpers / offline CSV ────────────────────
 OFFLINE_URLS = {
-    "fed_speeches.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/fed_speeches.csv",
-    "yield_curve.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/yield_curve.csv",
-    "stable_flows.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/stable_flows.csv",
-    "cme_settles.csv": "https://raw.githubusercontent.com/MontrealAI/demo-assets/main/cme_settles.csv",
+    "fed_speeches.csv": f"https://raw.githubusercontent.com/MontrealAI/demo-assets/{DEMO_ASSETS_REV}/fed_speeches.csv",
+    "yield_curve.csv": f"https://raw.githubusercontent.com/MontrealAI/demo-assets/{DEMO_ASSETS_REV}/yield_curve.csv",
+    "stable_flows.csv": f"https://raw.githubusercontent.com/MontrealAI/demo-assets/{DEMO_ASSETS_REV}/stable_flows.csv",
+    "cme_settles.csv": f"https://raw.githubusercontent.com/MontrealAI/demo-assets/{DEMO_ASSETS_REV}/cme_settles.csv",
 }
 
 _DEFAULT_ROWS = {

--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -26,6 +26,9 @@
 set -Eeuo pipefail
 shopt -s inherit_errexit
 
+# Pinned demo-assets revision (override with env variable)
+DEMO_ASSETS_REV=${DEMO_ASSETS_REV:-90fe9b623b3a0ae5475cf4fa8693d43cb5ba9ac5}
+
 # ────────────────────────── helpers ──────────────────────────
 say()  { printf '\033[1;36m▶ %s\033[0m\n' "$*"; }
 warn() { printf '\033[1;33m⚠ %s\033[0m\n' "$*" >&2; }
@@ -135,10 +138,10 @@ say "Syncing offline CSV snapshots"
 mkdir -p "$offline_dir"
 mkdir -p "$placeholder_dir"
 declare -A SRC=(
-  [fed_speeches.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/main/fed_speeches.csv"
-  [yield_curve.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/main/yield_curve.csv"
-  [stable_flows.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/main/stable_flows.csv"
-  [cme_settles.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/main/cme_settles.csv"
+  [fed_speeches.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/${DEMO_ASSETS_REV}/fed_speeches.csv"
+  [yield_curve.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/${DEMO_ASSETS_REV}/yield_curve.csv"
+  [stable_flows.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/${DEMO_ASSETS_REV}/stable_flows.csv"
+  [cme_settles.csv]="https://raw.githubusercontent.com/MontrealAI/demo-assets/${DEMO_ASSETS_REV}/cme_settles.csv"
 )
 for f in "${!SRC[@]}"; do
   if [[ -f "$offline_dir/$f" ]]; then

--- a/tests/test_macro_launcher.py
+++ b/tests/test_macro_launcher.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import re
 from pathlib import Path
 
 import pytest
@@ -149,3 +150,18 @@ def test_run_macro_demo_requires_curl(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "curl is required" in result.stderr
+
+
+def test_demo_assets_revision_pinned() -> None:
+    expected = "90fe9b623b3a0ae5475cf4fa8693d43cb5ba9ac5"
+    with open(RUN_SCRIPT) as f:
+        text = f.read()
+    m = re.search(r"DEMO_ASSETS_REV=\$\{DEMO_ASSETS_REV:-([0-9a-f]{40})\}", text)
+    assert m, "revision variable missing"
+    assert m.group(1) == expected
+
+    from alpha_factory_v1.demos.macro_sentinel import data_feeds
+
+    assert data_feeds.DEMO_ASSETS_REV == expected
+    for url in data_feeds.OFFLINE_URLS.values():
+        assert expected in url


### PR DESCRIPTION
## Summary
- pin offline CSV snapshot revision for macro demo
- allow override via `DEMO_ASSETS_REV` in `run_macro_demo.sh`
- document pinned revision in Macro Sentinel README
- note revision variable in `data_feeds.py`
- check pinned URLs in tests

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684cdaf2cd40833394d4b162c717a5b0