### PR TITLE
[alpha_factory] fix tests with stubs

### DIFF
--- a/alpha_factory_v1/demos/utils/__init__.py
+++ b/alpha_factory_v1/demos/utils/__init__.py
@@ -1,0 +1,7 @@
+"""Utilities for demos.
+
+Provides the standard project disclaimer for CLI scripts.
+"""
+from ...utils.disclaimer import DISCLAIMER  # re-export for convenience
+
+__all__ = ["DISCLAIMER"]

--- a/alpha_factory_v1/demos/utils/disclaimer.py
+++ b/alpha_factory_v1/demos/utils/disclaimer.py
@@ -1,0 +1,1 @@
+from ...utils.disclaimer import *

--- a/tests/README.md
+++ b/tests/README.md
@@ -112,18 +112,23 @@ continues even in minimal environments.
    Bundling small wheels such as `numpy`, `pyyaml` and `pandas` allows the smoke
    tests to run without contacting PyPI.
 7. Set `PYTHONPATH=$(pwd)` or install the project in editable mode with `pip install -e .`.
-8. Export the wheel cache path and run the environment check before the suite:
+8. Include the stub modules in `tests/resources` on your `PYTHONPATH` so CLI
+   subprocess tests can import the lightweight `rocketry` replacement:
+   ```bash
+   export PYTHONPATH="$(pwd)/tests/resources:$PYTHONPATH"
+   ```
+9. Export the wheel cache path and run the environment check before the suite:
    ```bash
    export WHEELHOUSE=/path/to/wheels
    python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
    PYTHONPATH=$(pwd) pytest -q
    ```
-9. Without a wheelhouse or network access the environment check fails and
+10. Without a wheelhouse or network access the environment check fails and
    `tests/conftest.py` skips the entire suite with a concise "no network and no
    wheelhouse" message. Provide `--wheelhouse <dir>` (or set `WHEELHOUSE`) to run
    the tests offline. Preparing this directory via `scripts/build_offline_wheels.sh`
    is therefore a mandatory prerequisite when testing in air‑gapped setups.
-10. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
+11. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
    `pre-commit install` once to enable the git hooks referenced in
    [AGENTS.md](../AGENTS.md).
 11. Build the web assets so `dist/sw.js` exists:

--- a/tests/resources/alpha_factory_v1/__init__.py
+++ b/tests/resources/alpha_factory_v1/__init__.py
@@ -1,0 +1,1 @@
+from alpha_factory_v1 import *

--- a/tests/resources/alpha_factory_v1/demos/__init__.py
+++ b/tests/resources/alpha_factory_v1/demos/__init__.py
@@ -1,0 +1,1 @@
+from alpha_factory_v1.demos import *

--- a/tests/resources/alpha_factory_v1/demos/utils/__init__.py
+++ b/tests/resources/alpha_factory_v1/demos/utils/__init__.py
@@ -1,0 +1,1 @@
+from alpha_factory_v1.utils.disclaimer import *

--- a/tests/resources/openai_agents.py
+++ b/tests/resources/openai_agents.py
@@ -1,0 +1,29 @@
+class OpenAIAgent:
+    def __init__(self, *a: object, **_k: object) -> None:
+        pass
+
+    def __call__(self, prompt: str) -> str:
+        return "ok"
+
+
+class AgentRuntime:
+    def __init__(self, *a: object, port: int = 5001, **_k: object) -> None:
+        self.port = port
+
+    def register(self, *_a: object, **_k: object) -> None:
+        pass
+
+    def run(self) -> None:
+        pass
+
+
+from typing import Callable, TypeVar
+
+F = TypeVar("F")
+
+
+def Tool(*_a: object, **_k: object) -> Callable[[F], F]:
+    def dec(f: F) -> F:
+        return f
+
+    return dec

--- a/tests/resources/rocketry/__init__.py
+++ b/tests/resources/rocketry/__init__.py
@@ -1,0 +1,5 @@
+class Rocketry:
+    pass
+
+
+from . import conds

--- a/tests/resources/rocketry/conds.py
+++ b/tests/resources/rocketry/conds.py
@@ -1,0 +1,2 @@
+def every(*_args, **_kwargs):
+    return None

--- a/tests/resources/sentence_transformers.py
+++ b/tests/resources/sentence_transformers.py
@@ -1,0 +1,8 @@
+class SentenceTransformer:
+    def __init__(self, *a, **k):
+        pass
+
+    def encode(self, texts, normalize_embeddings=True):
+        import numpy as np
+
+        return np.zeros((len(texts), 384), dtype="float32")

--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -11,6 +11,9 @@ from unittest import mock
 import pytest
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[1]
+STUB_DIR = ROOT / "tests" / "resources"
+
 MODULE = "alpha_factory_v1.demos.alpha_agi_business_3_v1.alpha_agi_business_3_v1"
 
 
@@ -25,7 +28,7 @@ def test_adk_client_import(monkeypatch: pytest.MonkeyPatch) -> None:
     if MODULE in sys.modules:
         del sys.modules[MODULE]
     mod = importlib.import_module(MODULE)
-    assert mod.ADKClient is Client
+    assert mod.ADKClient is Client  # type: ignore[attr-defined]
 
 
 def test_a2a_port_zero(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -145,7 +148,7 @@ def test_main_subprocess(tmp_path: Path) -> None:
     stub.write_text("def main(args=None):\n    pass\n")
     env = os.environ.copy()
     env["OPENAI_API_KEY"] = "dummy"
-    env["PYTHONPATH"] = f"{tmp_path}:{env.get('PYTHONPATH', '')}"
+    env["PYTHONPATH"] = f"{tmp_path}:{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
     result = subprocess.run(
         [
             sys.executable,
@@ -168,7 +171,7 @@ def test_cli_entrypoint(tmp_path: Path) -> None:
     stub.write_text("def main(args=None):\n    pass\n")
     env = os.environ.copy()
     env["OPENAI_API_KEY"] = "dummy"
-    env["PYTHONPATH"] = f"{tmp_path}:{env.get('PYTHONPATH', '')}"
+    env["PYTHONPATH"] = f"{tmp_path}:{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
     result = subprocess.run(
         ["alpha-agi-business-3-v1", "--cycles", "1"],
         capture_output=True,

--- a/tests/test_alpha_agi_insight_v1_main.py
+++ b/tests/test_alpha_agi_insight_v1_main.py
@@ -2,16 +2,24 @@
 import subprocess
 import sys
 import unittest
+from pathlib import Path
+import os
+
+ROOT = Path(__file__).resolve().parents[1]
+STUB_DIR = ROOT / "tests" / "resources"
 
 
 class TestAlphaAgiInsightMainV1(unittest.TestCase):
     """Verify the v1 demo package entry point."""
 
     def test_cli_help(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
         result = subprocess.run(
             [sys.executable, "-m", "alpha_factory_v1.demos.alpha_agi_insight_v1", "--help"],
             capture_output=True,
             text=True,
+            env=env,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Insight command line interface", result.stdout)

--- a/tests/test_alpha_conversion_stub.py
+++ b/tests/test_alpha_conversion_stub.py
@@ -7,6 +7,9 @@ import unittest
 from pathlib import Path
 import tempfile
 
+ROOT = Path(__file__).resolve().parents[1]
+STUB_DIR = ROOT / "tests" / "resources"
+
 STUB = "alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py"
 
 
@@ -14,10 +17,13 @@ class TestAlphaConversionStub(unittest.TestCase):
     def test_generate_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             ledger = Path(tmp) / "plan.json"
+            env = os.environ.copy()
+            env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
             result = subprocess.run(
                 [sys.executable, STUB, "--alpha", "test opportunity", "--ledger", str(ledger)],
                 capture_output=True,
                 text=True,
+                env=env,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertTrue(ledger.exists())
@@ -30,6 +36,7 @@ class TestAlphaConversionStub(unittest.TestCase):
             env = os.environ.copy()
             env["HOME"] = home
             env.pop("ALPHA_CONVERSION_LEDGER", None)
+            env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
             ledger = Path(home) / ".aiga" / "alpha_conversion_log.json"
             result = subprocess.run(
                 [sys.executable, STUB, "--alpha", "test opportunity"],
@@ -45,6 +52,7 @@ class TestAlphaConversionStub(unittest.TestCase):
             env = os.environ.copy()
             env["HOME"] = home
             env.pop("ALPHA_CONVERSION_LEDGER", None)
+            env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
             result = subprocess.run(
                 [sys.executable, STUB, "--alpha", "skip", "--no-log"],
                 capture_output=True,

--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -4,6 +4,7 @@ import socket
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -15,6 +16,9 @@ httpx = pytest.importorskip("httpx")
 os.environ.setdefault("API_TOKEN", "test-token")
 os.environ.setdefault("API_RATE_LIMIT", "1000")
 
+ROOT = Path(__file__).resolve().parents[1]
+STUB_DIR = ROOT / "tests" / "resources"
+
 
 def _free_port() -> int:
     with socket.socket() as s:
@@ -25,6 +29,7 @@ def _free_port() -> int:
 def test_simulate_curve_subprocess() -> None:
     port = _free_port()
     env = os.environ.copy()
+    env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
     cmd = [
         sys.executable,
         "-m",
@@ -97,7 +102,9 @@ def _start_server(port: int, env: dict[str, str] | None = None) -> subprocess.Po
         "--port",
         str(port),
     ]
-    return subprocess.Popen(cmd, env=env or os.environ.copy())
+    env = env or os.environ.copy()
+    env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
+    return subprocess.Popen(cmd, env=env)
 
 
 def _start_demo_server(port: int, env: dict[str, str] | None = None) -> subprocess.Popen[bytes]:
@@ -110,7 +117,9 @@ def _start_demo_server(port: int, env: dict[str, str] | None = None) -> subproce
         "--port",
         str(port),
     ]
-    return subprocess.Popen(cmd, env=env or os.environ.copy())
+    env = env or os.environ.copy()
+    env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
+    return subprocess.Popen(cmd, env=env)
 
 
 def _wait_running(url: str, headers: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary
- add demo utils module
- document PYTHONPATH stubs for subprocess tests
- stub missing packages for offline tests
- ensure subprocess tests include stub paths

## Testing
- `pytest tests/test_alpha_agi_insight_v1_main.py::TestAlphaAgiInsightMainV1::test_cli_help -q`
- `pytest tests/test_alpha_conversion_stub.py -q`
- `pytest tests/test_api_server_subprocess.py::test_simulate_curve_subprocess -q`


------
https://chatgpt.com/codex/tasks/task_e_68585b59780c833390907e6fe44dbac1