### PR TITLE
[alpha_factory] self-heal offline fallback

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -25,8 +25,10 @@ chmod +x run_selfheal_demo.sh
 Browse **http://localhost:7863** → hit **“Heal Repository”**.
 
 * No config needed; the agent clones a tiny repo with a deliberate bug.
-* **With an OpenAI key** the agent uses GPT‑4o to reason about stack‑traces.  
+* **With an OpenAI key** the agent uses GPT‑4o to reason about stack‑traces.
 * **Offline?** Leave the key blank—Mixtral via Ollama drafts the patch.
+* If the remote clone fails, the demo falls back to the bundled
+  `sample_broken_calc` repository.
 
 ### Quick start (Python)
 Prefer a local run without Docker?
@@ -40,6 +42,19 @@ python agent_selfheal_entrypoint.py
 Then open **http://localhost:7863** and trigger **“Heal Repository”**.
 
 Set `GRADIO_SHARE=1` to expose a public link (useful on Colab).
+
+### Offline workflow
+
+When the host has no internet access, `agent_selfheal_entrypoint.py`
+automatically clones the included `sample_broken_calc` repository
+instead of pulling from GitHub. Install dependencies from a local
+wheelhouse and run the entrypoint directly:
+
+```bash
+WHEELHOUSE=/media/wheels python agent_selfheal_entrypoint.py
+```
+
+The dashboard behaves the same, but all code comes from the bundled repo.
 
 ---
 

--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/README.md
@@ -1,0 +1,4 @@
+# sample_broken_calc
+
+A minimal repository with a deliberate failing test used by the
+Self-Healing Repo demo when network access is unavailable.

--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/calc.py
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/calc.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+def add(a: int, b: int) -> int:
+    """Return the sum of a and b, intentionally broken."""
+    return a - b

--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/test_calc.py
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/test_calc.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+import calc
+
+def test_add():
+    assert calc.add(1, 1) == 2

--- a/tests/test_self_heal_clone.py
+++ b/tests/test_self_heal_clone.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from pathlib import Path
+from alpha_factory_v1.demos.self_healing_repo import agent_selfheal_entrypoint as entrypoint
+import subprocess
+
+
+def test_clone_sample_repo_fallback(tmp_path, monkeypatch):
+    target = tmp_path / "repo"
+    monkeypatch.setattr(entrypoint, "CLONE_DIR", str(target))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=1))
+    entrypoint.clone_sample_repo()
+    assert (target / "calc.py").exists()
+


### PR DESCRIPTION
## Summary
- bundle `sample_broken_calc` repo for the self‑healing demo
- clone from the local repo when network cloning fails
- document the offline workflow
- add unit test covering the fallback logic

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network connectivity)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py alpha_factory_v1/demos/self_healing_repo/README.md tests/test_self_heal_clone.py alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/README.md alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/calc.py alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/test_calc.py alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/__init__.py` *(fails: command not found)*
- `pytest -q` *(fails: environment check failed)*


------
https://chatgpt.com/codex/tasks/task_e_684d8b078e4083338df73a78279a7bf0