### PR TITLE
[alpha_factory] improve offline test guidance

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,6 +6,18 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 These integration tests expect the `alpha_factory_v1` package to be importable.
 
+When running the suite without internet access you **must** prepare a local
+wheelhouse first:
+
+```bash
+./scripts/build_offline_wheels.sh
+```
+
+Copy the resulting `wheels/` directory to the offline host and set
+`WHEELHOUSE=$(pwd)/wheels` before executing `python check_env.py --auto-install`
+or `pytest`. The environment check in `tests/conftest.py` will abort when neither
+network access nor a wheelhouse is available.
+
 ## Setup
 
 1. Install the development requirements:
@@ -66,7 +78,7 @@ fall back to CPU execution and are automatically skipped when `torch` is
 absent. Other optional packages behave the same way—tests relying on
 `fastapi`, `playwright` or `httpx` use `pytest.importorskip()` so the suite
 continues even in minimal environments.
-6. Build the wheelhouse on a machine with connectivity:
+6. Build the wheelhouse on a machine with connectivity **(mandatory when offline)**:
    ```bash
    ./scripts/build_offline_wheels.sh
    ```
@@ -85,7 +97,8 @@ continues even in minimal environments.
 9. Without a wheelhouse or network access the environment check fails and
    `tests/conftest.py` skips the entire suite with a concise "no network and no
    wheelhouse" message. Provide `--wheelhouse <dir>` (or set `WHEELHOUSE`) to run
-   the tests offline.
+   the tests offline. Preparing this directory via `scripts/build_offline_wheels.sh`
+   is therefore a mandatory prerequisite when testing in air‑gapped setups.
 10. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
    `pre-commit install` once to enable the git hooks referenced in
    [AGENTS.md](../AGENTS.md).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
+import warnings
 import pytest
 import sys
 import types
@@ -13,6 +14,12 @@ try:  # pragma: no cover - best effort environment setup
     args = ["--auto-install"]
     if wheelhouse:
         args += ["--wheelhouse", wheelhouse]
+    elif not has_network():  # warn when offline with no wheelhouse
+        warnings.warn(
+            "Neither network access nor a wheelhouse was detected. "
+            "Run './scripts/build_offline_wheels.sh' and set WHEELHOUSE before testing.",
+            RuntimeWarning,
+        )
     rc = check_env_main(args)
     if rc:
         if not wheelhouse and not has_network():


### PR DESCRIPTION
## Summary
- update `tests/README.md` with stronger instructions for running `scripts/build_offline_wheels.sh`
- warn when neither network access nor `WHEELHOUSE` is set

## Testing
- `pre-commit run --files tests/README.md tests/conftest.py` *(with heavy hooks skipped)*
- `pytest -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6856115db86c83339ae58c8d4396c3fe