### PR TITLE
[alpha_factory] docs: preflight reminder

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -43,7 +43,14 @@ chmod +x run_selfheal_demo.sh
 
 Alternatively run `af demo heal` from the repository root after installation.
 
-Before launching the dashboard or running tests, run `python alpha_factory_v1/scripts/preflight.py` (or `python check_env.py --auto-install`) from the repository root to confirm all dependencies. If the machine has no internet access, build a wheelhouse and run `python check_env.py --auto-install --wheelhouse <dir>` first (see **Build a wheelhouse & run offline**).
+### Preflight check
+
+Before launching the dashboard or running tests, run
+`python check_env.py --auto-install` or
+`python alpha_factory_v1/scripts/preflight.py` from the repository root.
+This installs any optional packages and validates your Python toolchain.
+When working offline pass `--wheelhouse <dir>` so packages install from a
+local wheelhouse (see **Build a wheelhouse & run offline**).
 
 Browse **http://localhost:7863** → hit **“Heal Repository”**.
 


### PR DESCRIPTION
## Summary
- mention preflight check near demo quick start

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/README.md` *(fails: network required)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ec63815808333b47b6876ab182102