### PR TITLE
[alpha_factory] bump openai-agents version references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Python must report 3.11 or 3.12 and Docker Compose must be at least 2.5.
   pip install -U pip
   ```
 - The script `alpha_factory_v1/scripts/preflight.py` enforces this requirement.
-- It verifies the optional `openai_agents` package is at least version `0.0.14`
+- It verifies the optional `openai_agents` package is at least version `0.0.17`
   when installed.
 - Run `./codex/setup.sh` from the repository root to install the project in editable mode with minimal runtime dependencies. The script installs `pre-commit` and sets up the git hook automatically. Execute it before contributing so all relative paths resolve correctly.
 - After installation, run `pre-commit run --all-files` once to verify formatting and hooks.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 # install Python dependencies
 COPY alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock /tmp/requirements.lock
 RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock
-RUN pip install --no-cache-dir "openai_agents>=0.0.14"
+RUN pip install --no-cache-dir "openai_agents>=0.0.17"
 
 # copy minimal package files for the Insight demo
 RUN mkdir -p alpha_factory_v1/demos

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -265,7 +265,7 @@ python ../../../check_env.py --auto-install
 ```
 
 `check_env.py` ensures the optional **`openai-agents`** package is at least
-version `0.0.14`. Verify manually with:
+version `0.0.17`. Verify manually with:
 
 ```bash
 python -c "import openai_agents, pkgutil; print(openai_agents.__version__)"

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -117,7 +117,7 @@ Install them all at once with:
 pip install -r requirements-demo.txt
 ```
 The `requirements-demo.txt` file installs these extras, including
-`openai>=1.82.0,<2.0` and `openai-agents>=0.0.16`.
+`openai>=1.82.0,<2.0` and `openai-agents>=0.0.17`.
 
 or install the packages individually.
 

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -61,10 +61,10 @@ pytest -m 'not e2e'
 ### Optional `openai-agents`
 
 For narrated actions and tool calls, install `openai-agents` version
-`>=0.0.16`:
+`>=0.0.17`:
 
 ```bash
-pip install -U 'openai-agents>=0.0.16'
+pip install -U 'openai-agents>=0.0.17'
 ```
 
 Leaving `OPENAI_API_KEY` empty keeps the demo offline and falls back to

--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -119,7 +119,7 @@ Python standard library.
   pip install -r requirements-demo.txt
   ```
   This installs optional packages like `openai>=1.82.0,<2.0` and
-  `openai-agents>=0.0.16` used by the Agents bridge.
+  `openai-agents>=0.0.17` used by the Agents bridge.
   See [tests/README.md](../../../tests/README.md) for full instructions.
 
 ### 9 · Running the Demo

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -35,7 +35,7 @@ else:
 MIN_PY = (3, 11)
 MAX_PY = (3, 13)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
-MIN_OPENAI_AGENTS_VERSION = "0.0.14"
+MIN_OPENAI_AGENTS_VERSION = "0.0.17"
 DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "python:3.11-slim")
 
 COLORS = {


### PR DESCRIPTION
## Summary
- sync docs and scripts with openai-agents 0.0.17

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: environment check failed)*
- `pre-commit run --files AGENTS.md Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/README.md alpha_factory_v1/demos/solving_agi_governance/README.md alpha_factory_v1/demos/cross_industry_alpha_factory/README.md alpha_factory_v1/demos/muzero_planning/README.md alpha_factory_v1/scripts/preflight.py` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68537c7a21088333a85880508b6488cc