### PR TITLE
[alpha_factory] document self-healing dependencies

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -20,6 +20,19 @@ incurred from using this software.
 
 ---
 
+## 🛠 Requirements
+
+The demo expects a few extra packages:
+
+- [`openai_agents`](https://openai.github.io/openai-agents-python/)
+- [`gradio`](https://gradio.app/)
+- [`pytest`](https://docs.pytest.org/)
+- GNU `patch`
+
+`run_selfheal_demo.sh` verifies that `patch` is installed but does not check for
+`openai_agents`. If `openai_agents` is missing, the script falls back to the
+bundled local model.
+
 ## 🚀 Quick start (Docker)
 
 ```bash


### PR DESCRIPTION
## Summary
- document required packages for the self-healing repo demo
- note that `run_selfheal_demo.sh` only checks for `patch`
- mention local-model fallback when `openai_agents` is missing

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684df0e60eac8333aaf06358e17c651d