### PR TITLE
[alpha_factory] docs: clarify self-heal setup

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -41,21 +41,23 @@ Browse **http://localhost:7863** → hit **“Heal Repository”**.
   `sample_broken_calc` repository.
 
 > **Note:** `run_selfheal_demo.sh` copies `config.env.sample` to `config.env` on the
-> first run. Edit this file to add your `OPENAI_API_KEY`, choose a `MODEL_NAME`,
-> tweak `TEMPERATURE`, and set other options.
+> first run. Edit this file to configure OpenAI or your local model.
+> Key settings include:
 
 ```bash
 OPENAI_API_KEY=
 MODEL_NAME="gpt-4o-mini"
 TEMPERATURE=0.3
 GRADIO_SHARE=0
+USE_LOCAL_LLM=true
+OLLAMA_BASE_URL="http://localhost:11434/v1"
 ```
 
-When `OPENAI_API_KEY` is blank the agent now falls back to a local
-model via Ollama. Set `USE_LOCAL_LLM=true` in `config.env` to force this
-behaviour even when a key is present. Use `OLLAMA_BASE_URL` to override
-the endpoint if the model runs elsewhere. The same file also lets you
-override `MODEL_NAME` and `TEMPERATURE` for custom tuning.
+When `OPENAI_API_KEY` is blank the agent falls back to the local model
+via Ollama. Set `USE_LOCAL_LLM=true` to force this behaviour even when
+a key is present. Use `OLLAMA_BASE_URL` when the model runs on a remote
+host. The same file also lets you override `MODEL_NAME` and
+`TEMPERATURE` for custom tuning.
 
 ### Quick start (Python)
 Prefer a local run without Docker?
@@ -115,10 +117,18 @@ The notebook sets `GRADIO_SHARE=1` so the dashboard URL appears automatically.
 | **2** | `suggest_patch` | LLM converts stack‑trace → unified diff |
 | **3** | `apply_patch_and_retst` | Diff applied atomically → tests pass |
 
-* Powered by **OpenAI Agents SDK v0.4** tool‑calling.  
-* **A2A protocol** ready: spin up multiple healers across micro‑repos.  
+* Powered by **OpenAI Agents SDK v0.4** tool‑calling.
+* **A2A protocol** ready: spin up multiple healers across micro‑repos.
 * **Model Context Protocol** streams only the diff—not the whole file—for
   context‑efficient reasoning.
+
+```
+clone repo → [sandbox pytest] → error log
+                    ↑             ↓
+        LLM diff ← [sandbox patch] ←┘
+                    ↓
+          [sandbox pytest] → commit+PR
+```
 
 ---
 

--- a/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
+++ b/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
@@ -52,7 +52,10 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['OPENAI_API_KEY'] = ''  # paste or leave blank for offline Mixtral"
+    "os.environ['OPENAI_API_KEY'] = ''  # paste API key or leave blank for offline\n",
+    "os.environ['USE_LOCAL_LLM'] = 'true'  # set false to use OpenAI if key present\n",
+    "os.environ['OLLAMA_BASE_URL'] = 'http://localhost:11434/v1'\n",
+    "os.environ['MODEL_NAME'] = 'gpt-4o-mini'\n"
    ]
   },
   {

--- a/alpha_factory_v1/demos/self_healing_repo/config.env.sample
+++ b/alpha_factory_v1/demos/self_healing_repo/config.env.sample
@@ -5,3 +5,5 @@ MODEL_NAME="gpt-4o-mini"
 TEMPERATURE=0.3
 GRADIO_SHARE=0
 SANDBOX_IMAGE="python:3.11-slim"
+USE_LOCAL_LLM=true
+OLLAMA_BASE_URL="http://localhost:11434/v1"

--- a/tests/test_self_healer_sandbox.py
+++ b/tests/test_self_healer_sandbox.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration test for the Self-Healing Repo demo."""
+
+from __future__ import annotations
+
+import importlib
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from alpha_factory_v1.demos.self_healing_repo.agent_core import (
+    diff_utils,
+    llm_client,
+    sandbox,
+    self_healer,
+)
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_self_healer_succeeds_with_local_llm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_src = Path(__file__).parent / "fixtures" / "self_heal_repo"
+    repo_path = tmp_path / "repo"
+    shutil.copytree(repo_src, repo_path)
+    subprocess.run(["git", "init"], cwd=repo_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+
+    monkeypatch.setenv("USE_LOCAL_LLM", "true")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    importlib.reload(llm_client)
+
+    patch = """--- a/calc.py
++++ b/calc.py
+@@
+-    return a - b
++    return a + b
+"""
+
+    monkeypatch.setattr(llm_client, "request_patch", lambda *_: patch)
+    monkeypatch.setattr(self_healer.SelfHealer, "commit_and_push_fix", lambda self: "branch")
+    monkeypatch.setattr(self_healer.SelfHealer, "create_pull_request", lambda self, branch: 1)
+
+    def fake_run(
+        cmd: list[str],
+        repo_dir: str,
+        *,
+        image: str | None = None,
+        mounts: dict[str, str] | None = None,
+    ) -> tuple[int, str]:
+        if "pytest" in cmd:
+            res = subprocess.run(
+                ["pytest", "-q", "--color=no"],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+            )
+            return res.returncode, res.stdout + res.stderr
+        if "patch" in cmd:
+            ok, out = diff_utils.apply_diff(patch, repo_dir=repo_dir)
+            return (0 if ok else 1), out
+        return 0, ""
+
+    monkeypatch.setattr(sandbox, "run_in_docker", fake_run)
+
+    workdir = tmp_path / "work"
+    healer = self_healer.SelfHealer(repo_url=str(repo_path), commit_sha=commit)
+    healer.working_dir = str(workdir)
+
+    pr = healer.run()
+
+    with open(workdir / "calc.py") as fh:
+        content = fh.read()
+    assert "a + b" in content
+    assert "1 passed" in healer.test_results
+    assert pr == 1
+    assert llm_client.USE_LOCAL_LLM
+


### PR DESCRIPTION
## Summary
- improve environment setup instructions in self-healing repo README
- expand config.env.sample with local-LLM defaults
- update Colab notebook to show USE_LOCAL_LLM usage
- add integration test for sandbox self-healer

## Testing
- `python scripts/check_python_deps.py` *(failed: Missing packages)*
- `python check_env.py --auto-install` *(failed: No network connectivity)*
- `pytest -q` *(failed: Environment check failed)*
- `pre-commit` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc7ef9eec83338fa13919324109d8