### PR TITLE
[alpha_factory] document offline wheelhouse setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Follow these steps when working without internet access.
 1. **Build a wheelhouse** on a machine with connectivity:
    ```bash
    mkdir -p /media/wheels
-   pip wheel -r requirements.txt -w /media/wheels
+   pip wheel -r requirements.lock -w /media/wheels
    pip wheel -r requirements-dev.txt -w /media/wheels
    ```
 
@@ -805,7 +805,7 @@ pip install -r requirements.lock
 #  with --wheelhouse <path> or place the wheels under ./wheels)
 # Build a wheelhouse if the machine has no internet access:
 #   mkdir -p /media/wheels
-#   pip wheel -r requirements.txt -w /media/wheels
+#   pip wheel -r requirements.lock -w /media/wheels
 #   pip wheel -r requirements-dev.txt -w /media/wheels
 ./quickstart.sh               # creates venv, installs deps, launches
 # Use `--wheelhouse /path/to/wheels` to install offline packages when

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -11,7 +11,7 @@ Run the following commands on a machine with connectivity:
 
 ```bash
 mkdir -p /media/wheels
-pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r requirements.lock -w /media/wheels
 pip wheel -r requirements-dev.txt -w /media/wheels
 ```
 These wheels cover the runtime and development dependencies needed for the test

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -9,7 +9,7 @@ Run these commands on a machine with connectivity:
 
 ```bash
 mkdir -p /media/wheels
-pip wheel -r requirements.txt -w /media/wheels
+pip wheel -r requirements.lock -w /media/wheels
 pip wheel -r requirements-dev.txt -w /media/wheels
 ```
 

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -6,9 +6,9 @@ machine with connectivity and copy it here:
 
 ```bash
 mkdir -p wheels
-pip wheel -r requirements.txt -w wheels
-pip wheel -r alpha_factory_v1/demos/muzero_planning/requirements.txt -w wheels
+pip wheel -r requirements.lock -w wheels
 pip wheel -r requirements-dev.txt -w wheels
+pip wheel -r alpha_factory_v1/demos/muzero_planning/requirements.txt -w wheels
 ```
 
 Set `WHEELHOUSE=$(pwd)/wheels` before running the setup script or tests:


### PR DESCRIPTION
## Summary
- clarify offline wheelhouse instructions for tests

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install --wheelhouse wheels` *(fails: could not install core packages)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files README.md docs/OFFLINE.md docs/OFFLINE_SETUP.md wheels/README.md` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684ee351426c8333bdbe7c6a7d38bf6a