### PR TITLE
[alpha_factory] document v0.1.0-alpha tag creation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,12 @@ Downstream users should consult this section when upgrading.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.
+- This tag points at commit `0ff79a4f`.
+- If cloning from a snapshot without tags, recreate it using:
+  ```bash
+  git tag -a v0.1.0-alpha 0ff79a4f -m "v0.1.0-alpha"
+  git push origin v0.1.0-alpha
+  ```
 
 
 ## [1.0.3] - 2025-07-10


### PR DESCRIPTION
## Summary
- document the `v0.1.0-alpha` tag location and how to recreate it

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network/wheelhouse)*
- `pytest -q` *(fails: skipped due to missing wheels/network)*
- `pre-commit run --files docs/CHANGELOG.md` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855d9d024d08333b4e999946047e0e5