### PR TITLE
[alpha_factory] check docker availability

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/sandbox.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/sandbox.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from typing import Iterable, Mapping
 
@@ -24,6 +25,8 @@ def run_in_docker(
     """
 
     image = image or DEFAULT_IMAGE
+    if not shutil.which("docker"):
+        raise RuntimeError("docker is required to run the sandbox")
     mounts = mounts or {}
     cmd = [
         "docker",

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -1,0 +1,9 @@
+import pytest
+import shutil
+from alpha_factory_v1.demos.self_healing_repo.agent_core import sandbox
+
+
+def test_run_in_docker_requires_docker(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    with pytest.raises(RuntimeError, match="docker is required"):
+        sandbox.run_in_docker(["echo", "hi"], repo_dir="/tmp")


### PR DESCRIPTION
## Summary
- error out of sandbox.run_in_docker when Docker is missing
- add regression test for missing Docker

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/agent_core/sandbox.py tests/test_sandbox_docker.py` *(fails: network setup issue)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ecfef45888333ac3cbf847667bb12