### PR TITLE
[alpha_factory] add offline wheel builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,9 @@ Python must report 3.11 or 3.12 and Docker Compose must be at least 2.5.
 
 Follow these steps when installing without internet access:
 
-- Build wheels using the helper script:
+ - Build wheels using the helper script:
   ```bash
-  ./tools/build_wheelhouse.sh
+  ./scripts/build_offline_wheels.sh
   ```
 
 - Generate a deterministic lock file with hashes:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Run `pre-commit run --all-files` after the dependencies finish installing.
 Offline example using a local wheelhouse:
 
 ```bash
-WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./quickstart.sh
+WHEELHOUSE=$(pwd)/wheels AUTO_INSTALL_MISSING=1 ./quickstart.sh
 ```
 
 Or launch the full stack with Docker:
@@ -182,30 +182,28 @@ Follow these steps when working without internet access.
 
 1. **Build a wheelhouse** on a machine with connectivity:
    ```bash
-   mkdir -p /media/wheels
-   pip wheel -r requirements.lock -w /media/wheels
-   pip wheel -r requirements-dev.txt -w /media/wheels
+   ./scripts/build_offline_wheels.sh
+   export WHEELHOUSE="$(pwd)/wheels"
    ```
 
 2. **Install from the wheelhouse** and verify packages. The setup script
    automatically uses a `wheels/` directory in the repository root when
    `WHEELHOUSE` is unset:
    ```bash
-   WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 ./codex/setup.sh
-WHEELHOUSE=/media/wheels AUTO_INSTALL_MISSING=1 \
-  python check_env.py --auto-install --wheelhouse /media/wheels
-  pip check
-```
+   AUTO_INSTALL_MISSING=1 ./codex/setup.sh
+   python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+   pip check
+   ```
   When network access is unavailable, install packages directly from the
   wheelhouse:
 ```bash
-WHEELHOUSE=/media/wheels pip install --no-index --find-links "$WHEELHOUSE" -r requirements.txt
+pip install --no-index --find-links "$WHEELHOUSE" -r requirements.txt
 # Install demo extras offline
-WHEELHOUSE=/media/wheels pip install --no-index --find-links "$WHEELHOUSE" -r \
+pip install --no-index --find-links "$WHEELHOUSE" -r \
   alpha_factory_v1/demos/era_of_experience/requirements.lock
 ```
-  `check_env.py` uses the wheels under `/media/wheels`. Set
-`WHEELHOUSE=/media/wheels` when running `pre-commit` or the tests so
+ `check_env.py` uses the wheels under `$WHEELHOUSE`. Set
+`WHEELHOUSE="$WHEELHOUSE"` when running `pre-commit` or the tests so
 dependencies install from the local cache. See
 [Offline Setup](alpha_factory_v1/scripts/README.md#offline-setup) for more
 details. A short reference lives in
@@ -217,7 +215,7 @@ offline installs.
 Run the environment check again when the machine is completely
 air‑gapped:
 ```bash
-python check_env.py --auto-install --wheelhouse /media/wheels
+python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 ```
 This mirrors the instructions in
 [alpha_factory_v1/scripts/README.md](alpha_factory_v1/scripts/README.md#offline-setup).
@@ -832,9 +830,7 @@ pip install -r requirements.lock
 # (If this fails with a network error, create a wheelhouse and rerun
 #  with --wheelhouse <path> or place the wheels under ./wheels)
 # Build a wheelhouse if the machine has no internet access:
-#   mkdir -p /media/wheels
-#   pip wheel -r requirements.lock -w /media/wheels
-#   pip wheel -r requirements-dev.txt -w /media/wheels
+#   ./scripts/build_offline_wheels.sh
 ./quickstart.sh               # creates venv, installs deps, launches
 # Use `--wheelhouse /path/to/wheels` to install offline packages when
 # the host has no internet access. The setup script automatically
@@ -843,7 +839,7 @@ pip install -r requirements.lock
 # /path/to/wheels` to verify and install packages. The setup script
 # exits with a message if neither network nor a wheelhouse are available.
 # Example offline workflow:
-#   export WHEELHOUSE=/media/wheels
+#   export WHEELHOUSE=$(pwd)/wheels
 #   python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 #   WHEELHOUSE=$WHEELHOUSE ./quickstart.sh
 #   WHEELHOUSE=$WHEELHOUSE pytest -q

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented in this file.
 - Added [`src/tools/analyse_backtrack.py`](../src/tools/analyse_backtrack.py) for visualising archive backtracks.
 - Documented how to build a wheelhouse for offline installs and updated
   `tests/README.md` with the instructions.
+- Added `scripts/build_offline_wheels.sh` to gather wheels for all lock files.
 - Removed outdated `OPENAI_CONTEXT_WINDOW` reference from the self-healing repo demo.
 
 ## [1.0.3] - 2025-07-10

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,10 +27,10 @@ git --version
 Build the wheelhouse before disconnecting from the network:
 
 ```bash
-./tools/build_wheelhouse.sh
+./scripts/build_offline_wheels.sh
 export WHEELHOUSE="$(pwd)/wheels"
 ```
-Use this variable when running `check_env.py --auto-install` and `pytest`.
+Run this script before executing `python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` and `pytest`.
 When no network connection is available, install dependencies from the
 wheel cache with:
 

--- a/scripts/build_offline_wheels.sh
+++ b/scripts/build_offline_wheels.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Collect wheels for offline installation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+mkdir -p wheels
+
+pip wheel -r requirements.lock -w wheels
+pip wheel -r requirements-dev.txt -w wheels
+pip wheel -r requirements-demo.lock -w wheels
+
+# Build wheels for each demo if a lock file exists
+while IFS= read -r -d '' req_file; do
+    pip wheel -r "$req_file" -w wheels
+done < <(find alpha_factory_v1/demos -name requirements.lock -print0 | sort -z)

--- a/tests/README.md
+++ b/tests/README.md
@@ -113,15 +113,16 @@ dependencies will cause the suite to skip tests or fail entirely.
 ### Wheelhouse quick start
 
 Build a local wheelhouse and run the environment check with `--wheelhouse` before
-starting the tests. The `tools/build_wheelhouse.sh` helper collects wheels for
+starting the tests. The `scripts/build_offline_wheels.sh` helper collects wheels for
 `requirements.lock`, `requirements-dev.txt`, `requirements-demo.lock` and each
 demo's lock file:
 
 ```bash
-./tools/build_wheelhouse.sh
+./scripts/build_offline_wheels.sh
 python check_env.py --auto-install --demo macro_sentinel --wheelhouse wheels
 PYTHONPATH=$(pwd) pytest -q
 ```
+Always run `scripts/build_offline_wheels.sh` before executing the environment check and tests.
 
 See [alpha_factory_v1/scripts/README.md](../alpha_factory_v1/scripts/README.md#offline-setup)
 for detailed steps. Skipping these commands typically leads to `pytest` errors
@@ -130,12 +131,14 @@ about missing modules.
 ### Offline quick start
 
 Build wheels on a machine with connectivity and reuse them offline. The easiest
-way is to run `./tools/build_wheelhouse.sh`, which downloads wheels for all
+way is to run `./scripts/build_offline_wheels.sh`, which downloads wheels for all
 locked requirements:
 
 ```bash
-./tools/build_wheelhouse.sh
+./scripts/build_offline_wheels.sh
 ```
+Run this once before calling `check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` or running the tests offline.
+Run this once before invoking `check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` and `pytest`.
 
 Copy the `wheels/` directory to the offline host and set `WHEELHOUSE`:
 
@@ -152,12 +155,13 @@ tests run without contacting PyPI.
 
 Create a wheelhouse so the tests run without contacting PyPI. Build the wheels on
 a machine with connectivity and copy the directory to the offline host. The
-`tools/build_wheelhouse.sh` script generates all necessary wheels from the lock
+`scripts/build_offline_wheels.sh` script generates all necessary wheels from the lock
 files including the MuZero and Macro Sentinel demos:
 
 ```bash
-./tools/build_wheelhouse.sh
+./scripts/build_offline_wheels.sh
 ```
+Run this once before calling `check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` or running the tests offline.
 
 Install and run the tests without contacting PyPI:
 

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -5,13 +5,14 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 This directory stores prebuilt wheels so the MuZero Planning demo and
 unit tests can run without network access. Build the wheelhouse on a
 machine with connectivity and copy it here. The helper script
-`tools/build_wheelhouse.sh` collects all required wheels from
+`scripts/build_offline_wheels.sh` collects all required wheels from
 `requirements.lock`, `requirements-dev.txt`, `requirements-demo.lock`
 and each demo's `requirements.lock` file:
 
 ```bash
-./tools/build_wheelhouse.sh
+./scripts/build_offline_wheels.sh
 ```
+Run this command before executing `python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"` and `pytest`.
 
 Set `WHEELHOUSE=$(pwd)/wheels` before running the setup script or tests:
 


### PR DESCRIPTION
## Summary
- add `build_offline_wheels.sh` to collect wheels
- reference the script in offline setup docs
- document running the script before `check_env.py --auto-install` and tests

## Testing
- `pre-commit` *(failed: could not install hooks)*
- `python check_env.py --auto-install --wheelhouse wheels` *(failed: wheelhouse empty)*
- `pytest -q` *(failed: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68543eaf8acc83338791e3ffc48727c5