### PR TITLE
[alpha_factory] parameterize connectivity test

### DIFF
--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -188,6 +188,7 @@ Sample CSVs (`wearable_daily.csv`, `edu_progress.csv`) are shipped in
 | `PG_PASSWORD` | `alpha` | TimescaleDB password for the live-feed logger. |
 | `LOG_LEVEL` | `INFO` | Logging verbosity. |
 | `PORT` | `7860` | Web UI port. |
+| `CONNECTIVITY_TEST_URL` | `https://example.com` | Probe used to detect internet access. |
 
 ---
 

--- a/alpha_factory_v1/demos/era_of_experience/config.env.sample
+++ b/alpha_factory_v1/demos/era_of_experience/config.env.sample
@@ -35,6 +35,7 @@ PG_PASSWORD=alpha
 ###########################  Observability  ##################################
 LOG_LEVEL=INFO                   # DEBUG | INFO | WARNING | ERROR
 # PORT=7860                       # web UI port
+# CONNECTIVITY_TEST_URL=https://example.com  # probe to verify network access
 
 ###############################################################################
 # 💡 TIP: No env vars? No problem. Just run the demo — it auto-switches to

--- a/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
+++ b/alpha_factory_v1/demos/era_of_experience/run_experience_demo.sh
@@ -45,6 +45,7 @@ sample_dir="${SAMPLE_DATA_DIR:-$demo_dir/offline_samples}"
 sample_dir="$(realpath -m "$sample_dir")"
 offline_dir="$sample_dir"
 export SAMPLE_DATA_DIR="$sample_dir"
+CONNECTIVITY_TEST_URL="${CONNECTIVITY_TEST_URL:-https://example.com}"
 
 cd "$root_dir"                                # required for build context
 
@@ -113,7 +114,7 @@ fi
 ############################## offline samples ################################
 say "Syncing offline experience snapshots in $offline_dir"
 mkdir -p "$offline_dir"
-if curl -sf https://example.com >/dev/null; then
+if curl -sf "$CONNECTIVITY_TEST_URL" >/dev/null; then
   offline_probe=0
 else
   warn "Connectivity test failed – using empty placeholders"


### PR DESCRIPTION
## Summary
- allow customizing the connectivity probe for Era-of-Experience demo
- document `CONNECTIVITY_TEST_URL`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68501d7fb7848333a9df71d2d8d71d12