### PR TITLE
Add Docker quickstart helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ./quickstart.sh
 # or using Docker
 docker compose up --build
+# or one-click image
+./run_quickstart.sh
 ```
 
 See [docs/quickstart.md](docs/quickstart.md) for detailed steps.
@@ -916,6 +918,14 @@ Start the full stack using Docker Compose:
 docker compose up --build
 ```
 Browse the dashboard at <http://localhost:8080>.
+
+## One-Click Docker Quickstart
+Run the minimal image directly:
+```bash
+./run_quickstart.sh
+```
+The script prints the project disclaimer, builds `docker/quickstart/Dockerfile`
+and launches the container with your `.env` file mounted.
 
 The same configuration can be installed via Helm:
 ```bash

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Minimal runtime image for the quickstart script
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Alpha-Factory with default extras
+COPY requirements.lock /tmp/requirements.lock
+RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock
+
+# Copy package source and install in editable mode
+COPY alpha_factory_v1 /app/alpha_factory_v1
+COPY af_requests /app/af_requests
+COPY pyproject.toml README.md /app/
+RUN pip install --no-cache-dir .
+
+# Provide example environment files
+COPY alpha_factory_v1/.env.sample /app/.env.sample
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/.env.sample /app/insight.env.sample
+
+CMD ["alpha-factory", "--help"]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,6 +61,11 @@ python check_env.py --auto-install  # may take several minutes
 ./quickstart.sh
 ```
 
+Alternatively build and run the Docker image in one step:
+```bash
+./run_quickstart.sh
+```
+
 Copy `.env.sample` to `.env` and add your API keys to enable cloud features. Without keys, the program falls back to the local Meta‑Agentic Tree Search:
 
 ```bash

--- a/run_quickstart.sh
+++ b/run_quickstart.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This repository is a conceptual research prototype. References to "AGI" and
+# "superintelligence" describe aspirational goals and do not indicate the
+# presence of a real general intelligence. Use at your own risk. Nothing herein
+# constitutes financial advice. MontrealAI and the maintainers accept no
+# liability for losses incurred from using this software.
+# See docs/DISCLAIMER_SNIPPET.md
+
+set -Eeuo pipefail
+trap 'echo -e "\n\u274c Error on line $LINENO" >&2' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+cat "$SCRIPT_DIR/docs/DISCLAIMER_SNIPPET.md"
+
+IMAGE="alpha-factory-quickstart"
+
+docker build -t "$IMAGE" docker/quickstart
+
+docker run --rm -it \
+  -v "$SCRIPT_DIR/.env:/app/.env" \
+  -p 8000:8000 "$IMAGE"


### PR DESCRIPTION
## Summary
- add `docker/quickstart` Dockerfile for Alpha‑Factory v1
- add `run_quickstart.sh` helper
- document one-click workflow in README
- reference script in docs/quickstart.md

## Testing
- `pre-commit run --files README.md docs/quickstart.md docker/quickstart/Dockerfile run_quickstart.sh` *(skipped lock verification and env-check)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685840e872c08333970f826a16ff70af