### PR TITLE
[alpha_factory] allow diffs anywhere inside clone

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -160,8 +160,10 @@ clone repo → [sandbox pytest] → error log
 ## 🛡️ Security & Ops
 
 * Container runs as **non‑root UID 1001**.  
-* Patch application sandboxed to `/tmp/demo_repo`.  
-* Rollback on any `patch` failure; originals restored.  
+* Patch application sandboxed to `/tmp/demo_repo`.
+* Rollback on any `patch` failure; originals restored.
+* Diff paths are validated relative to the cloned repository; any patch
+  touching files outside this tree is rejected.
 * **/__live** endpoint returns **200 OK** for readiness probes.
 
 ---

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
@@ -3,28 +3,44 @@
 import logging
 import re
 import subprocess
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_PATHS = ["alpha_factory_v1", "src", "tests"]  # example allowed directories
+# Paths relative to the cloned repository that patches may touch.  ``None``
+# means the entire repository is allowed.
+ALLOWED_PATHS: list[str] | None = None
 
 
-def parse_and_validate_diff(diff_text: str) -> str | None:
+def parse_and_validate_diff(
+    diff_text: str,
+    repo_dir: str,
+    allowed_paths: list[str] | None = None,
+) -> str | None:
     """Verify the LLM's output is a valid unified diff and meets safety criteria."""
     if not diff_text:
         return None
     # Basic unified diff check: should contain lines starting with '+++ ' and '--- '
     if "+++" not in diff_text or "---" not in diff_text:
         return None  # Not a diff format
-    # Ensure it’s not modifying files outside allowed paths
+    repo_root = Path(repo_dir).resolve()
+    allowed = allowed_paths if allowed_paths is not None else ALLOWED_PATHS
+    allowed_dirs = (
+        [repo_root.joinpath(p).resolve() for p in allowed]
+        if allowed
+        else [repo_root]
+    )
+
     for line in diff_text.splitlines():
-        # diff file headers start with '+++ ' or '--- '
         if line.startswith("+++ ") or line.startswith("--- "):
-            # Extract file path (after a/ or b/ prefixes in git diff)
-            m = re.match(r"^\+\+\+ b/(.+)$", line)
+            m = re.match(r"^[+-]{3} [ab]/(.+)$", line)
             if m:
                 file_path = m.group(1)
-                if not any(file_path.startswith(p + "/") for p in ALLOWED_PATHS):
+                target = (repo_root / file_path).resolve()
+                if not target.is_relative_to(repo_root):
+                    logger.warning("Diff outside repository: %s", file_path)
+                    return None
+                if not any(target.is_relative_to(d) for d in allowed_dirs):
                     logger.warning("Diff touches disallowed path: %s", file_path)
                     return None
     # (Additional checks: e.g., diff length, certain forbidden content can be added here.)

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
@@ -53,7 +53,9 @@ class SelfHealer:
         # Request a diff from LLM
         diff_response = llm_client.request_patch(prompt)
         # Validate that response is a unified diff
-        self.patch_diff = diff_utils.parse_and_validate_diff(diff_response)
+        self.patch_diff = diff_utils.parse_and_validate_diff(
+            diff_response, repo_dir=self.working_dir
+        )
         return self.patch_diff is not None
 
     def apply_patch(self):

--- a/tests/test_diff_utils_apply.py
+++ b/tests/test_diff_utils_apply.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
+import shutil
 import tempfile
+from pathlib import Path
+
 from alpha_factory_v1.demos.self_healing_repo.agent_core import diff_utils
 
 
@@ -19,3 +22,16 @@ def test_apply_diff_success():
         success, output = diff_utils.apply_diff(diff, repo_dir=repo)
         assert success
         assert "patching file" in output.lower()
+
+
+def test_apply_diff_in_sample_calc(tmp_path: Path) -> None:
+    repo_src = Path("alpha_factory_v1/demos/self_healing_repo/sample_broken_calc")
+    repo = tmp_path / "repo"
+    shutil.copytree(repo_src, repo)
+
+    diff = """--- a/calc.py\n+++ b/calc.py\n@@\n-    return a - b\n+    return a + b\n"""
+
+    assert diff_utils.parse_and_validate_diff(diff, repo_dir=str(repo))
+    success, _ = diff_utils.apply_diff(diff, repo_dir=str(repo))
+    assert success
+    assert "a + b" in (repo / "calc.py").read_text()

--- a/tests/test_self_healer_pipeline.py
+++ b/tests/test_self_healer_pipeline.py
@@ -27,7 +27,11 @@ def test_self_healer_applies_patch(tmp_path, monkeypatch):
 """
 
     monkeypatch.setattr(llm_client, "request_patch", lambda *_: patch)
-    monkeypatch.setattr(diff_utils, "parse_and_validate_diff", lambda diff: diff)
+    monkeypatch.setattr(
+        diff_utils,
+        "parse_and_validate_diff",
+        lambda diff, repo_dir, allowed_paths=None: diff,
+    )
     monkeypatch.setattr(self_healer.SelfHealer, "commit_and_push_fix", lambda self: "branch")
     monkeypatch.setattr(self_healer.SelfHealer, "create_pull_request", lambda self, branch: 1)
 


### PR DESCRIPTION
## Summary
- validate unified diff paths relative to the repository clone
- let `parse_and_validate_diff` accept an optional allowed paths list
- test applying a patch inside `sample_broken_calc`
- document path restriction behaviour in self-healing repo README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684dea88e7d48333aca125766337bdb8