### PR TITLE
[alpha_factory] warn on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ pip install -r requirements.lock
 docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 
 # The `alpha-factory` CLI also works when the package is installed:
+# A short warning is printed before startup.
 #   pip install -e .
 #   alpha-factory --list-agents
 #   alpha-asi-demo --demo   # launch the α‑ASI world‑model UI
@@ -1159,6 +1160,7 @@ The repository bundles a lightweight `edge_runner.py` helper for running
 Alpha‑Factory on air‑gapped or resource‑constrained devices. The script
 forwards to `alpha_factory_v1.edge_runner` and exposes additional flags
 like `--cycle`, `--loglevel` and `--version`.
+It prints the same warning as the main CLI before launching.
 
 Build the demo containers locally:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -43,6 +43,8 @@ DISCLAIMER = (
     "research prototype. Use at your own risk."
 )
 
+__all__ = ["DISCLAIMER", "DisclaimerGroup"]
+
 
 class DisclaimerGroup(click.Group):
     """Group that prints a short disclaimer before any output."""

--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -23,6 +23,9 @@ from typing import Callable
 
 from alpha_factory_v1 import run as af_run, __version__
 from alpha_factory_v1.utils.env import _env_int
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli import (
+    DISCLAIMER,
+)
 from src.utils.config import init_config
 
 log = logging.getLogger(__name__)
@@ -122,6 +125,7 @@ def main() -> None:
     flags.
     """
 
+    print(DISCLAIMER)
     init_config()
     args = parse_args()
 
@@ -152,7 +156,7 @@ def main() -> None:
 
     os.environ.setdefault("PGHOST", "sqlite")
 
-    af_run.run()
+    af_run.run(show_disclaimer=False)
 
 
 if __name__ == "__main__":

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -5,6 +5,10 @@ import os
 import argparse
 from pathlib import Path
 
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli import (
+    DISCLAIMER,
+)
+
 from .utils.env import _load_env_file
 
 from .scripts.preflight import main as preflight_main
@@ -64,9 +68,11 @@ def apply_env(args: argparse.Namespace) -> None:
         os.environ["LOGLEVEL"] = args.loglevel.upper()
 
 
-def run() -> None:
+def run(show_disclaimer: bool = True) -> None:
     """Entry point used by the ``alpha-factory`` console script."""
     args = parse_args()
+    if show_disclaimer:
+        print(DISCLAIMER)
     if args.version:
         print(__version__)
         return

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ presence of a real general intelligence. Use at your own risk.
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+- `alpha-factory` and `edge_runner.py` now print a short warning before startup.
 - Synced `openai`, `openai-agents` and `uvicorn` pins across requirements files
   and clarified why `requests` and `rich` differ between layers.
 - Documented `API_RATE_LIMIT`, `AGI_ISLAND_BACKENDS` and `ALERT_WEBHOOK_URL`


### PR DESCRIPTION
## Summary
- display shared disclaimer on orchestrator startup
- show warning from edge runner as well
- mention the warning in README
- note the new message in the changelog

## Testing
- `pre-commit run --files alpha_factory_v1/run.py alpha_factory_v1/edge_runner.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py README.md docs/CHANGELOG.md` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852fc34ba8c8333bd73f0268777c564