### PR TITLE
[alpha_factory] handle tmp directory cleanup

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
@@ -10,6 +10,7 @@ self-improving agent could be evolved inside a container.
 from __future__ import annotations
 
 import os
+import shutil
 import tarfile
 import tempfile
 from pathlib import Path
@@ -46,16 +47,16 @@ STORAGE_PATH = Path(os.getenv("STORAGE_PATH", "/tmp/evolution"))
 app = FastAPI(title="Evolution Worker")
 
 
-class MutationResponse(BaseModel):
+class MutationResponse(BaseModel):  # type: ignore[misc]
     child: List[float]
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore[misc]
 async def _prepare() -> None:
     STORAGE_PATH.mkdir(parents=True, exist_ok=True)
 
 
-@app.post("/mutate", response_model=MutationResponse)
+@app.post("/mutate", response_model=MutationResponse)  # type: ignore[misc]
 async def mutate(
     tar: UploadFile | None = File(None),
     repo_url: str | None = Form(None),
@@ -84,13 +85,10 @@ async def mutate(
         child = pop[0].genome
         return MutationResponse(child=child)
     finally:
-        for p in tmp_path.rglob("*"):
-            if p.is_file():
-                p.unlink()
-        tmp_path.rmdir()
+        shutil.rmtree(tmp_path, ignore_errors=True)
 
 
-@app.get("/healthz")
+@app.get("/healthz")  # type: ignore[misc]
 async def healthz() -> str:
     """Liveness probe."""
 


### PR DESCRIPTION
## Summary
- clean up mutate() with shutil.rmtree
- test nested tarball extraction cleans directory
- silence mypy warnings

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: No network connectivity detected)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py tests/test_evolution_worker.py` *(fails: proto-verify and requirements lock hooks)*

------
https://chatgpt.com/codex/tasks/task_e_685194eedc648333bd7922f55b7fe762