### PR TITLE
[alpha_factory] offline data refresh helper

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -76,7 +76,8 @@ repository and cover roughly March–April 2024 activity.
 
 These CSVs are pinned at revision `90fe9b623b3a0ae5475cf4fa8693d43cb5ba9ac5` of
 the demo-assets repo. Set `DEMO_ASSETS_REV=<sha>` to override when refreshing
-the snapshots.
+the snapshots. Run `python refresh_offline_data.py --revision <sha>` to
+synchronize them with a different commit from the external repository.
 
 To reuse existing CSV snapshots or share them across projects,
 set `OFFLINE_DATA_DIR=/path/to/csvs` in your shell or `config.env`.

--- a/alpha_factory_v1/demos/macro_sentinel/refresh_offline_data.py
+++ b/alpha_factory_v1/demos/macro_sentinel/refresh_offline_data.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utility to refresh offline CSV snapshots.
+
+Downloads the files listed in :data:`OFFLINE_URLS` from ``data_feeds.py``
+for a specific ``demo-assets`` revision and replaces the contents of the
+``offline_samples/`` directory. This script is intended for maintainers
+who update the pinned revision of the demo assets.
+
+Usage:
+    python refresh_offline_data.py --revision <sha>
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from urllib.request import urlopen
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Refresh offline CSV snapshots")
+    parser.add_argument(
+        "--revision",
+        required=True,
+        help="demo-assets commit SHA",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    os.environ["DEMO_ASSETS_REV"] = args.revision
+    from data_feeds import OFFLINE_URLS  # noqa: E402
+
+    offline_dir = Path(__file__).parent / "offline_samples"
+    offline_dir.mkdir(exist_ok=True)
+
+    for name, url in OFFLINE_URLS.items():
+        dest = offline_dir / name
+        tmp = dest.with_suffix(".tmp")
+        print(f"Downloading {url} -> {dest}")
+        try:
+            with urlopen(url, timeout=10) as r, open(tmp, "wb") as f:
+                f.write(r.read())
+            os.replace(tmp, dest)
+        except Exception as exc:  # pragma: no cover - network errors
+            if tmp.exists():
+                tmp.unlink()
+            print(f"Failed to download {url}: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add refresh_offline_data.py utility
- document how to use it in the Macro-Sentinel README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/refresh_offline_data.py alpha_factory_v1/demos/macro_sentinel/README.md` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_684d766c9c208333af37f40ab0493022