### PR TITLE
[alpha_factory] add experience demo tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -163,6 +163,16 @@ OPENAI_API_KEY=dummy pytest tests/test_meta_agentic_tree_search_demo.py::test_br
   `requirements-demo.txt` or they will be skipped automatically.
 - The meta-agentic tree search tests also rely on `numpy` and `pyyaml`. These packages are included in `requirements-dev.txt`, so running `pip install -r requirements-dev.txt` will install them.
 
+### Experience demo tests
+
+Run the Era‑of‑Experience checks without starting Docker:
+
+```bash
+pytest tests/test_experience_launcher.py tests/test_agent_experience_entrypoint.py
+```
+
+These tests verify the demo launcher script and the Python entrypoint with both OpenAI and Ollama settings.
+
 ## Troubleshooting
 
 ImportErrors during test collection usually mean optional packages are missing.

--- a/tests/test_agent_experience_entrypoint.py
+++ b/tests/test_agent_experience_entrypoint.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+
+import pytest
+
+
+class DummyButton:
+    def click(self, *a, **k):
+        pass
+
+
+class DummyBlocks:
+    def __init__(self, *a, **k):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def Markdown(self, *a, **k):
+        pass
+
+    def Dataframe(self, *a, **k):
+        pass
+
+    def Button(self, *a, **k):
+        return DummyButton()
+
+
+def mount_gradio_app(app, ui, path="/"):
+    return app
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, openai_key: str | None, base_url: str | None) -> str | None:
+    recorded: dict[str, str | None] = {}
+
+    stub = types.ModuleType("openai_agents")
+
+    def Tool(*_a, **_k):
+        def dec(f):
+            return f
+        return dec
+
+    class DummyMemory:
+        def __init__(self, *a, **k):
+            pass
+
+        def recent(self, _n: int):
+            return []
+
+    class DummyAgent:
+        def __init__(self, *a, **k) -> None:
+            self.memory = DummyMemory()
+
+        async def act(self) -> str:
+            return "done"
+
+        def observe(self, *_a) -> None:
+            pass
+
+    def DummyOpenAIAgent(*_a, **kw):
+        recorded["base_url"] = kw.get("base_url")
+        return object()
+
+    stub.Agent = DummyAgent
+    stub.OpenAIAgent = DummyOpenAIAgent
+    stub.Tool = Tool
+    stub.memory = types.SimpleNamespace(LocalQdrantMemory=DummyMemory)
+
+    gr_stub = types.SimpleNamespace(Blocks=DummyBlocks, mount_gradio_app=mount_gradio_app)
+
+    class DummyConfig:
+        def __init__(self, *a, **k):
+            pass
+
+    class DummyServer:
+        def __init__(self, *a, **k):
+            pass
+
+        async def serve(self) -> None:
+            pass
+
+    uvicorn_stub = types.SimpleNamespace(Config=DummyConfig, Server=DummyServer)
+
+    monkeypatch.setitem(sys.modules, "openai_agents", stub)
+    monkeypatch.setitem(sys.modules, "gradio", gr_stub)
+    monkeypatch.setitem(sys.modules, "uvicorn", uvicorn_stub)
+
+    if openai_key is None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("OPENAI_API_KEY", openai_key)
+    if base_url is None:
+        monkeypatch.delenv("LLM_BASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("LLM_BASE_URL", base_url)
+
+    module_name = "alpha_factory_v1.demos.era_of_experience.agent_experience_entrypoint"
+    sys.modules.pop(module_name, None)
+    mod = importlib.import_module(module_name)
+
+    async def one_event():
+        yield {"id": 1, "t": "0", "user": "a", "kind": "health", "payload": {}}
+
+    monkeypatch.setattr(mod, "experience_stream", one_event)
+    monkeypatch.setattr(mod.asyncio, "sleep", lambda *_a, **_kw: None)
+    asyncio.run(mod.main())
+    return recorded.get("base_url")
+
+
+def test_main_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    base = _run_main(monkeypatch, openai_key="dummy", base_url="http://ollama")
+    assert base is None
+
+
+def test_main_ollama(monkeypatch: pytest.MonkeyPatch) -> None:
+    base = _run_main(monkeypatch, openai_key="", base_url="http://ollama")
+    assert base == "http://ollama"

--- a/tests/test_experience_launcher.py
+++ b/tests/test_experience_launcher.py
@@ -272,3 +272,79 @@ def test_experience_launcher_gpu(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     log = docker_log.read_text()
     assert "--profile gpu" in log
     assert created
+
+
+@pytest.mark.skipif(
+    not Path("alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh").exists(),
+    reason="script missing",
+)  # type: ignore[misc]
+def test_experience_launcher_env_vars(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    script = Path("alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh")
+    config = script.parent / "config.env"
+    docker_log = tmp_path / "docker.log"
+    curl_log = tmp_path / "curl.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "STREAM_RATE_HZ=$STREAM_RATE_HZ" >> "$DOCKER_LOG"\n'
+        'echo "PORT=$PORT" >> "$DOCKER_LOG"\n'
+        'echo "$@" >> "$DOCKER_LOG"\n'
+        'if [ "$1" = "info" ]; then echo "{}"; fi\n'
+        'if [ "$1" = "version" ]; then echo "24.0.0"; fi\n'
+        "exit 0\n"
+    )
+    docker_stub.chmod(0o755)
+
+    curl_stub = bin_dir / "curl"
+    curl_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "$@" >> "$CURL_LOG"\n'
+        'out=""\n'
+        "for ((i=1;i<=$#;i++)); do\n"
+        '  if [ "${!i}" = "-o" ]; then\n'
+        "    j=$((i+1))\n"
+        "    out=${!j}\n"
+        "  fi\n"
+        "done\n"
+        'if [ -n "$out" ]; then echo sample > "$out"; fi\n'
+        'echo "OK"\n'
+    )
+    curl_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "SKIP_ENV_CHECK": "1",
+            "SAMPLE_DATA_DIR": str(tmp_path / "samples"),
+            "STREAM_RATE_HZ": "7",
+            "DOCKER_LOG": str(docker_log),
+            "CURL_LOG": str(curl_log),
+        }
+    )
+    env.pop("OPENAI_API_KEY", None)
+
+    if config.exists():
+        config.unlink()
+    try:
+        result = subprocess.run(
+            [f"./{script.name}", "--port", "9999"],
+            cwd=script.parent,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        created = config.exists()
+    finally:
+        if config.exists():
+            config.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert docker_log.exists()
+    log = docker_log.read_text()
+    assert "STREAM_RATE_HZ=7" in log
+    assert "PORT=9999" in log
+    assert created


### PR DESCRIPTION
## Summary
- check STREAM_RATE_HZ in run_experience_demo.sh
- add agent_experience_entrypoint.main tests
- document how to run these checks

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850189e463883338bdaad351ba73340