### PR TITLE
[alpha_factory] add license headers to service worker

### DIFF
--- a/src/interface/web_client/dist/service-worker.js
+++ b/src/interface/web_client/dist/service-worker.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 importScripts('workbox-sw.js');
 
 workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);

--- a/src/interface/web_client/src/sw.js
+++ b/src/interface/web_client/src/sw.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 /* eslint-disable no-restricted-globals */
 importScripts('workbox-sw.js');
 import {precacheAndRoute} from 'workbox-precaching';


### PR DESCRIPTION
## Summary
- add Apache-2.0 license header to service worker build artifact
- add license header to service worker source file

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network connectivity)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files src/interface/web_client/dist/service-worker.js src/interface/web_client/src/sw.js` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68540c5a40fc83338d8620181e856a66