### PR TITLE
Centralize disclaimer logic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,11 @@ repos:
         language: python
         pass_filenames: false
         files: \.(md|ipynb)$
+      - id: verify-disclaimer-helper
+        name: Ensure scripts import disclaimer helper
+        entry: python scripts/verify_disclaimer_helper.py
+        language: python
+        pass_filenames: false
       - id: py-compile
         name: Validate Python syntax with py_compile
         entry: python -m py_compile

--- a/alpha_factory_v1/demos/aiga_meta_evolution/__main__.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/__main__.py
@@ -6,8 +6,8 @@ indicate the presence of real general intelligence. Use at your own risk.
 """
 
 from .start_aiga_demo import main
-from ..utils.disclaimer import DISCLAIMER
+from ..utils.disclaimer import print_disclaimer
 
 if __name__ == "__main__":
-    print(DISCLAIMER)
+    print_disclaimer()
     main()

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/__main__.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """CLI entry point for the α‑AGI Business v3 demo."""
 from .alpha_agi_business_3_v1 import main
-from ..utils.disclaimer import DISCLAIMER
+from ..utils.disclaimer import print_disclaimer
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     import asyncio
 
-    print(DISCLAIMER)
+    print_disclaimer()
     asyncio.run(main())

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/__main__.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 import argparse
 from . import insight_demo
 from ... import get_version
-from ...utils.disclaimer import DISCLAIMER
+from ...utils.disclaimer import print_disclaimer
 import os
 
 
 def main(argv: list[str] | None = None) -> None:
-    print(DISCLAIMER)
+    print_disclaimer()
 
     parser = argparse.ArgumentParser(description="Run the α‑AGI Insight demo")
     parser.add_argument(

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/__main__.py
@@ -5,9 +5,9 @@ Run ``python -m alpha_factory_v1.demos.alpha_agi_insight_v1 --help`` to see
 available subcommands, including ``api-server`` to launch the REST API.
 """
 from .src.interface.cli import main
-from ..utils.disclaimer import DISCLAIMER
+from ..utils.disclaimer import print_disclaimer
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
-    print(DISCLAIMER)
+    print_disclaimer()
     main()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/minimal_ui.py
@@ -14,7 +14,7 @@ import sys
 from typing import Any, TYPE_CHECKING, cast
 
 from ..simulation import forecast, sector
-from .....utils.disclaimer import DISCLAIMER
+from .....utils.disclaimer import DISCLAIMER, print_disclaimer
 
 try:  # pragma: no cover - optional dependency
     import streamlit as _st
@@ -85,7 +85,7 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover - entry poi
         sys.exit("Streamlit not installed. Re-run with --text for console output.")
 
     if args.text or st is None:
-        print(DISCLAIMER)
+        print_disclaimer()
         traj = _simulate(5, "logistic", 6, 3)
         for record in _disruption_df(traj).to_dict(orient="records"):
             print(f"{record['sector']}: year {record['year']}")

--- a/alpha_factory_v1/demos/muzero_planning/__main__.py
+++ b/alpha_factory_v1/demos/muzero_planning/__main__.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import argparse
 import os
-from ...utils.disclaimer import DISCLAIMER
+from ...utils.disclaimer import print_disclaimer
 
 
 def main(argv: list[str] | None = None) -> None:
     """Launch the MuZero dashboard with optional CLI overrides."""
 
-    print(DISCLAIMER)
+    print_disclaimer()
 
     parser = argparse.ArgumentParser(description="Run MuZero planning demo")
     parser.add_argument(

--- a/alpha_factory_v1/demos/self_healing_repo.py
+++ b/alpha_factory_v1/demos/self_healing_repo.py
@@ -56,7 +56,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from ..utils.disclaimer import DISCLAIMER
+from ..utils.disclaimer import DISCLAIMER, print_disclaimer
 from typing import Optional
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -64,7 +64,7 @@ from typing import Optional
 # ────────────────────────────────────────────────────────────────────────────────
 try:
     # OpenAI Agents SDK (>= 0.4.0)
-    from agents import Runner  # type: ignore
+    from agents import Runner
 
     SDK_AVAILABLE = True
 except ModuleNotFoundError:  # pragma: no cover
@@ -73,7 +73,7 @@ except ModuleNotFoundError:  # pragma: no cover
 try:
     import git  # GitPython
 except ModuleNotFoundError:  # pragma: no cover
-    git = None  # type: ignore[misc]
+    git = None
 
 # Alpha‑Factory shared utilities
 from alpha_factory_v1.backend.agent_factory import build_core_agent
@@ -88,7 +88,7 @@ def _commit_patch(repo_path: Path, message: str = "auto‑fix: CI green 🟢") -
 
     try:
         repo = git.Repo(repo_path)
-    except git.InvalidGitRepositoryError:  # type: ignore[attr-defined]
+    except git.InvalidGitRepositoryError:
         return "[not a git repo ‑ skipping commit]"
 
     branch_name = "auto-fix"
@@ -130,7 +130,7 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 # Main logic
 # ────────────────────────────────────────────────────────────────────────────────
 def main(argv: Optional[list[str]] = None) -> None:
-    print(DISCLAIMER)
+    print_disclaimer()
     args = _parse_args(argv)
 
     if args.allow_local_code:

--- a/alpha_factory_v1/demos/validate_demos.py
+++ b/alpha_factory_v1/demos/validate_demos.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-from ..utils.disclaimer import DISCLAIMER
+from ..utils.disclaimer import print_disclaimer
 
 DEFAULT_DIR = os.path.dirname(__file__)
 
@@ -57,7 +57,7 @@ def main(base_dir: str = DEFAULT_DIR, min_lines: int = 3, require_code_block: bo
 if __name__ == "__main__":
     import argparse
 
-    print(DISCLAIMER)
+    print_disclaimer()
 
     parser = argparse.ArgumentParser(description="Validate demo directories")
     parser.add_argument(

--- a/alpha_factory_v1/edge_runner.py
+++ b/alpha_factory_v1/edge_runner.py
@@ -24,7 +24,7 @@ from typing import Callable
 
 from alpha_factory_v1 import run as af_run, __version__
 from alpha_factory_v1.utils.env import _env_int
-from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+from alpha_factory_v1.utils.disclaimer import print_disclaimer
 from src.utils.config import init_config
 
 log = logging.getLogger(__name__)
@@ -124,7 +124,7 @@ def main() -> None:
     flags.
     """
 
-    print(DISCLAIMER)
+    print_disclaimer()
     init_config()
     args = parse_args()
 

--- a/alpha_factory_v1/quickstart.sh
+++ b/alpha_factory_v1/quickstart.sh
@@ -22,6 +22,7 @@ cd "$SCRIPT_DIR/.."  # always operate from repository root
 export PYTHONPATH="${PWD}:${PYTHONPATH:-}"
 
 # use local wheels when available
+# shellcheck disable=SC2155
 if [[ -z "${WHEELHOUSE:-}" && -d wheels ]]; then
   export WHEELHOUSE="$(pwd)/wheels"
 fi
@@ -135,14 +136,15 @@ header
 check_deps
 info "Displaying disclaimer"
 python3 - <<'PY'
-from alpha_factory_v1.utils.disclaimer import DISCLAIMER
-print(DISCLAIMER)
+from alpha_factory_v1.utils.disclaimer import print_disclaimer
+print_disclaimer()
 PY
 check_python_version
 
 VENV_DIR=".venv"
 prompt "Create virtual environment at $VENV_DIR?" && create_venv
 
+# shellcheck source=/dev/null
 source "$VENV_DIR/bin/activate"
 
 if [[ $PRECHECK_ONLY -eq 1 ]]; then

--- a/alpha_factory_v1/run.py
+++ b/alpha_factory_v1/run.py
@@ -6,7 +6,7 @@ import os
 import argparse
 from pathlib import Path
 
-from .utils.disclaimer import DISCLAIMER
+from .utils.disclaimer import print_disclaimer
 
 from .utils.env import _load_env_file
 
@@ -71,7 +71,7 @@ def run(show_disclaimer: bool = True) -> None:
     """Entry point used by the ``alpha-factory`` console script."""
     args = parse_args()
     if show_disclaimer:
-        print(DISCLAIMER)
+        print_disclaimer()
     if args.version:
         print(__version__)
         return

--- a/alpha_factory_v1/utils/disclaimer.py
+++ b/alpha_factory_v1/utils/disclaimer.py
@@ -6,4 +6,10 @@ from pathlib import Path
 _DOCS_PATH = Path(__file__).resolve().parents[2] / "docs" / "DISCLAIMER_SNIPPET.md"
 DISCLAIMER: str = _DOCS_PATH.read_text(encoding="utf-8").strip()
 
-__all__ = ["DISCLAIMER"]
+
+def print_disclaimer() -> None:
+    """Print the project disclaimer."""
+    print(DISCLAIMER)
+
+
+__all__ = ["DISCLAIMER", "print_disclaimer"]

--- a/scripts/verify_disclaimer_helper.py
+++ b/scripts/verify_disclaimer_helper.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# See docs/DISCLAIMER_SNIPPET.md
+"""Fail if scripts include hard-coded disclaimer text instead of importing it."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PATTERNS = [
+    "This script is a conceptual research prototype.",
+    "This code is a conceptual research prototype.",
+    "This repository is a conceptual research prototype.",
+]
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_dirs = [repo_root / "scripts", repo_root / "alpha_factory_v1" / "scripts"]
+    script_paths = [
+        repo_root / "edge_runner.py",
+        repo_root / "quickstart.sh",
+        repo_root / "alpha_factory_v1" / "edge_runner.py",
+        repo_root / "alpha_factory_v1" / "quickstart.sh",
+        repo_root / "alpha_factory_v1" / "run.py",
+    ]
+
+    offenders: list[Path] = []
+
+    for d in script_dirs:
+        for p in d.rglob("*.py"):
+            if p.resolve() == Path(__file__).resolve():
+                continue
+            text = p.read_text(encoding="utf-8", errors="ignore")
+            if any(pattern in text for pattern in PATTERNS):
+                offenders.append(p.relative_to(repo_root))
+
+    for p in script_paths:
+        if not p.exists() or p.resolve() == Path(__file__).resolve():
+            continue
+        text = p.read_text(encoding="utf-8", errors="ignore")
+        if any(pattern in text for pattern in PATTERNS):
+            offenders.append(p.relative_to(repo_root))
+
+    if offenders:
+        print(
+            "Hard-coded disclaimer text detected. Import from alpha_factory_v1.utils.disclaimer instead:",
+            file=sys.stderr,
+        )
+        for path in offenders:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `print_disclaimer` helper
- replace disclaimer prints with helper usage
- add lint to check scripts for inlined disclaimers

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}' | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_6858aff92664833393ccd9076624f81c