### PR TITLE
[alpha_factory] update self heal demo docs

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -41,6 +41,8 @@ chmod +x run_selfheal_demo.sh
 ./run_selfheal_demo.sh
 ```
 
+Alternatively run `af demo heal` from the repository root after installation.
+
 Before launching the dashboard or running tests, run `python alpha_factory_v1/scripts/preflight.py` (or `python check_env.py --auto-install`) from the repository root to confirm all dependencies. If the machine has no internet access, build a wheelhouse and run `python check_env.py --auto-install --wheelhouse <dir>` first (see **Offline workflow**).
 
 Browse **http://localhost:7863** → hit **“Heal Repository”**.
@@ -91,7 +93,7 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e ../../..
 pip install -r ../../backend/requirements.txt
 sudo apt-get update && sudo apt-get install -y patch  # install GNU patch if missing
-python agent_selfheal_entrypoint.py
+python -m alpha_factory_v1.demos.self_healing_repo.agent_selfheal_entrypoint
 ```
 Then open **http://localhost:7863** and trigger **“Heal Repository”**.
 
@@ -105,18 +107,16 @@ clones the bundled `sample_broken_calc` repository instead of pulling
 from GitHub. Build a wheelhouse first so Python packages install
 without the network:
 
-```bash
-cd /path/to/AGI-Alpha-Agent-v0
-mkdir -p /media/wheels
-pip wheel -r requirements.lock -w /media/wheels
-pip wheel -r requirements-dev.txt -w /media/wheels
-python check_env.py --auto-install --wheelhouse /media/wheels
-```
+- `cd /path/to/AGI-Alpha-Agent-v0`
+- `mkdir -p /media/wheels`
+- `pip wheel -r requirements.lock -w /media/wheels`
+- `pip wheel -r requirements-dev.txt -w /media/wheels`
+- `python check_env.py --auto-install --wheelhouse /media/wheels`
 
 Then launch the entrypoint using that wheelhouse:
 
 ```bash
-WHEELHOUSE=/media/wheels python agent_selfheal_entrypoint.py
+WHEELHOUSE=/media/wheels python -m alpha_factory_v1.demos.self_healing_repo.agent_selfheal_entrypoint
 ```
 
 The dashboard behaves the same, but all code comes from the bundled repo.


### PR DESCRIPTION
## Summary
- document running with `af demo heal`
- update Python start command
- list offline wheelhouse steps

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/README.md` *(fails: proto-verify missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_684ebaf23c088333bde69b1df61b267d