### PR TITLE
[alpha_factory] add smoke marker

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,14 @@ These integration tests expect the `alpha_factory_v1` package to be importable.
    ```bash
    python check_env.py --auto-install
    ```
+
+### Quick health check
+
+Run the smoke tests to confirm the core dependencies work:
+
+```bash
+pytest -m smoke
+```
 These commands download packages from PyPI, so ensure you have either
 internet connectivity or a wheelhouse available via `--wheelhouse <dir>`
 (or the `WHEELHOUSE` environment variable).

--- a/tests/test_af_requests.py
+++ b/tests/test_af_requests.py
@@ -8,6 +8,8 @@ import sys
 
 import pytest
 
+pytestmark = pytest.mark.smoke
+
 
 def test_fallback_to_internal_shim() -> None:
     """``af_requests`` should expose the internal lightweight implementation when

--- a/tests/test_cache_version.py
+++ b/tests/test_cache_version.py
@@ -2,6 +2,11 @@
 from pathlib import Path
 import json
 
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
 def test_cache_version_matches_package() -> None:
     repo = Path(__file__).resolve().parents[1]
     browser = repo / "alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"

--- a/tests/test_ping_agent.py
+++ b/tests/test_ping_agent.py
@@ -2,16 +2,23 @@
 import asyncio
 import unittest
 
+import pytest
 from alpha_factory_v1.backend.agents.ping_agent import PingAgent
+
+pytestmark = pytest.mark.smoke
+
 
 class DummyOrch:
     def __init__(self):
         self.published = []
+
     async def publish(self, topic, msg):
         self.published.append((topic, msg))
+
     async def subscribe(self, topic):
         if False:
             yield
+
 
 class TestPingAgent(unittest.TestCase):
     def test_run_cycle_publishes(self):
@@ -25,6 +32,7 @@ class TestPingAgent(unittest.TestCase):
         self.assertEqual(topic, "agent.ping")
         self.assertIn("agent", payload)
         self.assertEqual(payload["agent"], agent.NAME)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- tag basic tests with `@pytest.mark.smoke`
- mention running `pytest -m smoke` as a quick health check

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: wheelhouse empty and no network)*
- `pre-commit run --files tests/test_af_requests.py tests/test_cache_version.py tests/test_ping_agent.py tests/README.md` *(fails: verify-requirements-lock and proto checks)*
- `pytest -m smoke` *(fails: Environment check failed)*

------
https://chatgpt.com/codex/tasks/task_e_685463e11ebc833388e4ed83ec760d5c