### PR TITLE
[alpha_factory] add license header to demo package

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Agent-core package for the Self-Healing Repo demo."""


### PR DESCRIPTION
## Summary
- add Apache 2.0 header and short docstring for `agent_core`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/agent_core/__init__.py` *(skipped heavy hooks)*
- `python scripts/check_python_deps.py` *(fails: numpy, pandas missing)*
- `python check_env.py --auto-install` *(fails: no network access)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684db254495c8333a1875b87877cf05b