### PR TITLE
[alpha_factory] add WHEELHOUSE support to quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,6 +36,7 @@ wheel cache with:
 
 ```bash
 python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+WHEELHOUSE="$WHEELHOUSE" ./quickstart.sh
 ```
 
 See [docs/OFFLINE_INSTALL.md](OFFLINE_INSTALL.md) for detailed steps.

--- a/scripts/demo_setup.sh
+++ b/scripts/demo_setup.sh
@@ -4,11 +4,38 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
+
+usage() {
+  cat <<EOF
+Usage: $0
+
+Prepare the demo virtual environment. Set WHEELHOUSE to a directory
+with wheels for offline installation.
+EOF
+}
+
+if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "${WHEELHOUSE:-}" && -d wheels ]]; then
+  export WHEELHOUSE="$(pwd)/wheels"
+fi
+PIP_ARGS=()
+if [[ -n "${WHEELHOUSE:-}" ]]; then
+  PIP_ARGS=(--no-index --find-links "$WHEELHOUSE")
+fi
+
 VENV_DIR=".venv"
 if [ ! -d "$VENV_DIR" ]; then
   python3 -m venv "$VENV_DIR"
-  "$VENV_DIR/bin/pip" install -U pip
+  "$VENV_DIR/bin/pip" install "${PIP_ARGS[@]}" -U pip
 fi
-"$VENV_DIR/bin/pip" install -r requirements.txt -r requirements-dev.txt
-"$VENV_DIR/bin/python" check_env.py --auto-install
+"$VENV_DIR/bin/pip" install "${PIP_ARGS[@]}" -r requirements.txt -r requirements-dev.txt
+env_opts=()
+if [[ -n "${WHEELHOUSE:-}" ]]; then
+  env_opts+=(--wheelhouse "$WHEELHOUSE")
+fi
+"$VENV_DIR/bin/python" check_env.py --auto-install "${env_opts[@]}"
 echo "Demo environment ready. Activate via 'source $VENV_DIR/bin/activate'"


### PR DESCRIPTION
## Summary
- support WHEELHOUSE env var in `alpha_factory_v1/quickstart.sh` and `scripts/demo_setup.sh`
- update quickstart docs for offline quickstart installs

## Testing
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install` *(fails without wheelhouse or network)*
- `pytest -q` *(fails: Environment check failed)*
- `pre-commit run --files alpha_factory_v1/quickstart.sh scripts/demo_setup.sh docs/quickstart.md` *(hook `proto-verify` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68549e8890408333b282e5b0d0e649eb