### PR TITLE
[alpha_factory] add missing-sdk test

### DIFF
--- a/tests/test_aiga_bridge_no_agents.py
+++ b/tests/test_aiga_bridge_no_agents.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+def test_aiga_bridge_no_agents(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Import bridge without agents packages and expect helpful error."""
+    monkeypatch.delitem(sys.modules, "openai_agents", raising=False)
+    monkeypatch.delitem(sys.modules, "agents", raising=False)
+
+    # Reload backend so the missing SDK shim is installed
+    importlib.reload(importlib.import_module("alpha_factory_v1.backend"))
+
+    # Provide minimal curriculum_env to avoid gymnasium dependency
+    env_stub = types.ModuleType("curriculum_env")
+
+    class DummyEnv:
+        pass
+
+    env_stub.CurriculumEnv = DummyEnv  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "alpha_factory_v1.demos.aiga_meta_evolution.curriculum_env",
+        env_stub,
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="OpenAI Agents SDK is required"):
+        importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.openai_agents_bridge")


### PR DESCRIPTION
## Summary
- add regression test ensuring openai_agents bridge fails gracefully when OpenAI Agents SDK is missing

## Testing
- `pre-commit run --files tests/test_aiga_bridge_no_agents.py`
- `pytest tests/test_aiga_bridge_no_agents.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68508b31224c8333a217790576fd7c6b