### PR TITLE
[alpha_factory] Add project overview doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ docker compose up --build
 See [docs/quickstart.md](docs/quickstart.md) for detailed steps.
 
 New to the project? Read the [Getting Started guide](docs/INTRO.md) for a short overview.
+First-time users should also read the [Project Overview](docs/OVERVIEW.md).
 
 
 # **META-AGENTIC** α‑AGI 👁️✨

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,0 +1,35 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Project Overview
+
+`AGI-Alpha-Agent-v0` explores a meta-agentic framework where agents spawn, evaluate and refine other agents. The codebase ships an offline-friendly demo called **α‑AGI Insight** that runs either locally or via the OpenAI Agents API when keys are provided.
+
+The Insight demo implements a best‑first search over agent rewrite chains. It can forecast disruptive sectors and iteratively improve plans by rewriting itself. When no cloud credentials exist, it falls back to a local Meta-Agentic Tree Search with small sample datasets.
+
+Key capabilities include:
+
+- Modular orchestrator that selects between local and remote runtimes
+- Tools to run demos entirely offline using a wheelhouse
+- Example agents and a minimal browser client
+
+## Minimal Setup
+
+1. Verify the environment and install Python packages:
+   ```bash
+   python check_env.py --auto-install
+   ```
+2. Copy the sample environment:
+   ```bash
+   cp alpha_factory_v1/.env.sample .env
+   ```
+3. Launch the default stack:
+   ```bash
+   ./quickstart.sh
+   ```
+4. Run the Insight demo:
+   ```bash
+   alpha-agi-insight-v1 --episodes 5
+   ```
+   Add API keys in `.env` to enable cloud features; otherwise the demo stays offline.
+
+For a deeper dive, read [docs/quickstart.md](docs/quickstart.md) and the other documents in this folder.


### PR DESCRIPTION
## Summary
- add high level Overview page under `docs`
- link to the new Overview from the README for newcomers

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests error out)*
- `pre-commit run verify-disclaimer-snippet --files docs/OVERVIEW.md README.md` *(failed to complete due to environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_6858b6d98b908333871402615d46c9da