### PR TITLE
[alpha_factory] add offline install quickstart

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -122,6 +122,9 @@ WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
 This mirrors the repository's offline setup instructions so the demo works
 without internet access.
 
+For a concise overview of the offline workflow see
+[the repository guide](../../../docs/OFFLINE_INSTALL.md).
+
 ---
 
 ## ⚙️ Configuration

--- a/docs/OFFLINE_INSTALL.md
+++ b/docs/OFFLINE_INSTALL.md
@@ -1,0 +1,42 @@
+# Offline Installation Quickstart
+
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice.
+
+This guide summarises how to install the project without internet access and run the Macro-Sentinel demo.
+
+## 1. Build the wheelhouse
+Run these commands on a machine with connectivity:
+
+```bash
+mkdir -p /media/wheels
+pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r alpha_factory_v1/requirements-colab.txt -w /media/wheels
+```
+
+## 2. Create lock files
+Compile reproducible requirements from the wheel cache:
+
+```bash
+pip-compile --generate-hashes --output-file requirements.lock requirements.txt
+pip-compile --no-index --find-links /media/wheels --generate-hashes \
+    --output-file alpha_factory_v1/requirements-colab.lock \
+    alpha_factory_v1/requirements-colab.txt
+```
+
+## 3. Verify the environment
+Use `check_env.py` to install any missing packages from the wheelhouse:
+
+```bash
+python check_env.py --auto-install --wheelhouse /media/wheels
+```
+
+## 4. Launch Macro-Sentinel
+Start the demo with offline data feeds:
+
+```bash
+cd alpha_factory_v1/demos/macro_sentinel
+LIVE_FEED=0 ./run_macro_demo.sh
+```
+
+See [docs/OFFLINE_SETUP.md](OFFLINE_SETUP.md) for additional details.
+


### PR DESCRIPTION
## Summary
- document offline install workflow
- link offline instructions from Macro-Sentinel demo

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d78b0dab883339f07063604b0c989