### PR TITLE
[alpha_factory] validate batch size

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py
@@ -158,6 +158,8 @@ class CurriculumEnv(gym.Env):
 
     def reset_batch(self, batch_size: int):
         """Vectorised variant of :meth:`reset`."""
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
         obs, infos = zip(*(self.reset() for _ in range(batch_size)))
         return np.stack(obs), infos
 

--- a/alpha_factory_v1/tests/test_aiga_meta_evolution.py
+++ b/alpha_factory_v1/tests/test_aiga_meta_evolution.py
@@ -19,6 +19,11 @@ class CurriculumEnvTest(unittest.TestCase):
         self.assertIn("genome_id", info)
         self.assertLessEqual(info["difficulty"], 10)
 
+    def test_reset_batch_invalid_size(self):
+        env = ce.CurriculumEnv(genome=ce.EnvGenome(max_steps=10), size=6)
+        with self.assertRaises(ValueError):
+            env.reset_batch(0)
+
 
 @unittest.skipUnless(np and torch, "optional deps missing")
 class MetaEvolverTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- raise `ValueError` on non-positive batch sizes in CurriculumEnv.reset_batch
- test invalid `reset_batch` argument

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/curriculum_env.py alpha_factory_v1/tests/test_aiga_meta_evolution.py` *(fails: could not initialize git hook environments)*

------
https://chatgpt.com/codex/tasks/task_e_6850c3ee57548333badb58107f88354f