### PR TITLE
[alpha_factory] document placeholder and add cycle heuristic

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,6 +34,11 @@ gracefully when optional dependencies (like Kafka or FastAPI) are missing.
   coordinating their execution and heartbeats.
 - **Memory Fabric** – pluggable storage combining vector and graph databases.
 - **Telemetry** – Prometheus metrics exporting agent cycle latency and errors.
+- *Placeholder logic* – `transfer_test.evaluate_agent` merely echoes the
+  archived score. Future updates will evaluate agents on the selected model.
+  `MetaRefinementAgent` also includes a very naive log parser that suggests
+  increasing an agent's cycle period when cycles consistently exceed five
+  seconds.
 
 For more details see `docs/DESIGN.md` and the module docstrings within
 `alpha_factory_v1/backend`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,9 @@ Downstream users should consult this section when upgrading.
 - Removed outdated `OPENAI_CONTEXT_WINDOW` reference from the self-healing repo demo.
 - Documented how to add new policies in `POLICY_RUNBOOK.md`.
 - Each demo README now clarifies that `__version__` denotes the demo revision, not the overall project release.
+- Clarified that `transfer_test.evaluate_agent` is a placeholder returning the archived
+  score. Added a simple heuristic in `MetaRefinementAgent` that proposes a longer
+  cycle period when logs show slow agent cycles.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.


### PR DESCRIPTION
## Summary
- mark evaluate_agent placeholder in docs
- mention placeholder behaviour in changelog
- tweak MetaRefinementAgent to detect slow cycles
- test cycle adjustment heuristic

## Testing
- `pre-commit run --files alpha_factory_v1/core/agents/meta_refinement_agent.py docs/ARCHITECTURE.md docs/CHANGELOG.md tests/test_meta_refinement_agent.py` *(fails: proto-verify; verify-requirements-lock)*
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pytest -q` *(fails: KeyboardInterrupt during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5ed11b08333b5b8bfaedf01487d