### PR TITLE
[alpha_factory] add bash syntax test for business v3 demo

### DIFF
--- a/tests/test_run_business_3_demo.py
+++ b/tests/test_run_business_3_demo.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test the alpha business v3 demo shell launcher."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path("alpha_factory_v1/demos/alpha_agi_business_3_v1/run_business_3_demo.sh")
+
+
+def test_run_business_3_demo_syntax() -> None:
+    """Validate shell script syntax with ``bash -n``."""
+    subprocess.run(["bash", "-n", str(SCRIPT)], check=True)
+
+
+def test_run_business_3_demo_help(tmp_path: Path) -> None:
+    """--help should exit successfully without a real Docker binary."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "docker.log"
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(f"#!/usr/bin/env bash\necho $@ >> '{log_file}'\nexit 0\n")
+    docker_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--help"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert log_file.read_text()


### PR DESCRIPTION
## Summary
- add tests/test_run_business_3_demo.py to validate the Business v3 demo shell script

## Testing
- `pre-commit run --files tests/test_run_business_3_demo.py` *(some hooks skipped)*
- `python scripts/check_python_deps.py` *(fails: numpy, pandas missing)*
- `python check_env.py --auto-install` *(fails: network unreachable)*
- `pytest -q tests/test_run_business_3_demo.py` *(fails: environment check skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68516ca5d18483339a057304ec67a5c7