### PR TITLE
docs: summarize offline variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ It demonstrates the best‑first search behind the other examples and runs witho
 <a name="63-offline-mode"></a>
 ### Offline Mode
 
-Follow these steps when working without internet access.
+Follow these steps when working without internet access. See
+[docs/OFFLINE_INSTALL.md#environment-variables](docs/OFFLINE_INSTALL.md#environment-variables)
+for a summary of required environment variables.
 
 1. **Build a wheelhouse** on a machine with connectivity:
    ```bash

--- a/alpha_factory_v1/quickstart.sh
+++ b/alpha_factory_v1/quickstart.sh
@@ -37,6 +37,7 @@ Bootstraps and launches Alpha-Factory in an isolated Python virtual environment.
   --skip-preflight   Skip automatic preflight checks before launching
   Pip install output logs to $PIP_LOG and failures abort the script.
   Set WHEELHOUSE to install packages from a local wheel cache.
+  See docs/OFFLINE_INSTALL.md#environment-variables for details.
   Any other options are passed directly to the orchestrator.
 EOF
 }

--- a/docs/OFFLINE_INSTALL.md
+++ b/docs/OFFLINE_INSTALL.md
@@ -32,6 +32,18 @@ Use `check_env.py` to install any missing packages from the wheelhouse:
 python check_env.py --auto-install --wheelhouse /media/wheels
 ```
 
+## Environment variables
+Set these variables when running offline so the helper scripts install
+packages from the local wheel cache and Insight never attempts network
+access:
+
+| Variable | Purpose |
+|----------|---------|
+| `WHEELHOUSE` | Directory containing prebuilt wheels. |
+| `AUTO_INSTALL_MISSING` | Set to `1` to automatically install missing packages. |
+| `AGI_INSIGHT_OFFLINE` | Set to `1` to force local inference models. |
+| `AGI_INSIGHT_BROADCAST` | Set to `0` to disable network broadcasting. |
+
 ## 4. Launch Macro-Sentinel
 Start the demo with offline data feeds:
 


### PR DESCRIPTION
## Summary
- document required offline variables in `docs/OFFLINE_INSTALL.md`
- cross-link from README
- mention the docs section in quickstart usage text

## Testing
- `pre-commit run --files README.md alpha_factory_v1/quickstart.sh docs/OFFLINE_INSTALL.md` *(fails: requirements.lock is outdated)*
- `pytest -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_68561715d980833383642c558568f3a1