### PR TITLE
[alpha_factory] update openai-agents note

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -249,6 +249,13 @@ Before running the demo, install optional dependencies:
 python ../../../check_env.py --auto-install
 ```
 
+`check_env.py` ensures the optional **`openai-agents`** package is at least
+version `0.0.14`. Verify manually with:
+
+```bash
+python -c "import openai_agents, pkgutil; print(openai_agents.__version__)"
+```
+
 Set `WHEELHOUSE=/path/to/wheels` when offline to install from a local
 wheelhouse. Create the wheelhouse first:
 


### PR DESCRIPTION
## Summary
- clarify that `openai-agents>=0.0.14` is expected in Insight demo
- show how to check the installed version

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/README.md -v`
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: Failed to install numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6852aee7456083338a0d906424f605d6