### PR TITLE
[alpha_factory] add prototype notice to demos

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Command line entrypoint for the α‑AGI Insight demo.
 
 This tiny wrapper lets users run ``python -m alpha_factory_v1.demos.alpha_agi_insight_v0``

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/api_server.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Minimal FastAPI wrapper for the α‑AGI Insight demo.
 
 The server exposes a single ``/insight`` endpoint that runs the

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Launch the Beyond Human Foresight variant of the α‑AGI Insight demo.
 
 This thin wrapper prints a short banner then delegates to

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_dashboard.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_dashboard.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Streamlit dashboard for the α‑AGI Insight demo."""
 from __future__ import annotations
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """α‑AGI Insight demo using Meta‑Agentic Tree Search.
 
 This script predicts which industry sector will see the greatest AGI

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Launch the α‑AGI Insight official demo.
 
 This helper ensures the environment is verified before delegating to the

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Entry point for the *Beyond Human Foresight* α‑AGI Insight demo.
 
 This wrapper automatically chooses the most capable runtime for the

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Production launcher for the α‑AGI Insight demo.
 
 This helper unifies environment validation with automatic runtime

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_zero_data.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_zero_data.py
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
+# This code is a conceptual research prototype.
+# References to "AGI" and "superintelligence" describe aspirational goals
+# and do not indicate the presence of a real general intelligence.
+# Use at your own risk. Nothing herein constitutes financial advice.
+# MontrealAI and the maintainers accept no liability for losses incurred.
 """Zero-data launcher for the α‑AGI Insight demo.
 
 This wrapper enforces offline execution by setting ``ALPHA_AGI_OFFLINE=true``


### PR DESCRIPTION
## Summary
- add the research prototype disclaimer to alpha insight demo launchers

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py alpha_factory_v1/demos/alpha_agi_insight_v0/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v0/beyond_human_foresight.py alpha_factory_v1/demos/alpha_agi_insight_v0/insight_dashboard.py alpha_factory_v1/demos/alpha_agi_insight_v0/insight_demo.py alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo.py alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_final.py alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_production.py alpha_factory_v1/demos/alpha_agi_insight_v0/official_demo_zero_data.py` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: no network and no wheelhouse)*

------
https://chatgpt.com/codex/tasks/task_e_6856c6f78d20833380f83b07d04b100b