### PR TITLE
[alpha_factory] docs: add minimal offline example

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -341,6 +341,17 @@ without internet access.
 LLAMA_MODEL_PATH=/path/model.gguf alpha-agi-business-3-v1
 ```
 
+#### Minimal Example
+
+Install the demo with a local model and run one cycle:
+
+```bash
+pip install -r requirements.txt llama-cpp-python
+LLAMA_MODEL_PATH=/path/model.gguf alpha-agi-business-3-v1
+```
+
+The `openai-agents` package is optional in this setup.
+
 ---
 
 <a id="9"></a>


### PR DESCRIPTION
## Summary
- document a minimal offline example for the Business 3 demo
- note that `openai-agents` is optional

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850e234f6b48333a01d494a8a4c7dd3