### PR TITLE
[alpha_factory] enhance network detection fallback

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -186,12 +186,26 @@ IMPORT_NAMES = {
 
 
 def has_network(timeout: float = 1.0) -> bool:
-    """Return ``True`` if ``pypi.org`` is reachable on port 443."""
-    try:
-        with socket.create_connection(("pypi.org", 443), timeout=timeout):
-            return True
-    except OSError:
-        return False
+    """Return ``True`` if any of the test hosts is reachable.
+
+    The function attempts to connect to ``pypi.org``, ``1.1.1.1`` and
+    ``github.com`` in that order. It returns ``True`` as soon as one
+    connection succeeds and ``False`` only if all attempts fail.
+    """
+
+    hosts = [
+        ("pypi.org", 443),
+        ("1.1.1.1", 443),
+        ("github.com", 443),
+    ]
+
+    for host in hosts:
+        try:
+            with socket.create_connection(host, timeout=timeout):
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/tests/test_check_env_network.py
+++ b/tests/test_check_env_network.py
@@ -48,3 +48,40 @@ def test_skip_net_check(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(check_env, "has_network", _fail_net)
     rc = check_env.main(["--auto-install", "--skip-net-check"])
     assert rc == 0
+
+
+def test_has_network_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return True when later test hosts are reachable."""
+
+    attempts = []
+
+    class _Sock:
+        def __enter__(self) -> "_Sock":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            pass
+
+    def _connect(addr: tuple[str, int], timeout: float = 1.0) -> _Sock:
+        attempts.append(addr)
+        if addr[0] == "pypi.org":
+            raise OSError
+        return _Sock()
+
+    monkeypatch.setattr(check_env.socket, "create_connection", _connect)  # type: ignore[attr-defined]
+    assert check_env.has_network() is True
+    assert attempts == [("pypi.org", 443), ("1.1.1.1", 443)]
+
+
+def test_has_network_all_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return False when none of the hosts are reachable."""
+
+    attempts = []
+
+    def _connect(_addr: tuple[str, int], timeout: float = 1.0) -> None:
+        attempts.append(_addr)
+        raise OSError
+
+    monkeypatch.setattr(check_env.socket, "create_connection", _connect)  # type: ignore[attr-defined]
+    assert check_env.has_network() is False
+    assert len(attempts) >= 3


### PR DESCRIPTION
## Summary
- check network connectivity by probing pypi.org, 1.1.1.1 and github.com
- test fallback behaviour in has_network

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*
- `pytest -q tests/test_check_env_network.py` *(fails: no network and no wheelhouse)*
- `pre-commit run --files check_env.py tests/test_check_env_network.py` *(some hooks skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6855bc5b78d0833390ad1fd24571f7c7