### PR TITLE
[alpha_factory] add license headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 FROM python:3.11-slim
 
 # install build tools and pnpm for the React UI

--- a/sandbox.Dockerfile
+++ b/sandbox.Dockerfile
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 FROM python:3.11-slim
 RUN apt-get update && apt-get install -y --no-install-recommends patch \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX headers to `Dockerfile` and `sandbox.Dockerfile`

## Testing
- `pre-commit run --files Dockerfile sandbox.Dockerfile` *(fails: Makefile:26: *** missing separator.  Stop.)*
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(fails: no network connectivity)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68540afc1e948333bb65fa892f751af6