### PR TITLE
[alpha_factory] update check_env behaviour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Please report security vulnerabilities as described in our [Security Policy](SEC
    `pre-commit` isn't found, run `pip install pre-commit` and re-run the script.
 - Install `pytest` and `prometheus_client` using
   `python check_env.py --auto-install` or `pip install pytest prometheus_client`.
+- Setting `ALPHA_FACTORY_FULL=1` forces `check_env.py` to install heavy extras
+  even without `--auto-install`.
 
 Confirm installed versions:
 ```bash


### PR DESCRIPTION
## Summary
- install `HEAVY_EXTRAS` automatically when `ALPHA_FACTORY_FULL=1`
- document new behaviour in contributor guide

## Testing
- `python scripts/check_python_deps.py && python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly', ValueError: openai_agents.__spec__ is None, ImportError: openai_agents package is required, ModuleNotFoundError: No module named 'gradio', ImportError: cannot import name 'patcher_core', ImportError: cannot import name 'patcher_core', ModuleNotFoundError: No module named 'plotly')*
- `pre-commit run --files check_env.py AGENTS.md` *(fails: requirements.lock is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_68582b83b17883338462e4a1c6eed9f5