### PR TITLE
[alpha_factory] add default OpenAI timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,7 @@ for instructions and example volume mounts.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `OPENAI_API_KEY` | _(empty)_ | API key for hosted models. Offline mode is used when empty. |
+| `OPENAI_TIMEOUT_SEC` | `30` | Timeout for OpenAI API requests in seconds. |
 | `NO_LLM` | `0` | Set to `1` to skip the LLM planner even when `OPENAI_API_KEY` is provided. |
 | `ALPHA_ASI_LLM_MODEL` | `gpt-4o-mini` | Planner model name used by the world model demo. |
 | `ALPHA_ASI_SEED` | `42` | Deterministic RNG seed for the demo (can also be set via `general.seed` in `config.yaml`). |

--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -96,6 +96,8 @@ except ModuleNotFoundError:  # pragma: no cover
     def tool(fn=None, **_):  # type: ignore
         return (lambda f: f)(fn) if fn else lambda f: f
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 
 try:
     from kafka import KafkaProducer  # type: ignore
@@ -336,6 +338,7 @@ class BiotechAgent(AgentBase):
                 ],
                 temperature=0,
                 max_tokens=600,
+                timeout=OPENAI_TIMEOUT_SEC,
             )
             answer = chat.choices[0].message.content.strip()
         else:

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -93,6 +93,8 @@ except ModuleNotFoundError:  # pragma: no cover
 
     openai = None  # type: ignore
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
@@ -347,6 +349,7 @@ class ClimateRiskAgent(AgentBase):
                     model="gpt-4o",
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=256,
+                    timeout=OPENAI_TIMEOUT_SEC,
                 )
                 actions = json.loads(resp.choices[0].message.content)
             except Exception as exc:  # noqa: BLE001

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -85,6 +85,8 @@ except ModuleNotFoundError:  # pragma: no cover
     def tool(fn=None, **_):  # type: ignore
         return (lambda f: f)(fn) if fn else lambda f: f
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 
 try:
     import adk  # type: ignore
@@ -388,6 +390,7 @@ class CyberThreatAgent(AgentBase):
         try:
             resp = await openai.ChatCompletion.acreate(
                 model="gpt-4o", messages=[{"role": "user", "content": prompt}], max_tokens=300
+                , timeout=OPENAI_TIMEOUT_SEC
             )
             return json.loads(resp.choices[0].message.content)
         except (openai.OpenAIError, json.JSONDecodeError) as exc:

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -93,6 +93,8 @@ except ModuleNotFoundError:  # pragma: no cover
     def tool(fn=None, **_kw):  # type: ignore
         return (lambda f: f)(fn) if fn else lambda f: f
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 
 try:
     import adk  # type: ignore
@@ -481,6 +483,7 @@ class DrugDesignAgent(AgentBase):
         try:
             resp = await openai.ChatCompletion.acreate(
                 model="gpt-4o", messages=[{"role": "user", "content": prompt}], max_tokens=60
+                , timeout=OPENAI_TIMEOUT_SEC
             )
             return resp.choices[0].message.content.strip()
         except Exception as exc:  # noqa: BLE001

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -78,6 +78,8 @@ except ModuleNotFoundError:  # pragma: no cover
     def tool(fn=None, **_):  # type: ignore
         return (lambda f: f)(fn) if fn else lambda f: f
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 
 try:
     from kafka import KafkaProducer  # type: ignore
@@ -347,6 +349,7 @@ class PolicyAgent(AgentBase):
                 ],
                 temperature=0,
                 max_tokens=700,
+                timeout=OPENAI_TIMEOUT_SEC,
             )
             answer = chat.choices[0].message.content.strip()
         else:

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -81,6 +81,8 @@ except ModuleNotFoundError:  # pragma: no cover
 
     openai = None  # type: ignore
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
@@ -350,6 +352,7 @@ class RetailDemandAgent(AgentBase):
                     model="gpt-4o",
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=200,
+                    timeout=OPENAI_TIMEOUT_SEC,
                 )
                 recs = json.loads(chat.choices[0].message.content)
             except (openai.OpenAIError, json.JSONDecodeError) as exc:

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -86,6 +86,8 @@ except ModuleNotFoundError:  # pragma: no cover
     def tool(fn=None, **_):  # type: ignore
         return (lambda f: f)(fn) if fn else lambda f: f
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 
 try:
     import adk  # type: ignore
@@ -353,6 +355,7 @@ class SmartContractAgent(AgentBase):
                     model="gpt-4o",
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=256,
+                    timeout=OPENAI_TIMEOUT_SEC,
                 )
                 suggestions += [s.strip("- •") for s in resp.choices[0].message.content.split("\n") if s]
             except Exception as exc:  # noqa: BLE001

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -118,6 +118,9 @@ from backend.orchestrator import _publish  # re‑use event bus hook
 
 logger = logging.getLogger(__name__)
 
+# Timeout (seconds) for OpenAI API requests
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 # ---------------------------------------------------------------------------
 # Env‑helper (robust env var parsing)
 # ---------------------------------------------------------------------------
@@ -291,6 +294,7 @@ class SupplyChainAgent(AgentBase):  # noqa: D101
                     model="gpt-4o",
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=200,
+                    timeout=OPENAI_TIMEOUT_SEC,
                 )
                 extra = json.loads(resp.choices[0].message.content)
                 recs.append(extra)

--- a/alpha_factory_v1/backend/world_model.py
+++ b/alpha_factory_v1/backend/world_model.py
@@ -42,6 +42,7 @@ with contextlib.suppress(ModuleNotFoundError):
     from muzero import muzero  # MuZero-general
 with contextlib.suppress(ModuleNotFoundError):
     import openai  # OpenAI SDK
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 with contextlib.suppress(ModuleNotFoundError):
     from llama_cpp import Llama
 with contextlib.suppress(Exception):
@@ -179,6 +180,7 @@ class LLMSimulator:
                 temperature=0.3,
                 max_tokens=80,
                 messages=[{"role": "user", "content": prompt}],
+                timeout=OPENAI_TIMEOUT_SEC,
             )
             return rsp["choices"][0]["message"]["content"]  # type: ignore[index]
         if self._use_local:

--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -29,6 +29,8 @@ openai = None
 with contextlib.suppress(ModuleNotFoundError):
     import openai  # type: ignore
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 try:
     from openai_agents import OpenAIAgent  # noqa: F401
 except ImportError:
@@ -83,6 +85,7 @@ def convert_alpha(alpha: str, *, ledger: Path | None = None, model: str = "gpt-4
             resp = openai.ChatCompletion.create(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
+                timeout=OPENAI_TIMEOUT_SEC,
             )
             plan = json.loads(resp.choices[0].message.content)
             if not isinstance(plan, dict):

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -28,6 +28,9 @@ from tempfile import NamedTemporaryFile
 
 logger = logging.getLogger(__name__)
 
+# Timeout (seconds) for OpenAI API requests
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 try:
     from filelock import FileLock
 except Exception:  # pragma: no cover - optional dependency
@@ -107,6 +110,7 @@ def discover_alpha(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
                 response_format={"type": "json_object"},
+                timeout=OPENAI_TIMEOUT_SEC,
             )
             picks = json.loads(resp.choices[0].message.content)
             if isinstance(picks, dict):

--- a/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py
@@ -21,6 +21,8 @@ from typing import List, Dict
 with contextlib.suppress(ModuleNotFoundError):
     import openai  # type: ignore
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 SAMPLE_ALPHA: List[Dict[str, str]] = [
     {
         "sector": "Energy",
@@ -68,6 +70,7 @@ def discover_alpha(
                 model="gpt-4o-mini",
                 messages=[{"role": "user", "content": prompt}],
                 response_format={"type": "json_object"},
+                timeout=OPENAI_TIMEOUT_SEC,
             )
             picks = json.loads(resp.choices[0].message.content)  # type: ignore[index]
             if isinstance(picks, dict):

--- a/alpha_factory_v1/demos/omni_factory_demo/omni_factory_demo.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/omni_factory_demo.py
@@ -67,6 +67,8 @@ with contextlib.suppress(ModuleNotFoundError):
 with contextlib.suppress(ModuleNotFoundError):
     import openai_agents_sdk as oas  # type: ignore
 
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 with contextlib.suppress(ModuleNotFoundError):
     import google_adk as gadk  # type: ignore
 
@@ -205,6 +207,7 @@ def _llm_one_liner(prompt: str) -> str:
             temperature=CFG.temperature,
             max_tokens=60,
             messages=[{"role": "user", "content": prompt}],
+            timeout=OPENAI_TIMEOUT_SEC,
         )
         return resp.choices[0].message.content.strip()  # type: ignore[index]
     except Exception:  # pragma: no cover – network/quotas/etc.

--- a/alpha_factory_v1/demos/self_healing_repo/agent_core/llm_client.py
+++ b/alpha_factory_v1/demos/self_healing_repo/agent_core/llm_client.py
@@ -12,6 +12,9 @@ OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4-0613")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 USE_LOCAL_LLM = os.getenv("USE_LOCAL_LLM", "false").lower() == "true"
 
+# Timeout (seconds) for OpenAI API requests
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
 
 def call_local_model(prompt_messages: list[dict[str, str]]) -> str:
     """Return a response from a locally hosted model."""
@@ -103,6 +106,7 @@ def request_patch(prompt_messages: list[dict[str, str]]) -> str:
             messages=prompt_messages,
             functions=functions,
             function_call={"name": "propose_patch"},
+            timeout=OPENAI_TIMEOUT_SEC,
         )
     except openai.Error as exc:  # pragma: no cover - API error handling
         logger.error("OpenAI API request failed: %s", exc)

--- a/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
+++ b/alpha_factory_v1/demos/solving_agi_governance/governance_sim.py
@@ -88,8 +88,9 @@ def summarise_with_agent(mean_coop: float, *, agents: int, rounds: int, delta: f
     except Exception:
         return base_msg
 
+    timeout = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
     try:
-        client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"), timeout=timeout)
         completion = client.chat.completions.create(
             model="gpt-4o",
             messages=[
@@ -97,6 +98,7 @@ def summarise_with_agent(mean_coop: float, *, agents: int, rounds: int, delta: f
                 {"role": "user", "content": base_msg},
             ],
             max_tokens=60,
+            timeout=timeout,
         )
         return cast(str, completion.choices[0].message.content).strip()
     except openai.AuthenticationError:

--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/deploy_sovereign_agentic_agialpha_agent_v0.sh
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/deploy_sovereign_agentic_agialpha_agent_v0.sh
@@ -377,6 +377,7 @@ try:
     import openai
 except ImportError:
     openai = None
+OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 
 # Attempt optional anthropic
 try:
@@ -764,7 +765,8 @@ class ReasoningAgent:
                 response = openai.ChatCompletion.create(
                     model=self.model_name,
                     messages=[{"role":"system","content":prompt}],
-                    temperature=0.7
+                    temperature=0.7,
+                    timeout=OPENAI_TIMEOUT_SEC
                 )
                 return response.choices[0].message.content.strip()
             except Exception as e:

--- a/tests/test_cross_alpha_discovery.py
+++ b/tests/test_cross_alpha_discovery.py
@@ -168,6 +168,7 @@ class TestCrossAlphaDiscoveryStub(unittest.TestCase):
         openai_mock.ChatCompletion.create.assert_called_once()
         kwargs = openai_mock.ChatCompletion.create.call_args.kwargs
         self.assertEqual(kwargs.get("response_format"), {"type": "json_object"})
+        self.assertEqual(kwargs.get("timeout"), stub.OPENAI_TIMEOUT_SEC)
 
     def test_openai_v1_response_format(self) -> None:
         from alpha_factory_v1.demos.cross_industry_alpha_factory import (
@@ -186,6 +187,7 @@ class TestCrossAlphaDiscoveryStub(unittest.TestCase):
         openai_mock.chat.completions.create.assert_called_once()
         kwargs = openai_mock.chat.completions.create.call_args.kwargs
         self.assertEqual(kwargs.get("response_format"), {"type": "json_object"})
+        self.assertEqual(kwargs.get("timeout"), stub.OPENAI_TIMEOUT_SEC)
 
     def test_concurrent_writes(self) -> None:
         from alpha_factory_v1.demos.cross_industry_alpha_factory import (

--- a/tests/test_governance_sim.py
+++ b/tests/test_governance_sim.py
@@ -30,6 +30,10 @@ class TestGovernanceSim(unittest.TestCase):
                     stake=1.0,
                 )
         self.assertEqual(text, "ok")
+        mock_client.assert_called_once()
+        self.assertEqual(mock_client.call_args.kwargs.get("timeout"), 30)
+        kwargs = mock_client.return_value.chat.completions.create.call_args.kwargs
+        self.assertEqual(kwargs.get("timeout"), 30)
 
     def test_summary_auth_error(self) -> None:
         import openai

--- a/tests/test_llm_client_offline.py
+++ b/tests/test_llm_client_offline.py
@@ -58,6 +58,7 @@ def test_request_patch_respects_model_env(monkeypatch: pytest.MonkeyPatch) -> No
     client = _reload_client(monkeypatch, diff)
     client.request_patch([{"role": "user", "content": "fix"}])
     assert create_mock.call_args.kwargs.get("model") == "test-model"
+    assert create_mock.call_args.kwargs.get("timeout") == client.OPENAI_TIMEOUT_SEC
 
 
 def test_call_local_model_http(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- support `OPENAI_TIMEOUT_SEC` env var across demos and agents
- use the timeout when calling `openai.ChatCompletion.create`
- validate timeout in tests
- document the option in the README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files README.md alpha_factory_v1/backend/agents/biotech_agent.py alpha_factory_v1/backend/agents/climate_risk_agent.py alpha_factory_v1/backend/agents/cyber_threat_agent.py alpha_factory_v1/backend/agents/drug_design_agent.py alpha_factory_v1/backend/agents/policy_agent.py alpha_factory_v1/backend/agents/retail_demand_agent.py alpha_factory_v1/backend/agents/smart_contract_agent.py alpha_factory_v1/backend/agents/supply_chain_agent.py alpha_factory_v1/backend/world_model.py alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py alpha_factory_v1/demos/omni_factory_demo/alpha_discovery_stub.py alpha_factory_v1/demos/omni_factory_demo/omni_factory_demo.py alpha_factory_v1/demos/self_healing_repo/agent_core/llm_client.py alpha_factory_v1/demos/solving_agi_governance/governance_sim.py alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/deploy_sovereign_agialpha_agent_v0.sh tests/test_cross_alpha_discovery.py tests/test_governance_sim.py tests/test_llm_client_offline.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c544ec948333804266e933735d8a