### PR TITLE
[alpha_factory] Document offline wheelhouse usage

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -80,7 +80,14 @@ Run these commands before executing the suite:
 ```bash
 python scripts/check_python_deps.py
 python check_env.py --auto-install  # add --wheelhouse <dir> when offline
+# offline example using the bundled wheelhouse
+export WHEELHOUSE=$(pwd)/wheels
+python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 ```
+
+When working offline, always export `WHEELHOUSE=$(pwd)/wheels` and run
+`python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` before executing
+`pytest`. This matches the instructions in [AGENTS.md](../AGENTS.md).
 
 `check_python_deps.py` frequently reports missing modules such as `numpy`, `yaml`
 and `pandas`. Always run `python check_env.py --auto-install` after this check


### PR DESCRIPTION
## Summary
- clarify offline setup in `tests/README.md`

## Testing
- `pre-commit run --files tests/README.md` *(fails: proto-verify, verify-requirements-lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` *(fails: wheelhouse empty)*
- `pytest -k test_no_network -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_685405d5c0d8833380410930812df6c2