### PR TITLE
[alpha_factory] Add missing license headers

### DIFF
--- a/tests/test_llm_client_error_handling.py
+++ b/tests/test_llm_client_error_handling.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 import types
 import logging

--- a/tests/test_llm_client_offline.py
+++ b/tests/test_llm_client_offline.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 import types
@@ -56,4 +57,3 @@ def test_request_patch_respects_model_env(monkeypatch: pytest.MonkeyPatch) -> No
     client = _reload_client(monkeypatch, diff)
     client.request_patch([{"role": "user", "content": "fix"}])
     assert create_mock.call_args.kwargs.get("model") == "test-model"
-

--- a/tests/test_selfheal_env.py
+++ b/tests/test_selfheal_env.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import importlib
 import os


### PR DESCRIPTION
## Summary
- add Apache-2.0 headers to tests

## Testing
- `pre-commit run --files tests/test_llm_client_error_handling.py tests/test_llm_client_offline.py tests/test_selfheal_env.py --show-diff-on-failure` *(fails: ruff, flake8, mypy, proto-verify)*
- `python scripts/check_python_deps.py` *(fails: missing numpy, pandas)*
- `python check_env.py --auto-install` *(fails: no network connectivity)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e2577185883338be46a9389a81bb1