### PR TITLE
[alpha_factory] Add basic quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
+See [docs/QUICKSTART_BASICS.md](docs/QUICKSTART_BASICS.md) for a minimal walkthrough.
+
 Watch the run here: [Quickstart video](docs/assets/quickstart_insight.cast) ·
 [Asciinema link](https://asciinema.org/a/I0uXbfl9SLa6SjocAb8Ik8Mni)
 

--- a/docs/QUICKSTART_BASICS.md
+++ b/docs/QUICKSTART_BASICS.md
@@ -1,0 +1,22 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Quickstart Basics
+
+`AGI-Alpha-Agent-v0` showcases a meta-agentic framework where agents can spawn and refine other agents. The included **α‑AGI Insight** demo runs locally or with cloud APIs when keys are provided.
+
+## Steps
+
+1. Copy the sample environment file:
+   ```bash
+   cp alpha_factory_v1/.env.sample .env
+   ```
+2. Run the interactive setup wizard:
+   ```bash
+   python scripts/setup_wizard.py
+   ```
+3. Launch the demo:
+   ```bash
+   ./quickstart.sh
+   ```
+
+For advanced instructions see [README.md](../README.md).


### PR DESCRIPTION
## Summary
- document simple startup procedure in `docs/QUICKSTART_BASICS.md`
- link to the new document from the Quickstart section of `README.md`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 231 failed, 514 passed, 51 skipped, 10 errors)*
- `pre-commit run --files docs/QUICKSTART_BASICS.md README.md` *(failed to finish: interrupted during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_685951f970208333b714951e4014e9dd