### PR TITLE
[alpha_factory] enforce custom bus token

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -25,6 +25,11 @@ AGI_INSIGHT_BUS_KEY=/path/to/certs/bus.key
 AGI_INSIGHT_BUS_TOKEN=change_this_token
 ```
 
+Change `AGI_INSIGHT_BUS_TOKEN` to a unique secret before starting the
+orchestrator. When TLS is enabled the application exits with a
+``ValueError`` if this variable is empty or still set to the default
+``change_this_token``.
+
 ### Windows (PowerShell)
 
 Install the [OpenSSL Windows binaries](https://slproweb.com/products/Win32OpenSSL.html) and run the equivalent commands:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/utils/config.py
@@ -92,6 +92,11 @@ class Settings(SettingsBase):
                 self.solana_wallet = Path(self.solana_wallet_file).read_text(encoding="utf-8").strip()
             except Exception as exc:  # pragma: no cover - optional
                 _log.warning("Failed to load wallet file %s: %s", self.solana_wallet_file, exc)
+        if self.bus_cert and self.bus_key:
+            if not self.bus_token or self.bus_token == "change_this_token":
+                raise ValueError(
+                    "AGI_INSIGHT_BUS_TOKEN must be set and cannot be 'change_this_token' when TLS is enabled"
+                )
 
 
 CFG = Settings()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_bus_secure.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_bus_secure.py
@@ -29,7 +29,7 @@ def _gen_certs(tmp: Path) -> tuple[str, str, bytes, str]:
     subprocess.run(["bash", str(script)], cwd=tmp, check=True, capture_output=True)
     cert = tmp / "certs" / "bus.crt"
     key = tmp / "certs" / "bus.key"
-    token = "change_this_token"
+    token = "tok"
     ca = cert.read_bytes()
     return str(cert), str(key), ca, token
 
@@ -92,3 +92,11 @@ def test_bus_secure(tmp_path: Path) -> None:
 
     asyncio.run(run())
     assert len(received) == 1 and received[0].payload["v"] == 1
+
+
+def test_default_token_rejected(tmp_path: Path) -> None:
+    """Using the default token should fail when TLS is enabled."""
+    port = _free_port()
+    cert, key, _ca, _ = _gen_certs(tmp_path)
+    with pytest.raises(ValueError):
+        config.Settings(bus_port=port, bus_cert=cert, bus_key=key, bus_token="change_this_token")

--- a/tests/test_bus_ssl_gen.py
+++ b/tests/test_bus_ssl_gen.py
@@ -28,7 +28,7 @@ def _gen_certs(tmp: Path) -> tuple[str, str, bytes, str]:
     subprocess.run(["bash", str(script)], cwd=tmp, check=True, capture_output=True)
     cert = tmp / "certs" / "bus.crt"
     key = tmp / "certs" / "bus.key"
-    token = "change_this_token"
+    token = "tok"
     ca = cert.read_bytes()
     return str(cert), str(key), ca, token
 


### PR DESCRIPTION
## Summary
- enforce a custom bus token when TLS is enabled
- document the new requirement in bus TLS docs
- fix TLS tests to use a non-default token
- add regression test for default token usage

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68522b19fd7c83339a08c7b7de6cfa73