### PR TITLE
[alpha_factory] add wheelhouse note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,26 @@ wheelhouse when offline). Once it succeeds, execute the tests:
 ```bash
 pytest -q
 ```
+
+## Pre-commit Hooks
+
+Install the git hooks once and run them before each commit:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+### Air-Gapped Setup
+
+If `pre-commit` cannot fetch dependencies because the machine has no internet
+access, build a wheelhouse and set `WHEELHOUSE` before running the hooks. A
+helper script is provided:
+
+```bash
+./scripts/build_offline_wheels.sh
+export WHEELHOUSE="$(pwd)/wheels"
+pre-commit run --all-files
+```
+
+See [AGENTS.md](AGENTS.md) for the full offline workflow.


### PR DESCRIPTION
## Summary
- document how to use a wheelhouse for pre-commit

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --wheelhouse $(pwd)/wheels` *(fails: no wheelhouse or network)*
- `pytest -q` *(fails: environment check failed)*
- `pre-commit run --files CONTRIBUTING.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545567afb483339eda9f4d619f190d