### PR TITLE
[alpha_factory] check openai_agents version in env check

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -26,6 +26,7 @@ demo. Currently ``macro_sentinel`` checks for ``gradio``, ``aiohttp`` and
 
 import importlib.util
 import subprocess
+from alpha_factory_v1.scripts.preflight import check_openai_agents_version
 import os
 import sys
 import argparse
@@ -255,6 +256,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     missing_required: list[str] = []
     missing_optional: list[str] = []
+    openai_agents_found = False
     for pkg in REQUIRED + extra_required + OPTIONAL:
         import_name = IMPORT_NAMES.get(pkg, pkg)
         try:
@@ -268,6 +270,8 @@ def main(argv: Optional[List[str]] = None) -> int:
                 missing_optional.append(pkg)
             else:
                 missing_required.append(pkg)
+        elif pkg == "openai_agents":
+            openai_agents_found = True
     missing = missing_required + missing_optional
     if missing:
         print("WARNING: Missing packages:", ", ".join(missing))
@@ -323,11 +327,15 @@ def main(argv: Optional[List[str]] = None) -> int:
                         ", ".join(missing_required),
                     )
                     return 1
+
         else:
             hint = "pip install " + " ".join(missing)
             if wheelhouse:
                 hint = f"pip install --no-index --find-links {wheelhouse} " + " ".join(missing)
             print("Some features may be degraded. Install with:", hint)
+
+    if openai_agents_found and not check_openai_agents_version():
+        return 1
 
     if not missing_required:
         print("Environment OK")

--- a/tests/test_check_env_openai_agents_version.py
+++ b/tests/test_check_env_openai_agents_version.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+import importlib
+import types
+import unittest
+from typing import Any
+from unittest import mock
+
+import check_env
+
+
+class TestCheckEnvOpenAIAgentsVersion(unittest.TestCase):
+    def _run_check(self, module_name: str, version: str | None) -> int:
+        fake_mod = types.SimpleNamespace()
+        if version is not None:
+            fake_mod.__version__ = version
+        orig_import_module = importlib.import_module
+        orig_find_spec = importlib.util.find_spec
+
+        def _fake_import(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == module_name:
+                return fake_mod
+            return orig_import_module(name, *args, **kwargs)
+
+        def _fake_find_spec(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == module_name:
+                return object()
+            if name in {"openai_agents", "agents"}:
+                return None
+            return orig_find_spec(name, *args, **kwargs)
+
+        with (
+            mock.patch("importlib.import_module", side_effect=_fake_import),
+            mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
+            mock.patch.object(check_env, "REQUIRED", []),
+            mock.patch.object(check_env, "OPTIONAL", [module_name]),
+            mock.patch.object(check_env, "warn_missing_core", lambda: []),
+        ):
+            return check_env.main([])
+
+    def test_old_version_fails(self) -> None:
+        for name in ("openai_agents", "agents"):
+            with self.subTest(module=name):
+                self.assertNotEqual(self._run_check(name, "0.0.13"), 0)
+
+    def test_new_version_ok(self) -> None:
+        for name in ("openai_agents", "agents"):
+            with self.subTest(module=name):
+                self.assertEqual(self._run_check(name, "0.0.15"), 0)
+
+    def test_missing_version_fails(self) -> None:
+        for name in ("openai_agents", "agents"):
+            with self.subTest(module=name):
+                self.assertNotEqual(self._run_check(name, None), 0)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `check_env.py` validates the `openai_agents` runtime
- add regression tests for version enforcement

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: Environment check failed)*


------
https://chatgpt.com/codex/tasks/task_e_684cf6001fa48333a7150d2a89e1d9e4