### PR TITLE
[alpha_factory] add demo env options

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -135,6 +135,7 @@ without internet access.
 | `ETHERSCAN_API_KEY` | *(blank)* | Enables on‑chain stable‑flow collector |
 | `TW_BEARER_TOKEN` | *(blank)* | Twitter/X API bearer token for Fed speech stream |
 | `PG_PASSWORD` | `alpha` | TimescaleDB superuser password |
+| `REDIS_PASSWORD` | *(blank)* | Optional password for the Redis cache |
 | `LIVE_FEED` | `0` | 1 uses live FRED/Etherscan feeds |
 | `POLL_INTERVAL_SEC` | `15` | Seconds between macro event polls (1 offline) |
 | `OFFLINE_DATA_DIR` | `offline_samples/` | Path for CSV snapshots |

--- a/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
@@ -67,7 +67,14 @@ services:
 
   redis:
     image: redis:7-alpine
-    command: ["redis-server","--save","", "--appendonly","no"]
+    command:
+      - sh
+      - -c
+      - >-
+        redis-server --save '' --appendonly no
+        ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
     volumes:
       - redis_data:/data
     healthcheck:
@@ -90,9 +97,13 @@ services:
 ################################################################################
   prometheus:
     image: prom/prometheus:v2.52.0
+    environment:
+      - PROMETHEUS_SCRAPE_INTERVAL=${PROMETHEUS_SCRAPE_INTERVAL:-15s}
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-    command: ["--config.file=/etc/prometheus/prometheus.yml"]
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --config.expand-env
     ports: ["9090:9090"]
     restart: unless-stopped
 
@@ -124,7 +135,7 @@ services:
     environment:
       <<: *common-env
       DATABASE_URL: "postgresql://alpha:${PG_PASSWORD:-alpha}@timescaledb:5432/macro_ticks"
-      REDIS_URL: "redis://redis:6379"
+      REDIS_URL: "redis://:${REDIS_PASSWORD:-}@redis:6379"
       VECTOR_HOST: "qdrant:6333"
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434/v1}"
     volumes:
@@ -150,7 +161,7 @@ services:
     image: python:3.11-slim
     environment:
       <<: *common-env
-      REDIS_URL: "redis://redis:6379"
+      REDIS_URL: "redis://:${REDIS_PASSWORD:-}@redis:6379"
       FRED_API_KEY: "${FRED_API_KEY:-}"
       TW_BEARER_TOKEN: "${TW_BEARER_TOKEN:-}"
     volumes:

--- a/alpha_factory_v1/demos/macro_sentinel/observability/prometheus.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/observability/prometheus.yml
@@ -2,7 +2,7 @@
 # Scrapes orchestrator metrics and itself
 
 global:
-  scrape_interval: 15s
+  scrape_interval: ${PROMETHEUS_SCRAPE_INTERVAL:-15s}
 
 scrape_configs:
   - job_name: 'macro_sentinel'


### PR DESCRIPTION
## Summary
- allow redis auth in Macro-Sentinel demo
- make Prometheus scrape interval configurable
- append Redis password to orchestrator and collector URLs
- document new variables in the demo README
- verify compose config reflects env vars

## Testing
- `pre-commit` *(fails: Verify meta_agentic_tree_search_v0 requirements.lock is up to date)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*

------
https://chatgpt.com/codex/tasks/task_e_684d6cf445bc8333b4d97616f802a83a