### PR TITLE
Add pytest cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/
 # Key files
 *.key
 
+# Pytest artifacts
+.pytest_cache/
+


### PR DESCRIPTION
## Summary
- prevent pytest cache from being tracked in git
- verify the disclaimer snippet hook passes

## Testing
- `pre-commit run verify-disclaimer-snippet --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68581be823c48333bf419ee29a4a062a