### PR TITLE
[alpha_factory] expand OPA policies

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
@@ -12,7 +12,7 @@ from .base_agent import BaseAgent
 from ..utils import messaging
 from ..utils.logging import Ledger
 from ..utils.tracing import span
-from src.utils.opa_policy import violates_insider_policy
+from src.utils.opa_policy import violates_insider_policy, violates_exfil_policy
 
 
 class SafetyGuardianAgent(BaseAgent):
@@ -40,7 +40,7 @@ class SafetyGuardianAgent(BaseAgent):
             text_parts = [str(v) for v in env.payload.values() if isinstance(v, str)]
             text = " ".join(text_parts)
             status = "ok"
-            if "import os" in code or violates_insider_policy(text):
+            if "import os" in code or violates_insider_policy(text) or violates_exfil_policy(text):
                 status = "blocked"
             payload = dict(env.payload)
             payload["status"] = status

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project are documented in this file.
 - Documented how to build a wheelhouse for offline installs and updated
   `tests/README.md` with the instructions.
 - Removed outdated `OPENAI_CONTEXT_WINDOW` reference from the self-healing repo demo.
+
+## [1.0.3] - 2025-07-10
+- Extended OPA rules to block additional finance domains and detect exfiltration commands.
+- Documented policy update workflow in `docs/POLICY_RUNBOOK.md`.
 - Added CI workflow running lint, type checks, tests and Docker build with
   automated image deployment on tags and rollback on failure. Metrics are
   exported via OpenTelemetry and can be viewed in Grafana or the Streamlit

--- a/docs/POLICY_RUNBOOK.md
+++ b/docs/POLICY_RUNBOOK.md
@@ -21,6 +21,19 @@ simulation step that runs longer than the configured timeout to avoid runaway lo
 Policy changes and new agents require human code review before promotion. Features are
 verified in a staging environment with tests and manual inspection.
 
+## Policy Updates & Testing
+
+Rego policies live under `policies/`. After editing any `.rego` file, run:
+
+```bash
+pre-commit run --files policies/<file>.rego src/utils/opa_policy.py
+python check_env.py --auto-install
+pytest -q
+```
+
+The hooks ensure pattern updates load correctly and unit tests exercise the new
+rules. Document notable policy changes in `docs/CHANGELOG.md`.
+
 ## Rollback
 
 `git tag stable` tracks the last known good release. If a new deployment fails, check out

--- a/policies/deny_exfil.rego
+++ b/policies/deny_exfil.rego
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+package exfil
+
+# Block suspicious data exfiltration commands
+
+deny[msg] {
+    re_match("(?i)curl\\s+https?://", input.text)
+    msg := "exfiltration attempt blocked"
+}
+
+deny[msg] {
+    re_match("(?i)scp\\s", input.text)
+    msg := "exfiltration attempt blocked"
+}

--- a/policies/deny_finance.rego
+++ b/policies/deny_finance.rego
@@ -4,7 +4,10 @@ package codegen
 banned_hosts = {
     "api.alpaca.markets",
     "api.binance.com",
-    "api.polygon.io"
+    "api.polygon.io",
+    "api.kraken.com",
+    "api.coinbase.com",
+    "api.gemini.com"
 }
 
 deny[msg] {

--- a/src/utils/opa_policy.py
+++ b/src/utils/opa_policy.py
@@ -18,7 +18,7 @@ def _load_banned_hosts() -> set[str]:
     m = re.search(r"banned_hosts\s*=\s*{([^}]*)}", text, re.DOTALL)
     if not m:
         return set()
-    hosts = [h.strip().strip('"') for h in m.group(1).split(',') if h.strip()]
+    hosts = [h.strip().strip('"') for h in m.group(1).split(",") if h.strip()]
     return set(hosts)
 
 
@@ -37,6 +37,18 @@ def _load_insider_patterns() -> list[str]:
 _INSIDER_RE = [re.compile(pat, re.IGNORECASE) for pat in _load_insider_patterns()]
 
 
+def _load_exfil_patterns() -> list[str]:
+    policy_path = _POLICY_DIR / "deny_exfil.rego"
+    try:
+        text = policy_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    return re.findall(r're_match\("([^"]+)",\s*input.text\)', text)
+
+
+_EXFIL_RE = [re.compile(pat, re.IGNORECASE) for pat in _load_exfil_patterns()]
+
+
 def violates_finance_policy(code: str) -> bool:
     """Return ``True`` if ``code`` references a banned finance API host."""
     for host in _BANNED_HOSTS:
@@ -48,6 +60,14 @@ def violates_finance_policy(code: str) -> bool:
 def violates_insider_policy(text: str) -> bool:
     """Return ``True`` if ``text`` matches the insider trading policy."""
     for pat in _INSIDER_RE:
+        if pat.search(text):
+            return True
+    return False
+
+
+def violates_exfil_policy(text: str) -> bool:
+    """Return ``True`` if ``text`` matches exfiltration patterns."""
+    for pat in _EXFIL_RE:
         if pat.search(text):
             return True
     return False


### PR DESCRIPTION
## Summary
- block several new finance APIs and exfiltration commands
- check for exfiltration in the SafetyGuardianAgent
- document how to update and test Rego policies

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py docs/CHANGELOG.md docs/POLICY_RUNBOOK.md policies/deny_finance.rego policies/deny_exfil.rego src/utils/opa_policy.py` *(fails: proto-verify, requirements lock)*
- `pytest -q` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854287350dc833391e5347269bdd328