### PR TITLE
[alpha_factory] improve rate limit cleanup

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -240,6 +240,10 @@ async def _count_requests(request, call_next):
     now = time.time()
     window = now - 60
     times = [t for t in _REQUEST_LOG.get(ip, []) if t > window]
+    if not times:
+        _REQUEST_LOG.pop(ip, None)
+    else:
+        _REQUEST_LOG[ip] = times
     if len(times) >= RATE_LIMIT:
         return JSONResponse({"detail": "rate limit exceeded"}, status_code=429)
     times.append(now)


### PR DESCRIPTION
## Summary
- drop empty IP entries from rate limiter

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py` *(fails: could not install pre-commit hooks due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685047b907448333ab304ced4dc0be1e