### PR TITLE
Add disclaimer comments to quickstart scripts

### DIFF
--- a/alpha_factory_v1/quickstart.sh
+++ b/alpha_factory_v1/quickstart.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
+# This repository is a conceptual research prototype. References to "AGI" and
+# "superintelligence" describe aspirational goals and do not indicate the
+# presence of a real general intelligence. Use at your own risk. Nothing herein
+# constitutes financial advice. MontrealAI and the maintainers accept no
+# liability for losses incurred from using this software.
+# See docs/DISCLAIMER_SNIPPET.md
 # Alpha-Factory Quickstart Launcher
 # Professional production-ready script to bootstrap and run Alpha-Factory v1
 set -Eeuo pipefail

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
+# This repository is a conceptual research prototype. References to "AGI" and
+# "superintelligence" describe aspirational goals and do not indicate the
+# presence of a real general intelligence. Use at your own risk. Nothing herein
+# constitutes financial advice. MontrealAI and the maintainers accept no
+# liability for losses incurred from using this software.
+# See docs/DISCLAIMER_SNIPPET.md
 # Wrapper script for alpha_factory_v1/quickstart.sh
 # Provides a friendly top-level entry point.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary
- include docs/DISCLAIMER_SNIPPET.md at top of both quickstart scripts

## Testing
- `pre-commit run --files quickstart.sh alpha_factory_v1/quickstart.sh` *(fails: KeyboardInterrupt during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_685601840c2083339c40b62f07586f21