### PR TITLE
[alpha_factory] Insert standard disclaimer

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -2,6 +2,8 @@
 
 This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.
 
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
 | Endpoint | Query/Path Params | Payload | Example Response |
 |---------|------------------|---------|-----------------|
 | **POST `/simulate`** | – | `{ "horizon": 5, "pop_size": 6, "generations": 3 }` | `{ "id": "d4e5f6a7" }` |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -2,6 +2,8 @@
 
 Documentation for the α‑AGI Insight demo.
 
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
 Whenever `src/utils/a2a.proto` changes, regenerate the protocol stubs:
 
 ```bash


### PR DESCRIPTION
## Summary
- mention the research disclaimer in insight docs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md` *(fails: Makefile:26: *** missing separator)*
- `pytest -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6852122bb50c833396dfa7164f4be0da