### PR TITLE
[alpha_factory] remove unused imports in tests

### DIFF
--- a/tests/test_aiga_workflow.py
+++ b/tests/test_aiga_workflow.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import socket
 import subprocess

--- a/tests/test_external_integrations.py
+++ b/tests/test_external_integrations.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import importlib
 import types
-from unittest.mock import patch, AsyncMock
-import asyncio
-import os
 import pytest
 
 HAS_OAI = importlib.util.find_spec("openai_agents") or importlib.util.find_spec("agents")
@@ -21,17 +18,18 @@ def test_build_llm_missing_api_key(monkeypatch):
 
     class DummyAgent:
         def __init__(self, *a, base_url=None, **kw):
-            captured['base_url'] = base_url
+            captured["base_url"] = base_url
 
     monkeypatch.setattr(oa, "OpenAIAgent", DummyAgent)
     monkeypatch.setenv("OPENAI_API_KEY", "")
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://testserver")
 
     import importlib as _imp
+
     mod = _imp.reload(_imp.import_module("alpha_factory_v1.demos.aiga_meta_evolution.utils"))
     llm = mod.build_llm()
     assert isinstance(llm, DummyAgent)
-    assert captured.get('base_url') == "http://testserver"
+    assert captured.get("base_url") == "http://testserver"
 
 
 @pytest.mark.skipif(not HAS_ADK, reason="google_adk package not installed")
@@ -54,10 +52,12 @@ def test_adk_auto_register(monkeypatch):
     monkeypatch.setenv("ALPHA_FACTORY_ENABLE_ADK", "true")
 
     import importlib as _imp
+
     bridge = _imp.reload(_imp.import_module("alpha_factory_v1.backend.adk_bridge"))
 
     class Dummy:
         name = "dummy"
+
         def run(self, prompt: str):
             return "ok"
 
@@ -65,9 +65,11 @@ def test_adk_auto_register(monkeypatch):
     assert registered
 
     called = {}
+
     def fake_run(app, host, port, log_level="info", **kw):
-        called['host'] = host
-        called['port'] = port
+        called["host"] = host
+        called["port"] = port
+
     monkeypatch.setattr("uvicorn.run", fake_run)
 
     bridge.maybe_launch(host="127.0.0.1", port=1234)
@@ -84,6 +86,7 @@ def test_adk_auto_register_disabled(monkeypatch):
     class DummyRouter:
         def __init__(self):
             self.app = types.SimpleNamespace(middleware=lambda *_a, **_k: lambda f: f)
+
         def register_agent(self, agent):
             raise AssertionError("should not register")
 
@@ -91,5 +94,6 @@ def test_adk_auto_register_disabled(monkeypatch):
     monkeypatch.delenv("ALPHA_FACTORY_ENABLE_ADK", raising=False)
 
     import importlib as _imp
+
     bridge = _imp.reload(_imp.import_module("alpha_factory_v1.backend.adk_bridge"))
     bridge.auto_register([object()])  # no error

--- a/tests/test_governance_bridge_offline.py
+++ b/tests/test_governance_bridge_offline.py
@@ -5,8 +5,6 @@ import builtins
 import subprocess
 import sys
 
-import pytest
-
 
 def test_governance_bridge_offline(monkeypatch):
     orig_import = builtins.__import__

--- a/tests/test_inspector_bridge_runtime.py
+++ b/tests/test_inspector_bridge_runtime.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import os
-import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -23,15 +22,16 @@ class TestInspectorBridgeRuntime(unittest.TestCase):
     def test_main_registers_agent(self) -> None:
         os.environ["ALPHA_FACTORY_ENABLE_ADK"] = "true"
         from alpha_factory_v1.backend import adk_bridge as _adk_bridge
+
         adk_bridge = importlib.reload(_adk_bridge)
 
         runtime = MagicMock()
-        with patch("openai_agents.AgentRuntime", return_value=runtime) as rt_cls, \
-                patch.object(adk_bridge, "auto_register") as auto_reg, \
-                patch.object(adk_bridge, "maybe_launch") as maybe_launch:
-            mod = importlib.reload(importlib.import_module(
-                "alpha_factory_v1.demos.alpha_asi_world_model.openai_agents_bridge"
-            ))
+        with patch("openai_agents.AgentRuntime", return_value=runtime) as rt_cls, patch.object(
+            adk_bridge, "auto_register"
+        ) as auto_reg, patch.object(adk_bridge, "maybe_launch") as maybe_launch:
+            mod = importlib.reload(
+                importlib.import_module("alpha_factory_v1.demos.alpha_asi_world_model.openai_agents_bridge")
+            )
             mod.main()
 
             rt_cls.assert_called_once_with(api_key=None)

--- a/tests/test_self_heal_clone.py
+++ b/tests/test_self_heal_clone.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 from types import SimpleNamespace
-from pathlib import Path
 import subprocess
 import importlib
 from alpha_factory_v1.demos.self_healing_repo import agent_selfheal_entrypoint as entrypoint
@@ -13,4 +12,3 @@ def test_clone_sample_repo_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=1))
     entrypoint.clone_sample_repo()
     assert (target / "calc.py").exists()
-

--- a/tests/test_selfheal_entrypoint_offline.py
+++ b/tests/test_selfheal_entrypoint_offline.py
@@ -5,8 +5,6 @@ import importlib
 import sys
 import types
 
-from alpha_factory_v1.demos.self_healing_repo.agent_core import llm_client
-
 
 class DummyBlocks:
     def __init__(self, *a, **k):

--- a/tests/test_world_model_open_endedness.py
+++ b/tests/test_world_model_open_endedness.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import importlib
-import os
 import sys
-from typing import Any
 
 import pytest
 


### PR DESCRIPTION
## Summary
- clean up unused imports across test modules
- run `ruff` to confirm no F401 warnings

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files tests/test_aiga_workflow.py tests/test_external_integrations.py tests/test_governance_bridge_offline.py tests/test_inspector_bridge_runtime.py tests/test_self_heal_clone.py tests/test_selfheal_entrypoint_offline.py tests/test_world_model_open_endedness.py` *(fails: proto-verify hook)*
- `ruff check tests`

------
https://chatgpt.com/codex/tasks/task_e_68542f9575f483338546298266b9fc4f