### PR TITLE
docs: reference tag v0.1.0-alpha

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ Downstream users should consult this section when upgrading.
 - Documented how to add new policies in `POLICY_RUNBOOK.md`.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
+- Git tag `v0.1.0-alpha`.
 
 
 ## [1.0.3] - 2025-07-10


### PR DESCRIPTION
## Summary
- reference the new git tag in CHANGELOG

## Testing
- `python check_env.py --auto-install` *(fails: no network)*
- `pre-commit run --files docs/CHANGELOG.md` *(fails: interrupted)*
- `git push origin v0.1.0-alpha` *(fails: no 'origin' remote)*

------
https://chatgpt.com/codex/tasks/task_e_68559160f9d88333adbbd756dbff5712