### PR TITLE
docs: clarify offline wheelhouse setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,6 +350,10 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
 ### Troubleshooting
 - If the stack fails to start, verify Docker and Docker Compose are running.
 - Setup errors usually mean Python is older than 3.11. Use Python 3.11 or 3.12 (>=3.11,<3.13).
+- When working offline, build the wheelhouse with `scripts/build_offline_wheels.sh` on a
+  machine with internet access, copy the `wheels/` directory to the repository root and set
+  `WHEELHOUSE=$(pwd)/wheels` before running `python check_env.py --auto-install` or the tests.
+  Bundling small wheels like `numpy`, `pyyaml` and `pandas` enables smoke tests without internet access.
 - Missing optional packages can cause test failures; first run
   `python scripts/check_python_deps.py` and then
   `python check_env.py --auto-install` (pass `--wheelhouse <path>` when offline)
@@ -360,8 +364,9 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
   repository no longer ships a full wheelhouse because some wheels exceed
   GitHub's 100 MB size limit. Build the wheelhouse with
   `scripts/build_offline_wheels.sh` on a machine with internet access and copy
-  the resulting directory to `wheels/`. Then set `WHEELHOUSE=$(pwd)/wheels`
-  before running `pytest`.
+  the resulting directory to `wheels/`. Set `WHEELHOUSE=$(pwd)/wheels` and
+  consider bundling `numpy`, `pyyaml` and `pandas` so the smoke tests run without
+  contacting PyPI.
 - If `pre-commit` reports "command not found", install it manually with
   `pip install pre-commit` and run `pre-commit install` once.
 - To reinstall the hooks, run `pip install -U pre-commit` and then

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -7,15 +7,20 @@
 This document summarises how to install the project without internet access.
 
 ## Build a wheelhouse
-Run these commands on a machine with connectivity:
+Run the helper script on a machine with connectivity:
 
 ```bash
-mkdir -p /media/wheels
-pip wheel -r requirements.lock -w /media/wheels
-pip wheel -r requirements-dev.txt -w /media/wheels
+./scripts/build_offline_wheels.sh
 ```
 
-Copy the directory to the offline host.
+This collects wheels for all lock files inside a `wheels/` directory. Copy this
+directory to the offline host.
+
+Set `WHEELHOUSE=$(pwd)/wheels` before running `check_env.py` or the tests:
+
+```bash
+export WHEELHOUSE=$(pwd)/wheels
+```
 
 ## Environment variables
 Set these before running the helper scripts:
@@ -28,12 +33,13 @@ export AUTO_INSTALL_MISSING=1
 `check_env.py` reads them to install packages from the wheelhouse when the network is unavailable.
 
 ### Prebuilt wheels for heavy dependencies
-`numpy` and `pandas` ship as binary wheels on PyPI. Grab them when
-constructing the wheelhouse so the offline installer does not attempt to
-compile these heavy packages from source:
+`numpy`, `PyYAML` and `pandas` ship as binary wheels on PyPI. These small wheels
+can be bundled with the repository so the smoke tests run offline. Grab them
+when constructing the wheelhouse so the installer does not attempt to compile
+them from source:
 
 ```bash
-pip wheel numpy pandas -w /media/wheels
+pip wheel numpy pyyaml pandas -w /media/wheels
 ```
 
 Include any other large dependencies, such as `torch` or `scipy`, by passing

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,9 +65,15 @@ fall back to CPU execution and are automatically skipped when `torch` is
 absent. Other optional packages behave the same way—tests relying on
 `fastapi`, `playwright` or `httpx` use `pytest.importorskip()` so the suite
 continues even in minimal environments.
-6. If the repository includes a `wheels/` directory, export
+6. Build the wheelhouse on a machine with connectivity:
+   ```bash
+   ./scripts/build_offline_wheels.sh
+   ```
+   Copy the resulting `wheels/` directory to the offline host and export
    `WHEELHOUSE=$(pwd)/wheels` **before running** `python check_env.py --auto-install`
-   and `pytest` so packages install from the bundled wheelhouse.
+   or `pytest` so packages install from the bundled wheels.
+   Bundling small wheels such as `numpy`, `pyyaml` and `pandas` allows the smoke
+   tests to run without contacting PyPI.
 7. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
 8. Export the wheel cache path and run the environment check before the suite:
    ```bash


### PR DESCRIPTION
## Summary
- document building offline wheels via script in OFFLINE_SETUP
- update tests README with exact offline steps and note small wheel bundles
- highlight WHEELHOUSE requirement in troubleshooting section

## Testing
- `pre-commit run --files docs/OFFLINE_SETUP.md tests/README.md AGENTS.md` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: Skipped: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_68555ee1e3e483339ef9d6ac1875c02b