### PR TITLE
[alpha_factory] Update README offline test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,12 @@ WHEELHOUSE="$WHEELHOUSE" pytest -q
 If network access is unavailable and the variable is unset these commands fail
 instead of falling back to PyPI.
 
+#### Offline or Restricted Environments
+
+Run `./scripts/build_offline_wheels.sh` to populate a wheelhouse on a
+machine with internet access, then set `WHEELHOUSE=<path>` before executing
+the tests so dependencies install from this local cache.
+
 #### Test Runtime
 
 Running `pytest` may take several minutes on the first run while caches are


### PR DESCRIPTION
## Summary
- document offline testing steps

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no wheelhouse & no network)*
- `pytest -q` *(fails: wheelhouse missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856b116fd8c8333a8424311fb4b97b3