### PR TITLE
[alpha_factory] handle missing openai-agents for macro sentinel

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
+++ b/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
@@ -38,7 +38,13 @@ except ModuleNotFoundError as exc:  # pragma: no cover - runtime check
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 import uvicorn
-from openai_agents import Agent, OpenAIAgent, Tool
+
+try:
+    from openai_agents import Agent, OpenAIAgent, Tool
+except ModuleNotFoundError as exc:  # pragma: no cover - runtime check
+    raise RuntimeError(
+        "openai-agents package missing. Run 'python ../../check_env.py --demo macro_sentinel --auto-install'."
+    ) from exc
 from data_feeds import stream_macro_events
 from simulation_core import MonteCarloSimulator
 


### PR DESCRIPTION
## Summary
- handle import error for `openai_agents` in macro sentinel entrypoint

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py` *(fails: proto-verify hook)*

------
https://chatgpt.com/codex/tasks/task_e_684d74baf8e08333b6621d9f3b89a5d1