### PR TITLE
[alpha_factory] allow clone dir override

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -51,13 +51,15 @@ TEMPERATURE=0.3
 GRADIO_SHARE=0
 USE_LOCAL_LLM=true
 OLLAMA_BASE_URL="http://localhost:11434/v1"
+CLONE_DIR="/tmp/demo_repo"  # sandbox for patched repo
 ```
 
 When `OPENAI_API_KEY` is blank the agent falls back to the local model
 via Ollama. Set `USE_LOCAL_LLM=true` to force this behaviour even when
 a key is present. Use `OLLAMA_BASE_URL` when the model runs on a remote
 host. The same file also lets you override `MODEL_NAME` and
-`TEMPERATURE` for custom tuning.
+`TEMPERATURE` for custom tuning. Set `CLONE_DIR` if you want the
+repository clone to live elsewhere.
 
 ### Windows (PowerShell)
 Run the same container with PowerShell:

--- a/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
@@ -20,7 +20,7 @@ GRADIO_SHARE = os.getenv("GRADIO_SHARE", "0") == "1"
 
 REPO_URL = "https://github.com/MontrealAI/sample_broken_calc.git"
 LOCAL_REPO = pathlib.Path(__file__).resolve().parent / "sample_broken_calc"
-CLONE_DIR = "/tmp/demo_repo"
+CLONE_DIR = os.getenv("CLONE_DIR", "/tmp/demo_repo")
 
 
 def clone_sample_repo() -> None:

--- a/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
+++ b/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
@@ -55,7 +55,8 @@
     "os.environ['OPENAI_API_KEY'] = ''  # paste API key or leave blank for offline\n",
     "os.environ['USE_LOCAL_LLM'] = 'true'  # set false to use OpenAI if key present\n",
     "os.environ['OLLAMA_BASE_URL'] = 'http://localhost:11434/v1'\n",
-    "os.environ['MODEL_NAME'] = 'gpt-4o-mini'\n"
+    "os.environ['MODEL_NAME'] = 'gpt-4o-mini'\n",
+    "os.environ['CLONE_DIR'] = '/tmp/demo_repo'  # optional clone location\n"
    ]
   },
   {

--- a/tests/test_self_heal_clone.py
+++ b/tests/test_self_heal_clone.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from types import SimpleNamespace
 from pathlib import Path
-from alpha_factory_v1.demos.self_healing_repo import agent_selfheal_entrypoint as entrypoint
 import subprocess
+import importlib
+from alpha_factory_v1.demos.self_healing_repo import agent_selfheal_entrypoint as entrypoint
 
 
 def test_clone_sample_repo_fallback(tmp_path, monkeypatch):
     target = tmp_path / "repo"
-    monkeypatch.setattr(entrypoint, "CLONE_DIR", str(target))
+    monkeypatch.setenv("CLONE_DIR", str(target))
+    importlib.reload(entrypoint)
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=1))
     entrypoint.clone_sample_repo()
     assert (target / "calc.py").exists()


### PR DESCRIPTION
## Summary
- allow overriding CLONE_DIR via environment variable
- document CLONE_DIR in the self-healing repo README and Colab notebook
- update self-healing repo clone test for new env var

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd166bbec8333a89cfa9e5f143714