### PR TITLE
[alpha_factory] Remove OPENAI_CONTEXT_WINDOW reference

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -258,7 +258,7 @@ clone repo → [sandbox pytest] → error log
 |---------|--------|
 | “patch: command not found” | Rebuild the Docker image; the Dockerfile now installs `patch` |
 | Port 7863 busy | Edit `ports:` in `docker-compose.selfheal.yml` |
-| LLM exceeds context | Patch diff is now chunked; increase `OPENAI_CONTEXT_WINDOW` env if needed |
+| LLM exceeds context | Reduce diff size; large patches may exceed the model's context window |
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 - Added [`src/tools/analyse_backtrack.py`](../src/tools/analyse_backtrack.py) for visualising archive backtracks.
 - Documented how to build a wheelhouse for offline installs and updated
   `tests/README.md` with the instructions.
+- Removed outdated `OPENAI_CONTEXT_WINDOW` reference from the self-healing repo demo.
 - Added CI workflow running lint, type checks, tests and Docker build with
   automated image deployment on tags and rollback on failure. Metrics are
   exported via OpenTelemetry and can be viewed in Grafana or the Streamlit


### PR DESCRIPTION
## Summary
- clean up README for self-healing repo demo
- note removal in changelog

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-mats-demo-lock,verify-mats-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,env-check,eslint-insight-browser,semgrep pre-commit run --files alpha_factory_v1/demos/self_healing_repo/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684f3595401883338dd3e436554e84e9