### PR TITLE
[alpha_factory] add Colab link

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -61,9 +61,15 @@ Add `--live` to pull in real sensor feeds (wearables, RSS, etc.):
   * interactive chat / tool console 💬
   * built‑in alpha detectors (yield curve & supply‑chain) 🔍 — they read from
     `alpha_factory_v1/demos/macro_sentinel/offline_samples/`, and the CSV
-    snapshots are already included in the repository
+snapshots are already included in the repository
 
 > **Offline/Private mode** — leave `OPENAI_API_KEY=` blank in <code>config.env</code>; the stack falls back to <strong>Ollama ✕ Mixtral‑8x7B</strong> and stays air‑gapped.
+
+### 📒 Interactive notebook demo
+
+Run the self-contained Colab notebook to launch the experience demo without any local setup.
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb)
 
 ## Offline Setup
 


### PR DESCRIPTION
## Summary
- link to the experience demo Colab notebook

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/README.md` *(fails: command not found)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f6bfcfec0833386ebab3bd6f64455