### PR TITLE
chore: prepare env before running tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run pytest inside container
         run: |
           docker run --rm ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} \
-            bash -c "python check_env.py --auto-install && pytest -q"
+            bash -c "python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse \"$WHEELHOUSE\"} && pytest -q"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
         run: make proto-verify
       - name: Run tests with coverage
         run: |
+          python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse "$WHEELHOUSE"}
           pytest --cov --cov-report=xml --cov-fail-under=70
       - name: Mutation tests
         run: |

--- a/README.md
+++ b/README.md
@@ -1098,8 +1098,8 @@ Install the project in editable mode so tests resolve imports:
 pip install -e .
 python check_env.py --auto-install  # times out after 10 minutes
 ```
-Run `python check_env.py --auto-install` again before executing `pytest` to
-ensure optional dependencies are present. When offline, set `WHEELHOUSE` or pass
+The `run_tests` helper automatically executes `python check_env.py --auto-install`
+before running `pytest`. When offline, set `WHEELHOUSE` or pass
 `--wheelhouse <dir>` so packages install from the local wheel cache. The
 repository ships with a `wheels/` directory that can be used as this cache.
 The full test suite relies on optional packages including `numpy`, `torch`,

--- a/alpha_factory_v1/scripts/run_tests.py
+++ b/alpha_factory_v1/scripts/run_tests.py
@@ -23,6 +23,13 @@ def run_tests(target: Path) -> int:
     ``pytest`` is preferred when available; otherwise ``unittest`` is used.
     The exit status of the invoked command is returned.
     """
+    repo_root = Path(__file__).resolve().parents[2]
+    cmd = [sys.executable, str(repo_root / "check_env.py"), "--auto-install"]
+    wheelhouse = os.getenv("WHEELHOUSE")
+    if wheelhouse:
+        cmd.extend(["--wheelhouse", wheelhouse])
+    subprocess.call(cmd)
+
     if importlib.util.find_spec("pytest"):
         cmd = [sys.executable, "-m", "pytest", str(target)]
     else:

--- a/src/self_evolution/harness.py
+++ b/src/self_evolution/harness.py
@@ -33,12 +33,20 @@ def _run_tests(repo: Path) -> int:
         "--rm",
         "-v",
         f"{repo}:/work",
-        "-w",
-        "/work",
-        IMAGE,
-        "pytest",
-        "-q",
     ]
+    wheelhouse = os.getenv("WHEELHOUSE")
+    if wheelhouse:
+        cmd.extend(["-e", f"WHEELHOUSE={wheelhouse}", "-v", f"{wheelhouse}:{wheelhouse}"])
+    cmd.extend(
+        [
+            "-w",
+            "/work",
+            IMAGE,
+            "bash",
+            "-c",
+            'python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse "$WHEELHOUSE"} && pytest -q',
+        ]
+    )
     proc = subprocess.run(cmd, capture_output=True, text=True)
     return proc.returncode
 


### PR DESCRIPTION
## Summary
- ensure `run_tests.py` installs dependencies before pytest
- run `check_env.py` in self evolution harness
- document automated check in README
- verify test env in CI

## Testing
- `pre-commit run --files alpha_factory_v1/scripts/run_tests.py src/self_evolution/harness.py README.md .github/workflows/ci.yml .github/workflows/build-and-test.yml` *(fails: mypy, verify-requirements-lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 52 failed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68594afe3cc48333910cc0ace0215ec4