### PR TITLE
[alpha_factory] Expand offline setup instructions

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -79,8 +79,17 @@ When running without internet access:
    <a href="https://github.com/MontrealAI/demo-assets">demo-assets</a> repository.
 2. Place both files in `offline_samples/` before executing
    <code>./run_experience_demo.sh</code> so the orchestrator can read them.
-3. If the environment check cannot reach PyPI, set `SKIP_ENV_CHECK=1` to skip
-   that step:
+3. Build a wheelhouse on an online machine:
+   ```bash
+   pip wheel -r requirements.txt -w /media/wheels
+   ```
+   Copy `/media/wheels` to the offline host.
+4. Run the environment check with the wheelhouse:
+   ```bash
+   python ../../../check_env.py --auto-install --wheelhouse /media/wheels
+   ```
+5. If the environment check still cannot reach PyPI, set `SKIP_ENV_CHECK=1` to
+   skip that step:
    ```bash
    SKIP_ENV_CHECK=1 ./run_experience_demo.sh
    ```


### PR DESCRIPTION
## Summary
- clarify offline instructions in `era_of_experience` README on building a wheelhouse and using `check_env.py`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Could not run tests due to missing wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_684f762b6da083339222d2974ec2304a