### PR TITLE
[alpha_factory] show disclaimer in minimal ui

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
@@ -13,6 +13,7 @@ import sys
 from typing import Any, TYPE_CHECKING, cast
 
 from ..simulation import forecast, sector
+from .cli import DISCLAIMER
 
 try:  # pragma: no cover - optional dependency
     import streamlit as _st
@@ -83,12 +84,14 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover - entry poi
         sys.exit("Streamlit not installed. Re-run with --text for console output.")
 
     if args.text or st is None:
+        print(DISCLAIMER)
         traj = _simulate(5, "logistic", 6, 3)
         for record in _disruption_df(traj).to_dict(orient="records"):
             print(f"{record['sector']}: year {record['year']}")
         return
 
     st.title("Disruption Forecast")
+    st.caption(DISCLAIMER)
     horizon = st.sidebar.slider("Horizon", 1, 20, 5)
     curve = st.sidebar.selectbox("Curve", ["logistic", "linear", "exponential"], index=0)
     pop_size = st.sidebar.slider("Population size", 2, 20, 6)


### PR DESCRIPTION
## Summary
- import DISCLAIMER constant in minimal_ui
- display disclaimer on startup for console and Streamlit modes

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py` *(with most hooks skipped)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*

------
https://chatgpt.com/codex/tasks/task_e_6852248d70d48333bdf8cdba7cd3964f