### PR TITLE
[alpha_factory] refactor orchestrator helpers

### DIFF
--- a/alpha_factory_v1/backend/orchestrator_base.py
+++ b/alpha_factory_v1/backend/orchestrator_base.py
@@ -28,8 +28,9 @@ class BaseOrchestrator:
         mem: object,
         loglevel: str,
         ssl_disable: bool,
+        manager: AgentManager | None = None,
     ) -> None:
-        self.manager = AgentManager(enabled, dev_mode, kafka_broker, cycle_seconds, max_cycle_sec)
+        self.manager = manager or AgentManager(enabled, dev_mode, kafka_broker, cycle_seconds, max_cycle_sec)
         self._rest_port = rest_port
         self._grpc_port = grpc_port
         self._model_max_bytes = model_max_bytes


### PR DESCRIPTION
## Summary
- extend `BaseOrchestrator` to accept an existing AgentManager
- use `BaseOrchestrator` in backend orchestrator implementation

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 98 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859f2d2ba4c833393213ce4e342b3b9