### PR TITLE
[alpha_factory] include gymnasium requirement

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -87,6 +87,8 @@ git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
 AUTO_INSTALL_MISSING=1 python check_env.py  # verify deps offline/online
 pip install -r alpha_factory_v1/requirements.txt
+# install from requirements-demo.txt or add `gymnasium[classic-control]`
+# check_env.py --auto-install does not currently install gymnasium
 # ensures `openai-agents` and friends are installed
 python alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
 # offline machines can supply predownloaded wheels:

--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -68,6 +68,7 @@ sentencepiece>=0.1.99
 
 # Genetic-algorithm engine (AIGA meta-evolution demo)
 deap>=1.4
+gymnasium[classic-control]>=0.29
 
 # ─────────── Finance & markets integration ────────────────────────────
 ccxt>=4.3               # exchange API client (Binance testnet, etc.)


### PR DESCRIPTION
## Summary
- add gymnasium to meta-evolution runtime requirements
- mention gymnasium in the quick-start instructions
- note that check_env.py --auto-install does not install gymnasium yet

## Testing
- `pre-commit run --files alpha_factory_v1/requirements.txt alpha_factory_v1/demos/aiga_meta_evolution/README.md` *(fails: Makefile:26: *** missing separator)*
- `pytest -q tests/test_aiga_meta_cli.py tests/test_aiga_service_e2e.py` *(fails: Environment check failed, run 'python check_env.py --auto-install')*

------
https://chatgpt.com/codex/tasks/task_e_685040d3f2c48333b54a14295ef6fed6