### PR TITLE
Add release tagging helper

### DIFF
--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -8,10 +8,12 @@
 4. Execute `pytest -q` and ensure all tests pass.
 5. Build the web client with `make build_web`.
 6. Update `docs/CHANGELOG.md` with the new version.
-7. Commit changes and tag the release: `git tag -s vX.Y.Z -m "vX.Y.Z"`.
-   Ensure `pre-commit run --all-files`, `python check_env.py --auto-install` and
-   `pytest -q` all succeed before creating the tag. When offline, pass
-   `--wheelhouse <dir>` to `check_env.py` and run the tests from that wheelhouse.
+7. Commit changes and tag the release using `./scripts/create_release_tag.sh <commit>`.
+   The helper creates the annotated tag `v0.1.0-alpha` (defaults to `HEAD` when
+   no commit is provided). Ensure `pre-commit run --all-files`,
+   `python check_env.py --auto-install` and `pytest -q` all succeed before
+   creating the tag. When offline, pass `--wheelhouse <dir>` to `check_env.py`
+   and run the tests from that wheelhouse.
 8. Push commits and tags to GitHub.
 9. The `CI` workflow builds the image and uploads release artifacts.
 

--- a/scripts/create_release_tag.sh
+++ b/scripts/create_release_tag.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+# Create the v0.1.0-alpha annotated release tag.
+
+set -euo pipefail
+
+usage() {
+    cat <<USAGE
+Usage: $0 [commit]
+
+Create the annotated tag 'v0.1.0-alpha' at the given commit.
+If no commit is provided, HEAD is used.
+USAGE
+}
+
+if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
+    usage
+    exit 0
+fi
+
+commit=${1:-HEAD}
+
+git tag -a v0.1.0-alpha "$commit"
+echo "Created tag v0.1.0-alpha at $commit"


### PR DESCRIPTION
## Summary
- add `scripts/create_release_tag.sh` helper to create annotated tags
- reference the helper in `LAUNCH.md`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: No network/wheelhouse)*
- `pytest -q` *(fails: requires wheelhouse or network)*
- `pre-commit run --files scripts/create_release_tag.sh LAUNCH.md` *(fails: proto-verify and verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685613d92e288333a420e2829e7a5554