### PR TITLE
Add missing disclaimer links

### DIFF
--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/backend/README.md
+++ b/alpha_factory_v1/backend/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha-Factory Backend

--- a/alpha_factory_v1/backend/agents/README.md
+++ b/alpha_factory_v1/backend/agents/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha‑Factory v1 👁️✨ — Backend α‑AGI Agents Suite

--- a/alpha_factory_v1/backend/environments/README.md
+++ b/alpha_factory_v1/backend/environments/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Backend Environments

--- a/alpha_factory_v1/dashboards/README.md
+++ b/alpha_factory_v1/dashboards/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha Factory Dashboards

--- a/alpha_factory_v1/docs/README.md
+++ b/alpha_factory_v1/docs/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Documentation Overview

--- a/alpha_factory_v1/docs/REMOTE_SWARM.md
+++ b/alpha_factory_v1/docs/REMOTE_SWARM.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Remote Swarm Quick‑start

--- a/alpha_factory_v1/docs/alpha_agi_agent.md
+++ b/alpha_factory_v1/docs/alpha_agi_agent.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/docs/alpha_agi_business.md
+++ b/alpha_factory_v1/docs/alpha_agi_business.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/helm/alpha-factory-remote/README.md
+++ b/alpha_factory_v1/helm/alpha-factory-remote/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # alpha-factory-remote Helm Chart

--- a/alpha_factory_v1/helm/alpha-factory/README.md
+++ b/alpha_factory_v1/helm/alpha-factory/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # alpha-factory Helm Chart

--- a/alpha_factory_v1/tests/README.md
+++ b/alpha_factory_v1/tests/README.md
@@ -1,3 +1,4 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 🧪 Test Suite · Alpha‑Factory v1 👁


### PR DESCRIPTION
## Summary
- add DISCLAIMER_SNIPPET link to missing alpha_factory_v1 READMEs
- verify Markdown files contain the disclaimer link

## Testing
- `pre-commit run --files $FILES` *(with heavy hooks skipped)*
- `pytest -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_68557d9a9e4c8333a70d19d119227ad6