### PR TITLE
[alpha_factory] add check_env step to marketplace demo

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/colab_alpha_agi_marketplace_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/colab_alpha_agi_marketplace_demo.ipynb
@@ -4,13 +4,14 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# 🛒 Alpha‑AGI Marketplace · Colab Notebook\n",
+        "# \ud83d\uded2 Alpha\u2011AGI Marketplace \u00b7 Colab Notebook\n",
         "\n",
-        "Run the Alpha‑Factory marketplace micro-demo.\n",
+        "Run the Alpha\u2011Factory marketplace micro-demo.\n",
         "\n",
-        "* 🔧 Start the orchestrator\n",
-        "* 📨 Queue a sample job and inspect memory\n",
-        "* 🔴 Works offline via Mixtral unless you provide an `OPENAI_API_KEY`\n",
+        "* \ud83d\udd27 Start the orchestrator\n",
+        "* \ud83d\udce8 Queue a sample job and inspect memory\n",
+        "* \ud83d\udd34 Works offline via Mixtral unless you provide an `OPENAI_API_KEY`\n",
+        "* \u2705 After setup run `python check_env.py --auto-install`\n",
         "\n",
         "Paste your OpenAI key below or leave blank to run offline."
       ]
@@ -43,12 +44,12 @@
         "set -euo pipefail\n",
         "REPO=AGI-Alpha-Agent-v0\n",
         "if [ ! -d \"$REPO/.git\" ]; then\n",
-        "  echo '📥 Cloning repo ...'\n",
+        "  echo '\ud83d\udce5 Cloning repo ...'\n",
         "  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git $REPO\n",
         "fi\n",
         "cd $REPO\n",
         "\n",
-        "echo '🔧 Installing dependencies ...'\n",
+        "echo '\ud83d\udd27 Installing dependencies ...'\n",
         "pip install -q -r alpha_factory_v1/requirements-colab.txt\n",
         "pip install -q uvicorn fastapi pyngrok ctransformers==0.2.27\n",
         "\n",
@@ -100,7 +101,17 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 🚀 Launch orchestrator (background)"
+        "## \ud83d\ude80 Launch orchestrator (background)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "%cd AGI-Alpha-Agent-v0\n",
+        "!python check_env.py --auto-install\n"
       ]
     },
     {
@@ -120,7 +131,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 🔗 Expose API with pyngrok"
+        "## \ud83d\udd17 Expose API with pyngrok"
       ]
     },
     {
@@ -134,7 +145,7 @@
         "conf.get_default().region = 'us'\n",
         "api = ngrok.connect(8000, 'http')\n",
         "display(Markdown(f'[Open API docs]({api.public_url}/docs)'))\n",
-        "print('API →', api.public_url)"
+        "print('API \u2192', api.public_url)"
       ],
       "execution_count": null,
       "outputs": []
@@ -143,7 +154,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## ✅ Check orchestrator status"
+        "## \u2705 Check orchestrator status"
       ]
     },
     {
@@ -154,8 +165,8 @@
       "source": [
         "from alpha_factory_v1.demos.alpha_agi_marketplace_v1 import MarketplaceClient\n",
         "client = MarketplaceClient()\n",
-        "print('health →', client.health())\n",
-        "print('agents →', client.agents())"
+        "print('health \u2192', client.health())\n",
+        "print('agents \u2192', client.agents())"
       ],
       "execution_count": null,
       "outputs": []
@@ -164,7 +175,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 📋 Queue sample job and view memory"
+        "## \ud83d\udccb Queue sample job and view memory"
       ]
     },
     {
@@ -186,7 +197,7 @@
         "job = json.load(open(SAMPLE_JOB))\n",
         "client.queue_job(job)\n",
         "time.sleep(2)\n",
-        "print('recent memory →', client.recent_memory(job['agent']))"
+        "print('recent memory \u2192', client.recent_memory(job['agent']))"
       ],
       "execution_count": null,
       "outputs": []
@@ -196,7 +207,7 @@
       "metadata": {},
       "source": [
         "---\n",
-        "### 🎉 All set!\n",
+        "### \ud83c\udf89 All set!\n",
         "Use the API URL above to monitor progress or trigger your own jobs."
       ]
     }


### PR DESCRIPTION
## Summary
- ensure Alpha-AGI Marketplace notebook instructs users to run `check_env.py`
- add a cell that calls `python check_env.py --auto-install`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_marketplace_v1/colab_alpha_agi_marketplace_demo.ipynb` *(fails: could not install hooks)*
- `papermill alpha_factory_v1/demos/alpha_agi_marketplace_v1/colab_alpha_agi_marketplace_demo.ipynb /tmp/out.ipynb -k python3` *(fails: pip install error)*

------
https://chatgpt.com/codex/tasks/task_e_68515277160c8333904a574e64099ef7