### PR TITLE
fix: validate num for cross alpha discovery CLI

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -96,6 +96,9 @@ def discover_alpha(
     Returns:
         A list of dictionaries with ``sector`` and ``opportunity`` keys.
     """
+    if num < 1:
+        raise ValueError("num must be >= 1")
+
     if seed is not None:
         random.seed(seed)
     picks: List[Dict[str, str]] = []
@@ -177,7 +180,12 @@ def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapp
         return
 
     ledger = None if args.no_log else _ledger_path(args.ledger)
-    picks = discover_alpha(args.num, seed=args.seed, ledger=ledger, model=args.model)
+    try:
+        picks = discover_alpha(args.num, seed=args.seed, ledger=ledger, model=args.model)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return
+
     print(json.dumps(picks[0] if args.num == 1 else picks, indent=2))
     if ledger is not None:
         print(f"Logged to {ledger}")

--- a/alpha_factory_v1/tests/test_cross_industry_alpha.py
+++ b/alpha_factory_v1/tests/test_cross_industry_alpha.py
@@ -20,6 +20,10 @@ class TestCrossIndustryAlpha(unittest.TestCase):
         self.assertIsInstance(picks, list)
         self.assertEqual(len(picks), 1)
 
+    def test_discover_alpha_invalid_num(self) -> None:
+        with self.assertRaises(ValueError):
+            stub.discover_alpha(num=0, ledger=None, model="gpt-4o-mini")
+
     def test_discover_alpha_online(self) -> None:
         resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="[]"))])
         openai_mock = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=Mock(return_value=resp)))


### PR DESCRIPTION
## Summary
- validate `num` argument in `discover_alpha`
- handle `ValueError` in CLI
- test invalid num case

## Testing
- `pre-commit run --hook-stage manual --files alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py alpha_factory_v1/tests/test_cross_industry_alpha.py`
- `pytest alpha_factory_v1/tests/test_cross_industry_alpha.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856be1ad3ac8333ab08a0a4926b64d4