### PR TITLE
[alpha_factory] install pre-commit automatically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ Please report security vulnerabilities as described in our [Security Policy](SEC
 - Keep `package-lock.json` under version control so `npm ci` reproduces the same
   dependency tree.
 - Run `python alpha_factory_v1/scripts/preflight.py` to validate these tools.
-- If the `pre-commit` command is missing, run `pip install pre-commit` so the
-  git hooks work correctly.
+- Run `./codex/setup.sh` to install dependencies. The script automatically
+  installs `pre-commit` when missing and sets up the git hook.
 - Install `pytest` and `prometheus_client` using
   `python check_env.py --auto-install` or `pip install pytest prometheus_client`.
 
@@ -257,10 +257,10 @@ for modules, classes and functions.
   consistent style and type safety.
 - Run `mypy --config-file mypy.ini .` (or `pyright`) with a **strict** configuration. The
   `mypy.ini` configuration file is located at the repository root.
-- Install pre‑commit and set up the git hook:
+- Use `pre-commit` for linting and style checks. `./codex/setup.sh` installs it
+  when missing and configures the git hook:
 
 ```bash
-pip install pre-commit
 pre-commit install
 pre-commit run --all-files   # run once after installation
 pre-commit run --files <paths>   # before each commit

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -39,8 +39,10 @@ $PYTHON -m pip install --quiet "${wheel_opts[@]}" --upgrade pip setuptools wheel
 # Install pip-compile (pip-tools) early so hooks can verify lock files
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" pip-tools
 
-# Install pre-commit for git hooks
-$PYTHON -m pip install --quiet "${wheel_opts[@]}" pre-commit
+# Ensure pre-commit is available for git hooks
+if ! command -v pre-commit >/dev/null; then
+  $PYTHON -m pip install --quiet "${wheel_opts[@]}" pre-commit
+fi
 
 # Install package in editable mode
 $PYTHON -m pip install --quiet "${wheel_opts[@]}" -e .
@@ -170,6 +172,8 @@ if [[ "${FETCH_BROWSER_ASSETS:-1}" != "0" ]]; then
   $PYTHON scripts/fetch_assets.py
 fi
 
-# Set up pre-commit hooks
-pre-commit install
+# Set up pre-commit hooks if available
+if command -v pre-commit >/dev/null; then
+  pre-commit install
+fi
 


### PR DESCRIPTION
## Summary
- check if `pre-commit` exists in `codex/setup.sh`
- install and set up the hook when missing
- mention automatic pre-commit install in `AGENTS.md`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network access)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files codex/setup.sh AGENTS.md` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6854414ecc6c8333bdea36bb813bc374