### PR TITLE
[alpha_factory] fix self-heal fixture disclaimer link

### DIFF
--- a/tests/fixtures/self_heal_repo/README.md
+++ b/tests/fixtures/self_heal_repo/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # sample_broken_calc


### PR DESCRIPTION
## Summary
- fix relative disclaimer link in self-heal demo README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 231 failed, 514 passed, 51 skipped, 10 errors)*
- `pre-commit run --files tests/fixtures/self_heal_repo/README.md` *(with several hooks skipped)

------
https://chatgpt.com/codex/tasks/task_e_6858db0f5d2483338ac4d8c523b82c1e