### PR TITLE
[alpha_factory] Add WSL2 recommendation and Windows smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,29 @@ PY
           name: coverage-xml
           path: coverage.xml
 
+  windows-smoke:
+    name: "Windows Smoke"
+    needs: lint-type
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.lock
+          pip install -r requirements-dev.txt
+          pip install pytest
+      - name: Verify environment
+        run: |
+          python scripts/check_python_deps.py
+          python check_env.py --auto-install
+      - name: Run smoke tests
+        run: pytest -m smoke -q
+
   docker:
     name: "🐳 Docker build"
     needs: tests

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Set `OPENAI_API_KEY` and other required secrets in your environment or `.env`
 before launching the container. The orchestrator prints the
 [project disclaimer](docs/DISCLAIMER_SNIPPET.md) when it starts.
 
+**Recommended OS:** Linux or Windows with **WSL 2**. Native Windows often
+misbehaves due to path translation and volume mount issues. When on Windows,
+install WSL 2, enable Docker Desktop's *Use the WSL 2 based engine* option and
+clone the repository inside your Linux home directory.
+
 See [docs/INTRO_BASICS.md](docs/INTRO_BASICS.md) for the bare essentials or
 [docs/QUICKSTART_BASICS.md](docs/QUICKSTART_BASICS.md) for a minimal walkthrough.
 


### PR DESCRIPTION
## Summary
- recommend running on Linux or WSL2 in the README
- run smoke tests on Windows runners via `windows-smoke` job in CI

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 98 errors during collection)*
- `pre-commit run --files README.md .github/workflows/ci.yml` *(fails: verify-requirements-lock hook)*

------
https://chatgpt.com/codex/tasks/task_e_6859ec66f25c8333870cf897d284fcc7