### PR TITLE
[alpha_factory] Clarify API key instructions in tree search notebook

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -234,7 +234,7 @@ configured, falling back to the offline rewriter otherwise.
 ### Notebook quick start
 1. Click the “Open In Colab” badge at the top of this document.
 2. Execute the first cell to clone the repository and install dependencies.
-3. Optionally provide `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` values in the second cell.
+3. Optionally provide `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` values in the second cell. Leave the variable unset if you don't have a key.
 4. Run the demo cell to launch the search loop.
 5. Optionally invoke `openai_agents_bridge.py --verify-env` from a new cell to confirm your runtime.
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "import os\nos.environ['OPENAI_API_KEY'] = ''\nos.environ['OPENAI_MODEL'] = 'gpt-4o'"
+   "source": "import os\n# Set your API keys if available. Leave unset if none.\n# os.environ['OPENAI_API_KEY'] = 'sk-...'\n# os.environ['ANTHROPIC_API_KEY'] = 'sk-ant-...'\nos.environ['OPENAI_MODEL'] = 'gpt-4o'"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- clarify how to set API keys in `colab_meta_agentic_tree_search.ipynb`
- note leaving the key variable unset in the notebook quick start docs

## Testing
- `pre-commit` *(failed: KeyboardInterrupt while downloading semgrep)*
- `pytest -q` *(failed: environment check requires network or wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_68538e00d2b483338de5d5617295c75b