### PR TITLE
[alpha_factory] update insight demo docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -10,3 +10,22 @@ Whenever `src/utils/a2a.proto` changes, regenerate the protocol stubs:
 
 This updates `src/utils/a2a_pb2.py` and `tools/go_a2a_client/a2a.pb.go`.
 
+## Quickstart
+
+From the `alpha_factory_v1/demos/alpha_agi_insight_v1` directory run the
+environment check before launching the demo:
+
+```bash
+python ../../../check_env.py --auto-install
+```
+
+Start the Insight demo with the repository root
+[quickstart.sh](../../../quickstart.sh):
+
+```bash
+../../../quickstart.sh
+```
+
+An interactive walkthrough is available in the Colab notebook
+[colab_alpha_agi_insight_v1.ipynb](../colab_alpha_agi_insight_v1.ipynb).
+


### PR DESCRIPTION
## Summary
- document alpha agi insight quickstart options

## Testing
- `python scripts/check_python_deps.py` *(fails: missing packages)*
- `python check_env.py --auto-install` *(fails: no network detected)*
- `pytest -q` *(fails: could not install prometheus_client)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68520c771788833394b2cc5d682da871