### PR TITLE
docs: clarify release tag requirements

### DIFF
--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -9,6 +9,9 @@
 5. Build the web client with `make build_web`.
 6. Update `docs/CHANGELOG.md` with the new version.
 7. Commit changes and tag the release: `git tag -s vX.Y.Z -m "vX.Y.Z"`.
+   Ensure `pre-commit run --all-files`, `python check_env.py --auto-install` and
+   `pytest -q` all succeed before creating the tag. When offline, pass
+   `--wheelhouse <dir>` to `check_env.py` and run the tests from that wheelhouse.
 8. Push commits and tags to GitHub.
 9. The `CI` workflow builds the image and uploads release artifacts.
 


### PR DESCRIPTION
## Summary
- document that pre-commit, `check_env.py`, and pytest must pass before tagging a release
- highlight the `--wheelhouse` flag for offline release preparations

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network and no wheelhouse)*
- `pytest -q` *(fails: no network and no wheelhouse)*
- `pre-commit run --all-files` *(fails: could not initialize hooks due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68558ad8a1408333be30c6e06a1f267a