### PR TITLE
[alpha_factory] centralize docs disclaimer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 # Contributor Guide
 

--- a/BACKGROUND.md
+++ b/BACKGROUND.md
@@ -1,9 +1,8 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 
 # **META-AGENTIC** α‑AGI 👁️✨
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice.
 
 **Out‑learn · Out‑think · Out‑design · Out‑strategise · Out‑execute**
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 # Contributor Covenant Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 # Contributing
 

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -1,4 +1,4 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 # Release Checklist
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 
 # **META-AGENTIC** α‑AGI 👁️✨
-
-**Out‑learn · Out‑think · Out‑design · Out‑strategise · Out‑execute**
-
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 **Official and *pioneering* definition – Meta-Agentic (adj.)**: Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents. *The term was **pioneered by [Vincent Boucher](https://www.linkedin.com/in/montrealai/), President of MONTREAL.AI**.*
 
 ```mermaid
@@ -38,12 +36,8 @@ flowchart TD
 ---
 
 ## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
-
-# 🚀 [ 🎖️ α‑AGI Ascension 🌌 ]
 
 ## Humanity’s Structured Rise to Economic Supremacy via Strategic AGI Mastery
 
@@ -423,9 +417,7 @@ curl -X POST http://localhost:8000/simulate \
 ```
 
 ## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 ## Further Reading
 - [docs/DESIGN.md](docs/DESIGN.md) — architecture overview and agent roles.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 # Security Policy
 

--- a/docs/DISCLAIMER_SNIPPET.md
+++ b/docs/DISCLAIMER_SNIPPET.md
@@ -1,0 +1,1 @@
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,7 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See DISCLAIMER_SNIPPET.md](DISCLAIMER_SNIPPET.md)
 
 # Project Documentation
 
-This demo is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the
-presence of a real general intelligence. Use at your own risk.
 
 ## Building the React Dashboard
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+[See ../docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # SPDX-License-Identifier: Apache-2.0
 # 🧪 Root Test Suite


### PR DESCRIPTION
## Summary
- centralize project disclaimer as docs/DISCLAIMER_SNIPPET.md
- reference the snippet from project docs instead of repeating text

## Testing
- `pre-commit run --files AGENTS.md BACKGROUND.md CODE_OF_CONDUCT.md CONTRIBUTING.md LAUNCH.md README.md SECURITY.md docs/README.md tests/README.md docs/DISCLAIMER_SNIPPET.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685445144dec8333bceb07cc01814fb7