### PR TITLE
[alpha_factory] default wheelhouse fallback

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -188,7 +188,11 @@ def has_network(timeout: float = 1.0) -> bool:
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate runtime dependencies",
-        epilog="Example: pip wheel -r requirements-core.txt -w /media/wheels",
+        epilog=(
+            "Example: pip wheel -r requirements-core.txt -w /media/wheels\n"
+            "If no --wheelhouse is provided and the repository contains a"
+            " 'wheels/' directory, that path is used automatically."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
@@ -198,7 +202,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     parser.add_argument(
         "--wheelhouse",
-        help="Optional path to a local wheelhouse for offline installs",
+        help=(
+            "Optional path to a local wheelhouse for offline installs. "
+            "Defaults to <repo>/wheels when that directory exists."
+        ),
     )
     parser.add_argument(
         "--timeout",
@@ -224,6 +231,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     wheelhouse = args.wheelhouse or os.getenv("WHEELHOUSE")
+    if not wheelhouse:
+        default_wh = Path(__file__).resolve().parent / "wheels"
+        if default_wh.is_dir():
+            wheelhouse = str(default_wh)
     auto = args.auto_install or os.getenv("AUTO_INSTALL_MISSING") == "1"
     skip_net_check = args.skip_net_check
     pip_timeout = args.timeout

--- a/tests/test_check_env_network.py
+++ b/tests/test_check_env_network.py
@@ -12,16 +12,13 @@ def _no_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(check_env, "warn_missing_core", lambda: [])
 
 
-def test_offline_no_wheelhouse(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
-    """Fail fast when offline without a wheelhouse."""
+def test_offline_no_wheelhouse(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback to repo wheelhouse when offline and no option is given."""
     _no_missing(monkeypatch)
     monkeypatch.setattr(check_env, "has_network", lambda: False)
     monkeypatch.delenv("WHEELHOUSE", raising=False)
     rc = check_env.main(["--auto-install"])
-    out = capsys.readouterr().out
-    assert rc == 1
-    assert "--wheelhouse <dir>" in out
-    assert "No network connectivity" in out
+    assert rc == 0
 
 
 def test_offline_with_wheelhouse(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- default `--wheelhouse` to repo `wheels/` directory when available
- mention fallback in help text
- adjust network tests for new default behavior

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --skip-net-check`
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files check_env.py tests/test_check_env_network.py` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc9fe9c8833392d86844fd299246