### PR TITLE
[alpha_factory] add Apache license header

### DIFF
--- a/tools/go_a2a_client/main.go
+++ b/tools/go_a2a_client/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (


### PR DESCRIPTION
## Summary
- add missing SPDX header to go_a2a_client main

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network and no wheelhouse)*
- `pytest -q` *(fails: no network and no wheelhouse)*
- `pre-commit run --files tools/go_a2a_client/main.go` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685554930b908333b30fd66a9444966f