### PR TITLE
[alpha_factory] add offline mode notice

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
@@ -38,6 +38,16 @@
     "fi\n",
     "pip -q install -r requirements.txt\n",
     "python ../../check_env.py --auto-install || true\n",
+    "python - <<'PY'\n",
+    "import importlib.util, os\n",
+    "pkgs=['openai_agents','google_adk']\n",
+    "found=[p for p in pkgs if importlib.util.find_spec(p)]\n",
+    "keys=[k for k in ('OPENAI_API_KEY','ANTHROPIC_API_KEY') if os.getenv(k)]\n",
+    "if found or keys:\n",
+    "    print('\\n\u001b[92mOptional packages: '+', '.join(found or ['none'])+'; API keys: '+', '.join(keys or ['none'])+'\u001b[0m\\n')\n",
+    "else:\n",
+    "    print('\\n\u001b[93mOffline mode: missing optional packages and API keys\u001b[0m\\n')\n",
+    "PY\n",
     "python run_demo.py --episodes 10 --rewriter openai\n"
    ]
   },


### PR DESCRIPTION
## Summary
- add a quick check for optional packages and API keys
- print a colorized offline mode message when missing

## Testing
- `python check_env.py --auto-install --skip-net-check --allow-basic-fallback`
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb` *(fails: proto-verify missing)*
- `pytest -q` *(failed: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_685376f917b08333a1f3cd2e1e9a56a6