### PR TITLE
[alpha_factory] move demo logging config

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py
@@ -17,7 +17,6 @@ import sys
 from pathlib import Path
 from typing import cast
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o")
@@ -192,6 +191,7 @@ else:
 
 
 def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="OpenAI Agents bridge for MATS")
     parser.add_argument("--episodes", type=int, default=10, help="Search episodes when offline")
     parser.add_argument("--target", type=int, default=5, help="Target integer when offline")

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py
@@ -13,7 +13,6 @@ import pathlib
 from pathlib import Path
 from typing import Any, List, Optional, cast
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 if __package__ is None:  # pragma: no cover - allow execution via `python run_demo.py`
@@ -150,6 +149,7 @@ def load_config(path: Path) -> dict[str, Any]:
 
 
 def main(argv: List[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="Run the Meta-Agentic Tree Search demo")
     parser.add_argument("--episodes", type=int, help="Number of search iterations")
     parser.add_argument("--config", type=Path, default=Path("configs/default.yaml"), help="YAML configuration")


### PR DESCRIPTION
## Summary
- avoid side effects when importing the MATS demo modules
- configure logging inside `main()`

## Testing
- `pre-commit run black --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py`
- `pre-commit run ruff-format --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py`
- `pre-commit run ruff --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py`
- `pre-commit run flake8 --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py`
- `pre-commit run mypy --files alpha_factory_v1/demos/meta_agentic_tree_search_v0/run_demo.py alpha_factory_v1/demos/meta_agentic_tree_search_v0/openai_agents_bridge.py`
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854016a122083338e576973a98bd942