### PR TITLE
[alpha_factory] add offline_prepare helper

### DIFF
--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -12,6 +12,12 @@ Run the helper script on a machine with connectivity:
 ./scripts/build_offline_wheels.sh
 ```
 
+To build the wheelhouse **and** regenerate all lock files in one step:
+
+```bash
+./scripts/offline_prepare.sh
+```
+
 This collects wheels for all lock files inside a `wheels/` directory. Copy this
 directory to the offline host.
 

--- a/scripts/offline_prepare.sh
+++ b/scripts/offline_prepare.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+# Build wheels and compile lock files for offline installation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+usage() {
+  cat <<USAGE
+Usage: $0
+
+Build the offline wheelhouse and regenerate all lock files.
+Run this on a machine with internet access and copy the 'wheels/'
+directory to the offline host. Set WHEELHOUSE=\"\$(pwd)/wheels\" before
+running './codex/setup.sh' or 'python check_env.py --auto-install'.
+USAGE
+}
+
+if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
+  usage
+  exit 0
+fi
+
+"$SCRIPT_DIR/build_offline_wheels.sh"
+
+if command -v pip-compile >/dev/null; then
+  PIP_COMPILE=pip-compile
+else
+  PIP_COMPILE="python -m piptools compile"
+fi
+
+opts=(--generate-hashes --quiet)
+if [[ -n "${WHEELHOUSE:-}" ]]; then
+  opts+=(--no-index --find-links "$WHEELHOUSE")
+fi
+
+run_compile() {
+  local req=$1 lock=$2
+  $PIP_COMPILE "${opts[@]}" "$req" -o "$lock"
+}
+
+run_compile requirements.txt requirements.lock
+run_compile requirements-demo.txt requirements-demo.lock
+run_compile alpha_factory_v1/requirements.txt alpha_factory_v1/requirements.lock
+run_compile alpha_factory_v1/requirements-colab.txt alpha_factory_v1/requirements-colab.lock
+run_compile alpha_factory_v1/backend/requirements.txt alpha_factory_v1/backend/requirements-lock.txt
+
+for req in alpha_factory_v1/demos/*/requirements.txt; do
+  lock="${req%txt}lock"
+  if [[ -f "$lock" ]]; then
+    run_compile "$req" "$lock"
+  fi
+done
+
+echo "Offline wheelhouse and lock files ready."
+usage


### PR DESCRIPTION
## Summary
- automate offline environment prep in `scripts/offline_prepare.sh`
- document the helper script in Offline Setup docs

## Testing
- `pre-commit run --files scripts/offline_prepare.sh docs/OFFLINE_SETUP.md` *(fails: verify-requirements-lock)*
- `pip-compile --generate-hashes --output-file requirements.lock requirements.txt` *(fails: AttributeError from pip-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68596bf6b8b0833389712f3066a8143e