### PR TITLE
[alpha_factory] add missing license headers

### DIFF
--- a/src/interface/web_client/package.json
+++ b/src/interface/web_client/package.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "name": "agi-web-client",
   "private": true,

--- a/src/interface/web_client/playwright.config.ts
+++ b/src/interface/web_client/playwright.config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({

--- a/src/interface/web_client/tsconfig.json
+++ b/src/interface/web_client/tsconfig.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "compilerOptions": {
     "target": "ESNext",

--- a/src/interface/web_client/tsconfig.node.json
+++ b/src/interface/web_client/tsconfig.node.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 {
   "compilerOptions": {
     "composite": true,

--- a/src/interface/web_client/workbox.config.js
+++ b/src/interface/web_client/workbox.config.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 module.exports = {
   globDirectory: 'dist/',
   globPatterns: ['**/*.{js,css,html,wasm,woff2,svg,webmanifest,json}'],


### PR DESCRIPTION
## Summary
- add SPDX headers to web client configs

## Testing
- `pre-commit run --files src/interface/web_client/package.json src/interface/web_client/tsconfig.json src/interface/web_client/tsconfig.node.json src/interface/web_client/workbox.config.js src/interface/web_client/playwright.config.ts` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68556b32fbb48333aae17898d734be01