### PR TITLE
[alpha_factory] add smoke test marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 markers =
     e2e: end-to-end integration tests
+    smoke: quick core dependency health checks
 testpaths = tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -50,7 +50,7 @@ command succeeds without contacting PyPI. `torch` in particular is heavy and
 may take several minutes to install. When it is unavailable you can still run
 a lightweight smoke check via:
 ```bash
-pytest -m 'not e2e'
+pytest -m smoke
 ```
 Running without a GPU is fully supported. The world model and evolution tests
 fall back to CPU execution and are automatically skipped when `torch` is
@@ -84,7 +84,7 @@ Example:
 mkdir -p wheels
 pip wheel -r requirements.lock -w wheels
 WHEELHOUSE=$(pwd)/wheels python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
-PYTHONPATH=$(pwd) WHEELHOUSE="$WHEELHOUSE" pytest -m 'not e2e' -q
+PYTHONPATH=$(pwd) WHEELHOUSE="$WHEELHOUSE" pytest -m smoke -q
 ```
 
 Tests may skip when optional dependencies are unavailable.

--- a/tests/test_check_env_core.py
+++ b/tests/test_check_env_core.py
@@ -2,6 +2,10 @@
 import importlib.util
 import check_env
 
+import pytest
+
+pytestmark = pytest.mark.smoke
+
 
 def test_check_env_errors_without_core(monkeypatch):
     calls = []

--- a/tests/test_check_env_network.py
+++ b/tests/test_check_env_network.py
@@ -5,6 +5,8 @@ import pytest
 import subprocess
 import check_env
 
+pytestmark = pytest.mark.smoke
+
 
 def _no_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(check_env, "REQUIRED", [])

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -2,6 +2,10 @@
 import importlib
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.utils import config
 
+import pytest
+
+pytestmark = pytest.mark.smoke
+
 
 def test_settings_offline_enabled_when_missing_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -10,6 +10,8 @@ import pytest
 
 import src.utils.config as cfg
 
+pytestmark = pytest.mark.smoke
+
 
 def test_load_dotenv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env = tmp_path / "sample.env"


### PR DESCRIPTION
## Summary
- register new smoke pytest marker
- mark basic config and check_env tests as smoke
- mention `pytest -m smoke` in the test docs

## Testing
- `python scripts/check_python_deps.py` *(fails: missing numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: no network, wheelhouse empty)*
- `pytest -m smoke -q` *(fails: environment check skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6854561305bc8333a949fb961836fb11