### PR TITLE
[alpha_factory] fix A2A socket double start

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -331,8 +331,6 @@ if __name__ == "__main__":
     # register with agent mesh (optional)
     if AgentRuntime:
         AgentRuntime.register(SERVICE_NAME, f"http://localhost:{API_PORT}")
-    if A2ASocket:
-        service.evolver.start_socket()
     if adk_bridge and adk_bridge.adk_enabled():
         evolver_agent = EvolverAgent()
         adk_bridge.auto_register([evolver_agent])

--- a/tests/test_aiga_service.py
+++ b/tests/test_aiga_service.py
@@ -4,6 +4,10 @@
 from typing import Any, cast
 
 import importlib
+import runpy
+import sys
+import types
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -18,3 +22,49 @@ def test_health_endpoint() -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert set(data) >= {"status", "generations", "best_fitness"}
+
+
+@pytest.mark.usefixtures("non_network")
+def test_socket_started_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MetaEvolver should start the A2A socket only once."""
+    counter = types.SimpleNamespace(count=0)
+
+    class DummySocket:
+        def start(self) -> None:  # noqa: D401 - test stub
+            counter.count += 1
+
+    stub_a2a = types.ModuleType("a2a")
+    stub_a2a.A2ASocket = lambda *a, **k: DummySocket()
+
+    stub_oa = types.ModuleType("openai_agents")
+    stub_oa.Agent = object
+    stub_oa.AgentRuntime = object
+    stub_oa.OpenAIAgent = object
+
+    def _tool(*_a, **_k):
+        def dec(func):
+            return func
+
+        return dec
+
+    stub_oa.Tool = _tool
+
+    monkeypatch.setitem(sys.modules, "a2a", stub_a2a)
+    monkeypatch.setitem(sys.modules, "openai_agents", stub_oa)
+    monkeypatch.setattr("uvicorn.run", lambda *_a, **_k: None)
+
+    sys.modules.pop(
+        "alpha_factory_v1.demos.aiga_meta_evolution.meta_evolver",
+        None,
+    )
+    sys.modules.pop(
+        "alpha_factory_v1.demos.aiga_meta_evolution.agent_aiga_entrypoint",
+        None,
+    )
+
+    runpy.run_module(
+        "alpha_factory_v1.demos.aiga_meta_evolution.agent_aiga_entrypoint",
+        run_name="__main__",
+    )
+
+    assert counter.count == 1


### PR DESCRIPTION
## Summary
- avoid starting A2A socket twice in agent entrypoint
- test that the socket is started exactly once

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py tests/test_aiga_service.py` *(fails: hook proto-verify; Makefile missing)*
- `pytest -q` *(fails: Skipped: Environment check failed, run 'python check_env.py --auto-install')*

------
https://chatgpt.com/codex/tasks/task_e_68505ed52afc8333b3e725e079f5d6cc