### PR TITLE
[alpha_factory] refactor heartbeat monitoring

### DIFF
--- a/alpha_factory_v1/backend/agent_supervisor.py
+++ b/alpha_factory_v1/backend/agent_supervisor.py
@@ -117,3 +117,14 @@ async def monitor_agents(
                 await r.restart(bus, ledger)
                 if on_restart:
                     on_restart(r)
+
+
+def handle_heartbeat(runners: Dict[str, AgentRunner], env: object) -> None:
+    """Update the heartbeat timestamp for ``env.sender`` if it exists."""
+    payload = getattr(env, "payload", None)
+    if payload and getattr(payload, "get", lambda *_: None)("heartbeat"):
+        sender = getattr(env, "sender", None)
+        if sender in runners:
+            r = runners[sender]
+            r.last_beat = getattr(env, "ts", time.time())
+            r.restart_streak = 0

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -61,6 +61,17 @@ if not logging.getLogger().handlers:
     )
 log = logging.getLogger("alpha_factory.orchestrator")
 
+_manager: BaseOrchestrator | None = None
+
+
+def _publish(topic: str, msg: dict[str, object]) -> None:
+    """Expose bus.publish for agent modules."""
+    if _manager is not None:
+        try:
+            _manager.manager.bus.publish(topic, msg)
+        except Exception:  # pragma: no cover - best effort
+            log.exception("publish failed")
+
 
 class Orchestrator(BaseOrchestrator):
     """Default Alpha‑Factory orchestrator."""
@@ -88,6 +99,9 @@ class Orchestrator(BaseOrchestrator):
             loglevel=LOGLEVEL,
             ssl_disable=SSL_DISABLE,
         )
+
+        global _manager
+        _manager = self
 
         log.info(
             "Bootstrapped %d agent(s): %s",


### PR DESCRIPTION
## Summary
- share heartbeat handler in `agent_supervisor`
- subclass backend orchestrator in Insight demo
- expose `_publish` in backend orchestrator for agents

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6859bc4fa86c83339637b5e2ccfc96c8