### PR TITLE
[alpha_factory] defer agent mesh registration

### DIFF
--- a/alpha_factory_v1/backend/agent_manager.py
+++ b/alpha_factory_v1/backend/agent_manager.py
@@ -40,6 +40,10 @@ class AgentManager:
 
     async def start(self) -> None:
         """Launch heartbeat and regression guard tasks."""
+        for r in self.runners.values():
+            register = getattr(r.inst, "_register_mesh", None)
+            if register:
+                asyncio.create_task(register())
 
         self._hb_task = asyncio.create_task(hb_watch(self.runners))
         self._reg_task = asyncio.create_task(regression_guard(self.runners))

--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -280,7 +280,8 @@ class BiotechAgent(AgentBase):
             self._producer = None
 
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ── OpenAI Agents SDK tools ──────────────────────────────────────────
     @tool(description="Ask a biotech-related question; returns answer with citations.")

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -247,8 +247,7 @@ class ClimateRiskAgent(AgentBase):
             self._producer = None
 
         # ADK mesh heartbeat
-        if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+        # Registration is scheduled by the orchestrator once the event loop is running
 
     # ────────────────────────────────────────────────────────────────
     # OpenAI Agents SDK tools

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -233,7 +233,8 @@ class CyberThreatAgent(AgentBase):
             self._producer = None
 
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ------------------------------------------------------------------
     # OpenAI Agents SDK tools

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -409,7 +409,8 @@ class DrugDesignAgent(AgentBase):
                 value_serializer=lambda v: json.dumps(v).encode(),
             )
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ------------------------------------------------------------------
     # Tools

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -272,7 +272,8 @@ class EnergyAgent(AgentBase):
             else None
         )
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # -------------------------- OpenAI tools ----------------------------- #
     @tool(description="48-hour ahead demand & PV forecast (JSON list).")

--- a/alpha_factory_v1/backend/agents/finance_agent.py
+++ b/alpha_factory_v1/backend/agents/finance_agent.py
@@ -352,7 +352,8 @@ class FinanceAgent(AgentBase):
 
         # ── ADK mesh registration ──
         if self.cfg.adk_mesh and "adk" in globals():
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ───────────── OpenAI Agents SDK tools ─────────────
     @tool(description="Return latest factor z-scores (JSON str).")

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -223,7 +223,8 @@ class ManufacturingAgent(AgentBase):
 
         # ADK mesh -------------------------------------------------------
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ------------------------------------------------------------------
     # OpenAI Agents SDK tools ------------------------------------------

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -297,7 +297,8 @@ class PolicyAgent(AgentBase):
             self._qps = Gauge("af_policy_queries", "Total PolicyAgent queries")
 
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ── OpenAI tools ─────────────────────────────────────────────────────
 

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -246,7 +246,8 @@ class RetailDemandAgent(AgentBase):
 
         # ADK mesh (optional)
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ------------------------------------------------------------------
     # OpenAI Agents SDK tools

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -232,7 +232,8 @@ class SmartContractAgent(AgentBase):
         )
 
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ------------------------------------------------------------------
     # OpenAI Agent tools

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -219,7 +219,8 @@ class SupplyChainAgent(AgentBase):  # noqa: D101
         self.cfg.data_root.mkdir(parents=True, exist_ok=True)
         self._wm: WorldModel = WorldModel()
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # ----------------------------- tools ----------------------------- #
 

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -275,7 +275,8 @@ class TalentMatchAgent(AgentBase):
 
         # ADK
         if self.cfg.adk_mesh and adk:
-            asyncio.create_task(self._register_mesh())
+            # registration scheduled by orchestrator after loop start
+            pass
 
     # -------------------------------------------------------------
     #   Database helpers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,3 +42,11 @@ gracefully when optional dependencies (like Kafka or FastAPI) are missing.
 
 For more details see `docs/DESIGN.md` and the module docstrings within
 `alpha_factory_v1/backend`.
+
+## Agent lifecycle
+
+Agents are instantiated synchronously so their constructors **must not** schedule
+asynchronous tasks. The orchestrator invokes each agent's optional
+`_register_mesh()` coroutine once the event loop is running and calls the
+`setup()` coroutine for heavy initialisation. This allows agents to be created in
+standard blocking code without errors about missing event loops.


### PR DESCRIPTION
## Summary
- schedule ADK mesh registration from AgentManager
- note async lifecycle in architecture doc
- remove premature create_task calls in agents

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError)*
- `pre-commit run --files alpha_factory_v1/backend/agent_manager.py alpha_factory_v1/backend/agents/biotech_agent.py alpha_factory_v1/backend/agents/climate_risk_agent.py alpha_factory_v1/backend/agents/cyber_threat_agent.py alpha_factory_v1/backend/agents/drug_design_agent.py alpha_factory_v1/backend/agents/energy_agent.py alpha_factory_v1/backend/agents/finance_agent.py alpha_factory_v1/backend/agents/manufacturing_agent.py alpha_factory_v1/backend/agents/policy_agent.py alpha_factory_v1/backend/agents/retail_demand_agent.py alpha_factory_v1/backend/agents/smart_contract_agent.py alpha_factory_v1/backend/agents/supply_chain_agent.py alpha_factory_v1/backend/agents/talent_match_agent.py docs/ARCHITECTURE.md` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685a264146888333a89f2baa2312f659