### PR TITLE
[alpha_factory] add sandbox patch check

### DIFF
--- a/tests/test_preflight_sandbox.py
+++ b/tests/test_preflight_sandbox.py
@@ -1,0 +1,19 @@
+import subprocess
+from alpha_factory_v1.scripts import preflight
+
+
+def test_check_patch_in_sandbox_ok(monkeypatch):
+    def fake_run(cmd, capture_output=True, text=True):
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert preflight.check_patch_in_sandbox("img")
+
+
+def test_check_patch_in_sandbox_missing(monkeypatch):
+    def fake_run(*_a, **_k):
+        return subprocess.CompletedProcess([], 1, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert not preflight.check_patch_in_sandbox("img")
+


### PR DESCRIPTION
## Summary
- check for `/usr/bin/patch` inside the sandbox container in `preflight.py`
- add unit tests covering the new sandbox check

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy, yaml, pandas missing)*
- `python check_env.py --auto-install` *(fails: no network connectivity)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/scripts/preflight.py tests/test_preflight_sandbox.py` *(failed: semgrep hook requires network)*

------
https://chatgpt.com/codex/tasks/task_e_684f16cc0cc88333acff6fad2ea61c06