### PR TITLE
[alpha_factory] add colab notebook and badge

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -4,6 +4,9 @@
 © 2025 Montreal.AI — All rights reserved
 -->
 
+# α‑AGI Insight v1 — Beyond Human Foresight
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb)
+
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
 <p align="center">
@@ -204,9 +207,11 @@ graph TD
 
 ## 2 Quick-start
 
-> **Prerequisites**  
-> • Python ≥ 3.11 • Git • Docker (only for container mode)  
+> **Prerequisites**
+> • Python ≥ 3.11 • Git • Docker (only for container mode)
 > *(Optional)* Node ≥ 20 + pnpm if you plan to rebuild the React front-end.
+
+Or try the hosted notebook: [colab_alpha_agi_insight_v1.ipynb](colab_alpha_agi_insight_v1.ipynb).
 
 ```bash
 # ❶ Clone & enter demo

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "This notebook is a conceptual research prototype. References to 'AGI' or 'superintelligence' describe aspirational goals and do not indicate the presence of real general intelligence. Use at your own risk."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# \u03b1-AGI Insight v1 Demo\nExplore the production Insight demo directly in Colab. The notebook installs dependencies, checks the environment and launches a local API with a Streamlit dashboard."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "%%bash --no-stderr\nif [[ ! -d AGI-Alpha-Agent-v0 ]]; then\n  git clone --depth 1 https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git -q\nfi\ncd AGI-Alpha-Agent-v0\npip install -q -r alpha_factory_v1/requirements-colab.lock\npython check_env.py --auto-install || true\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Optional API token and OpenAI key"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import os\nos.environ['OPENAI_API_KEY'] = ''\nos.environ['API_TOKEN'] = 'demo'"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Run the cell below to start the API server and open the Streamlit dashboard."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import subprocess, sys, os, time\nfrom google.colab import output\nroot='AGI-Alpha-Agent-v0'\napi_env=os.environ.copy()\napi_env.setdefault('API_TOKEN','demo')\nsubprocess.Popen([sys.executable,'-m','alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server','--host','0.0.0.0','--port','8000'],cwd=root,env=api_env)\nsubprocess.Popen(['streamlit','run','alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py','--server.headless','true','--server.port','8501'],cwd=root)\ntime.sleep(3)\noutput.serve_kernel_port_as_window(8501)\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Colab notebook for α‑AGI Insight v1 demo
- show Colab badge in Insight v1 README and link from quick-start section

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851927156f88333bc7291c2a711424c