### PR TITLE
[alpha_factory] update offline test docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -102,6 +102,7 @@ Build wheels on a machine with connectivity and reuse them offline:
 
 ```bash
 mkdir -p wheels
+pip wheel -r alpha_factory_v1/requirements-core.txt -w wheels
 pip wheel -r requirements.txt -w wheels
 pip wheel -r requirements-dev.txt -w wheels
 pip wheel -r alpha_factory_v1/demos/aiga_meta_evolution/requirements.txt -w wheels
@@ -112,7 +113,7 @@ Copy the `wheels/` directory to the offline host and set `WHEELHOUSE`:
 ```bash
 export WHEELHOUSE=/path/to/wheels
 python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
-PYTHONPATH=$(pwd) pytest -q
+PYTHONPATH=$(pwd) WHEELHOUSE="$WHEELHOUSE" pytest -q
 ```
 
 The environment check installs any missing packages from `WHEELHOUSE` so the
@@ -127,6 +128,7 @@ demo requirements if needed):
 
 ```bash
 mkdir -p wheels
+pip wheel -r alpha_factory_v1/requirements-core.txt -w wheels
 pip wheel -r requirements.txt -w wheels
 pip wheel -r alpha_factory_v1/demos/muzero_planning/requirements.txt -w wheels
 pip wheel -r alpha_factory_v1/demos/macro_sentinel/requirements.txt -w wheels


### PR DESCRIPTION
## Summary
- explain how to build a wheelhouse from `requirements-core.txt`
- note passing `WHEELHOUSE` to `pytest` when offline

## Testing
- `WHEELHOUSE=$(pwd)/wheels python check_env.py --auto-install --wheelhouse $(pwd)/wheels` *(fails: Could not find a version that satisfies the requirement numpy)*
- `WHEELHOUSE=$(pwd)/wheels pytest -q tests/test_no_network.py` *(fails: Could not find a version that satisfies the requirement numpy)*
- `WHEELHOUSE=$(pwd)/wheels pre-commit run --files tests/README.md` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68518a87f5b08333bee3829b37a2156d