### PR TITLE
[alpha_factory] add requirements file for era_experience demo

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -26,8 +26,10 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 - At least **4 CPU cores** (or a modest GPU) for smooth local runs
 - *(Optional)* `OPENAI_API_KEY` for cloud LLMs — leave blank to use the built‑in Mixtral via Ollama
 - If running without `run_experience_demo.sh`, install the
-  [`openai-agents`](https://openai.github.io/openai-agents-python/) SDK and
-  `gradio` via `pip install openai-agents gradio`.
+  dependencies from `requirements.txt` with:
+  ```bash
+  pip install -r requirements.txt
+  ```
   Then, you can run the script directly with a command like:
   ```bash
   SAMPLE_DATA_DIR=/path/to/csvs python agent_experience_entrypoint.py
@@ -39,7 +41,7 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/era_of_experience
-python ../../../check_env.py --auto-install  # optional env check
+python ../../../check_env.py --demo era_experience --auto-install  # optional env check
 chmod +x run_experience_demo.sh
 ./run_experience_demo.sh      # ← THAT’S IT
 ```
@@ -272,7 +274,7 @@ Verify the demo locally with Python's builtin test runner:
 python -m unittest tests.test_era_experience
 ```
 
-Run `python ../../../check_env.py --auto-install` first and make sure it
+Run `python ../../../check_env.py --demo era_experience --auto-install` first and make sure it
 completes successfully before running any tests. Tests will fail if core
 packages such as `numpy` are missing, in addition to optional ones like
 `pytest` and `openai-agents`.

--- a/alpha_factory_v1/demos/era_of_experience/requirements.txt
+++ b/alpha_factory_v1/demos/era_of_experience/requirements.txt
@@ -1,0 +1,6 @@
+# Era-of-Experience demo dependencies
+# Reuse the main project requirements and add demo extras
+-r ../../requirements.txt
+openai-agents==0.0.17
+gradio
+sentence-transformers>=2.4

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -78,7 +78,8 @@ need curl
 if [[ "${SKIP_ENV_CHECK:-0}" != "1" ]]; then
   if command -v python3 &>/dev/null && [[ -f ../check_env.py ]]; then
     say "Checking host Python packages"
-    python3 ../check_env.py --auto-install || warn "Environment check failed"
+    python3 ../check_env.py --demo era_experience --auto-install || \
+      warn "Environment check failed"
   fi
 fi
 

--- a/check_env.py
+++ b/check_env.py
@@ -87,6 +87,11 @@ DEMO_PACKAGES = {
         "aiohttp",
         "qdrant_client",
     ],
+    "era_experience": [
+        "openai_agents",
+        "gradio",
+        "sentence_transformers",
+    ],
 }
 
 # Optional integrations that may not be present in restricted environments.
@@ -107,6 +112,7 @@ PIP_NAMES = {
     "yaml": "PyYAML",
     "gradio": "gradio",
     "aiohttp": "aiohttp",
+    "sentence_transformers": "sentence-transformers",
     "opentelemetry": "opentelemetry-api",
     "opentelemetry-api": "opentelemetry-api",
     "qdrant_client": "qdrant-client",


### PR DESCRIPTION
## Summary
- add requirements list for the era-of-experience demo
- run env check via `--demo era_experience`
- mention the new requirements file in docs and scripts
- map `sentence_transformers` pip name in env checker

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/requirements.txt alpha_factory_v1/demos/era_of_experience/README.md alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh check_env.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f67206ac883339ade77a66dbc1fa3