### PR TITLE
chore: show disclaimer in quickstart

### DIFF
--- a/alpha_factory_v1/quickstart.sh
+++ b/alpha_factory_v1/quickstart.sh
@@ -56,6 +56,12 @@ header() {
 
 header
 
+# display project disclaimer before environment checks
+python3 - <<'PY'
+from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+print(DISCLAIMER)
+PY
+
 # check python version
 python3 - <<'PY'
 import sys


### PR DESCRIPTION
## Summary
- print the project disclaimer before running quickstart checks

## Testing
- `pre-commit run --files alpha_factory_v1/quickstart.sh` *(fails: Makefile missing separator)*
- `pytest -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6855d7e993048333a6e0b3121df466e9