### PR TITLE
[alpha_factory] add missing disclaimer links

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 🛠️ Production Deployment Guide — AI‑GA Meta‑Evolution

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Best Alpha Opportunity Workflow

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/CONCEPTUAL_FRAMEWORK.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/CONCEPTUAL_FRAMEWORK.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Conceptual Framework – Alpha‑AGI Business v1

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Quick Start – Alpha‑AGI Business v1 Demo

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -1,4 +1,4 @@
-# [See ../../../docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 # API Overview
 
 This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Changelog

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # α‑AGI Insight v1 – Design Overview

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Bus TLS Setup

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/mermaid.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/mermaid.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ```mermaid

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 - 2025‑04‑25 Initial auto‑generated docs bundle

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Quick‑Start

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!-- SPDX-License-Identifier: Apache-2.0 -->

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ```mermaid


### PR DESCRIPTION
## Summary
- ensure demo docs start with the required disclaimer link

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: no network and no wheelhouse)*
- `pytest -q` *(failed: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6854db2e40f88333907cdae09120738d