### PR TITLE
[alpha_factory] Seedable MonteCarlo simulator

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -19,6 +19,7 @@ This demonstration is a conceptual research prototype. Any references to AGI or 
 | **LLM fail‑over** | GPT‑4o when `OPENAI_API_KEY` present, Mixtral‑8x7B (Ollama) otherwise |
 | **Live + offline feeds** | FRED yield curve, Fed RSS speeches, Etherscan on‑chain flows |
 | **Risk engine** | 10 k × 30‑day 3‑factor Monte‑Carlo (< 20 ms CPU) |
+| **Seeded runs** | Use `MonteCarloSimulator(seed=42)` for reproducible results |
 | **Action layer** | Draft JSON orders for Micro‑ES futures (Alpaca stub) |
 | **Observability** | TimescaleDB, Redis stream, Prometheus & Grafana dashboard |
 | **A2A gateway** | Optional Google ADK server via `ALPHA_FACTORY_ENABLE_ADK=1` |

--- a/tests/test_simulation_core.py
+++ b/tests/test_simulation_core.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+
+from alpha_factory_v1.demos.macro_sentinel import simulation_core
+
+
+class TestSimulationCore(unittest.TestCase):
+    def test_seed_reproducibility(self) -> None:
+        try:
+            import numpy as np  # noqa: F401
+            import pandas as pd  # noqa: F401
+        except ModuleNotFoundError:
+            self.skipTest("numpy/pandas not available")
+
+        sim = simulation_core.MonteCarloSimulator(n_paths=3, horizon=2, seed=42)
+        obs = {
+            "yield_10y": 4.0,
+            "yield_3m": 4.5,
+            "stable_flow": 10.0,
+            "es_settle": 5000.0,
+        }
+        factors = sim.simulate(obs)
+        expected = [0.989483, 1.02894, 0.998621]
+        for f, e in zip(factors, expected):
+            self.assertAlmostEqual(f, e, places=6)
+        self.assertAlmostEqual(sim.var(factors), -0.009602935809998603)
+        self.assertAlmostEqual(sim.cvar(factors), -0.010516713095912844)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- make MonteCarloSimulator accept an optional `seed` and use its own RNG
- document deterministic runs in the class docstring and macro sentinel README
- verify seeded behaviour with new tests

## Testing
- `pre-commit run --files alpha_factory_v1/demos/macro_sentinel/simulation_core.py alpha_factory_v1/demos/macro_sentinel/README.md tests/test_simulation_core.py` *(with nonessential hooks skipped)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: No network connectivity detected)*
- `pytest -q` *(failed: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d7d61b5c08333b9836d4e17c5f8f6