### PR TITLE
[alpha_factory] add memory limit to MemoryAgent

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -12,13 +12,14 @@ from .base_agent import BaseAgent
 from ..utils import messaging, logging as insight_logging
 from ..utils.logging import Ledger
 from ..utils.tracing import span
+import os
 import json
 from pathlib import Path
 
 log = insight_logging.logging.getLogger(__name__)
 
 
-class MemoryAgent(BaseAgent):
+class MemoryAgent(BaseAgent):  # type: ignore[misc]
     """Persist artefacts produced by other agents."""
 
     def __init__(
@@ -29,8 +30,18 @@ class MemoryAgent(BaseAgent):
         *,
         backend: str = "gpt-4o",
         island: str = "default",
+        memory_limit: int | None = None,
     ) -> None:
         super().__init__("memory", bus, ledger, backend=backend, island=island)
+        if memory_limit is None:
+            raw = os.getenv("AGI_INSIGHT_MEMORY_LIMIT")
+            if raw:
+                try:
+                    memory_limit = int(raw)
+                except ValueError:
+                    log.warning("invalid AGI_INSIGHT_MEMORY_LIMIT=%s", raw)
+                    memory_limit = None
+        self._limit = memory_limit
         self.records: list[dict[str, object]] = []
         self._store = Path(store_path) if store_path else None
         if self._store and self._store.exists():
@@ -42,6 +53,12 @@ class MemoryAgent(BaseAgent):
                     self.records.append(json.loads(line))
                 except Exception as exc:  # noqa: BLE001 - ignore bad records
                     log.warning("invalid record: %s", exc)
+        if self._limit is not None and len(self.records) > self._limit:
+            self.records = self.records[-self._limit :]
+            if self._store:
+                with self._store.open("w", encoding="utf-8") as fh:
+                    for rec in self.records:
+                        fh.write(json.dumps(rec) + "\n")
 
     async def run_cycle(self) -> None:
         """Periodically report memory size."""
@@ -52,6 +69,14 @@ class MemoryAgent(BaseAgent):
         """Store payload for later retrieval."""
         with span("memory.handle"):
             self.records.append(env.payload)
-            if self._store:
-                with self._store.open("a", encoding="utf-8") as fh:
-                    fh.write(json.dumps(env.payload) + "\n")
+            if self._limit is not None and len(self.records) > self._limit:
+                excess = len(self.records) - self._limit
+                self.records = self.records[excess:]
+                if self._store:
+                    with self._store.open("w", encoding="utf-8") as fh:
+                        for rec in self.records:
+                            fh.write(json.dumps(rec) + "\n")
+            else:
+                if self._store:
+                    with self._store.open("a", encoding="utf-8") as fh:
+                        fh.write(json.dumps(env.payload) + "\n")

--- a/tests/test_memory_agent_file_persistence.py
+++ b/tests/test_memory_agent_file_persistence.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+import asyncio
+import json
+from pathlib import Path
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import memory_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config, messaging, logging
+import pytest
+
+
+def test_memory_agent_file_cap(tmp_path: Path) -> None:
+    mem_file = tmp_path / "mem.log"
+    cfg = config.Settings(bus_port=0, memory_path=str(mem_file))
+    bus = messaging.A2ABus(cfg)
+    ledger = logging.Ledger(str(tmp_path / "ledger.db"))
+    agent = memory_agent.MemoryAgent(bus, ledger, str(mem_file), memory_limit=2)
+
+    envs = [messaging.Envelope("a", "memory", {"v": i}, 0.0) for i in range(3)]
+
+    async def _run() -> None:
+        async with bus, ledger:
+            for env in envs:
+                await agent.handle(env)
+
+    asyncio.run(_run())
+
+    entries = [json.loads(line) for line in mem_file.read_text(encoding="utf-8").splitlines()]
+    assert [e["v"] for e in entries] == [1, 2]
+
+    agent2 = memory_agent.MemoryAgent(bus, ledger, str(mem_file), memory_limit=2)
+    assert [r["v"] for r in agent2.records] == [1, 2]
+
+
+def test_memory_agent_env_var_cap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mem_file = tmp_path / "mem.log"
+    monkeypatch.setenv("AGI_INSIGHT_MEMORY_LIMIT", "2")
+    cfg = config.Settings(bus_port=0, memory_path=str(mem_file))
+    bus = messaging.A2ABus(cfg)
+    ledger = logging.Ledger(str(tmp_path / "ledger.db"))
+    agent = memory_agent.MemoryAgent(bus, ledger, str(mem_file))
+
+    envs = [messaging.Envelope("a", "memory", {"i": i}, 0.0) for i in range(3)]
+
+    async def _run() -> None:
+        async with bus, ledger:
+            for env in envs:
+                await agent.handle(env)
+
+    asyncio.run(_run())
+
+    entries = [json.loads(line) for line in mem_file.read_text(encoding="utf-8").splitlines()]
+    assert [e["i"] for e in entries] == [1, 2]


### PR DESCRIPTION
## Summary
- limit stored records using `AGI_INSIGHT_MEMORY_LIMIT`
- trim history when the cap is reached and save the truncated list
- test cap behaviour and env var handling

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py tests/test_memory_agent_file_persistence.py` *(fails: proto-verify, verify requirements)*
- `PYTHONPATH=$(pwd) pytest -q tests/test_memory_agent_file_persistence.py` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851aaf597448333bb0d8d720c021c70