### PR TITLE
[alpha_factory] centralize disclaimer snippet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,8 @@ template). The sample file now lists every variable with its default value.
 - `.editorconfig` enforces UTF-8 encoding, LF line endings and the 120-character limit for Python and Markdown files.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
 for modules, classes and functions.
+- Import `DISCLAIMER` from `alpha_factory_v1.utils.disclaimer` whenever scripts
+  need to print the standard disclaimer.
 - Format code with `black` (line length 120) and run `ruff check` or `flake8` for linting, if available.
 - `pyproject.toml` contains the configuration for `black`, `ruff` and `flake8`.
   Adjust lint settings there if needed.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any, List, Set, TYPE_CHECKING, Literal
 
 from cachetools import TTLCache  # type: ignore[import-not-found]
-from .cli import DISCLAIMER
+from ....utils.disclaimer import DISCLAIMER
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from typing import Protocol

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -38,10 +38,7 @@ from src.utils.visual import plot_pareto
 from ..utils import config, logging
 from src.eval.foresight import evaluate as foresight_evaluate
 
-DISCLAIMER = (
-    "\N{WARNING SIGN} \N{GREEK SMALL LETTER ALPHA}\u2011AGI Insight is a conceptual "
-    "research prototype. Use at your own risk."
-)
+from ....utils.disclaimer import DISCLAIMER
 
 __all__ = ["DISCLAIMER", "DisclaimerGroup"]
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
@@ -13,7 +13,7 @@ import sys
 from typing import Any, TYPE_CHECKING, cast
 
 from ..simulation import forecast, sector
-from .cli import DISCLAIMER
+from ....utils.disclaimer import DISCLAIMER
 
 try:  # pragma: no cover - optional dependency
     import streamlit as _st

--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -24,9 +24,7 @@ from typing import Callable
 
 from alpha_factory_v1 import run as af_run, __version__
 from alpha_factory_v1.utils.env import _env_int
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli import (
-    DISCLAIMER,
-)
+from alpha_factory_v1.utils.disclaimer import DISCLAIMER
 from src.utils.config import init_config
 
 log = logging.getLogger(__name__)

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -6,9 +6,7 @@ import os
 import argparse
 from pathlib import Path
 
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli import (
-    DISCLAIMER,
-)
+from .utils.disclaimer import DISCLAIMER
 
 from .utils.env import _load_env_file
 

--- a/alpha_factory_v1/utils/disclaimer.py
+++ b/alpha_factory_v1/utils/disclaimer.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Project disclaimer helper."""
+
+from pathlib import Path
+
+_DOCS_PATH = Path(__file__).resolve().parents[2] / "docs" / "DISCLAIMER_SNIPPET.md"
+DISCLAIMER: str = _DOCS_PATH.read_text(encoding="utf-8").strip()
+
+__all__ = ["DISCLAIMER"]

--- a/tests/test_insight_api_server.py
+++ b/tests/test_insight_api_server.py
@@ -11,9 +11,7 @@ fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import api_server
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli import (
-    DISCLAIMER,
-)
+from alpha_factory_v1.utils.disclaimer import DISCLAIMER
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- add `utils.disclaimer` module that loads docs/DISCLAIMER_SNIPPET.md
- refactor run scripts and demos to use the new constant
- update tests and docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -m smoke` *(fails: no network)*

------
https://chatgpt.com/codex/tasks/task_e_6854d1d4aac48333865c0a4013656743