### PR TITLE
feat: modular orchestrator and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Watch the run here: [Quickstart video](docs/assets/quickstart_insight.cast) ·
 [Asciinema link](https://asciinema.org/a/I0uXbfl9SLa6SjocAb8Ik8Mni)
 
 See the [documentation](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/) for detailed steps and an overview of the project.
+For a concise high-level picture of how the main pieces fit together, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 
 # **META-AGENTIC** α‑AGI 👁️✨

--- a/alpha_factory_v1/backend/orchestrator_base.py
+++ b/alpha_factory_v1/backend/orchestrator_base.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Common orchestrator utilities used across demos."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Optional
+
+from .agent_manager import AgentManager
+from .api_server import start_servers
+
+
+class BaseOrchestrator:
+    """Simple helper managing an :class:`AgentManager` and optional servers."""
+
+    def __init__(
+        self,
+        enabled: set[str],
+        dev_mode: bool,
+        kafka_broker: str | None,
+        cycle_seconds: int,
+        max_cycle_sec: int,
+        *,
+        rest_port: int,
+        grpc_port: int,
+        model_max_bytes: int,
+        mem: object,
+        loglevel: str,
+        ssl_disable: bool,
+    ) -> None:
+        self.manager = AgentManager(enabled, dev_mode, kafka_broker, cycle_seconds, max_cycle_sec)
+        self._rest_port = rest_port
+        self._grpc_port = grpc_port
+        self._model_max_bytes = model_max_bytes
+        self._mem = mem
+        self._loglevel = loglevel
+        self._ssl_disable = ssl_disable
+        self._rest_task: Optional[asyncio.Task[None]] = None
+        self._grpc_server: Optional[object] = None
+
+    async def start(self) -> None:
+        """Launch REST and gRPC servers and background tasks."""
+        self._rest_task, self._grpc_server = await start_servers(
+            self.manager.runners,
+            self._model_max_bytes,
+            self._mem,
+            self._rest_port,
+            self._grpc_port,
+            self._loglevel,
+            self._ssl_disable,
+        )
+        await self.manager.start()
+
+    async def stop(self) -> None:
+        """Stop servers and agent manager."""
+        await self.manager.stop()
+        if self._rest_task:
+            self._rest_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._rest_task
+        if self._grpc_server:
+            self._grpc_server.stop(0)
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        """Run until ``stop_event`` is set."""
+        await self.start()
+        await self.manager.run(stop_event)
+        await self.stop()
+
+    def run_forever(self) -> None:
+        """Convenience wrapper used by scripts."""
+        asyncio.run(self.run(asyncio.Event()))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,39 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Architecture Overview
+
+This document gives a concise overview of the Alpha‑Factory stack.
+
+```mermaid
+flowchart TD
+    subgraph Orchestrator
+        O["BaseOrchestrator"]
+        M["AgentManager"]
+        S[(REST/gRPC)]
+    end
+    A["Agents"] -->|heartbeats| M
+    O --> M
+    O --> S
+    M -->|tasks| A
+    A -->|memory ops| F[(Memory Fabric)]
+    M -->|events| B[(Kafka)]
+```
+
+The orchestrator instantiates an `AgentManager` which schedules agent cycles and
+monitors their health. Optional REST and gRPC servers expose control endpoints.
+Agents persist data through the Memory Fabric and may publish events to Kafka.
+
+All components can run independently in development and are designed to fail
+gracefully when optional dependencies (like Kafka or FastAPI) are missing.
+
+## Key Components
+
+- **BaseOrchestrator** – shared helper that starts/stops the servers and
+  underlying `AgentManager`.
+- **AgentManager** – maintains a collection of `AgentRunner` instances,
+  coordinating their execution and heartbeats.
+- **Memory Fabric** – pluggable storage combining vector and graph databases.
+- **Telemetry** – Prometheus metrics exporting agent cycle latency and errors.
+
+For more details see `docs/DESIGN.md` and the module docstrings within
+`alpha_factory_v1/backend`.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -33,3 +33,5 @@ Key capabilities include:
    Add API keys in `.env` to enable cloud features; otherwise the demo stays offline.
 
 For a deeper dive, read [docs/quickstart.md](docs/quickstart.md) and the other documents in this folder.
+The [Architecture Overview](ARCHITECTURE.md) page summarises how the orchestrator,
+agents and memory components interact.


### PR DESCRIPTION
## Summary
- split common orchestration helpers into `BaseOrchestrator`
- reference architecture doc from README and overview
- document high level stack in new `ARCHITECTURE.md`

## Testing
- `pre-commit run --files alpha_factory_v1/backend/orchestrator_base.py alpha_factory_v1/backend/orchestrator.py README.md docs/ARCHITECTURE.md docs/OVERVIEW.md --show-diff-on-failure` *(fails: `proto-verify` and `verify-requirements-lock`)*
- `pytest -q` *(fails: 48 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_6859a3d2d40c8333835b4a8558fd1856