### PR TITLE
[alpha_factory] Skip gitignored files in disclaimer check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,6 +373,9 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
   `pip install pre-commit` and run `pre-commit install` once.
 - To reinstall the hooks, run `pip install -U pre-commit` and then
   `pre-commit install` again.
+- The `verify_disclaimer_snippet.py` hook now skips files ignored by Git. If you
+  see false positives from directories like `.pytest_cache`, ensure they are
+  listed in `.gitignore`.
 
 For detailed troubleshooting steps, see [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md).
 

--- a/scripts/verify_disclaimer_snippet.py
+++ b/scripts/verify_disclaimer_snippet.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+import subprocess
 
 
 def main() -> int:
@@ -16,6 +17,16 @@ def main() -> int:
     disclaimer_normalized = "".join(disclaimer_text.split())
 
     missing: list[Path] = []
+
+    def is_git_ignored(p: Path) -> bool:
+        try:
+            result = subprocess.run(
+                ["git", "check-ignore", "-q", str(p.relative_to(repo_root))],
+                cwd=repo_root,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
 
     def first_markdown_cell(nb_path: Path) -> str:
         try:
@@ -33,7 +44,7 @@ def main() -> int:
         return ""
 
     for path in repo_root.rglob("*"):
-        if path == snippet_path or ".git" in path.parts or not path.is_file():
+        if path == snippet_path or ".git" in path.parts or not path.is_file() or is_git_ignored(path):
             continue
         if path.suffix not in {".md", ".ipynb"}:
             continue


### PR DESCRIPTION
## Summary
- ignore files listed in `.gitignore` when verifying the disclaimer snippet
- document the new behaviour in `AGENTS.md`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 7 errors during collection)*
- `pre-commit run --files AGENTS.md scripts/verify_disclaimer_snippet.py` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68581f05faa083338081451649301bc3