### PR TITLE
Rename database service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - .env
     environment:
       AGI_INSIGHT_LEDGER_PATH: /app/ledger/audit.db
-      AGI_INSIGHT_DB: duckdb
+      AGI_INSIGHT_DB: postgres
     volumes:
       - ledger:/app/ledger
     ports:
@@ -30,7 +30,7 @@ services:
       timeout: 5s
       retries: 3
 
-  duckdb:
+  postgres:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: insight


### PR DESCRIPTION
## Summary
- rename `duckdb` service to `postgres`
- update AGI_INSIGHT_DB default

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files docker-compose.yml` *(fails: Missing packages: yaml)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly')*

------
https://chatgpt.com/codex/tasks/task_e_68570ad33e1c833393dfdbaa55aee614