### PR TITLE
[alpha_factory] add cross industry alpha tests

### DIFF
--- a/alpha_factory_v1/tests/test_cross_industry_alpha.py
+++ b/alpha_factory_v1/tests/test_cross_industry_alpha.py
@@ -1,0 +1,59 @@
+import os
+import json
+import tempfile
+import types
+from pathlib import Path
+from unittest.mock import Mock, patch
+import unittest
+
+from alpha_factory_v1.demos.cross_industry_alpha_factory import cross_alpha_discovery_stub as stub
+
+
+class TestCrossIndustryAlpha(unittest.TestCase):
+    def test_discover_alpha_offline(self) -> None:
+        openai_mock = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=Mock()))
+        with patch.object(stub, "openai", openai_mock, create=True):
+            with patch.dict(os.environ, {}, clear=True):
+                picks = stub.discover_alpha(num=1, ledger=None, model="gpt-4o-mini")
+        openai_mock.ChatCompletion.create.assert_not_called()
+        self.assertIsInstance(picks, list)
+        self.assertEqual(len(picks), 1)
+
+    def test_discover_alpha_online(self) -> None:
+        resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="[]"))])
+        openai_mock = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=Mock(return_value=resp)))
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "x"}):
+            with patch.object(stub, "openai", openai_mock, create=True):
+                stub.discover_alpha(num=1, ledger=None, model="gpt-4o-mini")
+        openai_mock.ChatCompletion.create.assert_called_once()
+        kwargs = openai_mock.ChatCompletion.create.call_args.kwargs
+        self.assertEqual(kwargs.get("response_format"), {"type": "json_object"})
+        self.assertEqual(kwargs.get("timeout"), stub.OPENAI_TIMEOUT_SEC)
+
+    def test_ledger_path_creation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = Path(tmp) / "dir" / "log.json"
+            path = stub._ledger_path(ledger)
+            self.assertEqual(path, ledger.resolve())
+            self.assertTrue(path.parent.exists())
+
+    def test_ledger_env_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_home, tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "ledger.json"
+            env = {"HOME": tmp_home, "CROSS_ALPHA_LEDGER": str(target)}
+            with patch.dict(os.environ, env, clear=False):
+                path = stub._ledger_path(None)
+            self.assertEqual(path, target.resolve())
+            self.assertTrue(path.parent.exists())
+
+    def test_ledger_default_home(self) -> None:
+        env = {"CROSS_ALPHA_LEDGER": ""}
+        with patch.dict(os.environ, env, clear=False):
+            path = stub._ledger_path(None)
+        expected = stub.DEFAULT_LEDGER.resolve()
+        self.assertEqual(path, expected)
+        self.assertTrue(path.parent.exists())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/README.md
+++ b/tests/README.md
@@ -228,6 +228,11 @@ OPENAI_API_KEY=dummy pytest tests/test_meta_agentic_tree_search_demo.py::test_br
 ```bash
 pytest tests/test_aiga_agents_bridge.py
 ```
+- `alpha_factory_v1/tests/test_cross_industry_alpha.py` exercises the
+  cross‑industry discovery helper:
+```bash
+pytest alpha_factory_v1/tests/test_cross_industry_alpha.py
+```
 - The optional integration checks in `test_external_integrations.py` exercise
   the real `openai_agents` and `google_adk` packages. Install them via
   `requirements-demo.txt` or they will be skipped automatically.


### PR DESCRIPTION
## Summary
- add unit tests for cross-industry alpha discovery
- verify `_ledger_path` behavior and OpenAI call logic
- document how to run the new tests

## Testing
- `pytest alpha_factory_v1/tests/test_cross_industry_alpha.py -q`
- `pre-commit run --files alpha_factory_v1/tests/test_cross_industry_alpha.py tests/README.md` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6854b7d2a66c8333b778f9de4443c4ba