### PR TITLE
[alpha_factory] refactor run_cycle

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -242,7 +242,6 @@ def run_cycle(
     model: Model,
     adk_client: Any | None = None,
     a2a_socket: Any | None = None,
-    loop: asyncio.AbstractEventLoop | None = None,
 ) -> None:
     """Execute one evaluation cycle, creating an event loop if required."""
 
@@ -266,32 +265,18 @@ def run_cycle(
         )
         return
 
-    if loop is None:
-        asyncio.run(
-            run_cycle_async(
-                orchestrator,
-                fin_agent,
-                res_agent,
-                ene_agent,
-                gdl_agent,
-                model,
-                adk_client,
-                a2a_socket,
-            )
+    asyncio.run(
+        run_cycle_async(
+            orchestrator,
+            fin_agent,
+            res_agent,
+            ene_agent,
+            gdl_agent,
+            model,
+            adk_client,
+            a2a_socket,
         )
-    else:
-        loop.run_until_complete(
-            run_cycle_async(
-                orchestrator,
-                fin_agent,
-                res_agent,
-                ene_agent,
-                gdl_agent,
-                model,
-                adk_client,
-                a2a_socket,
-            )
-        )
+    )
 
 
 async def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- simplify `run_cycle` for the alpha_agi_business_3_v1 demo
- exercise new behaviour in tests

## Testing
- `python alpha_factory_v1/scripts/preflight.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py tests/test_alpha_agi_business_3_v1.py` *(fails: requirements lock outdated)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68516edf5d38833385c4f5436c61faef