### PR TITLE
[alpha_factory] add offline llama cli test

### DIFF
--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -344,3 +344,33 @@ def test_foresight_evaluate_nonzero_metrics() -> None:
     scores = foresight_evaluate(repo)
     assert scores["rmse"] > 0
     assert scores["lead_time"] != 0
+
+
+def test_simulate_llama_model_path_forecast_table(tmp_path: Path) -> None:
+    """Ensure simulate prints a table with a local Llama model."""
+    cli_mod = pytest.importorskip(
+        "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli"
+    )
+
+    dummy = tmp_path / "weights.bin"
+    dummy.touch()
+
+    runner = CliRunner()
+    with patch.object(cli_mod, "asyncio"), patch.object(
+        cli_mod.orchestrator,
+        "Orchestrator",
+    ):
+        res = runner.invoke(
+            cli_mod.main,
+            [
+                "simulate",
+                "--horizon",
+                "1",
+                "--llama-model-path",
+                str(dummy),
+                "--offline",
+            ],
+        )
+
+    assert res.exit_code == 0
+    assert "year" in res.output and "capability" in res.output


### PR DESCRIPTION
## Summary
- ensure simulate prints forecast table when using local Llama models

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy, yaml, pandas missing)*
- `python check_env.py --auto-install` *(fails: no network/wheelhouse)*
- `pre-commit run --files tests/test_demo_cli.py` *(fails: environment setup interrupted)*
- `pytest -q tests/test_demo_cli.py::test_simulate_llama_model_path_forecast_table` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852f39426a48333851bccc2fb7d0399