### PR TITLE
[alpha_factory] fix qdrant version

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
+++ b/alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml
@@ -34,7 +34,7 @@ x-health-curl: &hc
 services:
   # ───────────── Vector Memory (Qdrant) ─────────────
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.8.1
     volumes:
       - qdrant_data:/qdrant/storage
     healthcheck:


### PR DESCRIPTION
# Summary
- pin the qdrant image in the Era of Experience demo to version `v1.8.1`

# Checks
- [x] I ran `pre-commit run --files alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml` *(failed: proto-verify missing separator)*
- [x] I ran `python check_env.py --auto-install` *(failed: network unavailable)*
- [x] I ran `pytest -q` *(failed: environment check requires network)*

# Testing
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/docker-compose.experience.yml` failed with `proto-verify` error
- `python check_env.py --auto-install` reported `No network connectivity detected`
- `pytest -q` aborted due to missing environment setup

------
https://chatgpt.com/codex/tasks/task_e_684f743b5b64833399bcd683d111aafe