### PR TITLE
[alpha_factory] refactor orchestrator into modular services

### DIFF
--- a/alpha_factory_v1/backend/agent_manager.py
+++ b/alpha_factory_v1/backend/agent_manager.py
@@ -20,6 +20,8 @@ class AgentManager:
         kafka_broker: str | None,
         cycle_seconds: int,
         max_cycle_sec: int,
+        *,
+        bus: EventBus | None = None,
     ) -> None:
         from backend.agents import list_agents, start_background_tasks
 
@@ -29,7 +31,7 @@ class AgentManager:
         if not names:
             raise RuntimeError(f"No agents selected – ENABLED={','.join(enabled) if enabled else 'ALL'}")
 
-        self.bus = EventBus(kafka_broker, dev_mode)
+        self.bus = bus or EventBus(kafka_broker, dev_mode)
         self.runners: Dict[str, AgentRunner] = {
             n: AgentRunner(n, cycle_seconds, max_cycle_sec, self.bus.publish) for n in names
         }

--- a/alpha_factory_v1/backend/agent_scheduler.py
+++ b/alpha_factory_v1/backend/agent_scheduler.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 
 from .agent_manager import AgentManager
+from .agent_runner import EventBus
 
 
 class AgentScheduler:
@@ -18,6 +19,8 @@ class AgentScheduler:
         kafka_broker: str | None,
         cycle_seconds: int,
         max_cycle_sec: int,
+        *,
+        bus: EventBus | None = None,
     ) -> None:
         self.manager = AgentManager(
             enabled,
@@ -25,6 +28,7 @@ class AgentScheduler:
             kafka_broker,
             cycle_seconds,
             max_cycle_sec,
+            bus=bus,
         )
 
     async def start(self) -> None:

--- a/alpha_factory_v1/backend/orchestrator_base.py
+++ b/alpha_factory_v1/backend/orchestrator_base.py
@@ -8,60 +8,30 @@ import contextlib
 from typing import Optional
 
 from .agent_manager import AgentManager
-from .api_server import start_servers
+from .services import APIServer, MetricsExporter
 
 
 class BaseOrchestrator:
     """Simple helper managing an :class:`AgentManager` and optional servers."""
 
-    def __init__(
-        self,
-        enabled: set[str],
-        dev_mode: bool,
-        kafka_broker: str | None,
-        cycle_seconds: int,
-        max_cycle_sec: int,
-        *,
-        rest_port: int,
-        grpc_port: int,
-        model_max_bytes: int,
-        mem: object,
-        loglevel: str,
-        ssl_disable: bool,
-        manager: AgentManager | None = None,
-    ) -> None:
-        self.manager = manager or AgentManager(enabled, dev_mode, kafka_broker, cycle_seconds, max_cycle_sec)
-        self._rest_port = rest_port
-        self._grpc_port = grpc_port
-        self._model_max_bytes = model_max_bytes
-        self._mem = mem
-        self._loglevel = loglevel
-        self._ssl_disable = ssl_disable
-        self._rest_task: Optional[asyncio.Task[None]] = None
-        self._grpc_server: Optional[object] = None
+    def __init__(self, manager: AgentManager, api_server: APIServer, metrics: MetricsExporter | None = None) -> None:
+        self.manager = manager
+        self.api_server = api_server
+        self.metrics = metrics
 
     async def start(self) -> None:
         """Launch REST and gRPC servers and background tasks."""
-        self._rest_task, self._grpc_server = await start_servers(
-            self.manager.runners,
-            self._model_max_bytes,
-            self._mem,
-            self._rest_port,
-            self._grpc_port,
-            self._loglevel,
-            self._ssl_disable,
-        )
+        if self.metrics:
+            self.metrics.start()
+        await self.api_server.start()
         await self.manager.start()
 
     async def stop(self) -> None:
         """Stop servers and agent manager."""
         await self.manager.stop()
-        if self._rest_task:
-            self._rest_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._rest_task
-        if self._grpc_server:
-            self._grpc_server.stop(0)
+        await self.api_server.stop()
+        if self.metrics:
+            self.metrics.stop()
 
     async def run(self, stop_event: asyncio.Event) -> None:
         """Run until ``stop_event`` is set."""

--- a/alpha_factory_v1/backend/services/__init__.py
+++ b/alpha_factory_v1/backend/services/__init__.py
@@ -1,0 +1,7 @@
+"""Service helpers for the orchestrator."""
+
+__all__ = ["APIServer", "KafkaService", "MetricsExporter"]
+
+from .api_server_service import APIServer
+from .kafka_service import KafkaService
+from .metrics_service import MetricsExporter

--- a/alpha_factory_v1/backend/services/api_server_service.py
+++ b/alpha_factory_v1/backend/services/api_server_service.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wrapper around the REST and gRPC servers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any, Dict, Optional
+
+from ..api_server import start_servers
+
+
+class APIServer:
+    """Launch and manage the REST and gRPC API servers."""
+
+    def __init__(
+        self,
+        runners: Dict[str, Any],
+        model_max_bytes: int,
+        mem: Any,
+        rest_port: int,
+        grpc_port: int,
+        loglevel: str,
+        ssl_disable: bool,
+    ) -> None:
+        self._runners = runners
+        self._model_max_bytes = model_max_bytes
+        self._mem = mem
+        self._rest_port = rest_port
+        self._grpc_port = grpc_port
+        self._loglevel = loglevel
+        self._ssl_disable = ssl_disable
+        self._rest_task: Optional[asyncio.Task] = None
+        self._grpc_server: Optional[Any] = None
+
+    @property
+    def rest_task(self) -> Optional[asyncio.Task]:
+        return self._rest_task
+
+    @property
+    def grpc_server(self) -> Optional[Any]:
+        return self._grpc_server
+
+    async def start(self) -> None:
+        self._rest_task, self._grpc_server = await start_servers(
+            self._runners,
+            self._model_max_bytes,
+            self._mem,
+            self._rest_port,
+            self._grpc_port,
+            self._loglevel,
+            self._ssl_disable,
+        )
+
+    async def stop(self) -> None:
+        if self._rest_task:
+            self._rest_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._rest_task
+        if self._grpc_server:
+            self._grpc_server.stop(0)

--- a/alpha_factory_v1/backend/services/kafka_service.py
+++ b/alpha_factory_v1/backend/services/kafka_service.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Kafka event bus wrapper."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..agent_runner import EventBus
+
+
+class KafkaService:
+    """Provide a Kafka-backed event bus if available."""
+
+    def __init__(self, broker: str | None, dev_mode: bool) -> None:
+        self._bus = EventBus(broker, dev_mode)
+
+    async def start(self) -> None:  # pragma: no cover - no async setup
+        return None
+
+    async def stop(self) -> None:  # pragma: no cover - close handled by EventBus
+        return None
+
+    def publish(self, topic: str, msg: Dict[str, Any]) -> None:
+        self._bus.publish(topic, msg)
+
+    @property
+    def bus(self) -> EventBus:
+        return self._bus

--- a/alpha_factory_v1/backend/services/metrics_service.py
+++ b/alpha_factory_v1/backend/services/metrics_service.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prometheus metrics exporter wrapper."""
+
+from __future__ import annotations
+
+from ..telemetry import init_metrics
+
+
+class MetricsExporter:
+    """Thin wrapper around :func:`init_metrics`."""
+
+    def __init__(self, port: int) -> None:
+        self._port = port
+
+    def start(self) -> None:
+        init_metrics(self._port)
+
+    def stop(self) -> None:  # pragma: no cover - no teardown required
+        return None

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_backend_rest_auth.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
-from alpha_factory_v1.backend import orchestrator
+from alpha_factory_v1.backend.api_server import build_rest
 
 
 class DummyRunner:
@@ -23,7 +23,7 @@ class DummyRunner:
 
 def _make_client(monkeypatch: pytest.MonkeyPatch, token: str = "secret") -> TestClient:
     monkeypatch.setenv("API_TOKEN", token)
-    app = orchestrator._build_rest({"dummy": DummyRunner()})
+    app = build_rest({"dummy": DummyRunner()}, 1024 * 1024, type("M", (), {"vector": type("Vec", (), {})()})())
     assert app is not None
     return TestClient(app)
 
@@ -49,4 +49,4 @@ def test_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_env_required(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("API_TOKEN", raising=False)
     with pytest.raises(RuntimeError):
-        orchestrator._build_rest({"dummy": DummyRunner()})
+        build_rest({"dummy": DummyRunner()}, 1024 * 1024, type("M", (), {"vector": type("Vec", (), {})()})())

--- a/alpha_factory_v1/tests/test_orchestrator_rest.py
+++ b/alpha_factory_v1/tests/test_orchestrator_rest.py
@@ -8,7 +8,7 @@ import pytest
 pytest.importorskip("fastapi", reason="fastapi is required for REST API tests")
 from fastapi.testclient import TestClient
 
-from alpha_factory_v1.backend.orchestrator import _build_rest
+from alpha_factory_v1.backend.api_server import build_rest as _build_rest
 
 
 class DummyRunner:

--- a/tests/test_api_server_service.py
+++ b/tests/test_api_server_service.py
@@ -1,0 +1,31 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from alpha_factory_v1.backend.services.api_server_service import APIServer
+
+
+@pytest.mark.asyncio
+async def test_api_server_start_stop(monkeypatch):
+    events = []
+
+    async def fake_start_servers(*a, **k):
+        events.append("start")
+
+        async def sleeper():
+            await asyncio.sleep(0)
+        task = asyncio.create_task(sleeper())
+        server = SimpleNamespace(stop=lambda code=0: events.append("stop"))
+        return task, server
+
+    monkeypatch.setattr(
+        "alpha_factory_v1.backend.services.api_server_service.start_servers",
+        fake_start_servers,
+    )
+
+    srv = APIServer({}, 1, object(), 0, 0, "INFO", True)
+    await srv.start()
+    assert events == ["start"]
+    await srv.stop()
+    assert events[-1] == "stop"

--- a/tests/test_kafka_service.py
+++ b/tests/test_kafka_service.py
@@ -1,0 +1,21 @@
+from alpha_factory_v1.backend.services.kafka_service import KafkaService
+
+
+def test_kafka_service_publish(monkeypatch):
+    events = []
+
+    class DummyBus:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def publish(self, topic, msg):
+            events.append((topic, msg))
+
+    monkeypatch.setattr(
+        "alpha_factory_v1.backend.services.kafka_service.EventBus",
+        DummyBus,
+    )
+
+    svc = KafkaService("broker", False)
+    svc.publish("x", {"y": 1})
+    assert events == [("x", {"y": 1})]

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -1,0 +1,12 @@
+from alpha_factory_v1.backend.services.metrics_service import MetricsExporter
+
+
+def test_metrics_exporter_start(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        "alpha_factory_v1.backend.services.metrics_service.init_metrics",
+        lambda port: called.append(port),
+    )
+    exporter = MetricsExporter(9999)
+    exporter.start()
+    assert called == [9999]

--- a/tests/test_orchestrator_lifecycle.py
+++ b/tests/test_orchestrator_lifecycle.py
@@ -94,8 +94,8 @@ async def test_orchestrator_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     run_task = asyncio.create_task(orch.run(stop))
     await asyncio.sleep(0.2)  # allow servers to start
 
-    assert orch._rest_task is not None
-    assert orch._grpc_server is not None
+    assert orch.api_server.rest_task is not None
+    assert orch.api_server.grpc_server is not None
 
     import httpx
 
@@ -109,6 +109,6 @@ async def test_orchestrator_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     stop.set()
     await run_task
 
-    assert orch._rest_task.done()
+    assert orch.api_server.rest_task.done()
     for r in orch.manager.runners.values():
         assert r.task is None or r.task.done()


### PR DESCRIPTION
## Summary
- break orchestrator features into APIServer/KafkaService/MetricsExporter classes
- compose services in BaseOrchestrator
- update orchestrator to use new services
- adjust tests for new structure and add unit tests

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 76 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a101c6a4c8333bc3c9f2e8af39967