### PR TITLE
[alpha_factory] fix disclaimer link paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Summary

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha‑Factory v1 👁️✨ — **Interactive Demo & Agent Gallery**

--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 🛠️ Production Deployment Guide — AI‑GA Meta‑Evolution

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!--

--- a/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Best Alpha Opportunity Workflow

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/CONCEPTUAL_FRAMEWORK.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/CONCEPTUAL_FRAMEWORK.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Conceptual Framework – Alpha‑AGI Business v1

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Quick Start – Alpha‑AGI Business v1 Demo

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!-- README.md — Large‑Scale α‑AGI Business Demo (v1.0‑production) -->

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!--

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 # API Overview
 
 This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Changelog

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # α‑AGI Insight v1 – Design Overview

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 # α‑AGI Insight Docs
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Bus TLS Setup

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 This chart deploys the α-AGI Insight demo.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ### 🔬 Browser-only Insight demo

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # wasm-gpt2

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/mermaid.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/mermaid.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ```mermaid

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha AGI Insight Web Client

--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!-- README.md — α‑AGI Marketplace Demo (v1.4‑production) -->

--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Terms & Conditions

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!--

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 - 2025‑04‑25 Initial auto‑generated docs bundle

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Quick‑Start

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # α-ASI World-Model 🛰️ — Helm Chart 📦

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!-- SPDX-License-Identifier: Apache-2.0 -->

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 This directory contains supplementary assets for the **Cross‑Industry Alpha‑Factory** demo.

--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!--

--- a/alpha_factory_v1/demos/finance_alpha/README.md
+++ b/alpha_factory_v1/demos/finance_alpha/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha‑Factory Demos 📊

--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/demos/meta_agentic_agi/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/demos/meta_agentic_agi/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ```mermaid

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic Tree Search (MATS) Demo — v0

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!--

--- a/alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md
+++ b/alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # MuZero MCTS LLM Agent Demo

--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)

--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!--

--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # sample_broken_calc

--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]

--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Sovereign Agentic AGI Alpha Agent Demo

--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # `alpha_factory_v1/scripts` — Zero‑to‑Alpha in *One* Command ⚡️

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # API and CLI Usage
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Changelog
 
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 All notable changes to this project are documented in this file.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,8 +1,8 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Design Overview
 
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This document outlines the architecture of the Alpha Factory demo included in this repository. It also explains the individual agent roles and the Meta-Agentic Tree Search (MATS) algorithm used for evolutionary optimisation.
 

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -1,8 +1,8 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Offline Setup Guide
 
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This guide explains how to prepare and use a wheelhouse so `check_env.py` and the
 setup scripts work without internet access.

--- a/docs/OFFLINE_INSTALL.md
+++ b/docs/OFFLINE_INSTALL.md
@@ -1,8 +1,8 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Offline Installation Quickstart
 
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This guide summarises how to install the project without internet access and run the Macro-Sentinel demo.
 

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -1,8 +1,8 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Offline Setup Reference
 
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This document summarises how to install the project without internet access.
 

--- a/docs/POLICY_RUNBOOK.md
+++ b/docs/POLICY_RUNBOOK.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Policy Runbook
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Project Documentation
 

--- a/docs/deployment_security.md
+++ b/docs/deployment_security.md
@@ -1,8 +1,8 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Secure Deployment
 
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This guide explains how to protect Alpha-Factory in production.
 

--- a/docs/dgm_ops.md
+++ b/docs/dgm_ops.md
@@ -1,7 +1,7 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 ## Disclaimer
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # DGM Operations Runbook
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Quick Start Guide
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # Sandbox Resource Limits
 


### PR DESCRIPTION
## Summary
- update relative paths for `docs/DISCLAIMER_SNIPPET.md`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network)*
- `pytest -q` *(fails: Skipped, no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_68555319f228833383f7cb0c013a8e70