### PR TITLE
Refactor utilities into package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The initial release is tagged `v0.1.0-alpha`.
 
 For the full changelog, see [docs/CHANGELOG.md](docs/CHANGELOG.md).
 
+### Migration Note
+Production modules previously under `src/` now reside in
+`alpha_factory_v1.core`.
+Update imports accordingly.
+
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.

--- a/README.md
+++ b/README.md
@@ -1235,10 +1235,10 @@ ignored.
 ### 6.4 · Web Dashboard Quick-Start 📊
 Launch the local web interface:
 ```bash
-uvicorn src.interface.api_server:app --reload
-streamlit run src/interface/web_app.py
+uvicorn alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server:app --reload
+streamlit run alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_app.py
 # React client
-cd src/interface/web_client
+cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
 npm ci          # use the lock file for reproducible installs
 npm run dev       # http://localhost:5173
 # build production assets
@@ -1250,13 +1250,13 @@ Alternatively run inside Docker:
 # build the web client first so `dist/` exists
 make build_web
 # regenerate protobuf modules and Go stubs
-./tools/gen_proto_stubs.sh  # updates src/utils/a2a_pb2.py and tools/go_a2a_client/a2a.pb.go
+./tools/gen_proto_stubs.sh  # updates alpha_factory_v1/core/utils/a2a_pb2.py and tools/go_a2a_client/a2a.pb.go
 make compose-up  # builds and waits for healthy services
 ```
 Run `./tools/gen_proto_stubs.sh` whenever `src/utils/a2a.proto` changes to keep the
 Python and Go stubs up to date.
 Open <http://localhost:8080> in your browser. When `RUN_MODE=web`, the container
-serves the static files from `src/interface/web_client/dist` using `python -m
+serves the static files from `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist` using `python -m
 http.server`. The FastAPI demo also mounts this folder at `/` when present so the
 dashboard is reachable without additional tooling.
 
@@ -1272,7 +1272,7 @@ complexity from the final population.
 
 If Streamlit isn't installed or you're running on a headless server, use:
 ```bash
-python -m src.interface.minimal_ui --text
+python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.minimal_ui --text
 ```
 to display the forecast results directly in the console.
 

--- a/alpha_factory_v1/core/tools/dgm_import.py
+++ b/alpha_factory_v1/core/tools/dgm_import.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Import DGM lineage logs into :class:`~src.archive.db.ArchiveDB`."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+from alpha_factory_v1.core.archive.db import ArchiveDB, ArchiveEntry
+
+DEFAULT_ARCHIVE = Path(os.getenv("ARCHIVE_PATH", "archive.db"))
+
+
+def _parse_file(path: Path) -> Iterable[ArchiveEntry]:
+    """Yield archive entries from ``path``."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:  # noqa: BLE001 - skip invalid lines
+            continue
+        yield ArchiveEntry(
+            hash=rec["hash"],
+            parent=rec.get("parent"),
+            score=float(rec.get("score", 0.0)),
+            novelty=float(rec.get("novelty", 0.0)),
+            is_live=bool(rec.get("is_live", True)),
+            ts=float(rec.get("ts", 0.0)),
+        )
+
+
+def import_logs(log_dir: str | Path, *, db_path: str | Path = DEFAULT_ARCHIVE) -> int:
+    """Load DGM logs from ``log_dir`` into ``db_path``.
+
+    Args:
+        log_dir: Directory containing ``*.json`` log files.
+        db_path: Archive database path.
+
+    Returns:
+        Number of imported records.
+    """
+    db = ArchiveDB(db_path)
+    count = 0
+    for file in sorted(Path(log_dir).glob("*.json")):
+        for entry in _parse_file(file):
+            db.add(entry)
+            count += 1
+    return count
+
+
+__all__ = ["import_logs"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -258,7 +258,7 @@ def simulate(
         os.environ["LLAMA_MODEL_PATH"] = str(llama_model_path)
 
     if import_dgm is not None:
-        from ..tools import dgm_import
+        from alpha_factory_v1.core.tools import dgm_import
 
         dgm_import.import_logs(import_dgm)
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/__init__.py
@@ -1,4 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Utility helpers for the Insight demo."""
+"""Utility helpers for the Insight demo (deprecated)."""
+
+from warnings import warn
+from alpha_factory_v1.core.tools import dgm_import
+
+warn(
+    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.tools is deprecated; use alpha_factory_v1.core.tools",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["dgm_import"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/dgm_import.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/dgm_import.py
@@ -1,54 +1,11 @@
-# SPDX-License-Identifier: Apache-2.0
-"""Import DGM lineage logs into :class:`~src.archive.db.ArchiveDB`."""
+"""Compatibility wrapper for :mod:`alpha_factory_v1.core.tools.dgm_import`."""
 
-from __future__ import annotations
+from warnings import warn
+from alpha_factory_v1.core.tools.dgm_import import *  # noqa: F401,F403
 
-import json
-import os
-from pathlib import Path
-from typing import Iterable
-
-from alpha_factory_v1.core.archive.db import ArchiveDB, ArchiveEntry
-
-DEFAULT_ARCHIVE = Path(os.getenv("ARCHIVE_PATH", "archive.db"))
-
-
-def _parse_file(path: Path) -> Iterable[ArchiveEntry]:
-    """Yield archive entries from ``path``."""
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        try:
-            rec = json.loads(line)
-        except Exception:  # noqa: BLE001 - skip invalid lines
-            continue
-        yield ArchiveEntry(
-            hash=rec["hash"],
-            parent=rec.get("parent"),
-            score=float(rec.get("score", 0.0)),
-            novelty=float(rec.get("novelty", 0.0)),
-            is_live=bool(rec.get("is_live", True)),
-            ts=float(rec.get("ts", 0.0)),
-        )
-
-
-def import_logs(log_dir: str | Path, *, db_path: str | Path = DEFAULT_ARCHIVE) -> int:
-    """Load DGM logs from ``log_dir`` into ``db_path``.
-
-    Args:
-        log_dir: Directory containing ``*.json`` log files.
-        db_path: Archive database path.
-
-    Returns:
-        Number of imported records.
-    """
-    db = ArchiveDB(db_path)
-    count = 0
-    for file in sorted(Path(log_dir).glob("*.json")):
-        for entry in _parse_file(file):
-            db.add(entry)
-            count += 1
-    return count
-
-
-__all__ = ["import_logs"]
+warn(
+    "alpha_factory_v1.demos.alpha_agi_insight_v1.src.tools.dgm_import is deprecated; "
+    "use alpha_factory_v1.core.tools.dgm_import instead",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py
@@ -135,7 +135,7 @@ def test_transfer_test_runs(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_run(models: list[str], top_n: int) -> None:
         click.echo(f"models:{','.join(models)} top:{top_n}")
 
-    monkeypatch.setattr("src.tools.transfer_test.run_transfer_test", fake_run)
+    monkeypatch.setattr("alpha_factory_v1.core.tools.transfer_test.run_transfer_test", fake_run)
     runner = CliRunner()
     result = runner.invoke(cli.main, ["transfer-test"])
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,12 +25,13 @@ Downstream users should consult this section when upgrading.
 ### Breaking Changes
 - Core modules previously under `src/` now live in `alpha_factory_v1.core`.
 - Update imports accordingly.
+- Monitoring, governance and archive helpers moved under `alpha_factory_v1.core`.
 - `alpha-factory` and `edge_runner.py` now print a short warning before startup.
 - Synced `openai`, `openai-agents` and `uvicorn` pins across requirements files
   and clarified why `requests` and `rich` differ between layers.
 - Documented `API_RATE_LIMIT`, `AGI_ISLAND_BACKENDS` and `ALERT_WEBHOOK_URL`
   environment variables.
-- Added [`src/tools/analyse_backtrack.py`](../src/tools/analyse_backtrack.py) for visualising archive backtracks.
+- Added [`alpha_factory_v1/core/tools/analyse_backtrack.py`](../alpha_factory_v1/core/tools/analyse_backtrack.py) for visualising archive backtracks.
 - Documented how to build a wheelhouse for offline installs and updated
   `tests/README.md` with the instructions.
 - Added `scripts/build_offline_wheels.sh` to gather wheels for all lock files.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,21 +5,21 @@
 
 ## Building the React Dashboard
 
-The React dashboard sources live under `src/interface/web_client`. Build the static assets before serving the API:
+The React dashboard sources live under `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client`. Build the static assets before serving the API:
 
 ```bash
-pnpm --dir src/interface/web_client install
-pnpm --dir src/interface/web_client run build
+pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client install
+pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build
 ```
 
-The compiled files appear in `src/interface/web_client/dist` and are automatically served when running `uvicorn src.interface.api_server:app` with `RUN_MODE=web`.
+The compiled files appear in `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist` and are automatically served when running `uvicorn alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server:app` with `RUN_MODE=web`.
 
 ## Ablation Runner
 
-Use `src/tools/ablation_runner.py` to measure how disabling individual innovations affects benchmark performance. The script applies each patch from `benchmarks/patch_library/`, runs the benchmarks with and without each feature and generates `docs/ablation_heatmap.svg`.
+Use `alpha_factory_v1/core/tools/ablation_runner.py` to measure how disabling individual innovations affects benchmark performance. The script applies each patch from `benchmarks/patch_library/`, runs the benchmarks with and without each feature and generates `docs/ablation_heatmap.svg`.
 
 ```bash
-python -m src.tools.ablation_runner
+python -m alpha_factory_v1.core.tools.ablation_runner
 ```
 
 The resulting heatmap visualises the pass rate drop when a component is disabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ packages = [
     "alpha_factory_v1.core.self_evolution",
     "alpha_factory_v1.core.simulation",
     "alpha_factory_v1.core.utils",
+    "alpha_factory_v1.core.tools",
     "alpha_factory_v1.common",
     "alpha_factory_v1.common.utils",
     "alpha_factory_v1.utils",

--- a/tests/test_dgm_import.py
+++ b/tests/test_dgm_import.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 from alpha_factory_v1.core.archive.db import ArchiveDB
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.tools import dgm_import
+from alpha_factory_v1.core.tools import dgm_import
 
 
 def test_dgm_import(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- move dgm_import helper under alpha_factory_v1.core.tools
- add deprecation wrappers in demo paths
- make orchestrator restart alerts pluggable
- update documentation to new package paths
- update pyproject and changelog

## Testing
- `pre-commit run --files CHANGELOG.md README.md alpha_factory_v1/core/orchestrator.py alpha_factory_v1/core/tools/dgm_import.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/__init__.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/dgm_import.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_demo_cli.py docs/CHANGELOG.md docs/README.md pyproject.toml tests/test_dgm_import.py` *(fails: proto-verify, verify-requirements-lock; mypy errors)*
- `pytest -q` *(fails to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_685a157f24748333836af0003eef46d1