### PR TITLE
[alpha_factory] Remove duplicate disclaimer lines

### DIFF
--- a/docs/deployment_security.md
+++ b/docs/deployment_security.md
@@ -2,8 +2,6 @@
 
 # Secure Deployment
 
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
-
 This guide explains how to protect Alpha-Factory in production.
 
 ## TLS configuration

--- a/docs/dgm_ops.md
+++ b/docs/dgm_ops.md
@@ -1,7 +1,6 @@
 [See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 ## Disclaimer
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 # DGM Operations Runbook
 


### PR DESCRIPTION
## Summary
- trim redundant disclaimer link in DGM ops doc
- trim redundant disclaimer link in deployment security doc

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 88 errors during collection)*
- `pre-commit run --files docs/dgm_ops.md docs/deployment_security.md` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6857032329f88333adbea846d78220eb