### PR TITLE
[alpha_factory] support POLL_INTERVAL_SEC

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -136,6 +136,7 @@ without internet access.
 | `TW_BEARER_TOKEN` | *(blank)* | Twitter/X API bearer token for Fed speech stream |
 | `PG_PASSWORD` | `alpha` | TimescaleDB superuser password |
 | `LIVE_FEED` | `0` | 1 uses live FRED/Etherscan feeds |
+| `POLL_INTERVAL_SEC` | `15` | Seconds between macro event polls (1 offline) |
 | `OFFLINE_DATA_DIR` | `offline_samples/` | Path for CSV snapshots |
 | `DEFAULT_PORTFOLIO_USD` | `2000000` | Portfolio USD notional for Monte‑Carlo hedge sizing |
 | `ALPHA_FACTORY_ENABLE_ADK` | `0` | 1 exposes ADK gateway on port 9000 |

--- a/alpha_factory_v1/demos/macro_sentinel/config.env.sample
+++ b/alpha_factory_v1/demos/macro_sentinel/config.env.sample
@@ -25,6 +25,7 @@ REDIS_PASSWORD=            # optional redis auth (disabled if blank)
 FRED_API_KEY=              # https://fred.stlouisfed.org/docs/api/api_key.html
 TW_BEARER_TOKEN=           # Twitter/X API v2 bearer token for Fed chatter
 LIVE_FEED=0                # 1 → pull live APIs instead of offline CSVs
+POLL_INTERVAL_SEC=15       # poll interval in seconds (1 offline)
 
 # ┌───────────────────────────
 # │  Hedge execution venue

--- a/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
+++ b/alpha_factory_v1/demos/macro_sentinel/data_feeds.py
@@ -244,7 +244,7 @@ def _push_redis(evt: Dict[str, Any]) -> None:
     """Publish ``evt`` to a Redis stream when configured."""
     if not REDIS_URL:
         return
-    import redis  # type: ignore
+    import redis
     import json as _j
 
     r = redis.from_url(REDIS_URL)
@@ -286,6 +286,7 @@ async def stream_macro_events(live: bool = False) -> AsyncIterator[Dict[str, Any
         Event dictionaries with timestamp, speech, yields, stable flow and ES settle.
     """
     idx = 0
+    poll = float(os.getenv("POLL_INTERVAL_SEC", "15" if live else "1"))
     while True:
         evt: Dict[str, Any] = {"timestamp": dt.datetime.now(dt.timezone.utc).isoformat()}
         if live:
@@ -304,4 +305,4 @@ async def stream_macro_events(live: bool = False) -> AsyncIterator[Dict[str, Any
         _fanout(evt)
         yield evt
         idx = (idx + 1) % len(OFF_FED)
-        await asyncio.sleep(15 if live else 1)
+        await asyncio.sleep(poll)

--- a/tests/test_macro_sentinel.py
+++ b/tests/test_macro_sentinel.py
@@ -24,6 +24,22 @@ class TestMacroSentinel(unittest.TestCase):
         self.assertIn("stable_flow", evt)
         self.assertIn("es_settle", evt)
 
+    def test_stream_macro_events_respects_poll_interval(self) -> None:
+        async def run_check() -> None:
+            with (
+                patch.dict(os.environ, {"POLL_INTERVAL_SEC": "2"}),
+                patch(
+                    "alpha_factory_v1.demos.macro_sentinel.data_feeds.asyncio.sleep",
+                    new_callable=AsyncMock,
+                ) as sleep_mock,
+            ):
+                it = data_feeds.stream_macro_events(live=False)
+                await anext(it)
+                await anext(it)
+                sleep_mock.assert_awaited_with(2.0)
+
+        asyncio.run(run_check())
+
     def test_montecarlo_hedge_basic(self) -> None:
         sim = simulation_core.MonteCarloSimulator(n_paths=500, horizon=5)
         factors = sim.simulate(


### PR DESCRIPTION
## Summary
- add `POLL_INTERVAL_SEC` env var
- respect this variable in `stream_macro_events`
- document the new variable
- test the poll interval logic

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684cedbe642c833385766051d032507c