### PR TITLE
[alpha_factory] expose demo version

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -2,6 +2,8 @@
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
+Current demo version: `1.0.0`.
+
 
 # 👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo
 *Out-learn • Out-think • Out-design • Out-strategise • Out-execute*

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/__init__.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/__init__.py
@@ -1,2 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the cross-industry Alpha-Factory demo package.
+
+The ``__version__`` constant defined below denotes the demo revision and does not
+track the top-level :mod:`alpha_factory_v1` package version.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+__all__ = ["__version__"]
+
+__version__: Final[str] = "1.0.0"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,7 @@ Downstream users should consult this section when upgrading.
 - `simulate` command now accepts `--energy` and `--entropy` to set initial
   sector values. The React dashboard exposes matching input fields.
 - Version constant ``__version__`` defined in ``alpha_factory_v1.demos.alpha_agi_insight_v1.__init__``.
+- Version constant ``__version__`` defined in ``alpha_factory_v1.demos.cross_industry_alpha_factory.__init__``.
 
 ## [v1.0] - 2025-07-01
 - CLI commands `simulate`, `show-results`, `agents-status` and `replay` for running and inspecting forecasts.

--- a/tests/test_cross_industry_version.py
+++ b/tests/test_cross_industry_version.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify cross-industry demo exposes ``__version__``."""
+
+import importlib
+import unittest
+
+
+class TestCrossIndustryVersion(unittest.TestCase):
+    def test_has_version(self) -> None:
+        mod = importlib.import_module("alpha_factory_v1.demos.cross_industry_alpha_factory")
+        self.assertTrue(hasattr(mod, "__version__"))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `__version__` constant to cross-industry demo
- document new demo version
- mention version constant in changelog
- test that cross-industry demo exports `__version__`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install` *(fails: no network and no wheelhouse)*
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/__init__.py alpha_factory_v1/demos/cross_industry_alpha_factory/README.md docs/CHANGELOG.md tests/test_cross_industry_version.py` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: Skipped, no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_68562c45439c8333b2dc947a81c038e3