### PR TITLE
[alpha_factory] clarify wheelhouse usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,9 +343,12 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
   `python scripts/check_python_deps.py` and then
   `python check_env.py --auto-install` (pass `--wheelhouse <path>` when offline)
   if required.
-- Always execute `python check_env.py --auto-install` before running the tests
-  or `pre-commit` so optional dependencies install correctly. When offline,
-  provide `--wheelhouse <dir>` or set `WHEELHOUSE` to your wheel cache.
+ - Always execute `python check_env.py --auto-install` before running the tests
+   or `pre-commit` so optional dependencies install correctly. When offline,
+   provide `--wheelhouse <dir>` or set `WHEELHOUSE` to your wheel cache. The
+   repository ships with a wheelhouse under `wheels/`; set
+   `WHEELHOUSE=$(pwd)/wheels` before running `pytest` to use these prebuilt
+   wheels.
 - If `pre-commit` reports "command not found", install it manually with
   `pip install pre-commit` and run `pre-commit install` once.
 - To reinstall the hooks, run `pip install -U pre-commit` and then

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,10 +55,13 @@ fall back to CPU execution and are automatically skipped when `torch` is
 absent. Other optional packages behave the same way—tests relying on
 `fastapi`, `playwright` or `httpx` use `pytest.importorskip()` so the suite
 continues even in minimal environments.
-6. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
-7. Before running the tests, execute `python check_env.py --auto-install` once
+6. If the repository includes a `wheels/` directory, set `WHEELHOUSE=$(pwd)/wheels`
+   before running the environment check or tests so packages install from the
+   bundled wheelhouse.
+7. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
+8. Before running the tests, execute `python check_env.py --auto-install` once
    more (add `--wheelhouse <dir>` when offline), then run `pytest -q`.
-8. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
+9. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
    `pre-commit install` once to enable the git hooks referenced in
    [AGENTS.md](../AGENTS.md).
 


### PR DESCRIPTION
## Summary
- document the `wheels/` directory in tests/README and recommend setting `WHEELHOUSE`
- note this requirement in the AGENTS.md troubleshooting section

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `WHEELHOUSE=./wheels python check_env.py --auto-install --wheelhouse ./wheels` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files AGENTS.md tests/README.md` *(fails: network install interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6850cdbf19388333aae7e07a849d1756