### PR TITLE
[alpha_factory] modular orchestrator

### DIFF
--- a/alpha_factory_v1/backend/agent_manager.py
+++ b/alpha_factory_v1/backend/agent_manager.py
@@ -1,5 +1,71 @@
 # SPDX-License-Identifier: Apache-2.0
-# This code is a conceptual research prototype.
-"""Compatibility wrapper importing :mod:`agent_runner` symbols."""
+"""Agent scheduling and heartbeat management."""
 
-from .agent_runner import *  # noqa: F401,F403
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any, Dict, Optional
+
+from .agent_runner import AgentRunner, EventBus, hb_watch, regression_guard
+
+
+class AgentManager:
+    """Manage a collection of :class:`AgentRunner` instances."""
+
+    def __init__(
+        self,
+        enabled: set[str],
+        dev_mode: bool,
+        kafka_broker: str | None,
+        cycle_seconds: int,
+        max_cycle_sec: int,
+    ) -> None:
+        from backend.agents import list_agents, start_background_tasks
+
+        start_background_tasks()
+        avail = list_agents()
+        names = [n for n in avail if not enabled or n in enabled]
+        if not names:
+            raise RuntimeError(f"No agents selected – ENABLED={','.join(enabled) if enabled else 'ALL'}")
+
+        self.bus = EventBus(kafka_broker, dev_mode)
+        self.runners: Dict[str, AgentRunner] = {
+            n: AgentRunner(n, cycle_seconds, max_cycle_sec, self.bus.publish) for n in names
+        }
+        self._hb_task: Optional[asyncio.Task] = None
+        self._reg_task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Launch heartbeat and regression guard tasks."""
+
+        self._hb_task = asyncio.create_task(hb_watch(self.runners))
+        self._reg_task = asyncio.create_task(regression_guard(self.runners))
+
+    async def stop(self) -> None:
+        """Cancel helper tasks and wait for agent cycles to finish."""
+
+        if self._hb_task:
+            self._hb_task.cancel()
+        if self._reg_task:
+            self._reg_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            if self._hb_task:
+                await self._hb_task
+            if self._reg_task:
+                await self._reg_task
+        await asyncio.gather(*(r.task for r in self.runners.values() if r.task), return_exceptions=True)
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        """Drive all runners until *stop_event* is set."""
+
+        await self.start()
+        try:
+            while not stop_event.is_set():
+                await asyncio.gather(*(r.maybe_step() for r in self.runners.values()))
+                await asyncio.sleep(0.25)
+        finally:
+            await self.stop()
+
+
+__all__ = ["AgentManager"]

--- a/tests/test_orchestrator_no_fastapi.py
+++ b/tests/test_orchestrator_no_fastapi.py
@@ -10,11 +10,11 @@ class TestNoFastAPI(unittest.TestCase):
         import pytest
 
         pytest.skip("reload unstable in this environment")
-        mod_name = "alpha_factory_v1.backend.orchestrator"
+        mod_name = "alpha_factory_v1.backend.api_server"
         with mock.patch.dict(sys.modules, {"fastapi": None}):
             mod = importlib.import_module(mod_name)
             orch = importlib.reload(mod)
-            self.assertIsNone(orch._build_rest({}))
+            self.assertIsNone(orch.build_rest({}))
         importlib.reload(importlib.import_module(mod_name))
 
 

--- a/tests/test_orchestrator_rest.py
+++ b/tests/test_orchestrator_rest.py
@@ -11,6 +11,7 @@ import pytest
 pytest.importorskip("fastapi", reason="fastapi is required for REST API tests")
 from fastapi.testclient import TestClient  # noqa: E402
 
+from alpha_factory_v1.backend.api_server import build_rest as _build_rest
 from alpha_factory_v1.backend import orchestrator
 
 os.environ.setdefault("API_TOKEN", "test-token")
@@ -48,7 +49,7 @@ class TestRestAPI(unittest.TestCase):
         mem_stub = type("Mem", (), {"vector": vector})()
         runner = DummyRunner(DummyAgent())
         with mock.patch.object(orchestrator, "mem", mem_stub):
-            app = orchestrator._build_rest({"dummy": runner})
+            app = _build_rest({"dummy": runner})
             self.assertIsNotNone(app)
             client = TestClient(app)
             headers = {"Authorization": "Bearer test-token"}

--- a/tests/test_skill_test_route.py
+++ b/tests/test_skill_test_route.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 pytest.importorskip("fastapi")
 
-from alpha_factory_v1.backend import orchestrator
+from alpha_factory_v1.backend.api_server import build_rest as _build_rest
 
 
 class SimpleAgent:
@@ -26,7 +26,7 @@ class Runner:
 
 class TestSkillTestRoute(unittest.TestCase):
     def test_skill_test_endpoint(self) -> None:
-        app = orchestrator._build_rest({"simple": Runner(SimpleAgent())})
+        app = _build_rest({"simple": Runner(SimpleAgent())})
         self.assertIsNotNone(app)
         client = TestClient(app)
         headers = {"Authorization": "Bearer test-token"}


### PR DESCRIPTION
## Summary
- split orchestrator internals into helper modules
- start REST/GRPC servers via `api_server.start_servers`
- encapsulate agent heartbeat logic in `AgentManager`
- update tests to import from new modules

## Testing
- `pre-commit run --files alpha_factory_v1/backend/agent_manager.py alpha_factory_v1/backend/api_server.py alpha_factory_v1/backend/orchestrator.py tests/test_orchestrator_no_fastapi.py tests/test_orchestrator_rest.py tests/test_skill_test_route.py` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685992b614f883338d79fa066307006e