### PR TITLE
[alpha_factory] update env_check.sh

### DIFF
--- a/scripts/env_check.sh
+++ b/scripts/env_check.sh
@@ -5,5 +5,19 @@
 # check. ``check_python_deps.py`` now relies on ``python -m pip show`` for
 # speed and reliability.
 set -euo pipefail
+
+# Optionally set WHEELHOUSE to a directory with wheels for offline installs.
+# The script forwards "--wheelhouse" when defined.
+
 python scripts/check_python_deps.py
-python check_env.py --auto-install
+
+env_opts=()
+if [[ -n "${WHEELHOUSE:-}" ]]; then
+    if [[ ! -d "$WHEELHOUSE" ]]; then
+        echo "WHEELHOUSE directory '$WHEELHOUSE' does not exist" >&2
+        exit 1
+    fi
+    env_opts=(--wheelhouse "$WHEELHOUSE")
+fi
+
+python check_env.py --auto-install "${env_opts[@]}"


### PR DESCRIPTION
## Summary
- use `--wheelhouse` in `env_check.sh` when the env var is set
- document the optional variable in the script comments
- exit early with an error when the wheelhouse is missing

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: plotly, openai_agents, gradio)*
- `pre-commit run --files scripts/env_check.sh` *(fails: proto-verify, requirements lock)*


------
https://chatgpt.com/codex/tasks/task_e_68580e3305ac8333b2c80a6674ecfcbd