### PR TITLE
[alpha_factory] clarify tag verification steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ For the full changelog, see [docs/CHANGELOG.md](docs/CHANGELOG.md).
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.
 - This tag points at commit `0ff79a4f`.
-- If cloning from a snapshot without tags, recreate it using:
-  ```bash
-  git tag -a v0.1.0-alpha 0ff79a4f -m "v0.1.0-alpha"
-  git push origin v0.1.0-alpha
-  git tag            # verify the tag exists
-  ```
+ - If cloning from a snapshot without tags, recreate it using:
+    ```bash
+    # Verify the release tag
+    git tag -l v0.1.0-alpha
+    # Recreate the tag when missing
+    ./scripts/create_release_tag.sh HEAD
+    git push origin v0.1.0-alpha
+    ```
  - The package exposes `alpha_factory_v1.__version__ = "0.1.0-alpha"` at this release.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,12 +38,14 @@ Downstream users should consult this section when upgrading.
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.
 - This tag points at commit `0ff79a4f`.
-- If cloning from a snapshot without tags, recreate it using:
-  ```bash
-  git tag -a v0.1.0-alpha 0ff79a4f -m "v0.1.0-alpha"
-  git push origin v0.1.0-alpha
-  git tag            # verify the tag exists
-  ```
+ - If cloning from a snapshot without tags, recreate it using:
+    ```bash
+    # Verify the release tag
+    git tag -l v0.1.0-alpha
+    # Recreate the tag when missing
+    ./scripts/create_release_tag.sh HEAD
+    git push origin v0.1.0-alpha
+    ```
 - The package exposes `alpha_factory_v1.__version__ = "0.1.0-alpha"` at this release.
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary
- document checking `git tag -l v0.1.0-alpha`
- show how to recreate the release tag with `scripts/create_release_tag.sh`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'OpenAIAgent' from 'openai_agents')*
- `pre-commit run --files CHANGELOG.md docs/CHANGELOG.md README.md` *(fails: missing Makefile target in proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6856e94faadc83339899b6ef78167c24