### PR TITLE
[alpha_factory] docs: explain air-gapped bridge setup

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -323,6 +323,25 @@ the same helper agent is also exposed via an ADK gateway for A2A messaging.
 Visit `http://localhost:9000/docs` to explore the gateway when enabled (default port: 9000).
 To use a custom port, set the `GATEWAY_PORT` environment variable accordingly.
 
+#### Air‑gapped setup
+
+The bridge requires the `openai-agents` package and optionally `google-adk` when
+ADK federation is enabled. Build wheels on a machine with internet access:
+
+```bash
+pip wheel openai-agents google-adk -w /media/wheels
+```
+
+Install from this wheelhouse and verify the environment before launching the
+bridge:
+
+```bash
+python check_env.py --auto-install --wheelhouse /media/wheels
+WHEELHOUSE=/media/wheels python openai_agents_bridge.py --host http://localhost:8000
+```
+
+See [PRODUCTION_GUIDE.md](PRODUCTION_GUIDE.md) for detailed deployment tips.
+
 - The bridge exposes several helper tools:
 - `list_agents`
 - `trigger_discovery`


### PR DESCRIPTION
## Summary
- document how to build wheels and run `check_env.py` before launching the OpenAI Agents bridge offline
- link back to `PRODUCTION_GUIDE.md`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*
- `pre-commit run --hook-stage manual --files alpha_factory_v1/demos/alpha_agi_business_v1/README.md` *(fails: proto-verify hook error)*

------
https://chatgpt.com/codex/tasks/task_e_68507decf8a083339ee88b5ea6ca7450