### PR TITLE
[alpha_factory] Fix generated tests newline

### DIFF
--- a/src/tools/test_scribe.py
+++ b/src/tools/test_scribe.py
@@ -16,5 +16,5 @@ def generate_test(repo: str | Path, check: str) -> Path:
     idx = len(list(tests_dir.glob("test_generated_*.py")))
     test_path = tests_dir / f"test_generated_{idx}.py"
     code = f"def test_generated_{idx}():\n    assert {check}\n"
-    test_path.write_text(code, encoding="utf-8")
+    test_path.write_text(code + "\n", encoding="utf-8")
     return test_path


### PR DESCRIPTION
## Summary
- ensure generated tests end with a newline

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files src/tools/test_scribe.py` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: ModuleNotFoundError: plotly and others)*

------
https://chatgpt.com/codex/tasks/task_e_68571070ed308333b7300045fd7ddb8b