### PR TITLE
Fix openai-agents version check

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -36,7 +36,7 @@ else:
 MIN_PY = (3, 11)
 MAX_PY = (3, 13)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
-MIN_OPENAI_AGENTS_VERSION = "0.0.19"
+MIN_OPENAI_AGENTS_VERSION = "0.0.17"
 DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "python:3.11-slim")
 
 COLORS = {

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -4,5 +4,5 @@ torch>=2.2
 gymnasium[classic-control]>=0.29
 gradio>=4.35
 filelock>=3.13
-openai-agents>=0.0.19
+openai-agents>=0.0.17
 


### PR DESCRIPTION
## Summary
- ensure `preflight` uses openai-agents 0.0.17
- align demo requirements with the same minimum

## Testing
- `pre-commit run --files AGENTS.md alpha_factory_v1/scripts/preflight.py requirements-demo.txt` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee13d84883338736743e415abc04