### PR TITLE
[alpha_factory] add missing SPDX headers

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 PYTHON=${PYTHON:-python3}

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/polyglot_lite/__init__.py
+++ b/benchmarks/polyglot_lite/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/swebench_verified_mini/__init__.py
+++ b/benchmarks/swebench_verified_mini/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 PYTHON=${PYTHON:-python3}

--- a/infrastructure/docker-entrypoint.sh
+++ b/infrastructure/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -e
 MODE=${RUN_MODE:-web}
 if [ "$MODE" = "api" ]; then

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 # Wrapper script for alpha_factory_v1/quickstart.sh
 # Provides a friendly top-level entry point.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/env_check.sh
+++ b/scripts/env_check.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 python scripts/check_python_deps.py
 python check_env.py --auto-install

--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"

--- a/tests/test_check_env_core.py
+++ b/tests/test_check_env_core.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib.util
 import check_env
 


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX headers to miscellaneous scripts and modules

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

SPDX headers are now present in the updated files.

------
https://chatgpt.com/codex/tasks/task_e_684d963ff3a08333ae8c6068f5673c78