### PR TITLE
[alpha_factory] docs: add offline wheelhouse steps

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -43,7 +43,7 @@ chmod +x run_selfheal_demo.sh
 
 Alternatively run `af demo heal` from the repository root after installation.
 
-Before launching the dashboard or running tests, run `python alpha_factory_v1/scripts/preflight.py` (or `python check_env.py --auto-install`) from the repository root to confirm all dependencies. If the machine has no internet access, build a wheelhouse and run `python check_env.py --auto-install --wheelhouse <dir>` first (see **Offline workflow**).
+Before launching the dashboard or running tests, run `python alpha_factory_v1/scripts/preflight.py` (or `python check_env.py --auto-install`) from the repository root to confirm all dependencies. If the machine has no internet access, build a wheelhouse and run `python check_env.py --auto-install --wheelhouse <dir>` first (see **Build a wheelhouse & run offline**).
 
 Browse **http://localhost:7863** → hit **“Heal Repository”**.
 
@@ -104,18 +104,33 @@ Set `TEMPERATURE=0.3` (0‑2) to tune patch creativity.
 
 When the host has no internet access, `agent_selfheal_entrypoint.py`
 clones the bundled `sample_broken_calc` repository instead of pulling
-from GitHub. Build a wheelhouse first so Python packages install
-without the network:
+from GitHub.
 
-- `cd /path/to/AGI-Alpha-Agent-v0`
-- `mkdir -p /media/wheels`
-- `pip wheel -r requirements.lock -w /media/wheels`
-- `pip wheel -r requirements-dev.txt -w /media/wheels`
-- `python check_env.py --auto-install --wheelhouse /media/wheels`
+#### Build a wheelhouse & run offline
 
-Then launch the entrypoint using that wheelhouse:
+Create a wheelhouse so Python packages install without the network:
 
 ```bash
+cd /path/to/AGI-Alpha-Agent-v0
+mkdir -p /media/wheels
+pip wheel -r requirements.lock -w /media/wheels
+pip wheel -r requirements-dev.txt -w /media/wheels
+```
+
+Before each run install from the wheelhouse and set the required
+environment variables:
+
+```bash
+USE_LOCAL_LLM=true \
+OLLAMA_BASE_URL=http://localhost:11434/v1 \
+WHEELHOUSE=/media/wheels \
+python check_env.py --auto-install --wheelhouse $WHEELHOUSE
+```
+
+Launch the demo with the same variables:
+
+```bash
+USE_LOCAL_LLM=true OLLAMA_BASE_URL=http://localhost:11434/v1 \
 WHEELHOUSE=/media/wheels python -m alpha_factory_v1.demos.self_healing_repo.agent_selfheal_entrypoint
 ```
 

--- a/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
+++ b/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
@@ -61,7 +61,28 @@
     "os.environ['USE_LOCAL_LLM'] = 'true'  # set false to use OpenAI if key present\n",
     "os.environ['OLLAMA_BASE_URL'] = 'http://localhost:11434/v1'\n",
     "os.environ['OPENAI_MODEL'] = 'gpt-4o-mini'\n",
-    "os.environ['CLONE_DIR'] = '/tmp/demo_repo'  # optional clone location\n"
+    "os.environ['CLONE_DIR'] = '/tmp/demo_repo'  # optional clone location\n",
+    "os.environ['WHEELHOUSE'] = '/content/wheels'  # path to wheel cache\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "offline_wheelhouse",
+   "metadata": {},
+   "source": [
+    "### 2b \u00b7 Offline wheelhouse setup",
+    "",
+    "Upload a prebuilt wheelhouse to this runtime and set `WHEELHOUSE` so `check_env.py` installs from the cache. Combine with `USE_LOCAL_LLM` and `OLLAMA_BASE_URL` to run completely offline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run_check_env",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python ../../../check_env.py --auto-install --wheelhouse $WHEELHOUSE"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- explain building wheelhouses and running without internet in the self-healing repo demo README
- add matching setup instructions to the Colab notebook and show required env variables

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ec17b6c6c833396acdd17e34b10a3