### PR TITLE
[alpha_factory] add reward backend tests

### DIFF
--- a/tests/test_curiosity_reward.py
+++ b/tests/test_curiosity_reward.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`curiosity_reward` backend."""
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import curiosity_reward as cr
+
+
+def _reset_cache() -> None:
+    cr._seen = cr._LRUCounter(cr._MAX_ENTRIES)
+
+
+def test_first_time_event_score_is_one() -> None:
+    """First occurrence should return ``1.0``."""
+    _reset_cache()
+    value = cr.reward({}, None, {"event": 1})
+    assert value == 1.0
+
+
+def test_repeated_event_score_decreases() -> None:
+    """Repeated events yield lower scores."""
+    _reset_cache()
+    first = cr.reward({}, None, {"event": 1})
+    second = cr.reward({}, None, {"event": 1})
+    assert first == 1.0
+    assert 0.0 < second <= 1.0 and second < first

--- a/tests/test_fitness_reward.py
+++ b/tests/test_fitness_reward.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`fitness_reward` backend."""
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import fitness_reward as fr
+from pytest import approx
+
+
+def test_ideal_sensor_readings_near_one() -> None:
+    """Typical ideal metrics should yield ~1.0."""
+    sensors = {"steps": 10_000, "resting_hr": 60, "sleep_hours": 8, "cal_intake": 2100}
+    value = fr.reward(None, None, sensors)
+    assert 0.0 <= value <= 1.0
+    assert value == approx(1.0, rel=0, abs=1e-7)
+
+
+def test_reasonable_daily_metrics() -> None:
+    """Moderate readings still return a bounded score."""
+    sensors = {"steps": 8000, "resting_hr": 65, "sleep_hours": 7, "cal_intake": 2500}
+    value = fr.reward(None, None, sensors)
+    assert 0.0 <= value <= 1.0
+    assert value < 1.0


### PR DESCRIPTION
## Summary
- add tests for curiosity_reward
- add tests for fitness_reward

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q tests/test_curiosity_reward.py tests/test_fitness_reward.py` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f8431fb1883339c64be11c2376fb4