### PR TITLE
[alpha_factory] update CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,9 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-### Air-Gapped Setup
+### Pre-commit in Air-Gapped Setups
 
-If `pre-commit` cannot fetch dependencies because the machine has no internet
-access, build a wheelhouse and set `WHEELHOUSE` before running the hooks. A
-helper script is provided:
+When offline, build the wheelhouse first and point `pre-commit` to it:
 
 ```bash
 ./scripts/build_offline_wheels.sh
@@ -58,4 +56,4 @@ export WHEELHOUSE="$(pwd)/wheels"
 pre-commit run --all-files
 ```
 
-See [AGENTS.md](AGENTS.md) for the full offline workflow.
+Refer to [AGENTS.md](AGENTS.md#pre-commit-in-air-gapped-setups) for detailed steps.


### PR DESCRIPTION
## Summary
- document air-gapped pre-commit usage

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pandas)*
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files CONTRIBUTING.md` *(fails: repository clone interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685461768e1c8333a53967275a6237cd