### PR TITLE
[alpha_factory] clarify demo versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Clone the repository at the `v0.1.0-alpha` tag and run the helper script to star
 ```bash
 git clone --branch v0.1.0-alpha https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0
+python -c "import alpha_factory_v1; print(alpha_factory_v1.__version__)"  # prints 0.1.0-alpha
 python check_env.py --auto-install  # may run for several minutes
 # NumPy and pandas are required for realistic results; omit or add
 # `--allow-basic-fallback` to bypass this check.

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -14,6 +14,10 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 > [Apache 2.0 license](../../LICENSE) and
 > [security policy](../../SECURITY.md) for details.
 
+Each demo package exposes its own ``__version__`` constant. These
+numbers indicate the demo revision and are independent from the
+main ``alpha_factory_v1`` package version.
+
 ## 🗺️ Navigator
 | Section | Why read it? |
 |---------|--------------|

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/__init__.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Entry point for the α‑AGI Insight demo package."""
+"""Entry point for the α‑AGI Insight demo package.
+
+The ``__version__`` constant defined below is specific to this demo
+and does not track the top-level :mod:`alpha_factory_v1` package
+version.
+"""
 
 from __future__ import annotations
 
@@ -8,4 +13,3 @@ from typing import Final
 __all__ = ["__version__"]
 
 __version__: Final[str] = "1.1.0"
-

--- a/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
@@ -20,6 +20,8 @@
 │  • Strict, regulator-friendly defaults: deterministic seed, telemetry opt-in │
 │    only, graceful exit on NaN / divergence (SafetyAgent).                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
+The ``__version__`` constant below denotes the demo revision and is
+independent from the :mod:`alpha_factory_v1` package version.
 """
 
 from __future__ import annotations
@@ -33,6 +35,7 @@ from typing import Final, List
 # Re-export the runnable demo components
 try:  # optional heavy deps (numpy, torch, etc.)
     from .alpha_asi_world_model_demo import CFG, Orchestrator, app, _main as _demo_cli  # noqa: F401
+
     _DEPS_AVAILABLE = True
 except Exception:  # pragma: no cover - missing optional deps
     CFG = Orchestrator = app = _demo_cli = None  # type: ignore
@@ -83,9 +86,7 @@ def run_headless(steps: int = 50_000) -> Orchestrator:  # pragma: no cover
         >>> assert orch.learner.buffer  # trained a bit
     """
     if not _DEPS_AVAILABLE:
-        raise ImportError(
-            "Optional dependencies missing; install requirements.txt to run"
-        )
+        raise ImportError("Optional dependencies missing; install requirements.txt to run")
 
     orch = Orchestrator()
 
@@ -111,9 +112,7 @@ def run_ui(
         >>> α.run_ui(port=9999)  # then open http://localhost:9999
     """
     if not _DEPS_AVAILABLE:
-        raise ImportError(
-            "Optional dependencies missing; install requirements.txt to run"
-        )
+        raise ImportError("Optional dependencies missing; install requirements.txt to run")
 
     uvicorn = _lazy_import_uvicorn()
     uvicorn.run(
@@ -134,6 +133,7 @@ if os.getenv("ALPHA_ASI_SILENT", "0") != "1":
         "type `help(alpha_asi_world_model)` for details - or - "
         "`alpha_asi_world_model.run_ui()` to launch the dashboard.\n"
     )
+
 
 # Expose a CLI entry-point (python -m alpha_asi_world_model)
 def _module_cli() -> None:  # pragma: no cover

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Downstream users should consult this section when upgrading.
   git push origin v0.1.0-alpha
   git tag            # verify the tag exists
   ```
+ - The package exposes `alpha_factory_v1.__version__ = "0.1.0-alpha"` at this release.
 
 
 ## [1.0.3] - 2025-07-10


### PR DESCRIPTION
## Summary
- note that demos have independent version constants
- show how to verify package version during quickstart
- document release version in changelog

## Testing
- `python scripts/check_python_deps.py` *(fails: numpy, yaml, pandas missing)*
- `python check_env.py --auto-install` *(fails: no network or wheelhouse)*
- `pytest -q` *(fails: no network and no wheelhouse)*
- `pre-commit run --files README.md alpha_factory_v1/demos/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/__init__.py alpha_factory_v1/demos/alpha_asi_world_model/__init__.py docs/CHANGELOG.md` *(fails: proto-verify and requirements locks)*

------
https://chatgpt.com/codex/tasks/task_e_68560d6f57548333bc75537321b8fad2