### PR TITLE
[alpha_factory] add ADK curl example

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -197,15 +197,25 @@ ALPHA_FACTORY_ENABLE_ADK=true python openai_agents_bridge.py &
 ```
 
 This publishes the tools over the **A2A protocol** so other agents can
-orchestrate evolution remotely.
-Set `ALPHA_FACTORY_ENABLE_ADK=1` in `config.env` to auto-start the gateway
-when running `./run_aiga_demo.sh`.
+orchestrate evolution remotely. Enable the gateway whenever you need to
+federate multiple Alpha‑Factory instances or let external clients control
+evolution. Set `ALPHA_FACTORY_ENABLE_ADK=1` in `config.env` to auto-start the
+gateway when running `./run_aiga_demo.sh`.
 
 Define `ALPHA_FACTORY_ADK_TOKEN` to require this token on every ADK request:
 
 ```env
 ALPHA_FACTORY_ENABLE_ADK=1
 ALPHA_FACTORY_ADK_TOKEN="my_secret_token"
+```
+
+Interact with the running gateway using `curl`:
+
+```bash
+curl -X POST http://localhost:9000/v1/tasks \
+     -H "x-alpha-factory-token: my_secret_token" \
+     -H "Content-Type: application/json" \
+     -d '{"agent": "aiga_evolver", "content": "evolve 1"}'
 ```
 
 The optional ADK gateway integrates with the OpenAI Agents SDK bridge and


### PR DESCRIPTION
## Summary
- document how to hit the ADK gateway
- clarify when to turn it on and how agents connect

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/README.md` *(fails: verify-env-docs and env-check)*

------
https://chatgpt.com/codex/tasks/task_e_685099190a608333ae8f6711d48a3270