### PR TITLE
[alpha_factory] fix preflight agent check

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -133,14 +133,27 @@ def check_patch_in_sandbox(image: str = DEFAULT_SANDBOX_IMAGE) -> bool:
 
 
 def check_pkg(pkg: str) -> bool:
-    """Return True if *pkg* is importable."""
+    """Return True if *pkg* or its fallback is importable."""
+
     try:
         import importlib.util
 
-        found = importlib.util.find_spec(pkg) is not None
+        module = pkg
+        spec = importlib.util.find_spec(module)
+
+        if module == "openai_agents" and spec is None:
+            module = "agents"
+            spec = importlib.util.find_spec(module)
+
+        found = spec is not None
     except Exception:  # pragma: no cover - importlib failure is unexpected
         found = False
-    banner(f"{pkg} {'found' if found else 'missing'}", "GREEN" if found else "RED")
+        module = pkg
+
+    banner(
+        f"{module if found else pkg} {'found' if found else 'missing'}",
+        "GREEN" if found else "RED",
+    )
     return found
 
 


### PR DESCRIPTION
## Summary
- detect the `agents` module when checking for `openai_agents`
- keep version validation but report whichever module is found

## Testing
- `pre-commit run --files alpha_factory_v1/scripts/preflight.py black ruff ruff-format flake8 mypy` *(fails: proto-verify, verify-requirements-lock)*
- `python alpha_factory_v1/scripts/preflight.py | head -n 17`

------
https://chatgpt.com/codex/tasks/task_e_6856e31175248333846a6db87188f197