### PR TITLE
[alpha_factory] refine request type hints

### DIFF
--- a/alpha_factory_v1/af_requests.py
+++ b/alpha_factory_v1/af_requests.py
@@ -9,6 +9,7 @@ tests and demos.  Only the most common HTTP verbs and features are supported.
 from __future__ import annotations
 
 import json as _json
+from typing import Any, Mapping
 from urllib import error as _error
 from urllib import parse as _parse
 from urllib import request as _request
@@ -31,10 +32,16 @@ class Timeout(RequestException):
 class Response:
     """Lightweight HTTP response container."""
 
-    def __init__(self, status_code: int, content: bytes, headers: dict | None = None, url: str = "") -> None:
+    def __init__(
+        self,
+        status_code: int,
+        content: bytes,
+        headers: Mapping[str, str] | None = None,
+        url: str = "",
+    ) -> None:
         self.status_code = status_code
         self.content = content
-        self.headers = headers or {}
+        self.headers: dict[str, str] = dict(headers) if headers is not None else {}
         self.url = url
 
     @property
@@ -44,7 +51,7 @@ class Response:
         except UnicodeDecodeError:
             return self.content.decode("latin1", errors="replace")
 
-    def json(self):
+    def json(self) -> Any:
         return _json.loads(self.text)
 
     @property
@@ -60,10 +67,10 @@ def _call(
     method: str,
     url: str,
     *,
-    params: dict | None = None,
-    json: dict | None = None,
-    data: dict | bytes | None = None,
-    headers: dict | None = None,
+    params: Mapping[str, str] | None = None,
+    json: Mapping[str, Any] | None = None,
+    data: Mapping[str, str] | bytes | None = None,
+    headers: Mapping[str, str] | None = None,
     timeout: float | None = None,
 ) -> Response:
     if params:
@@ -101,8 +108,8 @@ def _call(
 def get(
     url: str,
     *,
-    params: dict | None = None,
-    headers: dict | None = None,
+    params: Mapping[str, str] | None = None,
+    headers: Mapping[str, str] | None = None,
     timeout: float | None = None,
 ) -> Response:
     """Perform a simple HTTP GET request."""
@@ -112,10 +119,10 @@ def get(
 def post(
     url: str,
     *,
-    params: dict | None = None,
-    json: dict | None = None,
-    data: dict | bytes | None = None,
-    headers: dict | None = None,
+    params: Mapping[str, str] | None = None,
+    json: Mapping[str, Any] | None = None,
+    data: Mapping[str, str] | bytes | None = None,
+    headers: Mapping[str, str] | None = None,
     timeout: float | None = None,
 ) -> Response:
     """Perform a minimal HTTP POST request."""
@@ -133,10 +140,10 @@ def post(
 def put(
     url: str,
     *,
-    params: dict | None = None,
-    json: dict | None = None,
-    data: dict | bytes | None = None,
-    headers: dict | None = None,
+    params: Mapping[str, str] | None = None,
+    json: Mapping[str, Any] | None = None,
+    data: Mapping[str, str] | bytes | None = None,
+    headers: Mapping[str, str] | None = None,
     timeout: float | None = None,
 ) -> Response:
     """HTTP PUT request."""
@@ -154,8 +161,8 @@ def put(
 def delete(
     url: str,
     *,
-    params: dict | None = None,
-    headers: dict | None = None,
+    params: Mapping[str, str] | None = None,
+    headers: Mapping[str, str] | None = None,
     timeout: float | None = None,
 ) -> Response:
     """HTTP DELETE request."""


### PR DESCRIPTION
## Summary
- refine typing in `alpha_factory_v1/af_requests.py`
- `Response.headers` is now typed and function arguments use generics

## Testing
- `ruff check alpha_factory_v1/af_requests.py`
- `mypy --strict alpha_factory_v1/af_requests.py`


------
https://chatgpt.com/codex/tasks/task_e_68542cb408fc833392cfef41f1fee0b4