### PR TITLE
[alpha_factory] capture pytest output in self-heal CI

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/.github/workflows/ci.yml
+++ b/alpha_factory_v1/demos/self_healing_repo/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: docker build -t selfheal-sandbox:latest -f ../../../../sandbox.Dockerfile ../../..
       - name: Run Tests
         id: tests
-        run: pytest -q
+        run: pytest -q | tee pytest.log
         continue-on-error: true   # Allow the job to continue even if tests fail
       - name: Upload logs artifact
         if: failure()

--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -191,8 +191,9 @@ Missing dependencies will cause tests to be skipped or fail.
 
 The directory includes `.github/workflows/self_heal.yml`—a workflow that
 monitors the main **CI** pipeline. When a `workflow_run` for **CI** on the
-`main` branch concludes with `failure`, GitHub downloads the test logs,
-checks out the failing commit and runs:
+`main` branch concludes with `failure`, GitHub downloads the test logs
+(saved as `pytest.log` in the CI workflow), checks out the failing commit
+and runs:
 
 ```bash
 python alpha_factory_v1/demos/self_healing_repo/patcher_core.py --repo .


### PR DESCRIPTION
## Summary
- capture pytest output in `alpha_factory_v1/demos/self_healing_repo/.github/workflows/ci.yml`
- clarify in README that CI stores the logs as `pytest.log`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/.github/workflows/ci.yml alpha_factory_v1/demos/self_healing_repo/README.md` *(failed due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f39c45ed48333bf68dba7228649c5