### PR TITLE
[alpha_factory] fix selfheal entrypoint tool

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
@@ -82,14 +82,16 @@ async def suggest_patch():
     return {"patch": patch}
 
 
-@Tool(name="apply_patch_and_retst", description="apply patch & retest")
+@Tool(name="apply_and_test", description="apply patch & retest")
 async def apply_and_test(patch: str):
     apply_patch(patch, repo_path=CLONE_DIR)
     return await run_tests()
 
 
+apply_patch_and_retst = apply_and_test
+
 # ── Agent orchestration ───────────────────────────────────────────────────────
-agent = Agent(llm=LLM, tools=[run_tests, suggest_patch, apply_patch_and_retst], name="Repo‑Healer")
+agent = Agent(llm=LLM, tools=[run_tests, suggest_patch, apply_and_test], name="Repo‑Healer")
 
 
 async def launch_gradio():

--- a/tests/test_selfheal_import_stubs.py
+++ b/tests/test_selfheal_import_stubs.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: ignore-errors
+import importlib
+import sys
+import types
+
+
+class DummyBlocks:
+    def __init__(self, *a, **k):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyMarkdown:
+    def __init__(self, *a, **k):
+        pass
+
+
+class DummyButton:
+    def __init__(self, *a, **k):
+        pass
+
+    def click(self, *a, **k):
+        pass
+
+
+def test_entrypoint_import_with_stubs(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "gradio",
+        types.SimpleNamespace(Blocks=DummyBlocks, Markdown=DummyMarkdown, Button=DummyButton),
+    )
+    stub = types.SimpleNamespace(
+        Agent=lambda *a, **k: object(),
+        OpenAIAgent=object,
+        Tool=lambda *a, **k: (lambda f: f),
+    )
+    monkeypatch.setitem(sys.modules, "openai_agents", stub)
+    sys.modules.pop(
+        "alpha_factory_v1.demos.self_healing_repo.agent_selfheal_entrypoint",
+        None,
+    )
+    mod = importlib.import_module("alpha_factory_v1.demos.self_healing_repo.agent_selfheal_entrypoint")
+    assert mod.apply_patch_and_retst is mod.apply_and_test


### PR DESCRIPTION
## Summary
- update the self-healing repo demo to reference `apply_and_test`
- keep backwards compatibility with `apply_patch_and_retst`
- add regression test for importing entrypoint with stubbed deps

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py tests/test_selfheal_import_stubs.py` *(fails: proto-verify)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ed82664288333bc76bae13eba5006