### PR TITLE
[alpha_factory] pin ollama version

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -65,10 +65,12 @@ present.
 
 Offline mode requires an [Ollama](https://ollama.com) server with the
 `mixtral:instruct` model available at `http://localhost:11434`. The Docker
-stack provisions this container automatically via the `offline` profile, but
-when running bare‑metal or inside Colab you must manually start `ollama serve`
-first. If the server runs elsewhere, set
-`OLLAMA_BASE_URL=http://<host>:11434/v1` in your shell or `config.env`.
+stack provisions this container automatically via the `offline` profile using
+`ollama/ollama:0.1.32`, but when running bare‑metal or inside Colab you must
+manually start `ollama serve` first. If the server runs elsewhere, set
+`OLLAMA_BASE_URL=http://<host>:11434/v1` in your shell or `config.env`. To
+upgrade or pin a different version, edit `docker-compose.macro.yml` and rebuild
+with `docker compose build --pull`.
 
 Offline sample data is fetched automatically the first time you run the
 launcher—no manual downloads required. These CSV snapshots mirror

--- a/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
+++ b/alpha_factory_v1/demos/macro_sentinel/docker-compose.macro.yml
@@ -38,7 +38,7 @@ x-health: &hc
 ################################################################################
 services:
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.1.32
     profiles: ["offline"]          # docker compose --profile offline …
     environment:
       - OLLAMA_MODELS=mixtral:instruct


### PR DESCRIPTION
## Summary
- pin ollama image used by Macro-Sentinel to `ollama/ollama:0.1.32`
- document the tag and how to update it in the demo README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d81657b8c8333a05a018b95dee86f