### PR TITLE
Add SPDX headers to JS files

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { pathToFileURL } from 'url';
 
 export function requireNode20() {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/error_boundary_limit.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/error_boundary_limit.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { initErrorBoundary, getErrorLog, clearErrorLog, record } from '../src/utils/errorBoundary.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/onnx_gpu_backend.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/onnx_gpu_backend.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm/pyodide.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm/pyodide.js
@@ -1,2 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
 // Pyodide 0.25 placeholder
 export async function loadPyodide() { throw new Error('Pyodide runtime unavailable'); }

--- a/tests/webgl_perf.test.js
+++ b/tests/webgl_perf.test.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { chromium } from 'playwright';


### PR DESCRIPTION
## Summary
- add Apache 2.0 headers to various JS sources

## Testing
- `python check_env.py --auto-install` *(fails: No network connectivity detected)*

------
https://chatgpt.com/codex/tasks/task_e_68561d81b874833390df9a94f0eb19b4