### PR TITLE
[alpha_factory] Add py_compile pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,11 @@ repos:
         entry: scripts/env_check.sh
         language: system
         pass_filenames: false
+      - id: py-compile
+        name: Validate Python syntax with py_compile
+        entry: python -m py_compile
+        language: python
+        types: [python]
       - id: eslint-insight-browser
         name: Lint Insight Browser with ESLint
         entry: scripts/run_eslint.sh


### PR DESCRIPTION
## Summary
- add a local hook running `python -m py_compile`

## Testing
- `pre-commit run py-compile --files alpha_factory_v1/demos/self_healing_repo/agent_core/diff_utils.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: wheelhouse required)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ed377fbc88333b0520b24b5e2de00