### PR TITLE
[alpha_factory] handle missing semgrep binary

### DIFF
--- a/src/interface/api_server.py
+++ b/src/interface/api_server.py
@@ -355,7 +355,9 @@ async def _static_analysis_task() -> None:
     interval = int(os.getenv("STATIC_ANALYSIS_INTERVAL", str(7 * 24 * 3600)))
     semgrep = shutil.which("semgrep")
     if not semgrep:
-        _log.warning("semgrep not installed – static analysis disabled")
+        _log.warning(
+            "semgrep not found. Install with `pip install semgrep` " "or set STATIC_ANALYSIS_INTERVAL=0 to disable"
+        )
         return
     await asyncio.sleep(interval)
     while True:


### PR DESCRIPTION
## Summary
- improve log message when `semgrep` isn't installed

## Testing
- `python scripts/check_python_deps.py` *(fails: missing packages)*
- `python check_env.py --auto-install` *(fails: no network connectivity)*
- `pre-commit run --files src/interface/api_server.py` *(fails: verify-requirements-lock)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_685448b395088333a7b42318942cbc8f