### PR TITLE
[alpha_factory] enforce tabs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,18 @@ compose-up:
 loadtest:
 	k6 run --summary-export=tools/loadtest/summary.json tools/loadtest/insight.js
 	@python - <<'PY2'
-import json
-with open('tools/loadtest/summary.json') as f:
-    data=json.load(f)
-print(f"p95 latency: {data['metrics']['http_req_duration']['p(95)']} ms")
+	import json
+	with open('tools/loadtest/summary.json') as f:
+	    data=json.load(f)
+	print(f"p95 latency: {data['metrics']['http_req_duration']['p(95)']} ms")
 PY2
 
 proto:
 	./scripts/gen_proto.py
 
 proto-verify:
-        $(MAKE) proto
-        git --no-pager diff --exit-code src/utils/a2a_pb2.py alpha_factory_v1/proto/go/a2a.pb.go
+	$(MAKE) proto
+	git --no-pager diff --exit-code src/utils/a2a_pb2.py alpha_factory_v1/proto/go/a2a.pb.go
 
 benchmark:
 	python benchmarks/docker_runner.py > bench_results.json


### PR DESCRIPTION
## Summary
- use tabs for commands under `loadtest` and `proto-verify`
- run `pre-commit` on the Makefile

## Testing
- `pre-commit run --files Makefile` *(fails: Makefile:30: *** missing separator.  Stop.)*


------
https://chatgpt.com/codex/tasks/task_e_685738934cc48333bc94eea5218cf328