### PR TITLE
[alpha_factory] release: 0.1.0-alpha

### DIFF
--- a/alpha_factory_v1/__init__.py
+++ b/alpha_factory_v1/__init__.py
@@ -17,7 +17,7 @@ try:  # attempt to read the installed package version
 
     __version__ = _version(__name__)
 except Exception:  # pragma: no cover - fallback when not installed
-    __version__ = "1.1.0"
+    __version__ = "0.1.0-alpha"
 
 __all__ = ["backend", "demos", "ui", "run", "get_version"]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ Downstream users should consult this section when upgrading.
 - Added `scripts/build_offline_wheels.sh` to gather wheels for all lock files.
 - Removed outdated `OPENAI_CONTEXT_WINDOW` reference from the self-healing repo demo.
 - Documented how to add new policies in `POLICY_RUNBOOK.md`.
+## [0.1.0-alpha] - 2024-05-01
+- Initial alpha release.
+
 
 ## [1.0.3] - 2025-07-10
 - Extended OPA rules to block additional finance domains and detect exfiltration commands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alpha-factory-v1"
-version = "1.1.0"
+version = "0.1.0-alpha"
 description = "Alpha-Factory v1"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"


### PR DESCRIPTION
## Summary
- bump version in `pyproject.toml` and `alpha_factory_v1.__init__`
- document the 0.1.0-alpha release in `docs/CHANGELOG.md`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network and no wheelhouse)*
- `pytest -q` *(fails: no network and no wheelhouse)*
- `pre-commit run --all-files` *(fails: could not initialize repos)*

------
https://chatgpt.com/codex/tasks/task_e_685589a4a0b88333868e7d9d64cf26bf