### PR TITLE
[alpha_factory] update MATS offline setup

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -173,6 +173,18 @@ in the project root when present, so placing your pre-built wheels there
 also works. See
 [docs/OFFLINE_SETUP.md](../../../docs/OFFLINE_SETUP.md) for a summary.
 
+To regenerate the pinned lock file after editing `requirements.txt`, install
+[`pip-tools`](https://pypi.org/project/pip-tools/) and run:
+
+```bash
+pip install pip-tools          # one-time setup
+pip-compile --generate-hashes -o requirements.lock requirements.txt
+```
+
+Run `python scripts/verify_mats_requirements_lock.py` to confirm the lock file
+matches `requirements.txt` (the pre-commit hook invokes this helper
+automatically).
+
 ### Environment variables
 The demo consults a few environment variables when choosing a rewrite strategy
 and model. Set these if you do not pass ``--rewriter`` or ``--model`` on the


### PR DESCRIPTION
## Summary
- mention `pip-tools` and helper script in MATS offline setup

## Testing
- `pre-commit run verify-mats-demo-lock --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md` *(fails: Could not find a version that satisfies the requirement fastapi<1.0,>=0.111)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_685309de1758833383b3ed3ac06f946e