### PR TITLE
[alpha_factory] Add intro basics walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
-See [docs/QUICKSTART_BASICS.md](docs/QUICKSTART_BASICS.md) for a minimal walkthrough.
+See [docs/INTRO_BASICS.md](docs/INTRO_BASICS.md) for the bare essentials or
+[docs/QUICKSTART_BASICS.md](docs/QUICKSTART_BASICS.md) for a minimal walkthrough.
 
 Watch the run here: [Quickstart video](docs/assets/quickstart_insight.cast) ·
 [Asciinema link](https://asciinema.org/a/I0uXbfl9SLa6SjocAb8Ik8Mni)

--- a/docs/INTRO_BASICS.md
+++ b/docs/INTRO_BASICS.md
@@ -1,0 +1,21 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Intro Basics
+
+This is the shortest path to run the demo locally.
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
+   cd AGI-Alpha-Agent-v0
+   ```
+2. **Launch the stack**
+   ```bash
+   ./quickstart.sh
+   # or using Docker
+   docker compose up --build
+   ```
+3. **Open the web UI**
+   Visit [http://localhost:8000](http://localhost:8000) in your browser.
+
+For more details see [README.md](../README.md).


### PR DESCRIPTION
## Summary
- add `docs/INTRO_BASICS.md`
- reference the new intro document in the README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AssertionError & errors)*
- `pre-commit run --files README.md docs/INTRO_BASICS.md` *(fails: network during semgrep setup)*

------
https://chatgpt.com/codex/tasks/task_e_6859649916b4833383a990e43a1a6b93