### PR TITLE
[alpha_factory] enhance patch error output

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
@@ -31,15 +31,15 @@ def parse_and_validate_diff(diff_text: str) -> str | None:
     return diff_text
 
 
-def apply_diff(diff_text: str, repo_dir: str) -> bool:
-    """Apply the unified diff to the repo_dir. Returns True if applied successfully."""
+def apply_diff(diff_text: str, repo_dir: str) -> tuple[bool, str]:
+    """Apply the unified diff to repo_dir. Returns (success, output)."""
     try:
-        # Use `patch` command to apply the diff
-        process = subprocess.run(["patch", "-p1"], input=diff_text, text=True, cwd=repo_dir, timeout=60)
+        process = subprocess.run(["patch", "-p1"], input=diff_text, text=True, cwd=repo_dir, timeout=60, capture_output=True)
+        output = (process.stdout or "") + (process.stderr or "")
         if process.returncode != 0:
-            logger.error("Patch command failed with code: %s", process.returncode)
-            return False
-        return True
+            logger.error("Patch command failed with code %s: %s", process.returncode, output)
+            return False, output
+        return True, output
     except Exception as e:
         logger.exception("Exception while applying patch: %s", e)
-        return False
+        return False, str(e)

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
@@ -56,7 +56,9 @@ class SelfHealer:
         """Apply the proposed diff to the working directory."""
         if not self.patch_diff:
             raise RuntimeError("No patch to apply")
-        success = diff_utils.apply_diff(self.patch_diff, repo_dir=self.working_dir)
+        success, output = diff_utils.apply_diff(self.patch_diff, repo_dir=self.working_dir)
+        if not success:
+            logger.error("Failed to apply patch:\n%s", output)
         return success
 
     def commit_and_push_fix(self):

--- a/tests/test_diff_utils_apply.py
+++ b/tests/test_diff_utils_apply.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+import tempfile
+from alpha_factory_v1.demos.self_healing_repo.agent_core import diff_utils
+
+
+def test_apply_diff_failure_returns_output():
+    with tempfile.TemporaryDirectory() as repo:
+        open(os.path.join(repo, "file.txt"), "w").close()
+        success, output = diff_utils.apply_diff("bad diff", repo_dir=repo)
+        assert not success
+        assert "patch" in output.lower()
+
+
+def test_apply_diff_success():
+    diff = """--- a/file.txt\n+++ b/file.txt\n@@\n-\n+ok\n"""
+    with tempfile.TemporaryDirectory() as repo:
+        open(os.path.join(repo, "file.txt"), "w").close()
+        success, output = diff_utils.apply_diff(diff, repo_dir=repo)
+        assert success
+        assert "patching file" in output.lower()

--- a/tests/test_self_healing_patcher.py
+++ b/tests/test_self_healing_patcher.py
@@ -74,8 +74,9 @@ class TestPatcherCore(unittest.TestCase):
             with open(file_path, "w") as fh:
                 fh.write("hello\n")
             bad_patch = "invalid diff"
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(RuntimeError) as cm:
                 patcher_core.apply_patch(bad_patch, repo_path=repo)
+            self.assertIn("patch command failed", str(cm.exception))
             with open(file_path) as fh:
                 self.assertEqual(fh.read(), "hello\n")
 


### PR DESCRIPTION
## Summary
- return patch command output from `apply_diff`
- log failure output in `SelfHealer.apply_patch`
- assert helpful message in patcher test
- add tests for `apply_diff`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q tests/test_self_healing_patcher.py::TestPatcherCore::test_apply_patch_failure_rollback tests/test_diff_utils_apply.py` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684db9a13ad48333b54df7e0a31f3bc0