### PR TITLE
[alpha_factory] add agents fallback

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -10,7 +10,8 @@ Alpha conversion stub.
 Given a text description of an opportunity, output a short JSON plan
 for how one might capitalise on it. Works fully offline via a canned
 response but will query OpenAI when ``OPENAI_API_KEY`` is set and the
-``openai`` package is available.
+``openai`` package is available. Compatible with either the
+``openai_agents`` package or the ``agents`` backport.
 """
 from __future__ import annotations
 
@@ -27,6 +28,16 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 openai = None
 with contextlib.suppress(ModuleNotFoundError):
     import openai  # type: ignore
+
+try:
+    from openai_agents import OpenAIAgent  # noqa: F401
+except ImportError:
+    try:  # pragma: no cover - fallback for legacy package
+        from agents import OpenAIAgent  # noqa: F401
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise SystemExit(
+            "openai-agents or agents package is required. Install with `pip install openai-agents`"
+        ) from exc
 
 SAMPLE_PLAN: Dict[str, Any] = {
     "steps": [

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# mypy: ignore-errors
 """
 This module is part of a conceptual research prototype. References to
 'AGI' or 'superintelligence' describe aspirational goals and do not
@@ -7,17 +8,25 @@ indicate the presence of real general intelligence. Use at your own risk.
 Alpha opportunity discovery agent stub.
 
 This lightweight example exposes a single tool via the OpenAI Agents SDK
-that requests the LLM to list live market inefficiencies. It falls back to
-a local model when no ``OPENAI_API_KEY`` is configured.
+(compatible with either the ``openai_agents`` package or the ``agents``
+backport) that requests the LLM to list live market inefficiencies. It
+falls back to a local model when no ``OPENAI_API_KEY`` is configured.
 """
 from __future__ import annotations
 
 try:
-    from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
-except Exception as exc:  # pragma: no cover - optional dependency
-    raise SystemExit("openai-agents package is required. Install with `pip install openai-agents`") from exc
+    from openai_agents import Agent, AgentRuntime, OpenAIAgent as _OpenAIAgent, Tool
+except ImportError:
+    try:  # pragma: no cover - fallback for legacy package
+        from agents import Agent, AgentRuntime, OpenAIAgent as _OpenAIAgent, Tool
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise SystemExit(
+            "openai-agents or agents package is required. Install with `pip install openai-agents`"
+        ) from exc
 
 from .utils import build_llm
+
+OpenAIAgent = _OpenAIAgent
 
 LLM = build_llm()
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
@@ -4,7 +4,8 @@ This module is part of a conceptual research prototype. References to
 'AGI' or 'superintelligence' describe aspirational goals and do not
 indicate the presence of real general intelligence. Use at your own risk.
 
-Shared helpers for the AI-GA Meta-Evolution demo.
+Shared helpers for the AI-GA Meta-Evolution demo. Compatible with either the
+``openai_agents`` package or the ``agents`` backport.
 """
 from __future__ import annotations
 
@@ -12,8 +13,13 @@ import os
 
 try:
     from openai_agents import OpenAIAgent
-except Exception as exc:  # pragma: no cover - optional dependency
-    raise SystemExit("openai-agents package is required. Install with `pip install openai-agents`") from exc
+except ImportError:
+    try:  # pragma: no cover - fallback for legacy package
+        from agents import OpenAIAgent
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise SystemExit(
+            "openai-agents or agents package is required. Install with `pip install openai-agents`"
+        ) from exc
 
 
 def build_llm() -> OpenAIAgent:

--- a/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# mypy: ignore-errors
 """
 This module is part of a conceptual research prototype. References to
 'AGI' or 'superintelligence' describe aspirational goals and do not
@@ -7,22 +8,30 @@ indicate the presence of real general intelligence. Use at your own risk.
 End-to-end Alpha Factory workflow demo.
 
 This script chains the ``alpha_discovery`` and ``alpha_conversion``
-stubs via the OpenAI Agents runtime. It works offline when
-``OPENAI_API_KEY`` is unset and can publish the agent over the
-Google ADK gateway when the ``ALPHA_FACTORY_ENABLE_ADK`` environment
+stubs via the OpenAI Agents runtime. It is compatible with either the
+``openai_agents`` package or the ``agents`` backport. The demo works
+offline when ``OPENAI_API_KEY`` is unset and can publish the agent over
+the Google ADK gateway when the ``ALPHA_FACTORY_ENABLE_ADK`` environment
 variable is set.
 """
 from __future__ import annotations
 
 try:
-    from openai_agents import Agent, AgentRuntime, OpenAIAgent, Tool
-except ImportError as exc:  # pragma: no cover
-    raise SystemExit("openai_agents package is required. Install with `pip install openai-agents`") from exc
+    from openai_agents import Agent, AgentRuntime, OpenAIAgent as _OpenAIAgent, Tool
+except ImportError:
+    try:  # pragma: no cover - fallback for legacy package
+        from agents import Agent, AgentRuntime, OpenAIAgent as _OpenAIAgent, Tool
+    except Exception as exc:  # pragma: no cover
+        raise SystemExit(
+            "openai-agents or agents package is required. Install with `pip install openai-agents`"
+        ) from exc
 
 from .utils import build_llm
 
 from alpha_opportunity_stub import identify_alpha
 from alpha_conversion_stub import convert_alpha
+
+OpenAIAgent = _OpenAIAgent
 
 try:
     from alpha_factory_v1.backend import adk_bridge

--- a/tests/test_aiga_agents_import.py
+++ b/tests/test_aiga_agents_import.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: ignore-errors
+import builtins
+import importlib
+import sys
+import types
+import unittest
+
+MODULES = [
+    "alpha_factory_v1.demos.aiga_meta_evolution.utils",
+    "alpha_factory_v1.demos.aiga_meta_evolution.alpha_opportunity_stub",
+    "alpha_factory_v1.demos.aiga_meta_evolution.workflow_demo",
+]
+
+
+class TestAigaAgentsImport(unittest.TestCase):
+    def test_import_with_agents_only(self, monkeypatch):
+        stub = types.ModuleType("agents")
+        stub.Agent = object
+        stub.AgentRuntime = object
+        stub.OpenAIAgent = object
+
+        def _tool(*_a, **_k):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+        stub.Tool = _tool
+
+        monkeypatch.setitem(sys.modules, "agents", stub)
+        sys.modules.pop("openai_agents", None)
+
+        orig_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "openai_agents":
+                raise ModuleNotFoundError(name)
+            return orig_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        for mod_name in MODULES:
+            mod = importlib.reload(importlib.import_module(mod_name))
+            self.assertIs(mod.OpenAIAgent, stub.OpenAIAgent)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add fallback import of `OpenAIAgent` from `agents` to aiga meta-evolution utils
- use the same logic in opportunity stub, conversion stub and workflow demo
- clarify docstrings to mention the agents backport
- test importing these modules when only `agents` is available

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/utils.py alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py tests/test_aiga_agents_import.py` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_685023a4bbf483339197fa2ebf70cb44