### PR TITLE
[alpha_factory] skip ledger when --no-log

### DIFF
--- a/tests/test_alpha_conversion_stub.py
+++ b/tests/test_alpha_conversion_stub.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
+import os
 import subprocess
 import sys
 import unittest
@@ -25,17 +26,34 @@ class TestAlphaConversionStub(unittest.TestCase):
             self.assertIn("steps", data)
 
     def test_default_ledger_path(self) -> None:
-        ledger = Path.home() / ".aiga" / "alpha_conversion_log.json"
-        if ledger.exists():
-            ledger.unlink()
-        result = subprocess.run(
-            [sys.executable, STUB, "--alpha", "test opportunity"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertTrue(ledger.exists())
-        ledger.unlink()
+        with tempfile.TemporaryDirectory() as home:
+            env = os.environ.copy()
+            env["HOME"] = home
+            env.pop("ALPHA_CONVERSION_LEDGER", None)
+            ledger = Path(home) / ".aiga" / "alpha_conversion_log.json"
+            result = subprocess.run(
+                [sys.executable, STUB, "--alpha", "test opportunity"],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(ledger.exists())
+
+    def test_no_log_skips_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            env = os.environ.copy()
+            env["HOME"] = home
+            env.pop("ALPHA_CONVERSION_LEDGER", None)
+            result = subprocess.run(
+                [sys.executable, STUB, "--alpha", "skip", "--no-log"],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            default_dir = Path(home) / ".aiga"
+            self.assertFalse(default_dir.exists())
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- avoid creating conversion ledger when logging disabled
- update alpha_conversion CLI logic for optional ledger path
- test new `--no-log` behaviour

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network)*
- `pytest -q` *(fails: environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py tests/test_alpha_conversion_stub.py` *(failed: interrupted due to long initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68503bbab35c833383b54f58c218638d