### PR TITLE
[alpha_factory] docs: add missing breaking changes section

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,7 +44,10 @@ Downstream users should consult this section when upgrading.
   git push origin v0.1.0-alpha
   git tag            # verify the tag exists
   ```
- - The package exposes `alpha_factory_v1.__version__ = "0.1.0-alpha"` at this release.
+- The package exposes `alpha_factory_v1.__version__ = "0.1.0-alpha"` at this release.
+
+### Breaking Changes
+- None.
 
 
 ## [1.0.3] - 2025-07-10


### PR DESCRIPTION
## Summary
- document that there are no breaking changes for v0.1.0-alpha

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: no network or wheelhouse)*
- `pytest -q` *(fails: missing dependencies/wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6856b4587af48333ac19aa4c61885446