### PR TITLE
[alpha_factory] extend experience launcher tests

### DIFF
--- a/tests/test_experience_launcher.py
+++ b/tests/test_experience_launcher.py
@@ -140,3 +140,135 @@ def test_experience_launcher_live(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     assert "--profile live-feed" in log
     assert "LIVE_FEED=1" in log
     assert created
+
+
+@pytest.mark.skipif(
+    not Path("alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh").exists(),
+    reason="script missing",
+)  # type: ignore[misc]
+def test_experience_launcher_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    script = Path("alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh")
+    config = script.parent / "config.env"
+    docker_log = tmp_path / "docker.log"
+    curl_log = tmp_path / "curl.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "$@" >> "$DOCKER_LOG"\n'
+        'if [ "$1" = "info" ]; then echo "{}"; fi\n'
+        'if [ "$1" = "version" ]; then echo "24.0.0"; fi\n'
+        "exit 0\n"
+    )
+    docker_stub.chmod(0o755)
+
+    curl_stub = bin_dir / "curl"
+    curl_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "$@" >> "$CURL_LOG"\n'
+        'out=""\n'
+        "for ((i=1;i<=$#;i++)); do\n"
+        '  if [ "${!i}" = "-o" ]; then\n'
+        "    j=$((i+1))\n"
+        "    out=${!j}\n"
+        "  fi\n"
+        "done\n"
+        'if [ -n "$out" ]; then echo sample > "$out"; fi\n'
+        'echo "OK"\n'
+    )
+    curl_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "SKIP_ENV_CHECK": "1",
+            "SAMPLE_DATA_DIR": str(tmp_path / "samples"),
+            "DOCKER_LOG": str(docker_log),
+            "CURL_LOG": str(curl_log),
+            "OPENAI_API_KEY": "dummy",
+        }
+    )
+
+    if config.exists():
+        config.unlink()
+    try:
+        result = subprocess.run([f"./{script.name}"], cwd=script.parent, env=env, capture_output=True, text=True)
+        created = config.exists()
+    finally:
+        if config.exists():
+            config.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert docker_log.exists()
+    log = docker_log.read_text()
+    assert "--profile offline" not in log
+    assert created
+
+
+@pytest.mark.skipif(
+    not Path("alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh").exists(),
+    reason="script missing",
+)  # type: ignore[misc]
+def test_experience_launcher_gpu(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    script = Path("alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh")
+    config = script.parent / "config.env"
+    docker_log = tmp_path / "docker.log"
+    curl_log = tmp_path / "curl.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "$@" >> "$DOCKER_LOG"\n'
+        'if [ "$1" = "info" ]; then echo "{"nvidia":{}}"; fi\n'
+        'if [ "$1" = "version" ]; then echo "24.0.0"; fi\n'
+        "exit 0\n"
+    )
+    docker_stub.chmod(0o755)
+
+    curl_stub = bin_dir / "curl"
+    curl_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "$@" >> "$CURL_LOG"\n'
+        'out=""\n'
+        "for ((i=1;i<=$#;i++)); do\n"
+        '  if [ "${!i}" = "-o" ]; then\n'
+        "    j=$((i+1))\n"
+        "    out=${!j}\n"
+        "  fi\n"
+        "done\n"
+        'if [ -n "$out" ]; then echo sample > "$out"; fi\n'
+        'echo "OK"\n'
+    )
+    curl_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "SKIP_ENV_CHECK": "1",
+            "SAMPLE_DATA_DIR": str(tmp_path / "samples"),
+            "DOCKER_LOG": str(docker_log),
+            "CURL_LOG": str(curl_log),
+            "OPENAI_API_KEY": "dummy",
+        }
+    )
+
+    if config.exists():
+        config.unlink()
+    try:
+        result = subprocess.run([f"./{script.name}"], cwd=script.parent, env=env, capture_output=True, text=True)
+        created = config.exists()
+    finally:
+        if config.exists():
+            config.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert docker_log.exists()
+    log = docker_log.read_text()
+    assert "--profile gpu" in log
+    assert created


### PR DESCRIPTION
## Summary
- add tests for GPU and API-key handling in experience launcher

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest tests/test_experience_launcher.py -vv` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f7f2cb7688333b3ce2df43a1e02b9