### PR TITLE
[alpha_factory] add disclaimer links

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -1,3 +1,4 @@
+# [See ../../../docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 # API Overview
 
 This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -1,3 +1,4 @@
+# [See ../../../docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 # α‑AGI Insight Docs
 
 Documentation for the α‑AGI Insight demo.


### PR DESCRIPTION
## Summary
- mention the docs disclaimer in demo README
- link to disclaimer snippet from API docs

## Testing
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68544e0ddbb083339c169aaa879c4d0f