### PR TITLE
[alpha_factory] enable offline self-heal

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -51,10 +51,11 @@ TEMPERATURE=0.3
 GRADIO_SHARE=0
 ```
 
-Set `USE_LOCAL_LLM=true` in `config.env` to force the agent to run the
-local Mixtral model when no API key is provided. The same file also lets
-you override `MODEL_NAME` and `TEMPERATURE` for custom models or
-tuning.
+When `OPENAI_API_KEY` is blank the agent now falls back to a local
+model via Ollama. Set `USE_LOCAL_LLM=true` in `config.env` to force this
+behaviour even when a key is present. Use `OLLAMA_BASE_URL` to override
+the endpoint if the model runs elsewhere. The same file also lets you
+override `MODEL_NAME` and `TEMPERATURE` for custom tuning.
 
 ### Quick start (Python)
 Prefer a local run without Docker?

--- a/tests/test_llm_client_offline.py
+++ b/tests/test_llm_client_offline.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+from types import ModuleType
+
+
+def _reload_client(monkeypatch: pytest.MonkeyPatch, diff: str) -> ModuleType:
+    stub = types.ModuleType("openai_agents")
+
+    class DummyAgent:
+        def __init__(self, *a: object, **k: object) -> None:
+            pass
+
+        def __call__(self, *_a: object, **_k: object) -> str:
+            return diff
+
+    stub.OpenAIAgent = DummyAgent  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "openai_agents", stub)
+    import alpha_factory_v1.demos.self_healing_repo.agent_core.llm_client as mod
+
+    return importlib.reload(mod)
+
+
+def test_request_patch_use_local_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    diff = "--- a/x\n+++ b/x\n@@\n-old\n+new\n"
+    monkeypatch.setenv("USE_LOCAL_LLM", "true")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    client = _reload_client(monkeypatch, diff)
+    out = client.request_patch([{"role": "user", "content": "fix"}])
+    assert out == diff
+
+
+def test_request_patch_no_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    diff = "--- a/y\n+++ b/y\n@@\n-old\n+new\n"
+    monkeypatch.setenv("USE_LOCAL_LLM", "false")
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    client = _reload_client(monkeypatch, diff)
+    out = client.request_patch([{"role": "user", "content": "fix"}])
+    assert out == diff


### PR DESCRIPTION
## Summary
- implement `call_local_model` to invoke a local OpenAI Agents endpoint
- switch `request_patch` to use the local model when offline
- document new offline LLM behaviour in the Self-Healing Repo README
- add unit tests covering offline patch generation

## Testing
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/agent_core/llm_client.py alpha_factory_v1/demos/self_healing_repo/README.md tests/test_llm_client_offline.py` *(fails: proto-verify)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest tests/test_llm_client_offline.py -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684dc41f8b108333a9d3944b7d9b3f3a