### PR TITLE
[alpha_factory] add aiga agents bridge test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -180,6 +180,11 @@ pytest -q
 ```bash
 OPENAI_API_KEY=dummy pytest tests/test_meta_agentic_tree_search_demo.py::test_bridge_online_mode
 ```
+- `tests/test_aiga_agents_bridge.py` exercises the AI-GA bridge when
+  `openai_agents` is installed:
+```bash
+pytest tests/test_aiga_agents_bridge.py
+```
 - The optional integration checks in `test_external_integrations.py` exercise
   the real `openai_agents` and `google_adk` packages. Install them via
   `requirements-demo.txt` or they will be skipped automatically.

--- a/tests/test_aiga_agents_bridge.py
+++ b/tests/test_aiga_agents_bridge.py
@@ -1,0 +1,56 @@
+"""Integration tests for the AI-GA OpenAI Agents bridge."""
+from __future__ import annotations
+
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import importlib
+import importlib.util
+import subprocess
+import sys
+import time
+from typing import Any
+
+import pytest
+
+_SKIP: Any = pytest.mark.skipif(
+    importlib.util.find_spec("openai_agents") is None,
+    reason="openai_agents not installed",
+)
+
+
+@_SKIP  # type: ignore[misc]
+def test_bridge_launch() -> None:
+    """Start ``openai_agents_bridge.main`` and confirm registration."""
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "alpha_factory_v1.demos.aiga_meta_evolution.openai_agents_bridge",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        time.sleep(2)
+        proc.terminate()
+        out, _ = proc.communicate(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+    assert "EvolverAgent" in out
+
+
+@_SKIP  # type: ignore[misc]
+def test_evolve_tool() -> None:
+    """Invoke ``evolve`` once and verify ``best_alpha`` output."""
+    mod = importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.openai_agents_bridge")
+    runtime = mod.AgentRuntime(api_key=None)
+    agent = mod.EvolverAgent()
+    runtime.register(agent)
+
+    asyncio.run(mod.evolve(1))
+    result = asyncio.run(mod.best_alpha())
+    assert "architecture" in result


### PR DESCRIPTION
## Summary
- add tests/test_aiga_agents_bridge.py covering the OpenAI Agents bridge
- document running the new test in tests/README.md

## Testing
- `pre-commit run --files tests/test_aiga_agents_bridge.py tests/README.md` *(some hooks skipped)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: No network)*
- `pytest -q tests/test_aiga_agents_bridge.py` *(failed: Environment check failed)*


------
https://chatgpt.com/codex/tasks/task_e_6850637f38e88333a74fad95ee723e7f