### PR TITLE
[alpha_factory] Improve business demo docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -341,6 +341,14 @@ without internet access.
 LLAMA_MODEL_PATH=/path/model.gguf alpha-agi-business-3-v1
 ```
 
+#### Dependency Checks
+
+Commonly missing packages include `numpy`, `pandas` and `openai-agents`.
+Run `python check_env.py --auto-install` to ensure these are installed.
+When offline, pass `--wheelhouse <dir>` so `check_env.py` can use local
+wheels. The demo requires either network access or a wheelhouse containing
+the required packages.
+
 #### Minimal Example
 
 Install the demo with a local model and run one cycle:


### PR DESCRIPTION
## Summary
- mention missing dependencies in the business demo README
- reference `check_env.py` for installation help
- note that numpy, pandas and openai-agents require network or a wheelhouse

## Testing
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md` *(fails: semgrep environment initialization blocked)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*


------
https://chatgpt.com/codex/tasks/task_e_685187abba548333a92df43d8276ead3