### PR TITLE
[alpha_factory] allow wheelhouse offline env

### DIFF
--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -123,10 +123,15 @@ When working on an air‑gapped machine build wheels ahead of time and tell
 ## 🤖 CI / GitHub Actions usage
 
 ```yaml
+      - name: Verify environment
+        run: python check_env.py --auto-install --wheelhouse /path/to/wheels
       - name: Build & smoke‑test α‑Factory
         run: |
           chmod +x alpha_factory_v1/scripts/install_alpha_factory_pro.sh
           alpha_factory_v1/scripts/install_alpha_factory_pro.sh --deploy --no-ui
+      - name: Run tests
+        run: |
+          WHEELHOUSE=/path/to/wheels pytest -q
 ```
 
 *The `--no-ui` flag speeds up CI by skipping the React build.*

--- a/check_env.py
+++ b/check_env.py
@@ -225,7 +225,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     demo = args.demo
     extra_required = DEMO_PACKAGES.get(demo, [])
 
-    network_ok = has_network()
+    network_ok = has_network() if not wheelhouse else True
     if auto and not wheelhouse and not network_ok:
         missing_core = [pkg for pkg in CORE if not check_pkg(pkg)]
         missing_required_tmp = []

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,7 +60,11 @@ continues even in minimal environments.
    bundled wheelhouse.
 7. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 8. Before running the tests, execute `python check_env.py --auto-install` once
-   more (add `--wheelhouse <dir>` when offline), then run `pytest -q`.
+   more (add `--wheelhouse <dir>` when offline). For example:
+   ```bash
+   python check_env.py --auto-install --wheelhouse /path/to/wheels
+   ```
+   Then run `pytest -q`.
 9. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
    `pre-commit install` once to enable the git hooks referenced in
    [AGENTS.md](../AGENTS.md).


### PR DESCRIPTION
## Summary
- skip network checks when `--wheelhouse` is provided in `check_env.py`
- show explicit wheelhouse command in test setup docs
- document wheelhouse usage in CI snippet

## Testing
- `pre-commit run --files check_env.py tests/README.md alpha_factory_v1/scripts/README.md` *(hooks skipped: proto-verify, verify-*-requirements-lock, env-check)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*

------
https://chatgpt.com/codex/tasks/task_e_6851b2ce94b08333a52c85fe680af1b7