### PR TITLE
[alpha_factory] fallback for patcher_cli

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -147,6 +147,17 @@ python patcher_core.py --repo <path>
 
 Install the optional `openai_agents` package and the `patch` utility beforehand so the script can suggest and apply fixes.
 
+When the library is missing the CLI automatically falls back to the offline model via
+`agent_core.llm_client.call_local_model`. Configure the environment variables to
+match your local setup:
+
+```bash
+OPENAI_MODEL=mixtral-8x7b \
+TEMPERATURE=0.3 \
+OLLAMA_BASE_URL=http://localhost:11434/v1 \
+python patcher_core.py --repo <path>
+```
+
 ### Before running tests
 
 Verify your environment first:

--- a/tests/test_patcher_core_cli_offline.py
+++ b/tests/test_patcher_core_cli_offline.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+import builtins
+import runpy
+import sys
+import types
+
+
+def test_patcher_cli_offline(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "test_ok.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    # stub openai to satisfy import in llm_client
+    monkeypatch.setitem(sys.modules, "openai", types.ModuleType("openai"))
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "openai_agents":
+            raise ModuleNotFoundError(name)
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(sys, "argv", ["patcher_core.py", "--repo", str(repo)])
+
+    runpy.run_module(
+        "alpha_factory_v1.demos.self_healing_repo.patcher_core", run_name="__main__"
+    )


### PR DESCRIPTION
## Summary
- fall back to `llm_client.call_local_model` when `openai_agents` is missing in `patcher_core`
- document offline CLI usage for the self-healing repo demo
- add regression test for the patcher CLI offline scenario

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/patcher_core.py alpha_factory_v1/demos/self_healing_repo/README.md tests/test_patcher_core_cli_offline.py` *(fails: command not found)*
- `pytest -q tests/test_patcher_core_cli_offline.py` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ec4b9122883338eaa1d0fabdb5bc8