### PR TITLE
[alpha_factory] include disclaimer snippet in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ packages = [
     "alpha_factory_v1.demos.alpha_agi_insight_v1.src",
     "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface",
     "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_client",
+    "alpha_factory_v1.utils",
     "af_requests",
     "src",
     "src.interface",
@@ -23,9 +24,10 @@ packages = [
     "alpha_factory_v1.demos.meta_agentic_tree_search_v0",
     "alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats",
 ]
+include-package-data = true
 
 [tool.setuptools.package-data]
-"alpha_factory_v1" = ["py.typed"]
+"alpha_factory_v1" = ["py.typed", "../docs/DISCLAIMER_SNIPPET.md"]
 "alpha_factory_v1.demos.alpha_agi_insight_v1" = ["py.typed"]
 "src.interface.web_client" = ["dist/**"]
 "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_client" = ["dist/**"]


### PR DESCRIPTION
## Summary
- ship docs/DISCLAIMER_SNIPPET.md inside the wheel
- expose alpha_factory_v1.utils package to include disclaimer helper

## Testing
- `pip install dist/alpha_factory_v1-1.1.0-py3-none-any.whl`
- `python - <<'EOF'
import alpha_factory_v1.utils.disclaimer as d
print('exists', d._DOCS_PATH.exists())
print(d.DISCLAIMER.splitlines()[0])
EOF`
- `pre-commit run --files pyproject.toml alpha_factory_v1/utils/disclaimer.py` *(fails: Interrupted (^C): KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6855553036108333993884ad7b035e3c