### PR TITLE
[alpha_factory] add self-healer pipeline test

### DIFF
--- a/tests/fixtures/self_heal_repo/README.md
+++ b/tests/fixtures/self_heal_repo/README.md
@@ -1,0 +1,4 @@
+# sample_broken_calc
+
+A minimal repository with a deliberate failing test used by the
+Self-Healing Repo demo when network access is unavailable.

--- a/tests/fixtures/self_heal_repo/calc.py
+++ b/tests/fixtures/self_heal_repo/calc.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+def add(a: int, b: int) -> int:
+    """Return the sum of a and b, intentionally broken."""
+    return a - b

--- a/tests/fixtures/self_heal_repo/test_calc.py
+++ b/tests/fixtures/self_heal_repo/test_calc.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+import calc
+
+def test_add():
+    assert calc.add(1, 1) == 2

--- a/tests/test_self_healer_pipeline.py
+++ b/tests/test_self_healer_pipeline.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import shutil
+import subprocess
+
+from alpha_factory_v1.demos.self_healing_repo.agent_core import self_healer, llm_client, diff_utils
+
+
+def test_self_healer_applies_patch(tmp_path, monkeypatch):
+    repo_src = Path(__file__).parent / "fixtures" / "self_heal_repo"
+    repo_path = tmp_path / "repo"
+    shutil.copytree(repo_src, repo_path)
+    subprocess.run(["git", "init"], cwd=repo_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+
+    workdir = tmp_path / "work"
+    healer = self_healer.SelfHealer(repo_url=str(repo_path), commit_sha=commit)
+    healer.working_dir = str(workdir)
+
+    patch = """--- a/calc.py
++++ b/calc.py
+@@
+-    return a - b
++    return a + b
+"""
+
+    monkeypatch.setattr(llm_client, "request_patch", lambda *_: patch)
+    monkeypatch.setattr(diff_utils, "parse_and_validate_diff", lambda diff: diff)
+    monkeypatch.setattr(self_healer.SelfHealer, "commit_and_push_fix", lambda self: "branch")
+    monkeypatch.setattr(self_healer.SelfHealer, "create_pull_request", lambda self, branch: 1)
+
+    pr = healer.run()
+
+    with open(workdir / "calc.py") as fh:
+        content = fh.read()
+    assert "a + b" in content
+    assert "1 passed" in healer.test_results
+    assert pr == 1


### PR DESCRIPTION
## Summary
- add a failing test repo fixture
- implement self-healer pipeline unit test

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `WHEELHOUSE=wheels python check_env.py --auto-install` *(fails: Could not find numpy wheel)*
- `pytest -k self_healer_pipeline -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d9410946c8333953754d80d37dd33