### PR TITLE
[alpha_factory] handle default API_TOKEN

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
@@ -10,9 +10,8 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-
-os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")
+
 
 
 def test_root_serves_index() -> None:
@@ -28,7 +27,7 @@ def test_problem_json_404() -> None:
     from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
 
     client = TestClient(api_server.app)
-    headers = {"Authorization": "Bearer test-token"}
+    headers = {"Authorization": "Bearer changeme"}
     resp = client.get("/results/missing", headers=headers)
     assert resp.status_code == 404
     data = resp.json()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
@@ -12,7 +12,6 @@ import pytest
 # Ensure repository root is on the Python path for subprocess execution
 REPO_ROOT = Path(__file__).resolve().parents[4]
 os.environ.setdefault("PYTHONPATH", str(REPO_ROOT))
-os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 fastapi = pytest.importorskip("fastapi")
@@ -30,6 +29,7 @@ def _free_port() -> int:
 def test_docs_available() -> None:
     port = _free_port()
     env = os.environ.copy()
+    env.pop("API_TOKEN", None)
     env["PYTHONPATH"] = str(REPO_ROOT)
     cmd = [
         sys.executable,
@@ -65,6 +65,7 @@ def test_docs_available() -> None:
 def test_simulation_endpoints() -> None:
     port = _free_port()
     env = os.environ.copy()
+    env.pop("API_TOKEN", None)
     env["PYTHONPATH"] = str(REPO_ROOT)
     cmd = [
         sys.executable,
@@ -77,7 +78,7 @@ def test_simulation_endpoints() -> None:
     ]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     url = f"http://127.0.0.1:{port}"
-    headers = {"Authorization": "Bearer test-token"}
+    headers = {"Authorization": "Bearer changeme"}
     try:
         for _ in range(100):
             try:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_ws_progress.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_ws_progress.py
@@ -12,8 +12,6 @@ from fastapi.testclient import TestClient
 
 # Ensure repository root is on the Python path
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-
-os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 
@@ -22,7 +20,7 @@ def test_ws_progress_receives_updates() -> None:
     from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
 
     client = TestClient(api_server.app)
-    headers = {"Authorization": "Bearer test-token"}
+    headers = {"Authorization": "Bearer changeme"}
 
     with client.websocket_connect("/ws/progress", headers=headers) as ws:
         resp = client.post(

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py
@@ -8,8 +8,6 @@ import pytest
 pytest.importorskip("fastapi")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-
-os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 


### PR DESCRIPTION
## Summary
- defer API token lookup to startup
- use a default placeholder when missing
- update Insight demo tests for new token behavior

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: Could not find numpy)*
- `WHEELHOUSE=$(pwd)/wheels pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_ws_progress.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_ws_progress.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_results_dir_permissions.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a2074f5c8333a83e16c3f1b2ba99