### PR TITLE
[alpha_factory] add SPDX headers to tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_token_required.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_token_required.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 pytest.importorskip("fastapi")

--- a/tests/test_aiga_bridge_no_agents.py
+++ b/tests/test_aiga_bridge_no_agents.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 import types

--- a/tests/test_llm_client_utils.py
+++ b/tests/test_llm_client_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.demos.self_healing_repo.agent_core import llm_client
 
 

--- a/tests/test_macro_agent_base_url.py
+++ b/tests/test_macro_agent_base_url.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import sys
 from types import ModuleType

--- a/tests/test_max_sim_tasks.py
+++ b/tests/test_max_sim_tasks.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import importlib
 from pathlib import Path

--- a/tests/test_preflight_sandbox.py
+++ b/tests/test_preflight_sandbox.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 from alpha_factory_v1.scripts import preflight
 
@@ -16,4 +17,3 @@ def test_check_patch_in_sandbox_missing(monkeypatch):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     assert not preflight.check_patch_in_sandbox("img")
-

--- a/tests/test_rate_lock.py
+++ b/tests/test_rate_lock.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 import shutil
 from alpha_factory_v1.demos.self_healing_repo.agent_core import sandbox

--- a/tests/test_selfheal_entrypoint_offline.py
+++ b/tests/test_selfheal_entrypoint_offline.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # mypy: ignore-errors
 import builtins
 import importlib


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX license line to several test modules

## Testing
- `pre-commit run --files tests/test_aiga_bridge_no_agents.py tests/test_preflight_sandbox.py tests/test_selfheal_entrypoint_offline.py tests/test_sandbox_docker.py tests/test_llm_client_utils.py tests/test_max_sim_tasks.py tests/test_rate_lock.py tests/test_macro_agent_base_url.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_api_token_required.py` *(fails: Module level import not at top of file)*
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(fails: no matching distribution found for numpy)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852b389f730833397bca8d0ec12fb3a