### PR TITLE
[alpha_factory] improve regression guard

### DIFF
--- a/alpha_factory_v1/backend/README.md
+++ b/alpha_factory_v1/backend/README.md
@@ -28,6 +28,8 @@ The orchestrator honours several variables to tune runtime behaviour:
 | `ALPHA_CYCLE_SECONDS` | Default agent cycle period | `60` |
 | `MAX_CYCLE_SEC` | Hard limit per agent run in seconds | `30` |
 | `ALPHA_ENABLED_AGENTS` | Comma-separated list of agents to run | *(all)* |
+| `ALPHA_REGRESSION_THRESHOLD` | Metric drop required to pause evolution | `0.8` |
+| `ALPHA_REGRESSION_WINDOW` | Number of scores considered for regression | `3` |
 
 ## Running Locally
 

--- a/alpha_factory_v1/backend/orchestrator.py
+++ b/alpha_factory_v1/backend/orchestrator.py
@@ -77,6 +77,10 @@ def publish(topic: str, msg: dict[str, object]) -> None:
             log.exception("publish failed")
 
 
+# Backwards‑compatibility alias used by legacy agents
+_publish = publish
+
+
 class Orchestrator(BaseOrchestrator):
     """Default Alpha‑Factory orchestrator."""
 
@@ -155,4 +159,5 @@ __all__ = [
     "MET_ERR",
     "MET_UP",
     "tracer",
+    "_publish",
 ]


### PR DESCRIPTION
## Summary
- add environment options for regression guard
- enforce moving average checks
- alias `_publish` for older agents
- document regression guard variables

## Testing
- `pre-commit run --files alpha_factory_v1/backend/agent_runner.py alpha_factory_v1/backend/orchestrator.py alpha_factory_v1/backend/README.md` *(fails: proto-verify, verify-requirements-lock)*
- `pytest tests/test_governance.py::test_regression_guard -q` *(fails: RuntimeError no running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_685a9065c4808333804f8cc5508c9b70