### PR TITLE
fix: update demos utils imports

### DIFF
--- a/alpha_factory_v1/demos/utils/__init__.py
+++ b/alpha_factory_v1/demos/utils/__init__.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
 """Utilities for demos.
 
 Provides the standard project disclaimer for CLI scripts.
 """
-from ...utils.disclaimer import DISCLAIMER  # re-export for convenience
+from ...utils.disclaimer import DISCLAIMER, print_disclaimer
 
-__all__ = ["DISCLAIMER"]
+__all__ = ["DISCLAIMER", "print_disclaimer"]

--- a/alpha_factory_v1/demos/utils/disclaimer.py
+++ b/alpha_factory_v1/demos/utils/disclaimer.py
@@ -1,1 +1,4 @@
-from ...utils.disclaimer import *
+# SPDX-License-Identifier: Apache-2.0
+from ...utils.disclaimer import DISCLAIMER, print_disclaimer
+
+__all__ = ["DISCLAIMER", "print_disclaimer"]


### PR DESCRIPTION
## Summary
- update demo utils with license headers
- re-export `DISCLAIMER` and `print_disclaimer`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/utils/__init__.py alpha_factory_v1/demos/utils/disclaimer.py` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6858b4628d948333853d56a869687509