### PR TITLE
[alpha_factory] add missing docstrings

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the self-healing demo package."""

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/llm_client.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/llm_client.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # llm_client.py
+"""LLM interface for generating patch suggestions."""
 import os, openai
 
 # Load config from env or default

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/test_runner.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/test_runner.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # test_runner.py
+"""Utilities for running project tests in isolation."""
 import subprocess
 import os
 

--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/__init__.py
@@ -1,1 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
+"""Small flawed calculator used for demo tests."""


### PR DESCRIPTION
## Summary
- add concise module-level docstrings for the self-healing demo modules

## Testing
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py alpha_factory_v1/demos/self_healing_repo/agent_core/llm_client.py alpha_factory_v1/demos/self_healing_repo/agent_core/test_runner.py alpha_factory_v1/demos/self_healing_repo/__init__.py alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/__init__.py` *(fails: No matching distribution found for k6-python)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe5ef91c8333b9b6d0d70846fad3