### PR TITLE
[alpha_factory] add offline wheelhouse script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,11 +61,9 @@ Python must report 3.11 or 3.12 and Docker Compose must be at least 2.5.
 
 Follow these steps when installing without internet access:
 
-- Build wheels using the same Python version as your virtual environment:
+- Build wheels using the helper script:
   ```bash
-  mkdir -p /media/wheels
-  pip wheel -r requirements.txt -w /media/wheels
-  pip wheel -r requirements-dev.txt -w /media/wheels
+  ./tools/build_wheelhouse.sh
   ```
 
 - Generate a deterministic lock file with hashes:
@@ -82,18 +80,21 @@ Follow these steps when installing without internet access:
   ```
 
 - Install from the wheelhouse (the setup script automatically sets
-  `WHEELHOUSE` to the `wheels/` directory in the repository root when
-  that directory exists):
+  `WHEELHOUSE` to the `wheels/` directory when it exists):
   ```bash
-  WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
-  WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 python check_env.py --auto-install --wheelhouse /media/wheels
+  export WHEELHOUSE="$(pwd)/wheels"
+  AUTO_INSTALL_MISSING=1 ./codex/setup.sh
+  python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
   ```
 
 - Verify package integrity:
   ```bash
   pip check
-  python check_env.py --auto-install --wheelhouse /media/wheels
+  python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
   ```
+
+- Set `WHEELHOUSE=$(pwd)/wheels` before running `check_env.py --auto-install`
+  and `pytest` when offline.
 
 - The setup script exits with an error if neither network access nor a
   wheelhouse is available. Build a wheelhouse as shown above and rerun

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,8 +17,18 @@ This tutorial shows how to install the prerequisites, run the Colab notebook and
    python --version
    docker --version
    docker compose version
-   git --version
-   ```
+git --version
+```
+
+### Offline setup
+
+Build the wheelhouse before disconnecting from the network:
+
+```bash
+./tools/build_wheelhouse.sh
+export WHEELHOUSE="$(pwd)/wheels"
+```
+Use this variable when running `check_env.py --auto-install` and `pytest`.
 
 ## Running the Colab notebook
 

--- a/tools/build_wheelhouse.sh
+++ b/tools/build_wheelhouse.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Build a local wheelhouse for offline installation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+mkdir -p wheels
+pip wheel -r requirements.lock -w wheels
+pip wheel -r requirements-dev.txt -w wheels
+


### PR DESCRIPTION
## Summary
- add `tools/build_wheelhouse.sh`
- document offline workflow in AGENTS.md
- update quickstart with wheelhouse instructions

## Testing
- `pre-commit run --files AGENTS.md docs/quickstart.md tools/build_wheelhouse.sh` *(fails: Verify alpha_factory_v1 requirements.lock is up to date)*
- `pytest -q` *(fails: missing prometheus_client)*

------
https://chatgpt.com/codex/tasks/task_e_685232ba818883338a2f57768340a334