### PR TITLE
[alpha_factory] use env var for ollama base URL

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
@@ -22,5 +22,5 @@ def build_llm() -> OpenAIAgent:
     return OpenAIAgent(
         model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
         api_key=api_key,
-        base_url=None if api_key else os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1"),
+        base_url=None if api_key else os.getenv("OLLAMA_BASE_URL", "http://ollama:11434/v1"),
     )

--- a/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
+++ b/alpha_factory_v1/demos/macro_sentinel/agent_macro_entrypoint.py
@@ -66,7 +66,7 @@ def _check_ollama(url: str) -> None:
 if os.getenv("OPENAI_API_KEY"):
     base_url = None
 else:
-    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434/v1")
     _check_ollama(base_url)
 
 LLM = OpenAIAgent(

--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -63,7 +63,7 @@ OPENAI_MODEL="gpt-4o-mini"
 TEMPERATURE=0.3
 GRADIO_SHARE=0
 USE_LOCAL_LLM=true
-OLLAMA_BASE_URL="http://localhost:11434/v1"
+OLLAMA_BASE_URL="http://ollama:11434/v1"
 CLONE_DIR="/tmp/demo_repo"  # sandbox for patched repo
 ```
 

--- a/alpha_factory_v1/demos/self_healing_repo/config.env.sample
+++ b/alpha_factory_v1/demos/self_healing_repo/config.env.sample
@@ -6,4 +6,4 @@ TEMPERATURE=0.3
 GRADIO_SHARE=0
 SANDBOX_IMAGE="python:3.11-slim"
 USE_LOCAL_LLM=true
-OLLAMA_BASE_URL="http://localhost:11434/v1"
+OLLAMA_BASE_URL="http://ollama:11434/v1"

--- a/tests/test_macro_agent_base_url.py
+++ b/tests/test_macro_agent_base_url.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+
+def test_agent_macro_entrypoint_custom_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = ModuleType("openai_agents")
+    captured = {}
+
+    class DummyOpenAI:
+        def __init__(self, *a, **kw) -> None:
+            captured["base_url"] = kw.get("base_url")
+
+    stub.Agent = object
+    stub.OpenAIAgent = DummyOpenAI
+    stub.Tool = lambda *_a, **_k: (lambda f: f)
+    monkeypatch.setitem(sys.modules, "openai_agents", stub)
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://example.com/v1")
+
+    mod_path = "alpha_factory_v1.demos.macro_sentinel.agent_macro_entrypoint"
+    sys.modules.pop(mod_path, None)
+
+    with patch(f"{mod_path}._check_ollama"):
+        importlib.import_module(mod_path)
+
+    assert captured["base_url"] == "http://example.com/v1"


### PR DESCRIPTION
## Summary
- point Mixtral macros entrypoint at `OLLAMA_BASE_URL`
- point AI-GA utils at `OLLAMA_BASE_URL`
- document new default URL for self-healing repo
- test macro entrypoint respects custom base URL

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*


------
https://chatgpt.com/codex/tasks/task_e_684e2ecf7d8883339a1322dd80a47813