### PR TITLE
[alpha_factory] clarify offline check_env step

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -8,9 +8,9 @@ The AI‑GA Meta‑Evolution service is a conceptual research prototype. Referen
    - Set `OPENAI_API_KEY` to enable cloud models. Leave empty to run fully offline via the bundled Mixtral model.
    - Optionally enable the Google ADK gateway by setting `ALPHA_FACTORY_ENABLE_ADK=true`. A token can be enforced with `ALPHA_FACTORY_ADK_TOKEN`.
    - For API protection, set `AUTH_BEARER_TOKEN` or provide `JWT_PUBLIC_KEY`/`JWT_ISSUER` values.
-   - Verify all Python packages are available. Run from the project root:
+   - Verify all Python packages are available. Run from this directory:
      ```bash
-     AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
+     AUTO_INSTALL_MISSING=1 python ../../check_env.py --auto-install
      ```
      This installs `openai-agents` (or the alternative `agents` package) and
      other requirements if they are missing.
@@ -33,11 +33,11 @@ before running the environment check:
 
 ```bash
 export WHEELHOUSE=$(pwd)/wheels
-AUTO_INSTALL_MISSING=1 python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+AUTO_INSTALL_MISSING=1 python ../../check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 ```
 
 Run `python scripts/check_python_deps.py` first to verify core packages,
-then `AUTO_INSTALL_MISSING=1 python check_env.py --auto-install`.
+then `AUTO_INSTALL_MISSING=1 python ../../check_env.py --auto-install`.
 Provide this directory via `WHEELHOUSE` when installing on the production host.
 Regenerate the lock file whenever `requirements.txt` changes:
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -136,11 +136,13 @@ Follow these steps when working **air‑gapped**:
 2. **Reuse the wheelhouse** whenever you install or check the environment:
    ```bash
    WHEELHOUSE=/path/to/wheels AUTO_INSTALL_MISSING=1 \
-     python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+     python ../../check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
    ```
 
    Always run the command above before executing `pytest` or any demo so all
-   optional dependencies are installed correctly.
+   optional dependencies are installed correctly. When **running tests offline**,
+   execute the same command first to ensure all extras install from your
+   wheelhouse.
 
 See [alpha_factory_v1/scripts/README.md](../../scripts/README.md#offline-setup)
 for additional tips on creating and using a wheelhouse. Consult


### PR DESCRIPTION
## Summary
- clarify offline wheelhouse command in AI-GA demo README
- mirror the same step in the production guide

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/README.md alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md` *(all hooks skipped)*
- `python check_env.py --auto-install` *(failed: wheelhouse required)*
- `WHEELHOUSE=$(pwd)/wheels AUTO_INSTALL_MISSING=1 python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` *(failed: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(failed: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850c7dacd3c8333b8da3832023e9436