### PR TITLE
[alpha_factory] cleanup self-healing repo imports

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
@@ -9,7 +9,12 @@ Self‑Healing Repo demo
 4. Opens a Pull Request‑style diff in the dashboard and re‑runs tests.
 """
 import logging
-import os, subprocess, shutil, asyncio, time, pathlib, json
+import asyncio
+import os
+import pathlib
+import shutil
+import subprocess
+
 import gradio as gr
 
 try:

--- a/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
+++ b/alpha_factory_v1/demos/self_healing_repo/patcher_core.py
@@ -26,8 +26,15 @@ All file‑system mutations stay **inside `repo_path`** for container safety.
 """
 
 from __future__ import annotations
-import subprocess, tempfile, pathlib, shutil, os, textwrap, re
-from typing import List, Tuple, Optional
+
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+import textwrap
+from typing import List, Optional, Tuple
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # avoid hard dependency unless actually used
@@ -147,9 +154,7 @@ if __name__ == "__main__":
         llm = OpenAIAgent(
             model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
             api_key=os.getenv("OPENAI_API_KEY"),
-            base_url=(
-                "http://ollama:11434/v1" if not os.getenv("OPENAI_API_KEY") else None
-            ),
+            base_url=("http://ollama:11434/v1" if not os.getenv("OPENAI_API_KEY") else None),
             temperature=float(_temp_env) if _temp_env is not None else None,
         )
     rc, out = validate_repo(args.repo)


### PR DESCRIPTION
## Summary
- simplify imports in the self-healing demo entrypoint
- split multi-import lines in patcher core

## Testing
- `ruff check --fix alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py alpha_factory_v1/demos/self_healing_repo/patcher_core.py`
- `black --check alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py alpha_factory_v1/demos/self_healing_repo/patcher_core.py`
- `pytest -q` *(fails: Environment check failed, requires `python check_env.py --auto-install`)*

------
https://chatgpt.com/codex/tasks/task_e_684edfdb2640833390c1c4b07ee9bfd7