### PR TITLE
[alpha_factory] push Docker image on release

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   DOCKER_IMAGE: alpha-factory
+  DOCKERHUB_REPO: montrealai/alpha-factory
 
 permissions:
   contents: write
@@ -77,6 +78,19 @@ jobs:
         run: |
           cosign generate --type slsaprovenance ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} > provenance.json
           cosign attest --yes --predicate provenance.json --type slsaprovenance ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image to Docker Hub
+        run: |
+          docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} $DOCKERHUB_REPO:${{ github.ref_name }}
+          docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} $DOCKERHUB_REPO:latest
+          docker push $DOCKERHUB_REPO:${{ github.ref_name }}
+          docker push $DOCKERHUB_REPO:latest
 
       - name: Upload artifacts to release
         if: github.event_name == 'release'

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -69,6 +69,14 @@ Alternatively build and run the Docker image in one step:
 ./run_quickstart.sh
 ```
 
+### Using the prebuilt Docker image
+
+```bash
+docker pull montrealai/alpha-factory:latest
+docker run --rm -p 8000:8000 \
+  -v $(pwd)/.env:/app/.env montrealai/alpha-factory:latest
+```
+
 Copy `.env.sample` to `.env` and add your API keys to enable cloud features. Without keys, the program falls back to the
 local Meta‑Agentic Tree Search:
 


### PR DESCRIPTION
## Summary
- push release images to Docker Hub
- document the prebuilt image in quickstart

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: VerifyWheelSigTests etc.)*
- `SKIP=semgrep pre-commit run --files .github/workflows/security.yml docs/quickstart.md` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6858d1c31d14833380d92862a9838876