### PR TITLE
[alpha_factory] build wheelhouse docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -57,9 +57,9 @@ fall back to CPU execution and are automatically skipped when `torch` is
 absent. Other optional packages behave the same way—tests relying on
 `fastapi`, `playwright` or `httpx` use `pytest.importorskip()` so the suite
 continues even in minimal environments.
-6. If the repository includes a `wheels/` directory, set `WHEELHOUSE=$(pwd)/wheels`
-   before running the environment check or tests so packages install from the
-   bundled wheelhouse.
+6. If the repository includes a `wheels/` directory, export
+   `WHEELHOUSE=$(pwd)/wheels` **before running** `python check_env.py --auto-install`
+   and `pytest` so packages install from the bundled wheelhouse.
 7. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 8. Export the wheel cache path and run the environment check before the suite:
    ```bash
@@ -113,12 +113,12 @@ dependencies will cause the suite to skip tests or fail entirely.
 ### Wheelhouse quick start
 
 Build a local wheelhouse and run the environment check with `--wheelhouse` before
-starting the tests:
+starting the tests. The `tools/build_wheelhouse.sh` helper collects wheels for
+`requirements.lock`, `requirements-dev.txt`, `requirements-demo.lock` and each
+demo's lock file:
 
 ```bash
-mkdir -p wheels
-pip wheel -r requirements.lock -w wheels
-pip wheel -r requirements-dev.txt -w wheels
+./tools/build_wheelhouse.sh
 python check_env.py --auto-install --demo macro_sentinel --wheelhouse wheels
 PYTHONPATH=$(pwd) pytest -q
 ```
@@ -129,14 +129,12 @@ about missing modules.
 
 ### Offline quick start
 
-Build wheels on a machine with connectivity and reuse them offline:
+Build wheels on a machine with connectivity and reuse them offline. The easiest
+way is to run `./tools/build_wheelhouse.sh`, which downloads wheels for all
+locked requirements:
 
 ```bash
-mkdir -p wheels
-pip wheel -r alpha_factory_v1/requirements-core.txt -w wheels
-pip wheel -r requirements.txt -w wheels
-pip wheel -r requirements-dev.txt -w wheels
-pip wheel -r alpha_factory_v1/demos/aiga_meta_evolution/requirements.txt -w wheels
+./tools/build_wheelhouse.sh
 ```
 
 Copy the `wheels/` directory to the offline host and set `WHEELHOUSE`:
@@ -153,17 +151,12 @@ tests run without contacting PyPI.
 ### Offline install
 
 Create a wheelhouse so the tests run without contacting PyPI. Build the wheels on
-a machine with connectivity and copy the directory to the offline host. Include
-`requirements.txt` and `requirements-dev.txt` (add the MuZero and Macro Sentinel
-demo requirements if needed):
+a machine with connectivity and copy the directory to the offline host. The
+`tools/build_wheelhouse.sh` script generates all necessary wheels from the lock
+files including the MuZero and Macro Sentinel demos:
 
 ```bash
-mkdir -p wheels
-pip wheel -r alpha_factory_v1/requirements-core.txt -w wheels
-pip wheel -r requirements.txt -w wheels
-pip wheel -r alpha_factory_v1/demos/muzero_planning/requirements.txt -w wheels
-pip wheel -r alpha_factory_v1/demos/macro_sentinel/requirements.txt -w wheels
-pip wheel -r requirements-dev.txt -w wheels
+./tools/build_wheelhouse.sh
 ```
 
 Install and run the tests without contacting PyPI:

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -4,13 +4,13 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 This directory stores prebuilt wheels so the MuZero Planning demo and
 unit tests can run without network access. Build the wheelhouse on a
-machine with connectivity and copy it here:
+machine with connectivity and copy it here. The helper script
+`tools/build_wheelhouse.sh` collects all required wheels from
+`requirements.lock`, `requirements-dev.txt`, `requirements-demo.lock`
+and each demo's `requirements.lock` file:
 
 ```bash
-mkdir -p wheels
-pip wheel -r requirements.lock -w wheels
-pip wheel -r requirements-dev.txt -w wheels
-pip wheel -r alpha_factory_v1/demos/muzero_planning/requirements.txt -w wheels
+./tools/build_wheelhouse.sh
 ```
 
 Set `WHEELHOUSE=$(pwd)/wheels` before running the setup script or tests:


### PR DESCRIPTION
## Summary
- document `tools/build_wheelhouse.sh` in `wheels/README.md`
- clarify how to use the wheelhouse in `tests/README.md`

## Testing
- `python check_env.py --auto-install --wheelhouse $(pwd)/wheels` *(fails: Wheelhouse /workspace/AGI-Alpha-Agent-v0/wheels has no wheels; falling back to network installs)*
- `pytest -q` *(fails: Skipped: Environment check failed, run 'python check_env.py --auto-install')*

------
https://chatgpt.com/codex/tasks/task_e_685431258d3483338ca14d2c4a10f593