### PR TITLE
[alpha_factory] add ruff checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff mypy
       - name: Ruff lint
-        run: ruff alpha_factory_v1/demos/alpha_agi_insight_v1
+        run: ruff check alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Mypy type-check
         run: mypy alpha_factory_v1/demos/alpha_agi_insight_v1 --strict
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,11 +249,11 @@ template). The sample file now lists every variable with its default value.
 - `.editorconfig` enforces UTF-8 encoding, LF line endings and the 120-character limit for Python and Markdown files.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
 for modules, classes and functions.
-- Format code with `black` (line length 120) and run `ruff` or `flake8` for linting, if available.
+- Format code with `black` (line length 120) and run `ruff check` or `flake8` for linting, if available.
 - `pyproject.toml` contains the configuration for `black`, `ruff` and `flake8`.
   Adjust lint settings there if needed.
 - Ensure code is formatted before committing.
-- Run `ruff` or `flake8` and `mypy --strict` before committing to enforce
+- Run `ruff check` or `flake8` and `mypy --strict` before committing to enforce
   consistent style and type safety.
 - Run `mypy --config-file mypy.ini .` (or `pyright`) with a **strict** configuration. The
   `mypy.ini` configuration file is located at the repository root.

--- a/alpha_factory_v1/demos/alpha_asi_world_model/.github/workflows/ci.yml
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           pip install ruff mypy
 
       - name: 🧹 Ruff lint
-        run: ruff .
+        run: ruff check .
 
       - name: 🏷️ Mypy type‑check
         run: mypy alpha_factory_v1/demos/alpha_asi_world_model --strict

--- a/check_env.py
+++ b/check_env.py
@@ -32,6 +32,7 @@ import os
 import sys
 import argparse
 import socket
+import shutil
 from pathlib import Path
 from typing import List, Optional
 
@@ -446,6 +447,9 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if demo == "macro_sentinel" and not os.getenv("ETHERSCAN_API_KEY"):
         print("WARNING: ETHERSCAN_API_KEY is unset; Etherscan collector disabled")
+
+    if (shutil.which("pre-commit") or (Path(".git/hooks/pre-commit").exists())) and not shutil.which("ruff"):
+        print("WARNING: 'pre-commit' enabled but 'ruff' command not found")
 
     if not missing_required:
         print("Environment OK")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pre-commit
 types-PyYAML
 types-requests
 papermill
+ruff


### PR DESCRIPTION
## Summary
- ensure ruff is part of requirements-dev.txt
- update docs and GitHub Actions to use `ruff check`
- check for ruff when pre-commit is enabled

## Testing
- `python check_env.py --auto-install --allow-basic-fallback --skip-net-check`
- `pytest -q` *(fails: no network and no wheelhouse)*
- `pre-commit run --files .github/workflows/ci.yml AGENTS.md alpha_factory_v1/demos/alpha_asi_world_model/.github/workflows/ci.yml check_env.py requirements-dev.txt`

------
https://chatgpt.com/codex/tasks/task_e_6854b356c2c48333aa3a4331ba930719