### PR TITLE
[alpha_factory] fix offline check_env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Follow these steps when installing without internet access:
 
  - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
 - Run `python scripts/check_python_deps.py` to quickly verify that `numpy`, `yaml` and `pandas` are installed. If it reports missing packages, execute `python check_env.py --auto-install` before running the tests. This step fetches packages from PyPI, so in air‑gapped setups you **must** pass `--wheelhouse <path>` or set `WHEELHOUSE` so `pip` installs from the local cache.
- - After setup, validate with `python check_env.py --auto-install`. This command reaches out to PyPI unless `--wheelhouse <path>` or the `WHEELHOUSE` environment variable is supplied. When working offline run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly.
+ - After setup, validate with `python check_env.py --auto-install`. This command reaches out to PyPI unless `--wheelhouse <path>` or the `WHEELHOUSE` environment variable is supplied. When working offline run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly. The test suite passes this variable to `check_env.py` automatically when set.
 - The unit tests rely on `fastapi`, `opentelemetry-api`, `openai-agents` and `google-adk`. `./codex/setup.sh` installs these packages automatically. When skipping the setup script, run
   `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no
   missing packages before running `pytest`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import os
 import pytest
 import sys
 import types
@@ -8,7 +9,11 @@ import importlib.util
 try:  # pragma: no cover - best effort environment setup
     from check_env import main as check_env_main
 
-    if check_env_main(["--auto-install"]):
+    wheelhouse = os.getenv("WHEELHOUSE")
+    args = ["--auto-install"]
+    if wheelhouse:
+        args += ["--wheelhouse", wheelhouse]
+    if check_env_main(args):
         pytest.skip(
             "Environment check failed, run 'python check_env.py --auto-install'",
             allow_module_level=True,


### PR DESCRIPTION
## Summary
- allow auto-install to succeed offline when packages already present
- pass wheelhouse path to check_env from tests
- mention WHEELHOUSE forwarding in docs

## Testing
- `python check_env.py --auto-install`
- `WHEELHOUSE=/tmp/empty_wheelhouse python check_env.py --auto-install`
- `pytest -q` *(fails: openai_agents.__spec__ is None, gradio missing)*
- `pre-commit run --files check_env.py tests/conftest.py AGENTS.md` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_685054d5a9408333935047b7c650af2e