### PR TITLE
[alpha_factory] fix diff utils indentation

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py
@@ -21,7 +21,7 @@ def parse_and_validate_diff(
     repo_dir: str,
     allowed_paths: list[str] | None = None,
 ) -> str | None:
-"""Verify the LLM's output is a valid unified diff and meets safety criteria.
+    """Verify the LLM's output is a valid unified diff and meets safety criteria.
 
     Diffs that exceed ``MAX_DIFF_LINES`` or ``MAX_DIFF_BYTES`` are rejected to
     avoid accidentally applying huge patches.


### PR DESCRIPTION
## Summary
- fix indentation for `parse_and_validate_diff`

## Testing
- `python -m py_compile alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ecedf6be08333b7f130919337848e