### PR TITLE
[alpha_factory] Clarify pre-commit setup in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ pytest -q
 
 ## Pre-commit Hooks
 
+Run `./codex/setup.sh` to install project dependencies. The script also
+installs `pre-commit` and all lint tools before configuring the git hook.
+If you skip the setup script, manually install these tools with
+`pip install pre-commit -r requirements-dev.txt` and then run
+`pre-commit install` once.
+
 Install the git hooks once and run them before each commit:
 
 ```bash


### PR DESCRIPTION
## Summary
- mention that `./codex/setup.sh` installs `pre-commit` and lint tools
- show how to manually install these tools when skipping the setup script

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network and no wheelhouse)*
- `pytest -q` *(fails: requires wheelhouse or network)*
- `pre-commit run --files CONTRIBUTING.md` *(fails: proto-verify hook and requirements lock)*

------
https://chatgpt.com/codex/tasks/task_e_6854aed5876083338e4d60f0e855ca06