### PR TITLE
[alpha_factory] test self-healer failure scenarios

### DIFF
--- a/tests/test_self_healer_pipeline.py
+++ b/tests/test_self_healer_pipeline.py
@@ -60,3 +60,104 @@ def test_self_healer_applies_patch(tmp_path, monkeypatch):
     assert any("pytest" in c for c in calls)
     assert applied
 
+
+def test_self_healer_aborts_on_invalid_diff(tmp_path, monkeypatch, caplog):
+    repo_src = Path(__file__).parent / "fixtures" / "self_heal_repo"
+    repo_path = tmp_path / "repo"
+    shutil.copytree(repo_src, repo_path)
+    subprocess.run(["git", "init"], cwd=repo_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+
+    workdir = tmp_path / "work"
+    healer = self_healer.SelfHealer(repo_url=str(repo_path), commit_sha=commit)
+    healer.working_dir = str(workdir)
+
+    monkeypatch.setattr(patcher_core, "generate_patch", lambda *_a, **_k: "bad")
+    monkeypatch.setattr(llm_client, "request_patch", lambda *_a, **_k: "bad")
+    monkeypatch.setattr(
+        diff_utils,
+        "parse_and_validate_diff",
+        lambda diff, repo_dir, allowed_paths=None: None,
+    )
+    pushed = []
+
+    def fake_push(self):
+        pushed.append(True)
+        return "branch"
+
+    monkeypatch.setattr(self_healer.SelfHealer, "commit_and_push_fix", fake_push)
+    monkeypatch.setattr(self_healer.SelfHealer, "create_pull_request", lambda self, branch: 1)
+
+    monkeypatch.setattr(sandbox, "run_in_docker", lambda *_a, **_k: (1, "fail"))
+
+    caplog.set_level("WARNING")
+    pr = healer.run()
+
+    assert pr is None
+    assert not pushed
+    assert any("valid patch" in rec.getMessage() for rec in caplog.records)
+
+
+def test_self_healer_does_not_push_on_failed_patch(tmp_path, monkeypatch, caplog):
+    repo_src = Path(__file__).parent / "fixtures" / "self_heal_repo"
+    repo_path = tmp_path / "repo"
+    shutil.copytree(repo_src, repo_path)
+    subprocess.run(["git", "init"], cwd=repo_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+
+    workdir = tmp_path / "work"
+    healer = self_healer.SelfHealer(repo_url=str(repo_path), commit_sha=commit)
+    healer.working_dir = str(workdir)
+
+    patch = """--- a/calc.py
++++ b/calc.py
+@@
+-    return a - b
++    return a + b
+"""
+
+    monkeypatch.setattr(llm_client, "request_patch", lambda *_a, **_k: patch)
+    monkeypatch.setattr(
+        diff_utils,
+        "parse_and_validate_diff",
+        lambda diff, repo_dir, allowed_paths=None: diff,
+    )
+    applied = []
+
+    def fake_apply(diff_text, repo_path):
+        applied.append(diff_text)
+        diff_utils.apply_diff(diff_text, repo_dir=repo_path)
+
+    monkeypatch.setattr(patcher_core, "apply_patch", fake_apply)
+
+    calls = []
+
+    def fake_run(cmd, repo_dir, *, image=None, mounts=None):
+        calls.append(cmd)
+        res = subprocess.run(["pytest", "-q", "--color=no"], cwd=repo_dir, capture_output=True, text=True)
+        return (res.returncode, res.stdout + res.stderr) if len(calls) == 1 else (1, res.stdout + res.stderr)
+
+    monkeypatch.setattr(sandbox, "run_in_docker", fake_run)
+
+    pushed = []
+
+    def fake_push(self):
+        pushed.append(True)
+        return "branch"
+
+    monkeypatch.setattr(self_healer.SelfHealer, "commit_and_push_fix", fake_push)
+    monkeypatch.setattr(self_healer.SelfHealer, "create_pull_request", lambda self, branch: 1)
+
+    caplog.set_level("WARNING")
+    pr = healer.run()
+
+    assert pr is None
+    assert applied
+    assert calls
+    assert not pushed
+    assert any("did not fix" in rec.getMessage() for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- extend self-healer pipeline tests to cover failure cases
- abort when patcher_core.generate_patch returns an invalid diff
- ensure no branch push when patch does not fix tests

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy, yaml, pandas missing)*
- `python check_env.py --auto-install` *(fails: no network connectivity)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f1f20d93c8333ae419b6781bb97d0