### PR TITLE
[alpha_factory] add observability profile

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -105,6 +105,16 @@ Sample CSVs (`wearable_daily.csv`, `edu_progress.csv`) are shipped in
    The orchestrator automatically switches to offline mode whenever
    `OPENAI_API_KEY` is left empty.
 
+3. Launch Prometheus and Grafana with the `--profile observability` option:
+
+   ```bash
+   docker compose --profile observability up
+   ```
+
+   Or set `COMPOSE_PROFILES=observability` when running
+   `./run_experience_demo.sh`. The Grafana dashboard is available at
+   `http://localhost:3001` (password `experience`).
+
 ---
 
 ## 🎓 Run on Colab (zero install)

--- a/alpha_factory_v1/demos/era_of_experience/observability/grafana_dashboards/starter.json
+++ b/alpha_factory_v1/demos/era_of_experience/observability/grafana_dashboards/starter.json
@@ -1,0 +1,19 @@
+{
+  "id": null,
+  "title": "Era-of-Experience",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "process_cpu_seconds_total"}
+      ],
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 0}
+    }
+  ]
+}

--- a/alpha_factory_v1/demos/era_of_experience/observability/grafana_datasources/datasource.yml
+++ b/alpha_factory_v1/demos/era_of_experience/observability/grafana_datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/alpha_factory_v1/demos/era_of_experience/observability/prometheus.yml
+++ b/alpha_factory_v1/demos/era_of_experience/observability/prometheus.yml
@@ -1,0 +1,14 @@
+# Prometheus config for Era-of-Experience demo
+# Pulls metrics from Pushgateway and itself
+
+global:
+  scrape_interval: ${PROMETHEUS_SCRAPE_INTERVAL:-15s}
+
+scrape_configs:
+  - job_name: 'pushgateway'
+    honor_labels: true
+    static_configs:
+      - targets: ['prom-push:9091']
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- add Prometheus/Grafana starter configs for Era-of-Experience
- mount observability files in compose
- document the optional `--profile observability` flow

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/observability/prometheus.yml alpha_factory_v1/demos/era_of_experience/observability/grafana_datasources/datasource.yml alpha_factory_v1/demos/era_of_experience/observability/grafana_dashboards/starter.json alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml alpha_factory_v1/demos/era_of_experience/README.md` *(failed: Verify requirements.lock step interrupted)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684f64142fe8833386f83352b909bf2a