### PR TITLE
[alpha_factory] add CLI overrides for business demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/.env.example
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/.env.example
@@ -1,10 +1,10 @@
 # Example settings for run_business_3_demo.sh
 # Copy to '.env' and edit as needed.
 
-OPENAI_API_KEY=
-LOCAL_LLM_URL=http://ollama:11434/v1
-ADK_HOST=http://localhost:9000
-A2A_HOST=localhost
-A2A_PORT=0
-LLAMA_MODEL_PATH=
-LLAMA_N_CTX=2048
+OPENAI_API_KEY=             # --openai-api-key
+LOCAL_LLM_URL=http://ollama:11434/v1  # --local-llm-url
+ADK_HOST=http://localhost:9000        # --adk-host
+A2A_HOST=localhost                    # --a2a-host
+A2A_PORT=0                            # --a2a-port
+LLAMA_MODEL_PATH=                     # --llama-model-path
+LLAMA_N_CTX=2048                      # --llama-n-ctx

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -315,6 +315,9 @@ $ alpha-agi-business-3-v1 --cycles 1 --loglevel info
   generate a short LLM comment. Leave it unset to run in fully offline mode.
 - `LOCAL_LLM_URL` – optional. Base URL for the local fallback model.
   Defaults to `http://ollama:11434/v1`.
+- Each variable can also be passed via command-line flags
+  (`--openai-api-key`, `--local-llm-url`, `--adk-host`,
+  `--a2a-port`, `--a2a-host`, `--llama-model-path`, `--llama-n-ctx`).
 - Python ≥3.11 with packages from `requirements.txt` installed. The
   `run_business_3_demo.sh` helper now builds a Docker image that includes
   `openai_agents` by default.
@@ -325,6 +328,7 @@ $ alpha-agi-business-3-v1 --cycles 1 --loglevel info
 - `A2A_PORT` – enable gRPC A2A messages when set to a port number.
 - `A2A_HOST` – host for the A2A gRPC server. Defaults to `localhost`.
 - `LLAMA_N_CTX` – context-window size for local models. Defaults to `2048`.
+- `LLAMA_MODEL_PATH` – path to a local `.gguf` weight file.
 
 #### Offline Usage
 


### PR DESCRIPTION
## Summary
- add CLI flags to alpha_agi_business_3_v1 for env overrides
- document new options in README and .env.example
- test CLI overrides for A2A, ADK and LLM

## Testing
- `python check_env.py --auto-install` *(fails: Could not install numpy)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md alpha_factory_v1/demos/alpha_agi_business_3_v1/.env.example tests/test_alpha_agi_business_3_v1.py` *(fails: KeyboardInterrupt during semgrep setup)*
- `pytest -q tests/test_alpha_agi_business_3_v1.py` *(skipped: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850d88e88008333b27b396858714c3f