### PR TITLE
[alpha_factory] allow runtime port override

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -82,6 +82,13 @@ ALPHA_FACTORY_ENABLE_ADK=1 python openai_agents_bridge.py
 ALPHA_FACTORY_ADK_TOKEN=my_token python openai_agents_bridge.py
 ```
 
+The runtime listens on port `5001` by default. Override it by exporting
+`AGENTS_RUNTIME_PORT` before launching:
+
+```bash
+AGENTS_RUNTIME_PORT=6001 python openai_agents_bridge.py
+```
+
 The bridge exposes health checks at
 `http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz` (or `/docs`).
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -177,6 +177,13 @@ Expose the evolver to the **OpenAI Agents SDK** runtime:
 python alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
 ```
 
+The runtime listens on port `5001` by default. Set `AGENTS_RUNTIME_PORT`
+to change the port:
+
+```bash
+AGENTS_RUNTIME_PORT=6001 python openai_agents_bridge.py
+```
+
 Requires the `openai-agents` or `agents` package (already installed above).
 If both are missing the script exits with an error.
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py
@@ -25,6 +25,7 @@ except ImportError:
         ) from exc
 
 from .utils import build_llm
+import os
 
 OpenAIAgent = _OpenAIAgent
 
@@ -70,7 +71,8 @@ def main(argv: list[str] | None = None) -> None:
         print(result)
         return
 
-    runtime = AgentRuntime(api_key=None)
+    agent_port = int(os.getenv("AGENTS_RUNTIME_PORT", "5001"))
+    runtime = AgentRuntime(api_key=None, port=agent_port)
     agent = AlphaDiscoveryAgent()
     runtime.register(agent)
     print("Registered AlphaDiscoveryAgent with runtime")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -33,6 +33,7 @@ if __package__ is None:
     sys.path.append(str(Path(__file__).resolve().parent))
     __package__ = "alpha_factory_v1.demos.aiga_meta_evolution"
 
+import os
 from typing import cast
 
 from .meta_evolver import MetaEvolver
@@ -108,9 +109,12 @@ class EvolverAgent(Agent):  # type: ignore[misc]
         return cast(dict[str, float | str], await best_alpha())
 
 
+AGENT_PORT = int(os.getenv("AGENTS_RUNTIME_PORT", "5001"))
+
+
 def main() -> None:
     _get_evolver()
-    runtime = AgentRuntime(api_key=None)
+    runtime = AgentRuntime(api_key=None, port=AGENT_PORT)
     agent = EvolverAgent()
     runtime.register(agent)
     print("Registered EvolverAgent with runtime")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py
@@ -27,6 +27,7 @@ except ImportError:
         ) from exc
 
 from .utils import build_llm
+import os
 
 from alpha_opportunity_stub import identify_alpha
 from alpha_conversion_stub import convert_alpha
@@ -71,8 +72,11 @@ class WorkflowAgent(Agent):
         return {"alpha": first, "plan": plan}
 
 
+AGENT_PORT = int(os.getenv("AGENTS_RUNTIME_PORT", "5001"))
+
+
 def main() -> None:
-    runtime = AgentRuntime(llm=LLM)
+    runtime = AgentRuntime(llm=LLM, port=AGENT_PORT)
     agent = WorkflowAgent()
     runtime.register(agent)
     print("Registered WorkflowAgent with runtime")

--- a/tests/test_alpha_opportunity_stub.py
+++ b/tests/test_alpha_opportunity_stub.py
@@ -1,13 +1,57 @@
 # SPDX-License-Identifier: Apache-2.0
+# mypy: ignore-errors
 import py_compile
 import unittest
 from pathlib import Path
+from typing import Callable
+import pytest
 
-STUB = Path('alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py')
+STUB = Path("alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py")
+
 
 class TestAlphaOpportunityStub(unittest.TestCase):
-    def test_stub_compiles(self):
-        py_compile.compile(STUB, doraise=True)
+    def test_stub_compiles(self) -> None:
+        py_compile.compile(str(STUB), doraise=True)
 
-if __name__ == '__main__':
+    def test_runtime_port_env(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        """AgentRuntime receives AGENTS_RUNTIME_PORT."""
+        import importlib
+        import sys
+        import types
+
+        captured: dict[str, int] = {}
+
+        class DummyRuntime:
+            def __init__(self, *a: object, port: int = 5001, **_k: object) -> None:
+                captured["port"] = port
+
+            def register(self, *_a: object, **_k: object) -> None:
+                pass
+
+            def run(self) -> None:
+                pass
+
+        stub = types.ModuleType("openai_agents")
+        stub.Agent = object
+        stub.AgentRuntime = DummyRuntime
+        stub.OpenAIAgent = object
+
+        def _tool(*_a: object, **_k: object) -> Callable[[object], object]:
+            def dec(f: object) -> object:
+                return f
+
+            return dec
+
+        stub.Tool = _tool
+        monkeypatch.setitem(sys.modules, "openai_agents", stub)
+        monkeypatch.delitem(sys.modules, "agents", raising=False)
+        monkeypatch.setenv("AGENTS_RUNTIME_PORT", "6101")
+
+        mod = importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.alpha_opportunity_stub")
+        importlib.reload(mod)
+        mod.main([])
+        self.assertEqual(captured["port"], 6101)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `AGENTS_RUNTIME_PORT` override in workflow demo, opportunity stub and bridge
- document custom runtime port in README and PRODUCTION_GUIDE
- test bridge and stub receive runtime port from environment

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py alpha_factory_v1/demos/aiga_meta_evolution/workflow_demo.py alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py alpha_factory_v1/demos/aiga_meta_evolution/README.md alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md tests/test_aiga_openai_bridge_offline.py tests/test_alpha_opportunity_stub.py` *(fails: Makefile:26: *** missing separator.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_6850a89cdb6883339df8b440734d116c