### PR TITLE
[alpha_factory] Add Breaking Changes section to changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 All notable changes to this project are documented in this file.
 
+## Breaking Changes
+Any incompatible API updates will be clearly listed under this heading for each release.
+Downstream users should consult this section when upgrading.
+
 ## [Unreleased]
 - `alpha-factory` and `edge_runner.py` now print a short warning before startup.
 - Synced `openai`, `openai-agents` and `uvicorn` pins across requirements files


### PR DESCRIPTION
## Summary
- document new Breaking Changes section in the changelog

## Testing
- `pre-commit run --files docs/CHANGELOG.md` *(fails: proto-verify Makefile error)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no wheelhouse)*
- `pytest -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6855882bd9148333997b2972fa5cbb88