### PR TITLE
[alpha_factory] add extra patcher tests

### DIFF
--- a/tests/test_patcher_core_additional.py
+++ b/tests/test_patcher_core_additional.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Extra tests for the self-healing patcher utilities."""
+
+from pathlib import Path
+from unittest import mock
+import pytest
+import shutil
+
+from alpha_factory_v1.demos.self_healing_repo import patcher_core
+
+
+_DEF_DIFF = """--- a/hello.txt
++++ b/hello.txt
+@@\n-hello\n+hi\n"""
+
+
+def test_apply_patch_invalid_diff(tmp_path: Path, monkeypatch: mock.MagicMock) -> None:
+    target = tmp_path / "hello.txt"
+    target.write_text("hello\n", encoding="utf-8")
+
+    def fake_run(cmd, cwd):
+        return 1, "patch failed"
+
+    monkeypatch.setattr(patcher_core, "_run", fake_run)
+    with pytest.raises(RuntimeError):
+        patcher_core.apply_patch("bad diff", repo_path=str(tmp_path))
+    assert target.read_text(encoding="utf-8") == "hello\n"
+
+
+def test_apply_patch_missing_patch_binary(tmp_path: Path, monkeypatch: mock.MagicMock) -> None:
+    (tmp_path / "hello.txt").write_text("hello\n", encoding="utf-8")
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    with pytest.raises(RuntimeError) as exc:
+        patcher_core.apply_patch(_DEF_DIFF, repo_path=str(tmp_path))
+    assert "patch` command not found" in str(exc.value)
+
+
+def test_apply_patch_rollback_on_failure(tmp_path: Path, monkeypatch: mock.MagicMock) -> None:
+    target = tmp_path / "hello.txt"
+    target.write_text("hello\n", encoding="utf-8")
+
+    def fake_run(cmd, cwd):
+        return 1, "patch failed"
+
+    monkeypatch.setattr(patcher_core, "_run", fake_run)
+    with pytest.raises(RuntimeError):
+        patcher_core.apply_patch(_DEF_DIFF, repo_path=str(tmp_path))
+
+    assert target.read_text(encoding="utf-8") == "hello\n"
+    assert not (tmp_path / "hello.txt.bak").exists()
+


### PR DESCRIPTION
## Summary
- extend self-healing patcher test coverage
- verify invalid diffs are rejected
- ensure patch command absence is handled
- confirm rollback when patching fails

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684dbfa03e4c8333bce87626a6975c00