### PR TITLE
[alpha_factory] enforce patch validation

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
+++ b/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
@@ -86,6 +86,7 @@ def _sanity_check_patch(patch: str, repo_root: pathlib.Path) -> None:
 def apply_patch(patch: str, repo_path: str) -> None:
     """Apply patch atomically with rollback on failure."""
     repo = pathlib.Path(repo_path)
+    _sanity_check_patch(patch, repo)
     if shutil.which("patch") is None:
         raise RuntimeError(
             '`patch` command not found. Install the utility, e.g., "sudo apt-get update && sudo apt-get install -y patch"'

--- a/tests/test_self_healing_patcher.py
+++ b/tests/test_self_healing_patcher.py
@@ -18,6 +18,18 @@ class TestPatcherCore(unittest.TestCase):
 """
             with self.assertRaises(ValueError):
                 patcher_core._sanity_check_patch(bad_patch, pathlib.Path(repo))
+    def test_apply_patch_rejects_unknown_file(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            open(os.path.join(repo, "file.py"), "w").close()
+            bad_patch = """--- a/missing.py
++++ b/missing.py
+@@
+-print('x')
++print('y')
+"""
+            with self.assertRaises(ValueError):
+                patcher_core.apply_patch(bad_patch, repo_path=repo)
+
 
     def test_nested_prefix_handling(self) -> None:
         with tempfile.TemporaryDirectory() as repo:


### PR DESCRIPTION
## Summary
- ensure apply_patch runs sanity checks before patching
- test rejection of patch diffs referencing unknown files

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `python check_env.py --auto-install --wheelhouse wheels` *(fails to install numpy)*
- `pytest tests/test_self_healing_patcher.py::TestPatcherCore::test_apply_patch_rejects_unknown_file -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/patcher_core.py tests/test_self_healing_patcher.py` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_684da0e950bc833383399bc6a84e5dd5