### PR TITLE
[alpha_factory] add ADK auth token options

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -140,6 +140,7 @@ without internet access.
 | `OFFLINE_DATA_DIR` | `offline_samples/` | Path for CSV snapshots |
 | `DEFAULT_PORTFOLIO_USD` | `2000000` | Portfolio USD notional for Monte‑Carlo hedge sizing |
 | `ALPHA_FACTORY_ENABLE_ADK` | `0` | 1 exposes ADK gateway on port 9000 |
+| `ALPHA_FACTORY_ADK_TOKEN` | *(blank)* | Require `x-alpha-factory-token` header when set |
 | `PROMETHEUS_SCRAPE_INTERVAL` | `15s` | Metrics polling frequency |
 | `GRAFANA_ADMIN_PASSWORD` | `alpha` | Grafana admin password |
 

--- a/alpha_factory_v1/demos/macro_sentinel/config.env.sample
+++ b/alpha_factory_v1/demos/macro_sentinel/config.env.sample
@@ -43,3 +43,4 @@ GRAFANA_ADMIN_PASSWORD=alpha
 # └───────────────────────────
 ENABLE_CUDA=0              # set to 1 to build CUDA image if NVIDIA runtime present
 ALPHA_FACTORY_ENABLE_ADK=0 # 1 → expose Google ADK gateway (A2A protocol)
+ALPHA_FACTORY_ADK_TOKEN=   # optional ADK auth token

--- a/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
+++ b/alpha_factory_v1/demos/macro_sentinel/run_macro_demo.sh
@@ -56,6 +56,7 @@ Usage: $(basename "$0") [--live] [--reset] [--help]
 
 Environment variables:
   CONNECTIVITY_CHECK_URL  Probe URL for outbound HTTPS check (default: https://pypi.org)
+  ALPHA_FACTORY_ADK_TOKEN  Optional ADK auth token
 EOF
 }
 


### PR DESCRIPTION
## Summary
- document `ALPHA_FACTORY_ADK_TOKEN` in Macro-Sentinel README
- add `ALPHA_FACTORY_ADK_TOKEN` to sample config
- mention the new token in `run_macro_demo.sh`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684cefa8557883339b0df727053983d9