### PR TITLE
[alpha_factory] honor STREAM_RATE_HZ

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -171,6 +171,24 @@ Sample CSVs (`wearable_daily.csv`, `edu_progress.csv`) are shipped in
        ./run_experience_demo.sh
    ```
 
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OPENAI_API_KEY` | _(empty)_ | API key for hosted models. Offline mode is used when empty. |
+| `MODEL_NAME` | `gpt-4o-mini` | Planner model name. |
+| `TEMPERATURE` | `0.40` | LLM sampling temperature. |
+| `MAX_TOKENS` | `4096` | Token limit for reasoning and tool calls. |
+| `OLLAMA_MODEL` | `mixtral:instruct` | Offline fallback model pulled by Ollama. |
+| `LLM_BASE_URL` | `http://ollama:11434/v1` | Override the local LLM endpoint. |
+| `STREAM_RATE_HZ` | `1` | Synthetic experience events per second. |
+| `LIVE_FEED` | `0` | Set to `1` to mix in real sensor/web data. |
+| `FITNESS_REWARD_WEIGHT` | `0.50` | Weight on `fitness_reward()`. |
+| `EDUCATION_REWARD_WEIGHT` | `0.50` | Weight on `education_reward()`. |
+| `PG_PASSWORD` | `alpha` | TimescaleDB password for the live-feed logger. |
+| `LOG_LEVEL` | `INFO` | Logging verbosity. |
+| `PORT` | `7860` | Web UI port. |
+
 ---
 
 ## 🎓 Run on Colab (zero install)

--- a/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
+++ b/alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py
@@ -81,6 +81,7 @@ TEMP = float(os.getenv("TEMPERATURE", "0.2"))
 LIVE_FEED = bool(int(os.getenv("LIVE_FEED", "0")))
 PORT = int(os.getenv("PORT", "7860"))
 LOG_LVL = os.getenv("LOG_LEVEL", "INFO").upper()
+STREAM_RATE = float(os.getenv("STREAM_RATE_HZ", "1"))
 
 logging.basicConfig(
     level=LOG_LVL,
@@ -109,6 +110,7 @@ async def experience_stream() -> AsyncIterator[Dict[str, Any]]:
     learn = ["Duolingo Spanish 10 min", "Khan Academy Calculus 15 min", "Read 'Nature' abstract"]
     health = ["Run 5 km", "Sleep 7 h 45 m", "Cycle 12 km", "Yoga 30 min"]
 
+    period = 1.0 / max(STREAM_RATE, 0.01)
     while True:
         uid += 1
         now = dt.datetime.now(dt.timezone.utc).isoformat()
@@ -118,7 +120,7 @@ async def experience_stream() -> AsyncIterator[Dict[str, Any]]:
             kind, payload = "learn", {"session": random.choice(learn)}
         evt = {"id": uid, "t": now, "user": random.choice(users), "kind": kind, "payload": payload}
         yield evt
-        await asyncio.sleep(1.5)  # ~0.66 Hz stream
+        await asyncio.sleep(period)
 
 
 # ────────────────────────────── sensor-motor tools ──────────────────────────

--- a/alpha_factory_v1/demos/era_of_experience/config.env.sample
+++ b/alpha_factory_v1/demos/era_of_experience/config.env.sample
@@ -17,13 +17,10 @@ MAX_TOKENS=4096                 # token cap for reasoning/tool calls
 
 ###########################  Offline fallback  ###############################
 OLLAMA_MODEL=mixtral:instruct    # pulled on first run (≈ 13 GB)
-OLLAMA_URL=http://ollama:11434   # internal service; override for LAN cache
 # LLM_BASE_URL=http://ollama:11434/v1  # custom base URL when OPENAI_API_KEY is unset
 
 ###########################  Experience agent  ###############################
 STREAM_RATE_HZ=1                 # synthetic experience events per second
-MEMORY_BACKEND=qdrant            # vector store: vector | qdrant | chroma
-MEMORY_CAPACITY=100000           # max embeddings before LRU eviction
 LIVE_FEED=0                      # 1 mixes in real sensor/web data
 
 ###########################  Reward shaping  #################################
@@ -34,11 +31,9 @@ EDUCATION_REWARD_WEIGHT=0.50     # weight on `education_reward()` backend
 # TimescaleDB password used by the live-feed logger (user = experience)
 PG_PASSWORD=alpha
 # DATABASE_URL=postgresql://alpha:alpha@timescaledb:5432/experience
-PROMETHEUS_PORT=9090             # metrics scrape port for Prometheus / Grafana
 
 ###########################  Observability  ##################################
 LOG_LEVEL=INFO                   # DEBUG | INFO | WARNING | ERROR
-ALLOWED_ORIGINS=*                # CORS for Gradio / proxy front-ends
 # PORT=7860                       # web UI port
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- support STREAM_RATE_HZ in the experience demo
- drop unused env vars from config.env.sample
- document available variables in README
- test STREAM_RATE_HZ event timing

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network)*
- `pytest -q tests/test_era_experience.py::TestEraOfExperience::test_stream_rate_env_controls_interval` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/era_of_experience/agent_experience_entrypoint.py alpha_factory_v1/demos/era_of_experience/config.env.sample alpha_factory_v1/demos/era_of_experience/README.md tests/test_era_experience.py` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_68500bfacba8833384d3cd5e8ce804fb