### PR TITLE
[alpha_factory] add deterministic seed test

### DIFF
--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -137,6 +137,29 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Best agents", result.stderr)
 
+    def test_run_demo_seed_repeat(self) -> None:
+        """Running the demo twice with the same seed yields identical results."""
+        cmd = [
+            sys.executable,
+            "-m",
+            "alpha_factory_v1.demos.meta_agentic_tree_search_v0.run_demo",
+            "--episodes",
+            "2",
+            "--seed",
+            "321",
+        ]
+
+        first = subprocess.run(cmd, capture_output=True, text=True)
+        second = subprocess.run(cmd, capture_output=True, text=True)
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+
+        first_line = [l for l in first.stderr.splitlines() if "Best agents" in l][-1]
+        second_line = [l for l in second.stderr.splitlines() if "Best agents" in l][-1]
+
+        self.assertEqual(first_line, second_line)
+
     def test_run_demo_verify_env(self) -> None:
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary
- test that the meta-agentic tree search demo is deterministic when run with the same seed

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: Wheelhouse has no wheels; network unreachable)*
- `pytest -q tests/test_meta_agentic_tree_search_demo.py::TestMetaAgenticTreeSearchDemo::test_run_demo_seed_repeat` *(fails: Environment check failed)*


------
https://chatgpt.com/codex/tasks/task_e_68538f67c02883339df5276d2e93d575