### PR TITLE
[alpha_factory] include MATS demo packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ packages = [
     "src",
     "src.interface",
     "src.interface.web_client",
+    "alpha_factory_v1.demos.meta_agentic_tree_search_v0",
+    "alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary
- include the meta_agentic_tree_search_v0 modules in the setuptools package list

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: Wheelhouse /workspace/AGI-Alpha-Agent-v0/wheels has no wheels; falling back to network installs)*
- `pip install -e .`
- `pre-commit run --files pyproject.toml` *(failed: verify-requirements-lock)*
- `pytest -q` *(failed: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6853fee14bc08333ad244fa14934f17b