### PR TITLE
[alpha_factory] make policy_qa async

### DIFF
--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -302,9 +302,8 @@ class PolicyAgent(AgentBase):
     # ── OpenAI tools ─────────────────────────────────────────────────────
 
     @tool(description="Answer a legal / policy question with citations. Arg str query.")
-    def policy_qa(self, query: str) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._qa_async(query))
+    async def policy_qa(self, query: str) -> str:  # noqa: D401
+        return await self._qa_async(query)
 
     @tool(description="Compare two versions. Arg JSON {'old':str,'new':str}")
     def compare_versions(self, req_json: str) -> str:  # noqa: D401


### PR DESCRIPTION
## Summary
- implement policy_qa as an async tool

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install`
- `pytest -k 'policy_agent' -q` *(fails: 77 errors during collection)*
- `pre-commit run --files alpha_factory_v1/backend/agents/policy_agent.py --hook-stage manual` *(fails: flake8 and mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a1e8368a08333aabf503661eb75c5