### PR TITLE
[alpha_factory] add invalid input tests

### DIFF
--- a/alpha_factory_v1/tests/test_cross_industry_alpha.py
+++ b/alpha_factory_v1/tests/test_cross_industry_alpha.py
@@ -24,6 +24,14 @@ class TestCrossIndustryAlpha(unittest.TestCase):
         with self.assertRaises(ValueError):
             stub.discover_alpha(num=0, ledger=None, model="gpt-4o-mini")
 
+    def test_discover_alpha_invalid_zero_default_model(self) -> None:
+        with self.assertRaises(ValueError):
+            stub.discover_alpha(num=0, ledger=None)
+
+    def test_discover_alpha_negative_num(self) -> None:
+        with self.assertRaises(ValueError):
+            stub.discover_alpha(num=-1, ledger=None)
+
     def test_discover_alpha_online(self) -> None:
         resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="[]"))])
         openai_mock = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=Mock(return_value=resp)))


### PR DESCRIPTION
## Summary
- extend cross industry alpha tests for zero & negative values

## Testing
- `pytest alpha_factory_v1/tests/test_cross_industry_alpha.py`

------
https://chatgpt.com/codex/tasks/task_e_6856c02e3c1083338629223b71281661