### PR TITLE
[alpha_factory] fix permissions for insight results dir

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -54,7 +54,7 @@ try:
     from fastapi.staticfiles import StaticFiles
     from fastapi.middleware.cors import CORSMiddleware
     from pydantic import BaseModel, Field
-import uvicorn
+    import uvicorn
     from .problem_json import problem_response
 except Exception as exc:  # pragma: no cover - optional
     FastAPI: Any | None = None
@@ -77,16 +77,12 @@ if app is not None:
 
     @app.on_event("startup")
     async def _start() -> None:
-        orch_mod = importlib.import_module(
-            "alpha_factory_v1.demos.alpha_agi_insight_v1.src.orchestrator"
-        )
+        orch_mod = importlib.import_module("alpha_factory_v1.demos.alpha_agi_insight_v1.src.orchestrator")
         app_f.state.orchestrator = orch_mod.Orchestrator()
         app_f.state.task = asyncio.create_task(app_f.state.orchestrator.run_forever())
         token = os.getenv("API_TOKEN")
         if not token:
-            logging.getLogger(__name__).warning(
-                "API_TOKEN not set; using insecure placeholder"
-            )
+            logging.getLogger(__name__).warning("API_TOKEN not set; using insecure placeholder")
             token = API_TOKEN_DEFAULT
         app_f.state.api_token = token
         _load_results()
@@ -157,6 +153,7 @@ if app is not None:
     )
     _max_results = int(os.getenv("MAX_RESULTS", "100"))
     _results_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(_results_dir, 0o700)
 
     def _load_results() -> None:
         entries: list[tuple[float, ResultsResponse]] = []

--- a/tests/test_results_dir_permissions.py
+++ b/tests/test_results_dir_permissions.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for results directory permissions."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+os.environ.setdefault("API_RATE_LIMIT", "1000")
+
+
+def test_existing_results_dir_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure permissions are tightened when directory already exists."""
+    path = tmp_path / "results"
+    path.mkdir(mode=0o755)
+    monkeypatch.setenv("SIM_RESULTS_DIR", str(path))
+
+    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
+
+    api_server = importlib.reload(api_server)
+
+    assert path.exists()
+    assert (path.stat().st_mode & 0o777) == 0o700


### PR DESCRIPTION
## Summary
- ensure restricted permissions on Insight results directory when it already exists
- add regression test for correcting pre-existing directory permissions

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py tests/test_results_dir_permissions.py` *(fails: environment build issues)*
- `pytest -q tests/test_results_dir_permissions.py` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851a4fc9a5883339fdcbe40af892b64