### PR TITLE
Fix duplicated disclaimer lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ flowchart TD
 ```
 
 ---
-
-## Disclaimer
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
-
-
 ## Humanity’s Structured Rise to Economic Supremacy via Strategic AGI Mastery
 
 ### 🎖️ α‑AGI Insight 👁️✨ — Beyond Human Foresight
@@ -426,9 +421,6 @@ curl -X POST http://localhost:8000/simulate \
   -H "Content-Type: application/json" \
   -d '{"horizon": 5, "pop_size": 6, "generations": 3, "mut_rate": 0.1, "xover_rate": 0.5, "curve": "linear", "energy": 1.0, "entropy": 1.0}'
 ```
-
-## Disclaimer
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
 
 ## Further Reading
 - [docs/DESIGN.md](docs/DESIGN.md) — architecture overview and agent roles.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 # Changelog
 
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 All notable changes to this project are documented in this file.
 

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -2,7 +2,6 @@
 
 # Offline Setup Guide
 
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This guide explains how to prepare and use a wheelhouse so `check_env.py` and the
 setup scripts work without internet access.

--- a/docs/OFFLINE_INSTALL.md
+++ b/docs/OFFLINE_INSTALL.md
@@ -2,7 +2,6 @@
 
 # Offline Installation Quickstart
 
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This guide summarises how to install the project without internet access and run the Macro-Sentinel demo.
 

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -2,7 +2,6 @@
 
 # Offline Setup Reference
 
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This document summarises how to install the project without internet access.
 


### PR DESCRIPTION
## Summary
- keep only a single disclaimer snippet per markdown file

## Testing
- `python scripts/verify_disclaimer_snippet.py`
- `pre-commit run --files README.md docs/CHANGELOG.md docs/OFFLINE.md docs/OFFLINE_INSTALL.md docs/OFFLINE_SETUP.md` *(fails: proto-verify & verify-requirements-lock)*
- `pytest -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_685624b3fc3883338c55df501a7df23b