### PR TITLE
[alpha_factory] update offline test instructions

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -106,6 +106,18 @@ When running without internet access:
    SKIP_ENV_CHECK=1 ./run_experience_demo.sh
    ```
 
+Offline test workflow (after copying `/media/wheels`):
+
+- **Build** the wheel cache on a machine with internet access as shown above.
+- **Set** `WHEELHOUSE=/media/wheels` and run:
+  ```bash
+  python ../../../check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+  ```
+- **Run** the unit tests with the wheelhouse available:
+  ```bash
+  WHEELHOUSE=$WHEELHOUSE pytest -q
+  ```
+
 
 ### 🔧 Configure &amp; advanced usage
 


### PR DESCRIPTION
## Summary
- clarify offline instructions in `era_of_experience/README.md`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f89b021a08333b0b638496cc44ef6