### PR TITLE
[alpha_factory] document STABLE_TOKEN env

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -133,6 +133,7 @@ without internet access.
 | `OLLAMA_BASE_URL` | `http://ollama:11434/v1` | Offline LLM endpoint |
 | `FRED_API_KEY` | *(blank)* | Enables live yield‑curve collector |
 | `ETHERSCAN_API_KEY` | *(blank)* | Enables on‑chain stable‑flow collector |
+| `STABLE_TOKEN` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606e48` | ERC‑20 token used for stablecoin flow tracking |
 | `TW_BEARER_TOKEN` | *(blank)* | Twitter/X API bearer token for Fed speech stream |
 | `PG_PASSWORD` | `alpha` | TimescaleDB superuser password |
 | `REDIS_PASSWORD` | *(blank)* | Optional password for the Redis cache |

--- a/alpha_factory_v1/demos/macro_sentinel/config.env.sample
+++ b/alpha_factory_v1/demos/macro_sentinel/config.env.sample
@@ -23,6 +23,8 @@ REDIS_PASSWORD=            # optional redis auth (disabled if blank)
 # │  Live macro collectors (optional)
 # └───────────────────────────
 FRED_API_KEY=              # https://fred.stlouisfed.org/docs/api/api_key.html
+ETHERSCAN_API_KEY=         # optional Etherscan API key for on-chain flows
+STABLE_TOKEN=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606e48  # stablecoin contract address
 TW_BEARER_TOKEN=           # Twitter/X API v2 bearer token for Fed chatter
 LIVE_FEED=0                # 1 → pull live APIs instead of offline CSVs
 POLL_INTERVAL_SEC=15       # poll interval in seconds (1 offline)

--- a/check_env.py
+++ b/check_env.py
@@ -42,6 +42,7 @@ def check_pkg(pkg: str) -> bool:
     except Exception:  # pragma: no cover - importlib failure is unexpected
         return False
 
+
 CORE = ["numpy", "yaml", "pandas"]
 
 
@@ -336,6 +337,9 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if openai_agents_found and not check_openai_agents_version():
         return 1
+
+    if demo == "macro_sentinel" and not os.getenv("ETHERSCAN_API_KEY"):
+        print("WARNING: ETHERSCAN_API_KEY is unset; Etherscan collector disabled")
 
     if not missing_required:
         print("Environment OK")

--- a/tests/test_macro_sentinel.py
+++ b/tests/test_macro_sentinel.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import unittest
 from typing import Any, Dict
 from unittest.mock import patch, AsyncMock
+import importlib
 
 from alpha_factory_v1.demos.macro_sentinel import data_feeds, simulation_core
 
@@ -134,6 +135,13 @@ class TestMacroSentinel(unittest.TestCase):
 
         title2 = asyncio.run(run_again())
         self.assertIsNone(title2)
+
+    def test_stable_token_env_override(self) -> None:
+        """STABLE_TOKEN should reflect the environment override."""
+        with patch.dict(os.environ, {"STABLE_TOKEN": "0x123"}):
+            mod = importlib.reload(data_feeds)
+            self.assertEqual(mod.STABLE_TOKEN, "0x123")
+        importlib.reload(data_feeds)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add STABLE_TOKEN variable to Macro‑Sentinel README and sample env
- warn when ETHERSCAN_API_KEY isn't configured in `check_env.py`
- test that the data feed respects STABLE_TOKEN environment overrides

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d71379cb88333a7c087f0607f0048