### PR TITLE
[alpha_factory] docs: add SAMPLE_DATA_DIR example

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -65,6 +65,13 @@ snapshots are already included in the repository
 
 > **Offline/Private mode** — leave `OPENAI_API_KEY=` blank in <code>config.env</code>; the stack falls back to <strong>Ollama ✕ Mixtral‑8x7B</strong> and stays air‑gapped.
 
+Customize the dataset directory by exporting `SAMPLE_DATA_DIR` (see
+`config.env.sample`) before launching the script:
+
+```bash
+SAMPLE_DATA_DIR=/path/to/csvs ./run_experience_demo.sh
+```
+
 ### 📒 Interactive notebook demo
 
 Run the self-contained Colab notebook to launch the experience demo without any local setup.


### PR DESCRIPTION
## Summary
- document SAMPLE_DATA_DIR in the Quick-start section

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: No network connectivity)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/README.md` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_684f80cbeeb08333be73da3b815fcd58