### PR TITLE
[alpha_factory] handle empty wheelhouse

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -235,6 +235,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         default_wh = Path(__file__).resolve().parent / "wheels"
         if default_wh.is_dir():
             wheelhouse = str(default_wh)
+
+    wheel_path = Path(wheelhouse).resolve() if wheelhouse else None
+    if wheel_path and not (wheel_path.is_dir() and any(wheel_path.glob("*.whl"))):
+        print(f"Wheelhouse {wheel_path} has no wheels; falling back to network installs")
+        wheel_path = None
+    wheelhouse = str(wheel_path) if wheel_path else None
     auto = args.auto_install or os.getenv("AUTO_INSTALL_MISSING") == "1"
     skip_net_check = args.skip_net_check
     pip_timeout = args.timeout

--- a/tests/test_check_env_wheelhouse.py
+++ b/tests/test_check_env_wheelhouse.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for wheelhouse handling in check_env."""
+
+import subprocess
+
+import check_env
+
+
+def _no_missing(monkeypatch):
+    monkeypatch.setattr(check_env, "REQUIRED", [])
+    monkeypatch.setattr(check_env, "OPTIONAL", [])
+    monkeypatch.setattr(check_env, "warn_missing_core", lambda: [])
+
+
+def test_empty_wheelhouse_fallback(tmp_path, monkeypatch, capsys):
+    """Ensure empty wheelhouse is ignored and network install is used."""
+    _no_missing(monkeypatch)
+    empty = tmp_path / "wheels"
+    empty.mkdir()
+    monkeypatch.setattr(check_env, "has_network", lambda: True)
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "", ""))
+    rc = check_env.main(["--auto-install", "--wheelhouse", str(empty)])
+    out = capsys.readouterr().out.lower()
+    assert rc == 0
+    assert "falling back to network" in out


### PR DESCRIPTION
## Summary
- skip wheelhouse directories that contain no wheels
- test fallback when wheelhouse is empty

## Testing
- `pre-commit run --files check_env.py tests/test_check_env_wheelhouse.py` *(failed: proto verification and requirements lock hooks)*
- `python check_env.py --auto-install` *(failed: no network connectivity)*
- `pytest -q tests/test_check_env_wheelhouse.py::test_empty_wheelhouse_fallback` *(skipped: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852ee6629108333b1b01658a1164fd7