### PR TITLE
Update test docs for web assets

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -126,6 +126,11 @@ continues even in minimal environments.
 10. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
    `pre-commit install` once to enable the git hooks referenced in
    [AGENTS.md](../AGENTS.md).
+11. Build the web assets so `dist/sw.js` exists:
+   ```bash
+   make build_web  # or run npm run build in insight_browser_v1
+   ```
+   Failing to generate this file causes `tests/test_cache_version.py` to fail.
 
 ### Wheelhouse requirement
 


### PR DESCRIPTION
## Summary
- mention that web assets must be built before running the tests
- note that missing `dist/sw.js` will break `test_cache_version.py`

## Testing
- `pre-commit run --files tests/README.md` *(with req/lock checks skipped)*
- `pytest -k test_cache_version -q` *(fails: FileNotFoundError for dist/sw.js)*


------
https://chatgpt.com/codex/tasks/task_e_68584aad7be08333811e815c5ce27543