### PR TITLE
[alpha_factory] use logging in demo modules

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -12,9 +12,13 @@ from __future__ import annotations
 import os
 import argparse
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 from typing import cast
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
 
@@ -28,7 +32,7 @@ def verify_env() -> None:
 
         check_env.main([])
     except Exception as exc:  # pragma: no cover - best effort
-        print(f"Environment verification failed: {exc}")
+        logger.warning("Environment verification failed: %s", exc)
 
 
 if __package__ is None:  # pragma: no cover - allow direct execution
@@ -146,11 +150,11 @@ if has_oai:
                 adk_bridge.auto_register([agent])
                 adk_bridge.maybe_launch()
             else:
-                print("ADK gateway disabled.")
+                logger.info("ADK gateway disabled.")
         except Exception as exc:  # pragma: no cover - ADK optional
-            print(f"ADK bridge unavailable: {exc}")
+            logger.warning("ADK bridge unavailable: %s", exc)
 
-        print("Registered MATSAgent with runtime")
+        logger.info("Registered MATSAgent with runtime")
         runtime.run()
 
 else:
@@ -226,7 +230,7 @@ def main(argv: list[str] | None = None) -> None:
         verify_env()
 
     if not has_oai:
-        print("openai-agents package is missing. Running offline demo...")
+        logger.info("openai-agents package is missing. Running offline demo...")
         run(
             episodes=args.episodes,
             target=args.target,

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import logging
 import os
 import random
 import sys
@@ -12,22 +13,25 @@ import pathlib
 from pathlib import Path
 from typing import Any, List, Optional, cast
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 if __package__ is None:  # pragma: no cover - allow execution via `python run_demo.py`
     # Add repository root so package imports resolve when executed directly
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
     __package__ = "alpha_factory_v1.demos.meta_agentic_tree_search_v0"
 
 if importlib.util.find_spec("yaml"):
-    import yaml as yaml_module
+    import yaml as yaml_module  # type: ignore
 
     yaml: Any | None = yaml_module
 else:  # pragma: no cover - fallback parser
     yaml = None
 
-from .mats.tree import Node, Tree
-from .mats.meta_rewrite import meta_rewrite, openai_rewrite, anthropic_rewrite
-from .mats.evaluators import evaluate
-from .mats.env import NumberLineEnv, LiveBrokerEnv
+from .mats.tree import Node, Tree  # noqa: E402
+from .mats.meta_rewrite import meta_rewrite, openai_rewrite, anthropic_rewrite  # noqa: E402
+from .mats.evaluators import evaluate  # noqa: E402
+from .mats.env import NumberLineEnv, LiveBrokerEnv  # noqa: E402
 
 
 def verify_environment() -> None:
@@ -37,9 +41,9 @@ def verify_environment() -> None:
 
         check_env.main([])
     except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover - optional helper
-        print(f"Environment verification failed: {exc}")
+        logger.warning("Environment verification failed: %s", exc)
     except Exception as exc:
-        print(f"Unexpected error during environment verification: {exc}")
+        logger.warning("Unexpected error during environment verification: %s", exc)
         raise
 
 
@@ -115,12 +119,12 @@ def run(
         child = Node(improved, reward=reward)
         tree.add_child(node, child)
         tree.backprop(child)
-        print(f"Episode {_+1:>3}: candidate {improved} → reward {reward:.3f}")
+        logger.info("Episode %3d: candidate %s → reward %.3f", _ + 1, improved, reward)
         if log_fh:
             log_fh.write(f"{_+1},{improved},{reward:.6f}\n")
     best = tree.best_leaf()
     score = best.reward / (best.visits or 1)
-    print(f"Best agents: {best.agents} score: {score:.3f}")
+    logger.info("Best agents: %s score: %.3f", best.agents, score)
     if log_fh:
         log_fh.write(f"best,{best.agents},{score:.6f}\n")
         log_fh.close()

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -24,7 +24,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_run_demo_openai_rewriter(self) -> None:
         result = subprocess.run(
@@ -41,7 +41,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_run_demo_anthropic_rewriter(self) -> None:
         result = subprocess.run(
@@ -58,7 +58,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_env_rollout(self) -> None:
         from alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats.env import (
@@ -118,7 +118,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_run_demo_with_seed(self) -> None:
         result = subprocess.run(
@@ -135,7 +135,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_run_demo_verify_env(self) -> None:
         result = subprocess.run(
@@ -151,7 +151,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_run_demo_market_data(self) -> None:
         import tempfile
@@ -173,7 +173,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_bridge_fallback(self) -> None:
         result = subprocess.run(
@@ -192,7 +192,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("offline demo", result.stdout.lower())
+        self.assertIn("offline demo", result.stderr.lower())
 
     def test_bridge_run_search_helper(self) -> None:
         import asyncio
@@ -265,7 +265,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Best agents", result.stdout)
+        self.assertIn("Best agents", result.stderr)
 
     def test_bridge_enable_adk(self) -> None:
         """Bridge accepts the --enable-adk flag."""
@@ -285,7 +285,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
 
 
-def test_bridge_online_mode(monkeypatch) -> None:
+def test_bridge_online_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("openai_agents")
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     result = subprocess.run(
@@ -302,7 +302,7 @@ def test_bridge_online_mode(monkeypatch) -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
-    assert "Best agents" in result.stdout
+    assert "Best agents" in result.stderr
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- switch run_demo and bridge helper to logging
- log to stderr instead of printing
- update tests to check stderr

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: skipped due to environment check)*
- `mypy alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py tests/test_meta_agentic_tree_search_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_685387307210833393c9be678eef31e7