### PR TITLE
[alpha_factory] add SPDX headers to two files

### DIFF
--- a/alpha_factory_v1/tests/test_cross_industry_alpha.py
+++ b/alpha_factory_v1/tests/test_cross_industry_alpha.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import json
 import tempfile

--- a/stubs/__init__.py
+++ b/stubs/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Summary
- add Apache license headers

## Testing
- `pre-commit run --files alpha_factory_v1/tests/test_cross_industry_alpha.py stubs/__init__.py` *(fails: Makefile:26: *** missing separator.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_685573b870bc8333bf5bc2265ebc7208