### PR TITLE
[alpha_factory] specify OpenAI Agents SDK version

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -26,10 +26,12 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 - At least **4 CPU cores** (or a modest GPU) for smooth local runs
 - *(Optional)* `OPENAI_API_KEY` for cloud LLMs — leave blank to use the built‑in Mixtral via Ollama
 - If running without `run_experience_demo.sh`, install the
-  dependencies from `requirements.txt` with:
+  dependencies from `requirements.txt` and ensure the **OpenAI Agents SDK** is at least version `0.0.14`:
   ```bash
   pip install -r requirements.txt
+  pip install 'openai-agents>=0.0.14'
   ```
+  `check_env.py` validates the SDK version (see also `alpha_factory_v1/scripts/preflight.py`).
   Then, you can run the script directly with a command like:
   ```bash
   SAMPLE_DATA_DIR=/path/to/csvs python agent_experience_entrypoint.py


### PR DESCRIPTION
## Summary
- document that `openai-agents` must be at least version 0.0.14
- mention `check_env.py` validates this and reference `preflight.py`

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy, pandas missing)*
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/README.md` *(fails: env-check hook)*

------
https://chatgpt.com/codex/tasks/task_e_684f683a056883339f80dcc5b0a08963