### PR TITLE
[alpha_factory] remove unused imports

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
-import subprocess
 import sys
 from google.protobuf import struct_pb2
 import tempfile

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -14,7 +14,6 @@ import contextlib
 import importlib
 import json
 import os
-import logging
 import hashlib
 import secrets
 import time


### PR DESCRIPTION
## Summary
- delete unused modules from `codegen_agent.py`
- drop unused import from `api_server.py`

## Testing
- `ruff check alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852b98577b08333b193f6061b9812b5