### PR TITLE
[alpha_factory] check for patch executable

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py
@@ -14,6 +14,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 
 import gradio as gr
 
@@ -46,6 +47,13 @@ from .patcher_core import generate_patch, apply_patch
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger(__name__)
+
+if shutil.which("patch") is None:
+    logger.error(
+        '`patch` command not found. Install the utility, e.g., "sudo apt-get update && sudo apt-get install -y patch"'
+    )
+    sys.exit(1)
+
 
 GRADIO_SHARE = os.getenv("GRADIO_SHARE", "0") == "1"
 


### PR DESCRIPTION
## Summary
- exit early if the `patch` command is missing in the self-healing repo demo

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/agent_selfheal_entrypoint.py` *(fails: proto-verify hook)*

------
https://chatgpt.com/codex/tasks/task_e_684ef2e8f9988333a6bd81f5bb23d80f