### PR TITLE
[alpha_factory] Add AF_MEMORY_DIR docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,6 +34,9 @@ PINNER_TOKEN=
 # IPFS gateway base URL
 IPFS_GATEWAY=https://ipfs.io/ipfs
 
+# Working memory directory used by demos and tests
+AF_MEMORY_DIR=/tmp/alphafactory
+
 # Cross-industry alpha demo settings
 CROSS_ALPHA_LEDGER=cross_alpha_log.json
 CROSS_ALPHA_MODEL=gpt-4o-mini

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,6 +72,10 @@ Alternatively build and run the Docker image in one step:
 Copy `.env.sample` to `.env` and add your API keys to enable cloud features. Without keys, the program falls back to the
 local Meta‑Agentic Tree Search:
 
+`AF_MEMORY_DIR` controls where the demos store their JSONL history. The sample
+file uses `/tmp/alphafactory`, which is wiped on reboot. Set it to a persistent
+folder if you want to keep results across sessions.
+
 ```bash
 alpha-agi-insight-v1 --episodes 5  # with or without OPENAI_API_KEY
 ```


### PR DESCRIPTION
## Summary
- document `AF_MEMORY_DIR` in quickstart guide
- add variable to `.env.sample`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 231 failed, 514 passed, 51 skipped, 10 errors)*
- `pre-commit run --files docs/quickstart.md .env.sample` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6858c25eb0748333b302d44587b1ffdd