### PR TITLE
[alpha_factory] update wheelhouse docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,10 +354,12 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
   if required.
  - Always execute `python check_env.py --auto-install` before running the tests
    or `pre-commit` so optional dependencies install correctly. When offline,
-   provide `--wheelhouse <dir>` or set `WHEELHOUSE` to your wheel cache. The
-   repository ships with a wheelhouse under `wheels/`; set
-   `WHEELHOUSE=$(pwd)/wheels` before running `pytest` to use these prebuilt
-   wheels.
+  provide `--wheelhouse <dir>` or set `WHEELHOUSE` to your wheel cache. The
+  repository no longer ships a full wheelhouse because some wheels exceed
+  GitHub's 100 MB size limit. Build the wheelhouse with
+  `scripts/build_offline_wheels.sh` on a machine with internet access and copy
+  the resulting directory to `wheels/`. Then set `WHEELHOUSE=$(pwd)/wheels`
+  before running `pytest`.
 - If `pre-commit` reports "command not found", install it manually with
   `pip install pre-commit` and run `pre-commit install` once.
 - To reinstall the hooks, run `pip install -U pre-commit` and then

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -2,9 +2,11 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 # Offline Wheelhouse
 
-This directory stores prebuilt wheels so the MuZero Planning demo and
-unit tests can run without network access. Build the wheelhouse on a
-machine with connectivity and copy it here. The helper script
+This directory normally stores prebuilt wheels so the MuZero Planning demo and
+unit tests can run without network access. **The wheelhouse is not committed**
+because some packages exceed GitHub's 100 MB size limit. Build the wheelhouse on
+a machine with connectivity and copy it here (or mount the directory) as
+needed. The helper script
 `scripts/build_offline_wheels.sh` collects all required wheels from
 `requirements.lock`, `requirements-dev.txt`, `requirements-demo.lock`
 and each demo's `requirements.lock` file:


### PR DESCRIPTION
## Summary
- document that wheelhouse isn't committed
- update AGENTS instructions on building wheels offline

## Testing
- `python check_env.py --auto-install --wheelhouse $(pwd)/wheels`
- `pytest -q` *(fails: SystemExit: openai_agents package is required. Install with `pip install openai-agents`)*

------
https://chatgpt.com/codex/tasks/task_e_685492135f248333b355962c9ed38de1