### PR TITLE
[alpha_factory] Add offline install docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -250,3 +250,14 @@ Agents communicate over a lightweight gRPC bus. On connection clients must
 perform a simple handshake by sending the literal string `proto_schema=1` to the
 `/bus.Bus/Send` method. The server replies with the same string. After the
 handshake, JSON encoded envelopes defined by `a2a.proto` may be transmitted.
+
+## Offline usage
+
+When network access is unavailable, install optional packages from a wheelhouse:
+
+```bash
+python check_env.py --auto-install --wheelhouse <dir>
+```
+
+Refer to [docs/OFFLINE_INSTALL.md](OFFLINE_INSTALL.md) for step‑by‑step
+instructions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,6 +31,14 @@ Build the wheelhouse before disconnecting from the network:
 export WHEELHOUSE="$(pwd)/wheels"
 ```
 Use this variable when running `check_env.py --auto-install` and `pytest`.
+When no network connection is available, install dependencies from the
+wheel cache with:
+
+```bash
+python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+```
+
+See [docs/OFFLINE_INSTALL.md](OFFLINE_INSTALL.md) for detailed steps.
 
 ## Running the Colab notebook
 


### PR DESCRIPTION
## Summary
- mention running `check_env.py` with `--wheelhouse` in the quickstart
- document offline install command in the API docs

## Testing
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-era-experience-requirements-lock,verify-mats-demo-lock,verify-mats-requirements-lock,verify-aiga-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,env-check,eslint-insight-browser pre-commit run --files docs/API.md docs/quickstart.md`
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: Could not find a version that satisfies fastapi)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852e5f305848333a53c71ea07975e86