### PR TITLE
[alpha_factory] add unit test for gather_signals

### DIFF
--- a/tests/test_alpha_report.py
+++ b/tests/test_alpha_report.py
@@ -23,6 +23,13 @@ class TestBestAlpha(unittest.TestCase):
         }
         self.assertEqual(alpha_report.best_alpha(signals), signals["yield_curve"])
 
+    def test_gather_signals_returns_mapping(self) -> None:
+        """``gather_signals`` should return all expected signal keys."""
+        signals = alpha_report.gather_signals()
+        self.assertIsInstance(signals, dict)
+        for key in ("yield_curve", "supply_chain"):
+            self.assertIn(key, signals)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- extend alpha report tests with `test_gather_signals_returns_mapping`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pre-commit run --files tests/test_alpha_report.py` *(fails: network issues cloning hooks)*
- `pytest tests/test_alpha_report.py` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f8b42ac28833398fae0fa23735e58