### PR TITLE
[alpha_factory] Update offline setup note

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -250,7 +250,15 @@ python ../../../check_env.py --auto-install
 ```
 
 Set `WHEELHOUSE=/path/to/wheels` when offline to install from a local
-wheelhouse.
+wheelhouse. Create the wheelhouse first:
+
+```bash
+pip wheel -r requirements.lock -w /path/to/wheels
+```
+
+Then run `python ../../../check_env.py --auto-install` with `WHEELHOUSE`
+set. See [../../scripts/README.md#offline-setup](../../scripts/README.md#offline-setup)
+for detailed steps.
 
 ---
 


### PR DESCRIPTION
## Summary
- document building wheels in the α‑AGI Insight demo README

## Testing
- `python check_env.py --auto-install` *(fails: no network)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/README.md` *(fails: KeyboardInterrupt)*
- `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/tests` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6851ca55dd3483338194a325c21e91c6