### PR TITLE
[alpha_factory] handle check_env failure

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
@@ -57,13 +57,14 @@ def ensure_deps() -> None:
     if checker.exists():
         env = os.environ.copy()
         env["AUTO_INSTALL_MISSING"] = "1"
-        result = subprocess.run([sys.executable, str(checker)], env=env, capture_output=True, text=True)
+        result = subprocess.run(
+            [sys.executable, str(checker)], env=env, capture_output=True, text=True
+        )
         if result.returncode != 0:
-            print(f"Dependency check failed with exit code {result.returncode}")
-            print("Output:")
-            print(result.stdout)
-            print("Errors:")
-            print(result.stderr)
+            print(result.stdout, end="")
+            if result.stderr:
+                print(result.stderr, end="", file=sys.stderr)
+            sys.exit(result.returncode)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- exit from start_aiga_demo.py when `check_env.py` reports an error

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network connectivity)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py` *(fails: initialization interrupted)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68503db1afc48333aa8b4b10b783208a