### PR TITLE
[alpha_factory] handle OpenAI errors gracefully

### DIFF
--- a/tests/test_llm_client_error_handling.py
+++ b/tests/test_llm_client_error_handling.py
@@ -1,0 +1,31 @@
+import sys
+import types
+import logging
+
+import pytest
+
+from tests.test_llm_client_offline import _reload_client
+
+
+def test_request_patch_handles_openai_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    class FailError(Exception):
+        pass
+
+    openai_stub = types.ModuleType("openai")
+    openai_stub.Error = FailError
+
+    def create(*_a: object, **_k: object) -> None:
+        raise FailError("boom")
+
+    openai_stub.ChatCompletion = types.SimpleNamespace(create=create)
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("USE_LOCAL_LLM", "false")
+
+    client = _reload_client(monkeypatch, "")
+
+    caplog.set_level(logging.ERROR)
+    out = client.request_patch([{"role": "user", "content": "fix"}])
+
+    assert out == ""
+    assert any("OpenAI API request failed" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- improve llm_client resiliency when OpenAI API fails
- test that failures return an empty string and log errors

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e00a7fcb08333918939d67ea46553