### PR TITLE
[alpha_factory] add missing package file

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # self_healer.py
-import os, shutil, subprocess
-from agent_core import llm_client, test_runner, diff_utils
+import os
+import shutil
+import subprocess
+
+from . import diff_utils, llm_client, test_runner
 
 class SelfHealer:
     def __init__(self, repo_url: str, commit_sha: str, base_branch: str = "main"):


### PR DESCRIPTION
## Summary
- add an empty `__init__.py` under `agent_core`
- import sibling modules using a relative path

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684da2a88af48333a190294c7949c90e