### PR TITLE
[alpha_factory] Self-healer branch reset

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -159,6 +159,10 @@ You can run the patcher directly on any repository:
 python patcher_core.py --repo <path>
 ```
 
+The CLI creates an `auto-fix/<date>-<hash>` branch when committing
+the patch. It uses `git checkout -B` so an existing branch with the
+same name will be overwritten.
+
 Install the optional `openai_agents` package and the `patch` utility beforehand so the script can suggest and apply fixes.
 
 When the library is missing the CLI automatically falls back to the offline model via

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/self_healer.py
@@ -96,7 +96,7 @@ class SelfHealer:
     def commit_and_push_fix(self):
         """Commit the changes to a new branch and push to remote."""
         branch_name = f"auto-fix/{generate_branch_name(self.error_log)}"
-        subprocess.run(["git", "checkout", "-b", branch_name], cwd=self.working_dir, check=True)
+        subprocess.run(["git", "checkout", "-B", branch_name], cwd=self.working_dir, check=True)
         subprocess.run(["git", "add", "."], cwd=self.working_dir, check=True)
         commit_msg = f"Auto-fix: {summarize_error(self.error_log)} [ci skip]"
         subprocess.run(["git", "commit", "-m", commit_msg], cwd=self.working_dir, check=True)


### PR DESCRIPTION
## Summary
- ensure self-healer uses `git checkout -B` for fix branch creation
- clarify manual healing docs around branch reset

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1e69e72c8333a3662e01eaf45e54