### PR TITLE
[alpha_factory] remove era_of_experience from ruff exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ exclude = [
     "alpha_factory_v1/demos/alpha_agi_insight_v0/*",
     "alpha_factory_v1/demos/alpha_agi_insight_v1/*",
     "alpha_factory_v1/demos/alpha_agi_marketplace_v1/*",
-    "alpha_factory_v1/demos/era_of_experience/*",
     "alpha_factory_v1/demos/finance_alpha/*",
     "alpha_factory_v1/demos/macro_sentinel/*",
     "alpha_factory_v1/demos/meta_agentic_agi/*",


### PR DESCRIPTION
## Summary
- remove `alpha_factory_v1/demos/era_of_experience/*` from ruff exclude list

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: No network connectivity detected)*
- `pre-commit run --files pyproject.toml` *(fails: could not install hooks without network)*
- `ruff check alpha_factory_v1/demos/era_of_experience`

------
https://chatgpt.com/codex/tasks/task_e_684f5fe4fb5883338ba88549cc4a5426