### PR TITLE
[alpha_factory] inline disclaimer in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 
 # **META-AGENTIC** α‑AGI 👁️✨
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 **Official and *pioneering* definition – Meta-Agentic (adj.)**: Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents. *The term was **pioneered by [Vincent Boucher](https://www.linkedin.com/in/montrealai/), President of MONTREAL.AI**.*
 
 ```mermaid

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -1,4 +1,4 @@
-# [See ../../../docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 # α‑AGI Insight Docs
 
 Documentation for the α‑AGI Insight demo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-[See DISCLAIMER_SNIPPET.md](DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Project Documentation
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-[See ../docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # SPDX-License-Identifier: Apache-2.0
 # 🧪 Root Test Suite


### PR DESCRIPTION
## Summary
- inline the legal disclaimer instead of linking to `DISCLAIMER_SNIPPET.md`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: Wheelhouse has no wheels)*
- `pytest -q` *(failed: environment check failed)*
- `pre-commit run --files README.md docs/README.md tests/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md` *(failed: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685452e63d148333a72325630e2b0e01