### PR TITLE
[alpha_factory] add disclaimer endpoint

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, List, Set, TYPE_CHECKING, Literal
 
 from cachetools import TTLCache  # type: ignore[import-not-found]
+from .cli import DISCLAIMER
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from typing import Protocol
@@ -49,7 +50,12 @@ try:
     from fastapi import FastAPI, HTTPException, WebSocket, Request, Depends
     from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
     from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-    from starlette.responses import Response, PlainTextResponse, JSONResponse
+    from starlette.responses import (
+        Response,
+        PlainTextResponse,
+        JSONResponse,
+        HTMLResponse,
+    )
     from fastapi.staticfiles import StaticFiles
     from fastapi.middleware.cors import CORSMiddleware
     from pydantic import BaseModel, Field
@@ -445,6 +451,15 @@ if app is not None:
             pass
         finally:
             _progress_ws.discard(websocket)
+
+    @app.get("/", include_in_schema=False)
+    async def root(request: Request) -> Response:
+        """Return the project disclaimer."""
+
+        accept = request.headers.get("accept", "").lower()
+        if "text/html" in accept:
+            return HTMLResponse(f"<p>{DISCLAIMER}</p>")
+        return PlainTextResponse(DISCLAIMER)
 
     # Serve the minimal React dashboard bundled with this demo
     web_dist = Path(__file__).resolve().parent / "web_client" / "dist"

--- a/tests/test_insight_api_server.py
+++ b/tests/test_insight_api_server.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Insight demo API server."""
+
+import importlib
+import os
+from typing import Any, cast
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli import (
+    DISCLAIMER,
+)
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    os.environ.setdefault("API_TOKEN", "test-token")
+    os.environ.setdefault("API_RATE_LIMIT", "1000")
+    api = importlib.reload(api_server)
+    return TestClient(cast(Any, api.app))
+
+
+def test_root_disclaimer_plain(client: TestClient) -> None:
+    """Plain text disclaimer is returned by default."""
+
+    r = client.get("/")
+    assert r.status_code == 200
+    assert r.text.strip() == DISCLAIMER
+
+
+def test_root_disclaimer_html(client: TestClient) -> None:
+    """HTML disclaimer is returned when requested."""
+
+    r = client.get("/", headers={"Accept": "text/html"})
+    assert r.status_code == 200
+    assert DISCLAIMER in r.text
+    assert r.headers.get("content-type", "").startswith("text/html")
+


### PR DESCRIPTION
## Summary
- add root disclaimer route to alpha_agi_insight_v1 api
- test plain text and HTML disclaimer responses

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py tests/test_insight_api_server.py` *(failed: Interrupted while initializing semgrep)*
- `python check_env.py --auto-install` *(failed: no wheelhouse & no network)*
- `pytest -q tests/test_insight_api_server.py` *(failed: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852fa7bdcd083339236933785f4efb3