### PR TITLE
[alpha_factory] fallback when openai_agents absent

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -30,8 +30,8 @@ The demo expects a few extra packages:
 - GNU `patch`
 
 `run_selfheal_demo.sh` verifies that `patch` is installed but does not check for
-`openai_agents`. If `openai_agents` is missing, the script falls back to the
-bundled local model.
+`openai_agents`. When the package is absent, the entrypoint now uses a minimal
+stub that calls the bundled offline model via `llm_client.call_local_model`.
 
 ## 🚀 Quick start (Docker)
 

--- a/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
@@ -10,7 +10,29 @@ Self‑Healing Repo demo
 import logging
 import os, subprocess, shutil, asyncio, time, pathlib, json
 import gradio as gr
-from openai_agents import Agent, OpenAIAgent, Tool
+try:
+    from openai_agents import Agent, OpenAIAgent, Tool
+except ModuleNotFoundError:  # offline fallback
+    from .agent_core import llm_client
+
+    def Tool(*_a, **_kw):  # type: ignore
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    class OpenAIAgent:  # type: ignore
+        def __init__(self, *_, **__):
+            pass
+
+        def __call__(self, prompt: str) -> str:
+            return llm_client.call_local_model([{"role": "user", "content": prompt}])
+
+    class Agent:  # type: ignore
+        def __init__(self, llm=None, tools=None, name=None) -> None:
+            self.llm = llm
+            self.tools = tools or []
+            self.name = name
 from patcher_core import generate_patch, apply_patch
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")

--- a/tests/test_selfheal_entrypoint_offline.py
+++ b/tests/test_selfheal_entrypoint_offline.py
@@ -1,0 +1,60 @@
+import builtins
+import importlib
+import sys
+import types
+
+import pytest
+
+from alpha_factory_v1.demos.self_healing_repo.agent_core import llm_client
+
+
+class DummyBlocks:
+    def __init__(self, *a, **k):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def launch(self, *a, **k):
+        pass
+
+
+class DummyMarkdown:
+    def __init__(self, *a, **k):
+        pass
+
+
+class DummyButton:
+    def __init__(self, *a, **k):
+        pass
+
+    def click(self, *a, **k):
+        pass
+
+
+def test_entrypoint_offline(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "gradio",
+        types.SimpleNamespace(Blocks=DummyBlocks, Markdown=DummyMarkdown, Button=DummyButton),
+    )
+
+    monkeypatch.setattr(llm_client, "call_local_model", lambda msgs: "local")
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "openai_agents":
+            raise ModuleNotFoundError(name)
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("alpha_factory_v1.demos.self_healing_repo.agent_selfheal_entrypoint", None)
+    entrypoint = importlib.import_module(
+        "alpha_factory_v1.demos.self_healing_repo.agent_selfheal_entrypoint"
+    )
+
+    assert entrypoint.LLM("hi") == "local"


### PR DESCRIPTION
## Summary
- fallback to local llm stub when `openai_agents` is missing
- document offline stub in the self-healing repo README
- test entrypoint imports and uses the stub without `openai_agents`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q tests/test_selfheal_entrypoint_offline.py` *(fails: Skipped: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e37d7cf288333b84568d95f3eb9e7