### PR TITLE
[alpha_factory] clarify secret config

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -31,3 +31,8 @@ Start the Insight demo with the repository root
 An interactive walkthrough is available in the Colab notebook
 [colab_alpha_agi_insight_v1.ipynb](../colab_alpha_agi_insight_v1.ipynb).
 
+
+## Configuration
+
+Before deploying the Helm charts, edit `alpha_factory_v1/helm/alpha-factory/values.yaml` and `alpha_factory_v1/helm/alpha-factory-remote/values.yaml`.
+Set `NEO4J_PASSWORD` to the real database password and configure a strong Grafana `adminPassword`.

--- a/alpha_factory_v1/helm/alpha-factory-remote/values.yaml
+++ b/alpha_factory_v1/helm/alpha-factory-remote/values.yaml
@@ -40,7 +40,7 @@ prometheus:
 
 grafana:
   enabled: true
-  adminPassword: REPLACE_ME  # TODO: set a secure Grafana password
+  adminPassword: REPLACE_ME  # Set a strong password before deployment
   defaultDashboardsEnabled: false         # we only want our custom one
 
   sidecar:

--- a/alpha_factory_v1/helm/alpha-factory/values.yaml
+++ b/alpha_factory_v1/helm/alpha-factory/values.yaml
@@ -24,7 +24,7 @@ env:
   NEWSAPI_KEY: ""
   NEO4J_URI: bolt://neo4j:7687
   NEO4J_USER: neo4j
-  NEO4J_PASSWORD: REPLACE_ME  # TODO: supply the real database password
+  NEO4J_PASSWORD: REPLACE_ME  # Set the real database password before deployment
   LLM_PROVIDER: openai
   MODEL_NAME: gpt-4-turbo
   PORT: "8000"
@@ -63,7 +63,7 @@ prometheus:
 
 grafana:
   enabled: true
-  adminPassword: REPLACE_ME  # TODO: set a secure Grafana password
+  adminPassword: REPLACE_ME  # Set a strong password before deployment
   defaultDashboardsEnabled: false
   sidecar:
     dashboards:


### PR DESCRIPTION
## Summary
- update `values.yaml` comments on database and Grafana passwords
- note configuration in Insight README

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy missing)*
- `python check_env.py --auto-install` *(fails to install numpy)*
- `pytest -q` *(fails: Could not find numpy)*
- `pre-commit run --files alpha_factory_v1/helm/alpha-factory/values.yaml alpha_factory_v1/helm/alpha-factory-remote/values.yaml alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68523d71d8f883338502ae872f669ef5