### PR TITLE
[alpha_factory] split deps and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ Or launch the full stack with Docker:
 docker compose up --build
 ```
 
+### Minimal Install
+
+The default `requirements.txt` pulls in a lean set of packages for the
+offline demos and tests:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Full Feature Install
+
+Install the heavier extras for finance, graph back‑ends and large
+language models:
+
+```bash
+pip install -r alpha_factory_v1/requirements.txt
+# or set ALPHA_FACTORY_FULL=1 when running `check_env.py --auto-install`
+```
+
 Detailed step‑by‑step instructions, including Colab usage,
 are available in [docs/quickstart.md](docs/quickstart.md).
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -96,6 +96,9 @@ python alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
 python alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py --help
 # or via module entrypoint
 python -m alpha_factory_v1.demos.aiga_meta_evolution --help
+# skip dependency checks or optional gateways via env flags:
+#   SKIP_DEPS_CHECK=1 ALPHA_FACTORY_ENABLE_ADK=0 \
+#   python alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
 ```
 
 Launch the **Ollama Mixtral** model in another terminal:

--- a/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py
@@ -9,6 +9,9 @@ Cross-platform launcher for the AI-GA meta-evolution demo.
 
 This utility mirrors ``run_aiga_demo.sh`` for users without a POSIX shell.
 It orchestrates the Docker Compose stack and optionally tails the logs.
+Set ``SKIP_DEPS_CHECK=1`` to bypass the environment validation step.
+Use ``ALPHA_FACTORY_ENABLE_ADK=1`` to expose the Google ADK gateway and
+``ALPHA_FACTORY_FULL=1`` to verify heavy optional packages.
 """
 from __future__ import annotations
 

--- a/alpha_factory_v1/requirements-core.txt
+++ b/alpha_factory_v1/requirements-core.txt
@@ -1,0 +1,51 @@
+# ======================================================================
+#  AGI-Alpha-Agent-v0  ·  Minimal runtime requirements  (May 2025)
+#  -- Install these packages for the leanest setup
+# ======================================================================
+
+# Core web runtimes
+fastapi>=0.111,<1.0
+uvicorn[standard]~=0.34
+flask~=3.0
+gunicorn~=21.2
+orjson~=3.9
+websockets~=15.0
+
+# Utilities / config / governance
+python-dotenv~=1.0
+pydantic~=2.7
+pydantic-settings~=2.9
+click~=8.2
+requests~=2.32
+cryptography~=45.0
+better-profanity~=0.7
+httpx~=0.28
+aiohttp~=3.9
+backoff~=2.2
+cachetools~=5.3
+PyYAML>=6.0
+rich>=13
+
+# Observability & task-orchestration
+prometheus-client~=0.19
+rocketry~=2.5
+opentelemetry-api~=1.33
+opentelemetry-sdk~=1.33
+
+# Testing & self-healing toolchain
+pytest~=8.2
+gitpython~=3.1
+playwright~=1.42
+
+# LLM / Agents stack
+openai>=1.82.0,<2.0
+anthropic>=0.21
+litellm>=1.31
+tiktoken>=0.5
+grpcio~=1.71
+grpcio-tools
+protobuf>=5
+
+# Numerical stack
+numpy>=1.26
+pandas>=2.0

--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -1,56 +1,19 @@
 # ======================================================================
-#  AGI-Alpha-Agent-v0  ·  Baseline runtime requirements  (May 2025)
-#  -- This file lists the minimum versions tested by CI; it is not a lock file
-#  -- Supports online (OpenAI/Anthropic keys) and fully offline runs
+#  AGI-Alpha-Agent-v0  ·  Full feature requirements  (May 2025)
+#  -- Includes heavy extras on top of the minimal core list
 #  -- All packages ship manylinux / pure-python wheels on PyPI
 # ======================================================================
 
-# ─────────── Core web runtimes ─────────────────────────────────────────
-fastapi>=0.111,<1.0
-uvicorn[standard]~=0.34
-flask~=3.0
-gunicorn~=21.2
-orjson~=3.9
-websockets~=15.0
 
-# ─────────── Utilities / config / governance ───────────────────────────
-python-dotenv~=1.0
-pydantic~=2.7
-pydantic-settings~=2.9
-click~=8.2
-requests~=2.32
-cryptography~=45.0
-better-profanity~=0.7
-httpx~=0.28
-aiohttp~=3.9
-backoff~=2.2
-cachetools~=5.3
-PyYAML>=6.0
-rich>=13           # CLI output only (backend omits to stay lean)
-
-# ─────────── Observability & task-orchestration ────────────────────────
-prometheus-client~=0.19
-rocketry~=2.5           # cron-like scheduler
-opentelemetry-api~=1.33
-opentelemetry-sdk~=1.33
+# Base dependencies
+-r requirements-core.txt
 
 # ─────────── Testing & self-healing toolchain ──────────────────────────
-pytest~=8.2
 gitpython~=3.1          # local PR simulation for self-healing demo
-playwright~=1.42
 
 # ─────────── LLM / Agents stack ────────────────────────────────────────
-openai>=1.82.0,<2.0       # GPT-4o & embeddings (sync with backend)
 openai-agents==0.0.17   # **critical** – official Agents SDK
-anthropic>=0.21         # Claude & MCP bridge
-litellm>=1.31           # local gateway / fallback router
-tiktoken>=0.5
-grpcio~=1.71
-grpcio-tools
-protobuf>=5
-
-# Google ADK – optional Agent-to-Agent federation (A2A protocol)
-google-adk>=0.3.0        # https://pypi.org/project/google-adk/
+google-adk>=0.3.0       # optional Agent-to-Agent federation
 
 # ─────────── Embeddings & RAG layer ────────────────────────────────────
 sentence-transformers>=2.4
@@ -58,8 +21,6 @@ faiss-cpu>=1.7.4
 chromadb>=0.5.23
 
 # ─────────── Numerical / optimisation stack ────────────────────────────
-numpy>=1.26
-pandas>=2.0
 scipy>=1.12
 ortools>=9.7.2996       # CP-SAT / MILP for Manufacturing & SupplyChain
 transformers>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# Root dependencies
--r alpha_factory_v1/requirements.txt
+# Root dependencies (minimal install)
+-r alpha_factory_v1/requirements-core.txt


### PR DESCRIPTION
## Summary
- separate minimal requirements into new file
- update environment check to detect ALPHA_FACTORY_FULL for heavy deps
- document minimal vs full install options
- note env flags for skipping optional components in start_aiga_demo

## Testing
- `pre-commit run --files alpha_factory_v1/requirements.txt alpha_factory_v1/requirements-core.txt requirements.txt check_env.py README.md alpha_factory_v1/demos/aiga_meta_evolution/start_aiga_demo.py alpha_factory_v1/demos/aiga_meta_evolution/README.md` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q tests/test_start_aiga_demo.py` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850cef86ec883339807e84d56e0f7a9