### PR TITLE
[alpha_factory] Update Insight demo offline wheelhouse guidance

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -558,7 +558,13 @@ pip wheel -r requirements.txt -w /media/wheels
 pip wheel -r requirements-dev.txt -w /media/wheels
 ```
 
-Set the wheelhouse before running the environment check and tests:
+Ensure `pytest` and `prometheus_client` wheels are available. Refer to
+[AGENTS.md](../../../AGENTS.md#offline-setup) and
+[docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for the full
+wheelhouse procedure.
+
+Set the wheelhouse before running the environment check and tests. This
+installs the required packages from the local cache:
 
 ```bash
 WHEELHOUSE=/media/wheels python check_env.py --auto-install


### PR DESCRIPTION
## Summary
- document installing pytest/prometheus_client from wheelhouse
- link to AGENTS.md and OFFLINE_SETUP.md for wheelhouse instructions

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` *(fails: No matching distribution for numpy)*
- `pytest -q` *(fails: Could not find a version that satisfies numpy)*


------
https://chatgpt.com/codex/tasks/task_e_68523b1298b083339ff01b578109db5a