### PR TITLE
[alpha_factory] Add reward backend tests

### DIFF
--- a/tests/test_education_reward.py
+++ b/tests/test_education_reward.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`education_reward` backend."""
+
+from collections import deque
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import education_reward as ed
+
+
+class DummyState:
+    def __init__(self) -> None:
+        self.history = deque()
+
+
+def test_learning_event_in_range() -> None:
+    state = DummyState()
+    result = {"context": "duolingo spanish lesson", "duration": 1800}
+    value = ed.reward(state, None, result)
+    assert isinstance(value, float)
+    assert 0.0 <= value <= 1.0
+
+
+def test_non_learning_event_zero() -> None:
+    state = DummyState()
+    value = ed.reward(state, None, {"context": "watch tv"})
+    assert value == 0.0

--- a/tests/test_efficiency_reward.py
+++ b/tests/test_efficiency_reward.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`efficiency_reward` backend."""
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import efficiency_reward as er
+
+
+def test_typical_payload_returns_float() -> None:
+    payload = {"latency_ms": 400, "tokens": 500, "cost_usd": 0.002, "energy_j": 20, "value": 0.8}
+    value = er.reward(None, None, payload)
+    assert isinstance(value, float)
+    assert 0.0 <= value <= 1.0
+
+
+def test_missing_value_returns_zero() -> None:
+    value = er.reward(None, None, {"latency_ms": 400})
+    assert value == 0.0
+
+
+def test_non_dict_returns_zero() -> None:
+    assert er.reward(None, None, 123) == 0.0

--- a/tests/test_energy_balance_reward.py
+++ b/tests/test_energy_balance_reward.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`energy_balance_reward` backend."""
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import energy_balance_reward as eb
+
+
+def _reset_ledger() -> None:
+    eb._ledger.clear()
+
+
+def test_typical_day_score_in_range() -> None:
+    _reset_ledger()
+    res = {"date": "2025-04-22", "calories_in": 2400, "calories_out": 600, "bmr": 1650}
+    value = eb.reward(None, None, res)
+    assert isinstance(value, float)
+    assert 0.0 <= value <= 1.0
+
+
+def test_non_dict_returns_zero() -> None:
+    _reset_ledger()
+    value = eb.reward(None, None, "bad")
+    assert value == 0.0

--- a/tests/test_habit_consistency_reward.py
+++ b/tests/test_habit_consistency_reward.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`habit_consistency_reward` backend."""
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import habit_consistency_reward as hc
+
+
+def _reset() -> None:
+    hc._last_seen.clear()
+
+
+def test_first_occurrence_positive() -> None:
+    _reset()
+    res = {"context": "run 5k", "time": "2025-04-22T07:00:00Z"}
+    value = hc.reward(None, None, res)
+    assert isinstance(value, float)
+    assert 0.0 <= value <= 1.0
+
+
+def test_repeat_within_day_high_score() -> None:
+    _reset()
+    res1 = {"context": "run 5k", "time": "2025-04-22T07:00:00Z"}
+    res2 = {"context": "run 5k", "time": "2025-04-23T06:00:00Z"}
+    hc.reward(None, None, res1)
+    value = hc.reward(None, None, res2)
+    assert 0.0 <= value <= 1.0
+    assert value > 0.5
+
+
+def test_missing_fields_zero() -> None:
+    _reset()
+    assert hc.reward(None, None, {"context": "run"}) == 0.0

--- a/tests/test_novel_solution_reward.py
+++ b/tests/test_novel_solution_reward.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`novel_solution_reward` backend."""
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import novel_solution_reward as ns
+
+
+def _reset() -> None:
+    ns._sig_mem.clear()
+    ns._idx = 0
+    if ns._emb_mem is not None:
+        ns._emb_mem.clear()
+
+
+def test_first_solution_yields_one() -> None:
+    _reset()
+    value = ns.reward(None, None, "solve x")
+    assert isinstance(value, float)
+    assert value == 1.0
+
+
+def test_repeated_solution_zero() -> None:
+    _reset()
+    ns.reward(None, None, "idea")
+    value = ns.reward(None, None, "idea")
+    assert 0.0 <= value <= 1.0
+    assert value == 0.0

--- a/tests/test_safety_compliance_reward.py
+++ b/tests/test_safety_compliance_reward.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`safety_compliance_reward` backend."""
+
+from alpha_factory_v1.demos.era_of_experience.reward_backends import safety_compliance_reward as sc
+
+
+def _reset() -> None:
+    sc._seen_request_ids.clear()
+
+
+def test_no_violation_returns_one() -> None:
+    _reset()
+    res = {"request_id": "r1", "violation": False}
+    value = sc.reward(None, None, res)
+    assert isinstance(value, float)
+    assert value == 1.0
+
+
+def test_unhandled_violation_penalty() -> None:
+    _reset()
+    res = {"request_id": "r2", "violation": True, "severity": 10, "autocorrected": False}
+    value = sc.reward(None, None, res)
+    assert value <= -1.0
+    assert value >= -2.0
+
+
+def test_duplicate_request_id_zero() -> None:
+    _reset()
+    res = {"request_id": "r3", "violation": False}
+    sc.reward(None, None, res)
+    assert sc.reward(None, None, res) == 0.0


### PR DESCRIPTION
## Summary
- add unit tests for energy balance, efficiency, education, habit consistency, novel solution and safety compliance reward backends

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --wheelhouse /tmp/wheels` *(fails: No matching distribution found)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68501e99b6208333b5961939470fdcdd