### PR TITLE
Update offline install docs

### DIFF
--- a/docs/OFFLINE_INSTALL.md
+++ b/docs/OFFLINE_INSTALL.md
@@ -6,20 +6,22 @@
 This guide summarises how to install the project without internet access and run the Macro-Sentinel demo.
 
 ## 1. Build the wheelhouse
-Run these commands on a machine with connectivity:
+Run the helper script on a machine with connectivity:
 
 ```bash
-mkdir -p /media/wheels
-pip wheel -r requirements.txt -w /media/wheels
-pip wheel -r alpha_factory_v1/requirements-colab.txt -w /media/wheels
+./scripts/build_offline_wheels.sh
 ```
+
+This collects wheels for all lock files inside a `wheels/` directory. Set
+`SMOKE_ONLY=1` to build a minimal wheelhouse containing only the packages needed
+for the smoke tests (`numpy`, `PyYAML`, `pandas` and `prometheus_client`).
 
 ## 2. Create lock files
 Compile reproducible requirements from the wheel cache:
 
 ```bash
 pip-compile --generate-hashes --output-file requirements.lock requirements.txt
-pip-compile --no-index --find-links /media/wheels --generate-hashes \
+pip-compile --no-index --find-links ./wheels --generate-hashes \
     --output-file alpha_factory_v1/requirements-colab.lock \
     alpha_factory_v1/requirements-colab.txt
 ```
@@ -28,7 +30,7 @@ pip-compile --no-index --find-links /media/wheels --generate-hashes \
 Use `check_env.py` to install any missing packages from the wheelhouse:
 
 ```bash
-python check_env.py --auto-install --wheelhouse /media/wheels
+python check_env.py --auto-install --wheelhouse ./wheels
 ```
 
 ## Environment variables
@@ -38,7 +40,7 @@ access:
 
 | Variable | Purpose |
 |----------|---------|
-| `WHEELHOUSE` | Directory containing prebuilt wheels. |
+| `WHEELHOUSE` | Directory containing prebuilt wheels (e.g. `./wheels`). |
 | `AUTO_INSTALL_MISSING` | Set to `1` to automatically install missing packages. |
 | `AGI_INSIGHT_OFFLINE` | Set to `1` to force local inference models. |
 | `AGI_INSIGHT_BROADCAST` | Set to `0` to disable network broadcasting. |

--- a/scripts/build_offline_wheels.sh
+++ b/scripts/build_offline_wheels.sh
@@ -10,6 +10,11 @@ cd "$REPO_ROOT"
 
 mkdir -p wheels
 
+if [[ "${SMOKE_ONLY:-0}" == "1" ]]; then
+    pip wheel numpy pyyaml pandas prometheus_client -w wheels
+    exit 0
+fi
+
 pip wheel -r requirements.lock -w wheels
 pip wheel -r requirements-dev.txt -w wheels
 pip wheel -r requirements-demo.lock -w wheels


### PR DESCRIPTION
## Summary
- document using `scripts/build_offline_wheels.sh` inside OFFLINE_INSTALL.md
- allow `SMOKE_ONLY` mode in build_offline_wheels.sh for small wheelhouse

## Testing
- `pre-commit run --files docs/OFFLINE_INSTALL.md scripts/build_offline_wheels.sh` *(fails: proto-verify, verify-requirements-lock)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -m smoke -q` *(errors: openai_agents package required)*

------
https://chatgpt.com/codex/tasks/task_e_6856d77ec7ac833381c45a4a42fe981d