### PR TITLE
[alpha_factory] Add environment setup section

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -16,6 +16,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 <p align="center">
   <a href="#quickstart" aria-label="Jump to quickstart">Quick-start</a> •
+  <a href="#environment-setup">Environment Setup</a> •
   <a href="#architecture">Architecture</a> •
   <a href="#cli-usage">CLI</a> •
   <a href="#web-ui">Web UI</a> •
@@ -239,6 +240,17 @@ docker run -it --rm -p 8501:8501   -e OPENAI_API_KEY=$OPENAI_API_KEY   ghcr.io/m
 
 For offline builds or the browser-based PWA, see
 [insight_browser_v1/README.md](insight_browser_v1/README.md).
+
+## Environment Setup
+
+Before running the demo, install optional dependencies:
+
+```bash
+python ../../../check_env.py --auto-install
+```
+
+Set `WHEELHOUSE=/path/to/wheels` when offline to install from a local
+wheelhouse.
 
 ---
 


### PR DESCRIPTION
## Summary
- update insight demo README with environment setup instructions

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: No network)*
- `pytest -q` *(failed: No network)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/README.md` *(failed: network init)*

------
https://chatgpt.com/codex/tasks/task_e_68519c17631083338ac6e23dbaac0943