### PR TITLE
[alpha_factory] refactor orchestrator modules

### DIFF
--- a/alpha_factory_v1/backend/agent_scheduler.py
+++ b/alpha_factory_v1/backend/agent_scheduler.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Agent scheduling utilities."""
+
+from __future__ import annotations
+
+import asyncio
+
+from .agent_manager import AgentManager
+
+
+class AgentScheduler:
+    """Drive a collection of agents through the :class:`AgentManager`."""
+
+    def __init__(
+        self,
+        enabled: set[str],
+        dev_mode: bool,
+        kafka_broker: str | None,
+        cycle_seconds: int,
+        max_cycle_sec: int,
+    ) -> None:
+        self.manager = AgentManager(
+            enabled,
+            dev_mode,
+            kafka_broker,
+            cycle_seconds,
+            max_cycle_sec,
+        )
+
+    async def start(self) -> None:
+        """Start heartbeat and regression checks."""
+        await self.manager.start()
+
+    async def stop(self) -> None:
+        """Stop the underlying manager."""
+        await self.manager.stop()
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        """Run agent cycles until ``stop_event`` is set."""
+        await self.start()
+        await self.manager.run(stop_event)
+        await self.stop()
+
+
+__all__ = ["AgentScheduler"]

--- a/alpha_factory_v1/backend/metrics.py
+++ b/alpha_factory_v1/backend/metrics.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prometheus metrics helpers."""
+
+from __future__ import annotations
+
+from .telemetry import (
+    init_metrics as _init_metrics,
+    MET_LAT,
+    MET_ERR,
+    MET_UP,
+    tracer,
+)
+
+__all__ = ["init_metrics", "MET_LAT", "MET_ERR", "MET_UP", "tracer"]
+
+
+def init_metrics(port: int) -> None:
+    """Initialise metric exporter."""
+    _init_metrics(port)


### PR DESCRIPTION
## Summary
- split orchestrator utilities into `agent_scheduler.py` and `metrics.py`
- refactor `Orchestrator` to assemble scheduler, API server and metrics
- expose `publish` helper for agent modules

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6859d53d4ed883339daac5ea54901fed