### PR TITLE
[alpha_factory] log disclaimer on API startup

### DIFF
--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -26,6 +26,9 @@ from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import alerts
 from src.utils.config import init_config
 from src.monitoring import metrics
 from src.capsules import CapsuleFacts, ImpactScorer, load_capsule_facts
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli import (
+    DISCLAIMER,
+)
 
 __all__ = [
     "app",
@@ -237,6 +240,7 @@ if app is not None:
 
     @app.on_event("startup")
     async def _start() -> None:
+        _log.warning(DISCLAIMER)
         orch_mod = importlib.import_module("alpha_factory_v1.demos.alpha_agi_insight_v1.src.orchestrator")
         app_f.state.orchestrator = orch_mod.Orchestrator()
         app_f.state.orch_task = asyncio.create_task(app_f.state.orchestrator.run_forever())


### PR DESCRIPTION
## Summary
- log the demo's disclaimer in `api_server` startup
- reuse the same disclaimer text from the Insight CLI

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*
- `pre-commit run --files src/interface/api_server.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522a5fadf883339782e2b227e5dbe7