### PR TITLE
[alpha_factory] enhance meta refinement

### DIFF
--- a/alpha_factory_v1/core/self_evolution/harness.py
+++ b/alpha_factory_v1/core/self_evolution/harness.py
@@ -90,8 +90,11 @@ def vote_and_merge(repo: str | Path, diff: str, registry: StakeRegistry, agent_i
         registry.vote(proposal, agent_id, False)
         shutil.rmtree(patched)
         return False
-    new_score = float((patched / "metric.txt").read_text().strip())
-    improved = new_score > baseline
+    try:
+        new_score = float((patched / "metric.txt").read_text().strip())
+    except Exception:
+        new_score = baseline
+    improved = new_score < baseline
     registry.vote(proposal, agent_id, improved)
     accepted = improved and registry.accepted(proposal)
     if accepted:

--- a/tests/test_self_evolution.py
+++ b/tests/test_self_evolution.py
@@ -20,7 +20,7 @@ def test_vote_and_merge_accepts_patch(tmp_path: Path) -> None:
 +++ b/metric.txt
 @@
 -1
-+2
++0
 """
     reg = StakeRegistry()
     reg.set_stake("orch", 1.0)
@@ -28,12 +28,12 @@ def test_vote_and_merge_accepts_patch(tmp_path: Path) -> None:
         patch.object(harness, "_run_tests", return_value=0),
         patch.object(harness, "run_preflight"),
         patch.object(
-            harness.patcher_core, "apply_patch", lambda d, repo_path: (Path(repo_path) / "metric.txt").write_text("2\n")
+            harness.patcher_core, "apply_patch", lambda d, repo_path: (Path(repo_path) / "metric.txt").write_text("0\n")
         ),
     ):
         accepted = harness.vote_and_merge(repo, diff, reg)
     assert accepted
-    assert (repo / "metric.txt").read_text().strip() == "2"
+    assert (repo / "metric.txt").read_text().strip() == "0"
 
 
 def test_vote_and_merge_reverts_on_failure(tmp_path: Path) -> None:
@@ -42,7 +42,7 @@ def test_vote_and_merge_reverts_on_failure(tmp_path: Path) -> None:
 +++ b/metric.txt
 @@
 -1
-+0
++2
 """
     reg = StakeRegistry()
     reg.set_stake("orch", 1.0)
@@ -50,7 +50,7 @@ def test_vote_and_merge_reverts_on_failure(tmp_path: Path) -> None:
         patch.object(harness, "_run_tests", return_value=1),
         patch.object(harness, "run_preflight"),
         patch.object(
-            harness.patcher_core, "apply_patch", lambda d, repo_path: (Path(repo_path) / "metric.txt").write_text("0\n")
+            harness.patcher_core, "apply_patch", lambda d, repo_path: (Path(repo_path) / "metric.txt").write_text("2\n")
         ),
     ):
         accepted = harness.vote_and_merge(repo, diff, reg)


### PR DESCRIPTION
## Summary
- parse orchestrator logs for latency/error metrics and target slow modules
- verify decreased metric before merging
- adapt tests for new metric rules

## Testing
- `pre-commit run --files alpha_factory_v1/core/agents/meta_refinement_agent.py alpha_factory_v1/core/self_evolution/harness.py tests/test_self_evolution.py tests/test_meta_refinement_agent.py` *(failed: environment setup interrupted)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(failed: 50 failed, 76 passed, 30 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859c22dfb408333a87ac97cf278a7cc