### PR TITLE
[alpha_factory] document offline wheels

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -240,6 +240,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     pip_timeout = args.timeout
     allow_basic = args.allow_basic_fallback
     demo = args.demo
+    wheel_msg = f" (wheelhouse: {wheelhouse})" if wheelhouse else ""
     extra_required = DEMO_PACKAGES.get(demo, [])
 
     missing_core = [pkg for pkg in CORE if not check_pkg(pkg)]
@@ -286,7 +287,10 @@ def main(argv: Optional[List[str]] = None) -> int:
                 try:
                     subprocess.run(cmd, check=True, timeout=pip_timeout)
                 except subprocess.SubprocessError as exc:
-                    print(f"Failed to install {pkg}", getattr(exc, "returncode", ""))
+                    print(
+                        f"Failed to install {pkg}{wheel_msg}",
+                        getattr(exc, "returncode", ""),
+                    )
                     return 1
 
     missing_core = warn_missing_core()
@@ -304,7 +308,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         try:
             subprocess.run(cmd, check=True, timeout=pip_timeout)
         except subprocess.SubprocessError as exc:
-            print("Failed to install core packages", getattr(exc, "returncode", ""))
+            print(
+                f"Failed to install core packages{wheel_msg}",
+                getattr(exc, "returncode", ""),
+            )
             return 1
         missing_core = warn_missing_core()
 
@@ -346,12 +353,17 @@ def main(argv: Optional[List[str]] = None) -> int:
                 "Then re-run with '--wheelhouse <dir>' (see "
                 "alpha_factory_v1/scripts/README.md)."
             )
+            if wheelhouse:
+                print(f"Wheelhouse used: {wheelhouse}")
             if not network_ok and not wheelhouse:
                 print("No network connectivity detected.")
             return 1
         except subprocess.CalledProcessError as exc:
             stderr = exc.stderr or ""
-            print("Failed to install baseline requirements", exc.returncode)
+            print(
+                f"Failed to install baseline requirements{wheel_msg}",
+                exc.returncode,
+            )
             if any(kw in stderr.lower() for kw in ["connection", "temporary failure", "network", "resolve"]):
                 print(
                     "Network failure detected.\n"
@@ -407,12 +419,17 @@ def main(argv: Optional[List[str]] = None) -> int:
                     "Create a wheelhouse with 'pip wheel -r requirements-core.txt -w /path/to/wheels'\n"
                     "then re-run with '--wheelhouse <dir>' (see alpha_factory_v1/scripts/README.md)."
                 )
+                if wheelhouse:
+                    print(f"Wheelhouse used: {wheelhouse}")
                 if not network_ok and not wheelhouse:
                     print("No network connectivity detected.")
                 return 1
             except subprocess.CalledProcessError as exc:
                 stderr = exc.stderr or ""
-                print("Automatic install failed with code", exc.returncode)
+                print(
+                    f"Automatic install failed with code{wheel_msg}",
+                    exc.returncode,
+                )
                 if any(kw in stderr.lower() for kw in ["connection", "temporary failure", "network", "resolve"]):
                     print(
                         "Network failure detected.\n"

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -25,6 +25,29 @@ export AUTO_INSTALL_MISSING=1
 
 `check_env.py` reads them to install packages from the wheelhouse when the network is unavailable.
 
+### Prebuilt wheels for heavy dependencies
+`numpy` and `pandas` ship as binary wheels on PyPI. Grab them when
+constructing the wheelhouse so the offline installer does not attempt to
+compile these heavy packages from source:
+
+```bash
+pip wheel numpy pandas -w /media/wheels
+```
+
+Include any other large dependencies, such as `torch` or `scipy`, by passing
+their names to `pip wheel` or `pip download` with the versions pinned in
+`requirements.lock`.
+
+If the repository already contains a `wheels/` directory you can use it as the
+wheelhouse directly:
+
+```bash
+export WHEELHOUSE="$(pwd)/wheels"
+```
+
+Run `check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` to install from
+this local cache.
+
 ## Verify packages
 Use the scripts below to confirm all requirements are satisfied:
 


### PR DESCRIPTION
## Summary
- clarify offline install guide with pip wheel instructions for numpy/pandas
- show wheelhouse path when check_env.py fails

## Testing
- `pre-commit run --files check_env.py docs/OFFLINE_SETUP.md` (with hooks skipped)
- `pytest -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6852ca3a904483338bf3b013982be2bb