### PR TITLE
[alpha_factory] simplify macro sentinel colab

### DIFF
--- a/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
+++ b/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
@@ -15,8 +15,11 @@
       "id": "768347ff",
       "metadata": {},
       "source": [
-        "# \ud83c\udf10\u00a0Macro\u2011Sentinel \u00b7 Colab Notebook\n",
-        "*Alpha\u2011Factory\u00a0v1\u00a0\ud83d\udc41\ufe0f\u2728\u00a0\u2014 Cross\u2011asset macro risk radar*"
+        "# \ud83c\udf10 Macro\u2011Sentinel \u00b7 Colab Notebook\n",
+        "*Alpha\u2011Factory v1 \ud83d\udc41\ufe0f\u2728 \u2014 Cross\u2011asset macro risk radar*\n",
+        "\n",
+        "Set the `OPENAI_API_KEY` environment variable for GPT\u20114o or leave it empty to use the bundled Mixtral model offline.\n",
+        "Run the cell in **Run all** below to install everything, fetch demo data and launch the dashboard."
       ]
     },
     {
@@ -62,6 +65,51 @@
       "outputs": [],
       "source": [
         "!nvidia-smi -L || echo '\ud83d\udd39 GPU not detected \u2014 running on CPU'"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Run all\n",
+        "Install dependencies, download snapshots and launch the Gradio UI in one step."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os, subprocess, pathlib, sys, re, queue, threading\n",
+        "root = pathlib.Path('AGI-Alpha-Agent-v0/alpha_factory_v1/demos/macro_sentinel')\n",
+        "if not root.parent.exists():\n",
+        "    subprocess.run(['git','clone','--depth','1','https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git'], check=True)\n",
+        "subprocess.run([sys.executable,'-m','pip','install','-q','-U',\n",
+        "                'openai-agents==0.0.17','gradio','aiohttp','psycopg2-binary',\n",
+        "                'qdrant-client','rich','pretty_errors','ollama-py~=0.1.4'], check=True)\n",
+        "subprocess.run([sys.executable,'refresh_offline_data.py'], cwd=root, check=True)\n",
+        "if not os.getenv('OPENAI_API_KEY'):\n",
+        "    try:\n",
+        "        subprocess.run(['ollama','serve'], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n",
+        "        subprocess.run(['ollama','pull','mixtral:instruct'], check=True)\n",
+        "    except FileNotFoundError:\n",
+        "        print('\u26a0\ufe0f Ollama not found; offline LLM will not work.')\n",
+        "proc = subprocess.Popen([sys.executable,'agent_macro_entrypoint.py'], cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)\n",
+        "link_q = queue.Queue()\n",
+        "def _tail():\n",
+        "    for line in proc.stdout:\n",
+        "        print(line, end='')\n",
+        "        m=re.search(r'(https://[\\w.-]+\\.gradio\\.live)', line)\n",
+        "        if m: link_q.put(m.group(1))\n",
+        "threading.Thread(target=_tail, daemon=True).start()\n",
+        "print('\u23f3 Waiting for Gradio tunnel...')\n",
+        "try:\n",
+        "    url=link_q.get(timeout=120)\n",
+        "    from IPython.display import Markdown, display\n",
+        "    display(Markdown(f'### \u2705 Dashboard ready: [Open \u2197]({url})'))\n",
+        "except queue.Empty:\n",
+        "    print('\u26a0\ufe0f Tunnel timeout')\n"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- add usage tips at the top of the Macro‑Sentinel notebook
- provide a new **Run all** section that fetches requirements, offline data and launches the dashboard automatically

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d865f1394833397ad9152de2a932d