### PR TITLE
[alpha_factory] enforce API_TOKEN requirement

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -482,8 +482,9 @@ local development or customization. See the
 
 `BUSINESS_HOST` sets the orchestrator URL used by helper commands to reach the REST API.
 
-`API_TOKEN` must be set to a non-empty value before launching the API server. The
-container exits during startup when this variable is empty.
+`API_TOKEN` must be set to a strong non-empty value before launching the API server.
+The container exits during startup when this variable is empty or still set to the
+default `changeme` placeholder.
 
 To secure the gRPC bus provide `AGI_INSIGHT_BUS_CERT`,
 `AGI_INSIGHT_BUS_KEY` and `AGI_INSIGHT_BUS_TOKEN`. When these are omitted set

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -81,9 +81,8 @@ if app is not None:
         app_f.state.orchestrator = orch_mod.Orchestrator()
         app_f.state.task = asyncio.create_task(app_f.state.orchestrator.run_forever())
         token = os.getenv("API_TOKEN")
-        if not token:
-            logging.getLogger(__name__).warning("API_TOKEN not set; using insecure placeholder")
-            token = API_TOKEN_DEFAULT
+        if not token or token == API_TOKEN_DEFAULT:
+            raise RuntimeError("API_TOKEN must be set to a strong value (not empty or 'changeme').")
         app_f.state.api_token = token
         _load_results()
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py
@@ -13,21 +13,22 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 
-
-def test_root_serves_index() -> None:
+def test_root_serves_index(monkeypatch: pytest.MonkeyPatch) -> None:
     from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
 
+    monkeypatch.setenv("API_TOKEN", "secret")
     client = TestClient(api_server.app)
     resp = client.get("/")
     assert resp.status_code == 200
     assert '<div id="root"></div>' in resp.text
 
 
-def test_problem_json_404() -> None:
+def test_problem_json_404(monkeypatch: pytest.MonkeyPatch) -> None:
     from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
 
+    monkeypatch.setenv("API_TOKEN", "secret")
     client = TestClient(api_server.app)
-    headers = {"Authorization": "Bearer changeme"}
+    headers = {"Authorization": "Bearer secret"}
     resp = client.get("/results/missing", headers=headers)
     assert resp.status_code == 404
     data = resp.json()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py
@@ -29,7 +29,7 @@ def _free_port() -> int:
 def test_docs_available() -> None:
     port = _free_port()
     env = os.environ.copy()
-    env.pop("API_TOKEN", None)
+    env["API_TOKEN"] = "secret"
     env["PYTHONPATH"] = str(REPO_ROOT)
     cmd = [
         sys.executable,
@@ -65,7 +65,7 @@ def test_docs_available() -> None:
 def test_simulation_endpoints() -> None:
     port = _free_port()
     env = os.environ.copy()
-    env.pop("API_TOKEN", None)
+    env["API_TOKEN"] = "secret"
     env["PYTHONPATH"] = str(REPO_ROOT)
     cmd = [
         sys.executable,
@@ -78,7 +78,7 @@ def test_simulation_endpoints() -> None:
     ]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     url = f"http://127.0.0.1:{port}"
-    headers = {"Authorization": "Bearer changeme"}
+    headers = {"Authorization": "Bearer secret"}
     try:
         for _ in range(100):
             try:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_token_required.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_token_required.py
@@ -1,0 +1,21 @@
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
+
+
+def _run_client() -> None:
+    with TestClient(api_server.app):
+        pass
+
+
+def test_startup_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("API_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        _run_client()
+
+    monkeypatch.setenv("API_TOKEN", "changeme")
+    with pytest.raises(RuntimeError):
+        _run_client()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_ws_progress.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_ws_progress.py
@@ -15,12 +15,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 os.environ.setdefault("API_RATE_LIMIT", "1000")
 
 
-def test_ws_progress_receives_updates() -> None:
+def test_ws_progress_receives_updates(monkeypatch: pytest.MonkeyPatch) -> None:
     """A POST to /simulate should emit progress events over the WebSocket."""
     from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
 
+    monkeypatch.setenv("API_TOKEN", "secret")
     client = TestClient(api_server.app)
-    headers = {"Authorization": "Bearer changeme"}
+    headers = {"Authorization": "Bearer secret"}
 
     with client.websocket_connect("/ws/progress", headers=headers) as ws:
         resp = client.post(


### PR DESCRIPTION
## Summary
- error on insecure API_TOKEN for Insight demo
- mention strong token requirement in README
- update tests for stricter token handling
- add test covering startup failure when token unset or default

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_static.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_server_subprocess.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_ws_progress.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_token_required.py` *(fails: Found 31 errors in 1 file)*

------
https://chatgpt.com/codex/tasks/task_e_685228bb63708333b6a847406dfd9496