### PR TITLE
[alpha_factory] consolidate orchestrator

### DIFF
--- a/alpha_factory_v1/backend/demo_orchestrator.py
+++ b/alpha_factory_v1/backend/demo_orchestrator.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reusable orchestrator base for demo agents."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import Callable, Dict, List
+
+import alpha_factory_v1.core.utils.a2a_pb2 as pb
+
+from .agent_supervisor import AgentRunner, handle_heartbeat, monitor_agents
+from alpha_factory_v1.core.archive.service import ArchiveService
+from alpha_factory_v1.core.archive.solution_archive import SolutionArchive
+from alpha_factory_v1.core.governance.stake_registry import StakeRegistry
+
+
+class DemoOrchestrator:
+    """Manage demo agents with ledger and restart logic."""
+
+    def __init__(
+        self,
+        bus: object,
+        ledger: object,
+        archive: ArchiveService,
+        solution_archive: SolutionArchive,
+        registry: StakeRegistry,
+        island_backends: Dict[str, str],
+        *,
+        err_threshold: int = 3,
+        backoff_exp_after: int = 3,
+        promotion_threshold: float = 0.0,
+    ) -> None:
+        self.bus = bus
+        self.ledger = ledger
+        self.archive = archive
+        self.solution_archive = solution_archive
+        self.registry = registry
+        self.island_backends = dict(island_backends)
+        self.runners: Dict[str, AgentRunner] = {}
+        self.island_pops: Dict[str, object] = {}
+        self.experiment_pops: Dict[str, Dict[str, object]] = {"default": self.island_pops}
+        self._err_threshold = err_threshold
+        self._backoff_exp_after = backoff_exp_after
+        self._promotion_threshold = promotion_threshold
+        self.bus.subscribe("orch", lambda env: handle_heartbeat(self.runners, env))
+        self._monitor_task: asyncio.Task[None] | None = None
+
+    def add_agent(self, agent: object) -> None:
+        runner = AgentRunner(agent)
+        self.runners[agent.name] = runner
+        self._register(runner)
+
+    def _register(self, runner: AgentRunner) -> None:
+        env = pb.Envelope(sender="orch", recipient="system", ts=time.time())
+        env.payload.update({"event": "register", "agent": runner.agent.name, "capabilities": runner.capabilities})
+        self.ledger.log(env)
+        self.bus.publish("system", env)
+        self.registry.set_stake(runner.agent.name, 1.0)
+        self.registry.set_threshold(f"promote:{runner.agent.name}", self._promotion_threshold)
+
+    def _record_restart(self, runner: AgentRunner) -> None:
+        env = pb.Envelope(sender="orch", recipient="system", ts=time.time())
+        env.payload.update({"event": "restart", "agent": runner.agent.name})
+        self.ledger.log(env)
+        self.bus.publish("system", env)
+
+    def slash(self, agent_id: str) -> None:
+        self.registry.burn(agent_id, 0.1)
+
+    def verify_merkle_root(self, expected: str, agent_id: str) -> None:
+        actual = self.ledger.compute_merkle_root()
+        if actual != expected:
+            self.slash(agent_id)
+
+    def verify_ledger(self, expected: str, agent_id: str) -> None:
+        actual = self.ledger.compute_merkle_root()
+        if actual != expected:
+            self.slash(agent_id)
+
+    async def evolve(
+        self,
+        scenario_hash: str,
+        fn: Callable[[list[float]], tuple[float, ...]],
+        genome_length: int,
+        *,
+        sector: str = "generic",
+        approach: str = "ga",
+        experiment_id: str = "default",
+        **kwargs: object,
+    ) -> object:
+        pops = self.experiment_pops.setdefault(experiment_id, {})
+        pop = await asyncio.to_thread(
+            fn,
+            [0.0] * genome_length,
+            scenario_hash=scenario_hash,
+            populations=pops,
+            **kwargs,
+        )
+        pops[scenario_hash] = pop
+        for ind in pop:
+            self.solution_archive.add(sector, approach, ind.score, {"genome": ind.genome})
+            self.archive.insert_entry({"experiment_id": experiment_id, "genome": ind.genome}, {"score": ind.score})
+        return pop
+
+    async def run_forever(self) -> None:
+        await self.bus.start()
+        self.ledger.start_merkle_task(3600)
+        self.archive.start_merkle_task(86_400)
+        for r in self.runners.values():
+            proposal = f"promote:{r.agent.name}"
+            if self.registry.accepted(proposal):
+                r.start(self.bus, self.ledger)
+        self._monitor_task = asyncio.create_task(
+            monitor_agents(
+                self.runners,
+                self.bus,
+                self.ledger,
+                err_threshold=self._err_threshold,
+                backoff_exp_after=self._backoff_exp_after,
+                on_restart=self._record_restart,
+            )
+        )
+        try:
+            while True:
+                await asyncio.sleep(0.5)
+        finally:
+            if self._monitor_task:
+                self._monitor_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._monitor_task
+            for r in self.runners.values():
+                if r.task:
+                    r.task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await r.task
+            await self.bus.stop()
+            await self.ledger.stop_merkle_task()
+            await self.archive.stop_merkle_task()
+            self.ledger.close()
+            self.archive.close()
+            self.solution_archive.close()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py
@@ -11,13 +11,9 @@ health checks.
 from __future__ import annotations
 
 import asyncio
-import time
-import contextlib
 import os
-import random
 from pathlib import Path
 from typing import Any, Callable, Dict, List, cast
-from google.protobuf import struct_pb2
 
 from .agents import (
     planning_agent,
@@ -31,15 +27,9 @@ from .agents import (
 )
 from alpha_factory_v1.core.agents.self_improver_agent import SelfImproverAgent
 from .utils import config, messaging, logging as insight_logging
-from .utils.tracing import agent_cycle_seconds
 from .utils import alerts
-from alpha_factory_v1.backend.agent_supervisor import (
-    AgentRunner,
-    monitor_agents,
-    handle_heartbeat,
-)
-from .utils.logging import Ledger
 from alpha_factory_v1.core.archive.service import ArchiveService
+from alpha_factory_v1.backend.agent_supervisor import AgentRunner
 from alpha_factory_v1.core.archive.solution_archive import SolutionArchive
 from .agents.base_agent import BaseAgent
 from alpha_factory_v1.core.governance.stake_registry import StakeRegistry
@@ -59,7 +49,7 @@ PROMOTION_THRESHOLD = float(os.getenv("PROMOTION_THRESHOLD", "0"))
 log = insight_logging.logging.getLogger(__name__)
 
 
-from alpha_factory_v1.backend.orchestrator import Orchestrator as BaseOrchestrator
+from alpha_factory_v1.backend.demo_orchestrator import DemoOrchestrator as BaseOrchestrator
 
 
 class Orchestrator(BaseOrchestrator):
@@ -68,38 +58,41 @@ class Orchestrator(BaseOrchestrator):
     def __init__(self, settings: config.Settings | None = None) -> None:
         self.settings = settings or config.CFG
         insight_logging.setup(json_logs=self.settings.json_logs)
-        self.bus = messaging.A2ABus(self.settings)
-        self.ledger = Ledger(
+        bus = messaging.A2ABus(self.settings)
+        ledger = Ledger(
             self.settings.ledger_path,
             rpc_url=self.settings.solana_rpc_url,
             wallet=self.settings.solana_wallet,
             broadcast=self.settings.broadcast,
             db=self.settings.db_type,
         )
-        self.archive = ArchiveService(
+        archive = ArchiveService(
             os.getenv("ARCHIVE_PATH", "archive.db"),
             rpc_url=self.settings.solana_rpc_url,
             wallet=self.settings.solana_wallet,
             broadcast=self.settings.broadcast,
         )
-        self.solution_archive = SolutionArchive(os.getenv("SOLUTION_ARCHIVE_PATH", "solutions.duckdb"))
-        self.registry = StakeRegistry()
-        self.island_pops: Dict[str, mats.Population] = {}
-        self.experiment_pops: Dict[str, Dict[str, mats.Population]] = {"default": self.island_pops}
+        solution_archive = SolutionArchive(os.getenv("SOLUTION_ARCHIVE_PATH", "solutions.duckdb"))
+        registry = StakeRegistry()
         if resource is not None:
             try:
                 limit = 8 * 1024 * 1024 * 1024
                 resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
             except Exception:  # pragma: no cover - unsupported platform
                 pass
-        self.island_backends: Dict[str, str] = dict(self.settings.island_backends)
-        self.runners: Dict[str, AgentRunner] = {}
-        self.bus.subscribe("orch", lambda env: handle_heartbeat(self.runners, env))
+        super().__init__(
+            bus,
+            ledger,
+            archive,
+            solution_archive,
+            registry,
+            self.settings.island_backends,
+            err_threshold=ERR_THRESHOLD,
+            backoff_exp_after=BACKOFF_EXP_AFTER,
+            promotion_threshold=PROMOTION_THRESHOLD,
+        )
         for agent in self._init_agents():
-            runner = AgentRunner(agent)
-            self.runners[agent.name] = runner
-            self._register(runner)
-        self._monitor_task: asyncio.Task[None] | None = None
+            self.add_agent(agent)
 
     def _init_agents(self) -> List[BaseAgent]:
         agents: List[BaseAgent] = []
@@ -137,19 +130,6 @@ class Orchestrator(BaseOrchestrator):
                     )
                 )
         return agents
-
-    def _register(self, runner: AgentRunner) -> None:
-        env = messaging.Envelope(
-            sender="orch",
-            recipient="system",
-            payload=struct_pb2.Struct(),
-            ts=time.time(),
-        )
-        env.payload.update({"event": "register", "agent": runner.agent.name, "capabilities": runner.capabilities})
-        self.ledger.log(env)
-        self.bus.publish("system", env)
-        self.registry.set_stake(runner.agent.name, 1.0)
-        self.registry.set_threshold(f"promote:{runner.agent.name}", PROMOTION_THRESHOLD)
 
     async def evolve(
         self,
@@ -190,77 +170,11 @@ class Orchestrator(BaseOrchestrator):
         return pop
 
     def _record_restart(self, runner: AgentRunner) -> None:
-        env = messaging.Envelope(
-            sender="orch",
-            recipient="system",
-            payload=struct_pb2.Struct(),
-            ts=time.time(),
-        )
-        env.payload.update({"event": "restart", "agent": runner.agent.name})
-        self.ledger.log(env)
-        self.bus.publish("system", env)
+        super()._record_restart(runner)
         alerts.send_alert(
             f"{runner.agent.name} restarted",
             self.settings.alert_webhook_url,
         )
-
-    def slash(self, agent_id: str) -> None:
-        """Burn 10% of ``agent_id`` stake."""
-        self.registry.burn(agent_id, 0.1)
-
-    def verify_merkle_root(self, expected: str, agent_id: str) -> None:
-        """Slash ``agent_id`` when the ledger's Merkle root mismatches ``expected``."""
-        actual = self.ledger.compute_merkle_root()
-        if actual != expected:
-            log.warning("Merkle mismatch for %s", agent_id)
-            self.slash(agent_id)
-
-    def verify_ledger(self, expected: str, agent_id: str) -> None:
-        """Slash ``agent_id`` when the current ledger root mismatches ``expected``."""
-        actual = self.ledger.compute_merkle_root()
-        if actual != expected:
-            log.warning("Merkle mismatch for %s", agent_id)
-            self.slash(agent_id)
-
-    async def run_forever(self) -> None:
-        await self.bus.start()
-        self.ledger.start_merkle_task(3600)
-        self.archive.start_merkle_task(86_400)
-        for r in self.runners.values():
-            proposal = f"promote:{r.agent.name}"
-            if self.registry.accepted(proposal):
-                r.start(self.bus, self.ledger)
-            else:
-                log.info("%s awaiting promotion", r.agent.name)
-        self._monitor_task = asyncio.create_task(
-            monitor_agents(
-                self.runners,
-                self.bus,
-                self.ledger,
-                err_threshold=ERR_THRESHOLD,
-                backoff_exp_after=BACKOFF_EXP_AFTER,
-                on_restart=self._record_restart,
-            )
-        )
-        try:
-            while True:
-                await asyncio.sleep(0.5)
-        finally:
-            if self._monitor_task:
-                self._monitor_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await self._monitor_task
-            for r in self.runners.values():
-                if r.task:
-                    r.task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await r.task
-            await self.bus.stop()
-            await self.ledger.stop_merkle_task()
-            await self.archive.stop_merkle_task()
-            self.ledger.close()
-            self.archive.close()
-            self.solution_archive.close()
 
 
 async def _main() -> None:  # pragma: no cover - CLI helper


### PR DESCRIPTION
## Summary
- add DemoOrchestrator base in backend for shared logic
- use DemoOrchestrator in Insight demo

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/backend/demo_orchestrator.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/orchestrator.py` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: import errors and syntax issues)*

------
https://chatgpt.com/codex/tasks/task_e_6859d825e5948333b93365ccf8964a44