### PR TITLE
[alpha_factory] network check option

### DIFF
--- a/tests/test_check_env_network.py
+++ b/tests/test_check_env_network.py
@@ -28,9 +28,24 @@ def test_offline_with_wheelhouse(monkeypatch: pytest.MonkeyPatch) -> None:
     """Allow offline installs when --wheelhouse is provided."""
     _no_missing(monkeypatch)
     monkeypatch.setattr(check_env, "has_network", lambda: False)
-    def _fake_run(*_a, **_k):
+
+    from typing import Any
+
+    def _fake_run(*_a: Any, **_k: Any) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess([], 0, "", "")
 
     monkeypatch.setattr(subprocess, "run", _fake_run)
     rc = check_env.main(["--auto-install", "--wheelhouse", "wheels"])
+    assert rc == 0
+
+
+def test_skip_net_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure --skip-net-check avoids connectivity checks."""
+    _no_missing(monkeypatch)
+
+    def _fail_net() -> bool:
+        raise AssertionError("has_network called")
+
+    monkeypatch.setattr(check_env, "has_network", _fail_net)
+    rc = check_env.main(["--auto-install", "--skip-net-check"])
     assert rc == 0


### PR DESCRIPTION
## Summary
- add `--skip-net-check` option to check_env
- avoid network check when dependencies already installed
- update tests for new flag

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --skip-net-check`
- `pre-commit run --files check_env.py tests/test_check_env_network.py` *(with SKIP for heavy hooks)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851bdb1f90c83339da68cff7383b485