### PR TITLE
[alpha_factory] improve offline guidance

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -75,8 +75,10 @@ continues even in minimal environments.
    python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
    PYTHONPATH=$(pwd) pytest -q
    ```
-9. Without a wheelhouse or internet access the environment check fails and
-   `tests/conftest.py` skips the entire suite.
+9. Without a wheelhouse or network access the environment check fails and
+   `tests/conftest.py` skips the entire suite with a concise "no network and no
+   wheelhouse" message. Provide `--wheelhouse <dir>` (or set `WHEELHOUSE`) to run
+   the tests offline.
 10. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
    `pre-commit install` once to enable the git hooks referenced in
    [AGENTS.md](../AGENTS.md).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,17 +7,19 @@ import importlib.util
 
 # Ensure runtime dependencies are present before collecting tests
 try:  # pragma: no cover - best effort environment setup
-    from check_env import main as check_env_main
+    from check_env import main as check_env_main, has_network
 
     wheelhouse = os.getenv("WHEELHOUSE")
     args = ["--auto-install"]
     if wheelhouse:
         args += ["--wheelhouse", wheelhouse]
-    if check_env_main(args):
-        pytest.skip(
-            "Environment check failed, run 'python check_env.py --auto-install'",
-            allow_module_level=True,
-        )
+    rc = check_env_main(args)
+    if rc:
+        if not wheelhouse and not has_network():
+            reason = "no network and no wheelhouse; run 'python check_env.py --auto-install --wheelhouse <dir>'"
+        else:
+            reason = "Environment check failed, run 'python check_env.py --auto-install'"
+        pytest.skip(reason, allow_module_level=True)
 except Exception as exc:  # pragma: no cover - environment issue
     pytest.skip(f"check_env execution failed: {exc}", allow_module_level=True)
 


### PR DESCRIPTION
## Summary
- clarify offline help text in `check_env.py`
- skip tests early when network is unavailable
- document offline skip message in tests/README

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network and no wheelhouse)*
- `pre-commit run --files check_env.py tests/conftest.py tests/README.md -v` *(fails: verify-requirements-lock)*
- `pytest -q` *(skipped: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6854ac65ecb483338257e38b501c0a9c