### PR TITLE
[alpha_factory] clarify offline wheelhouse setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,15 @@ Follow these steps when working without internet access.
 1. **Build a wheelhouse** on a machine with connectivity:
    ```bash
    ./scripts/build_offline_wheels.sh
-   export WHEELHOUSE="$(pwd)/wheels"
+   ```
+   The script collects all required wheels under `wheels/`. Copy this
+   directory to the offline host, for example using `scp` or a USB drive:
+   ```bash
+   scp -r wheels user@offline-host:/path/to/AGI-Alpha-Agent-v0/
+   ```
+   Then set the environment variable on the target machine:
+   ```bash
+   export WHEELHOUSE="/path/to/AGI-Alpha-Agent-v0/wheels"
    ```
 
 2. **Install from the wheelhouse** and verify packages. The setup script

--- a/check_env.py
+++ b/check_env.py
@@ -39,8 +39,9 @@ from typing import List, Optional
 NO_NETWORK_HINT = (
     "No network connectivity detected and no wheelhouse was provided.\n"
     "Build wheels with './scripts/build_offline_wheels.sh' on a machine with\n"
-    "internet access, then re-run using 'python check_env.py --auto-install\n"
-    "--wheelhouse <dir>' or set the WHEELHOUSE environment variable."
+    "internet access, copy the resulting 'wheels/' directory to this host,\n"
+    "then re-run using 'python check_env.py --auto-install --wheelhouse <dir>'\n"
+    "or set the WHEELHOUSE environment variable."
 )
 
 


### PR DESCRIPTION
## Summary
- clarify that `scripts/build_offline_wheels.sh` must run on a networked machine
- explain how to copy the generated `wheels/` directory
- update `check_env.py` to mention copying the wheelhouse

## Testing
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-era-experience-requirements-lock,verify-mats-demo-lock,verify-mats-requirements-lock,verify-aiga-requirements-lock,verify-backend-requirements-lock,env-check pre-commit run --files README.md check_env.py`
- `pytest -m smoke -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6854d7cf91108333b30498511df073a4