### PR TITLE
[alpha_factory] extend wheelhouse script

### DIFF
--- a/tools/build_wheelhouse.sh
+++ b/tools/build_wheelhouse.sh
@@ -10,4 +10,10 @@ cd "$REPO_ROOT"
 mkdir -p wheels
 pip wheel -r requirements.lock -w wheels
 pip wheel -r requirements-dev.txt -w wheels
+pip wheel -r requirements-demo.lock -w wheels
+
+# Build wheels for each demo if a lock file exists
+while IFS= read -r -d '' req_file; do
+    pip wheel -r "$req_file" -w wheels
+done < <(find alpha_factory_v1/demos -name requirements.lock -print0 | sort -z)
 


### PR DESCRIPTION
## Summary
- build wheels from requirements-demo.lock
- iterate over each demo requirements.lock to include them in the wheelhouse

## Testing
- `pre-commit run --files tools/build_wheelhouse.sh` *(all hooks skipped)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: no wheelhouse)*
- `pytest -q` *(failed: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68537f1553548333b49c72fca0c5a606