### PR TITLE
[alpha_factory] handle missing openai_agents

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
+++ b/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
@@ -38,7 +38,13 @@ except ModuleNotFoundError as exc:  # pragma: no cover - runtime check
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 import uvicorn
-from openai_agents import Agent, OpenAIAgent, Tool
+
+try:
+    from openai_agents import Agent, OpenAIAgent, Tool
+except ModuleNotFoundError as exc:  # pragma: no cover - runtime check
+    raise SystemExit(
+        "Run 'python ../../check_env.py --demo macro_sentinel --auto-install' or" " 'pip install openai-agents'"
+    ) from exc
 from data_feeds import stream_macro_events
 from simulation_core import MonteCarloSimulator
 

--- a/tests/test_macro_adk_integration.py
+++ b/tests/test_macro_adk_integration.py
@@ -22,32 +22,45 @@ def test_macro_entrypoint_launch(monkeypatch: pytest.MonkeyPatch) -> None:
         stub = ModuleType("openai_agents")
 
         class _Agent:
-            def __init__(self, *a, **kw):
+            def __init__(self, *a: object, **kw: object) -> None:
                 self.name = kw.get("name", "agent")
 
         class _OpenAI:
-            def __init__(self, *a, **kw):
+            def __init__(self, *a: object, **kw: object) -> None:
                 pass
 
-            def __call__(self, *_a, **_k):
+            def __call__(self, *_a: object, **_k: object) -> str:
                 return ""
 
-        def _tool(*_a, **_kw):
-            def _decorator(func):
+        def _tool(*_a: object, **_kw: object) -> object:
+            def _decorator(func: object) -> object:
                 return func
 
             return _decorator
 
-        stub.Agent = _Agent
-        stub.OpenAIAgent = _OpenAI
-        stub.Tool = _tool
+        setattr(stub, "Agent", _Agent)
+        setattr(stub, "OpenAIAgent", _OpenAI)
+        setattr(stub, "Tool", _tool)
         sys.modules["openai_agents"] = stub
 
     mod_path = "alpha_factory_v1.demos.macro_sentinel.agent_macro_entrypoint"
     sys.modules.pop(mod_path, None)
 
-    with patch("alpha_factory_v1.backend.adk_bridge.auto_register"), \
-         patch("alpha_factory_v1.backend.adk_bridge.maybe_launch") as maybe_launch:
+    with patch("alpha_factory_v1.backend.adk_bridge.auto_register"), patch(
+        "alpha_factory_v1.backend.adk_bridge.maybe_launch"
+    ) as maybe_launch:
         importlib.import_module(mod_path)
         maybe_launch.assert_called_once_with()
 
+
+def test_macro_entrypoint_missing_openai_agents(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing the entrypoint without openai_agents should exit."""
+
+    monkeypatch.delenv("ALPHA_FACTORY_ENABLE_ADK", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    sys.modules.pop("openai_agents", None)
+    mod_path = "alpha_factory_v1.demos.macro_sentinel.agent_macro_entrypoint"
+    sys.modules.pop(mod_path, None)
+
+    with pytest.raises(SystemExit, match="check_env.py --demo macro_sentinel"):
+        importlib.import_module(mod_path)


### PR DESCRIPTION
## Summary
- handle missing `openai_agents` in Macro-Sentinel entrypoint
- test the SystemExit path when `openai_agents` isn't installed

## Testing
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py tests/test_macro_adk_integration.py` *(fails: proto-verify)*
- `pytest tests/test_macro_adk_integration.py::test_macro_entrypoint_missing_openai_agents -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ce28d8ee083339ef1c6e5d8e5d385