### PR TITLE
Add wheel signature validation test

### DIFF
--- a/tests/test_verify_wheel_sig.py
+++ b/tests/test_verify_wheel_sig.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for verify_wheel_sig script."""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+from alpha_factory_v1.backend import agents as agents_mod
+from alpha_factory_v1.scripts import verify_wheel_sig
+
+
+class VerifyWheelSigTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.pkg_dir = Path(self.tmpdir.name)
+        (self.pkg_dir / "pkg").mkdir()
+        (self.pkg_dir / "pkg" / "__init__.py").write_text("")
+        (self.pkg_dir / "pyproject.toml").write_text(
+            """
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dummy"
+version = "0.0.1"
+"""
+        )
+        wheel_dir = self.pkg_dir / "dist"
+        wheel_dir.mkdir()
+        from setuptools import build_meta  # type: ignore
+
+        wheel_name = build_meta.build_wheel(str(wheel_dir))
+        self.wheel_path = wheel_dir / wheel_name
+
+        self.key_path = self.pkg_dir / "signing.key"
+        subprocess.run(
+            ["openssl", "genpkey", "-algorithm", "ed25519", "-out", str(self.key_path)],
+            check=True,
+        )
+        pub_bytes = subprocess.check_output(
+            ["openssl", "pkey", "-in", str(self.key_path), "-pubout", "-outform", "DER"]
+        )
+        self.pub_b64 = base64.b64encode(pub_bytes).decode()
+
+        sig_b64 = subprocess.check_output(
+            [
+                "sh",
+                "-c",
+                f"openssl dgst -sha512 -binary {self.wheel_path} | openssl pkeyutl -sign -inkey {self.key_path} | base64 -w0",
+            ]
+        ).decode()
+        self.sig_path = self.wheel_path.with_suffix(self.wheel_path.suffix + ".sig")
+        self.sig_path.write_text(sig_b64)
+        self.orig_pub = agents_mod._WHEEL_PUBKEY
+        agents_mod._WHEEL_PUBKEY = self.pub_b64
+
+    def tearDown(self) -> None:
+        agents_mod._WHEEL_PUBKEY = self.orig_pub
+        self.tmpdir.cleanup()
+
+    def _run_main(self, wheel: Path) -> int:
+        argv = ["verify_wheel_sig", str(wheel)]
+        with mock.patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit) as ctx:
+                verify_wheel_sig.main()
+            return ctx.exception.code  # type: ignore[no-any-return]
+
+    def test_valid_signature(self) -> None:
+        exit_code = self._run_main(self.wheel_path)
+        self.assertEqual(exit_code, 0)
+
+    def test_tampered_wheel_fails(self) -> None:
+        self.wheel_path.write_bytes(self.wheel_path.read_bytes() + b"x")
+        exit_code = self._run_main(self.wheel_path)
+        self.assertEqual(exit_code, 2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests/test_verify_wheel_sig.py to validate verify_wheel_sig.main

## Testing
- `python scripts/check_python_deps.py` *(fails: missing numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: no network and no wheelhouse)*
- `pytest tests/test_verify_wheel_sig.py -q` *(fails: skipped due to no network and no wheelhouse)*
- `pre-commit run --files tests/test_verify_wheel_sig.py` *(fails: multiple hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6855686e4c648333ba1a9d14627b855a