### PR TITLE
[alpha_factory] replace run_until_complete usage

### DIFF
--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -60,6 +60,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 from backend.agents.base import AgentBase  # pylint: disable=import-error
 from backend.agents import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # pylint: disable=import-error
@@ -286,16 +288,16 @@ class BiotechAgent(AgentBase):
     # ── OpenAI Agents SDK tools ──────────────────────────────────────────
     @tool(description="Ask a biotech-related question; returns answer with citations.")
     def ask_biotech(self, query: str) -> str:
-        return asyncio.get_event_loop().run_until_complete(self._ask_async(query))
+        return run_sync(self._ask_async(query))
 
     @tool(description="Design an experiment. Arg JSON {objective:str, budget:str?}.")
     def propose_experiment(self, obj_json: str) -> str:
         args = json.loads(obj_json or "{}")
-        return asyncio.get_event_loop().run_until_complete(self._exp_async(args))
+        return run_sync(self._exp_async(args))
 
     @tool(description="Return pathway map for entity URI or gene symbol.")
     def pathway_map(self, entity: str) -> str:
-        return asyncio.get_event_loop().run_until_complete(self._pathway_async(entity))
+        return run_sync(self._pathway_async(entity))
 
     @tool(description="Summarise latest alpha opportunities discovered by the agent.")
     def alpha_dashboard(self) -> str:
@@ -375,8 +377,7 @@ class BiotechAgent(AgentBase):
         }
 
     def optimise(self, sequence: str) -> Dict[str, Any]:
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._optimise_async(sequence))
+        return run_sync(self._optimise_async(sequence))
 
     # ── data ingest helpers ──────────────────────────────────────────────
     async def _ingest_pubmed(self, term: str):

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -62,6 +62,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ────────────────────────────────────────────────────────────────────────────────
 # Soft‑optional dependencies — IMPORT FAILURES ARE SILENT.
 # ────────────────────────────────────────────────────────────────────────────────
@@ -255,18 +257,15 @@ class ClimateRiskAgent(AgentBase):
 
     @tool(description="Dollar VaR for next 10 years under default SSP scenario.")
     def portfolio_var(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._compute_var(self.cfg.ssp_default))
+        return run_sync(self._compute_var(self.cfg.ssp_default))
 
     @tool(description="Ranked adaptation cap‑ex plan that halves VaR.")
     def adaptation_plan(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._plan_adaptations())
+        return run_sync(self._plan_adaptations())
 
     @tool(description="Stress test portfolio VaR under provided SSP (e.g. SSP5‑8.5). Parameter: ssp (str)")
     def stress_test(self, *, ssp: str) -> str:  # type: ignore  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._compute_var(ssp))
+        return run_sync(self._compute_var(ssp))
 
     # ────────────────────────────────────────────────────────────────
     # Orchestrator cycle

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -53,6 +53,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ---------------------------------------------------------------------------
 # Soft‑optional libraries (import guards keep offline mode viable)
 # ---------------------------------------------------------------------------
@@ -242,8 +244,7 @@ class CyberThreatAgent(AgentBase):
 
     @tool(description="Return JSON residual cyber‑risk (USD) + top open threats.")
     def audit(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._risk_snapshot())
+        return run_sync(self._risk_snapshot())
 
     @tool(
         description=(
@@ -252,8 +253,7 @@ class CyberThreatAgent(AgentBase):
         )
     )
     def patch_plan(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._plan_patches())
+        return run_sync(self._plan_patches())
 
     # ------------------------------------------------------------------
     # Core cycle invoked by orchestrator

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -47,6 +47,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ---------------------------------------------------------------------------
 # Soft‑optional deps (import‑guarded) ---------------------------------------
 # ---------------------------------------------------------------------------
@@ -418,8 +420,7 @@ class DrugDesignAgent(AgentBase):
 
     @tool(description="Generate a novel lead molecule with predicted properties and rationale.")
     def propose_lead(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._propose_async())
+        return run_sync(self._propose_async())
 
     @tool(description='Score a SMILES for potency & developability. Input: JSON "{"smi": "..."}" or raw SMILES.')
     def score_molecule(self, smi_json: str) -> str:  # noqa: D401
@@ -427,8 +428,7 @@ class DrugDesignAgent(AgentBase):
             smi = json.loads(smi_json).get("smi", smi_json)
         except json.JSONDecodeError:
             smi = smi_json.strip()
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._score_async(smi))
+        return run_sync(self._score_async(smi))
 
     # ------------------------------------------------------------------
     # Cycle

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -49,6 +49,7 @@ import math
 import os
 import random
 import threading
+from alpha_factory_v1.backend.utils.sync import run_sync
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -158,30 +159,6 @@ def _mcp(agent: str, payload: Any) -> Dict[str, Any]:
     }
 
 
-def _sync_run(coro: Awaitable[str]) -> str:
-    """Run ``coro`` synchronously regardless of event loop state."""
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-
-    result: list[str] = []
-
-    def _worker() -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        task = loop.create_task(coro)
-        try:
-            result.append(asyncio.get_event_loop().run_until_complete(task))
-        finally:
-            loop.close()
-
-    t = threading.Thread(target=_worker)
-    t.start()
-    t.join()
-    return result[0]
-
-
 # ---------------------------------------------------------------------------
 # Surrogate load / PV model ---------------------------------------------------
 class _SurrogateModel:
@@ -278,15 +255,15 @@ class EnergyAgent(AgentBase):
     # -------------------------- OpenAI tools ----------------------------- #
     @tool(description="48-hour ahead demand & PV forecast (JSON list).")
     def forecast_demand(self) -> str:
-        return _sync_run(self._forecast())
+        return run_sync(self._forecast())
 
     @tool(description="24-h battery/DR optimal dispatch schedule (JSON).")
     def optimise_dispatch(self) -> str:
-        return _sync_run(self._dispatch())
+        return run_sync(self._dispatch())
 
     @tool(description="Generate PPA/forward-curve hedge strategy JSON.")
     def hedge_strategy(self) -> str:
-        return _sync_run(self._hedge())
+        return run_sync(self._hedge())
 
     # ----------------------- Orchestrator hook --------------------------- #
     async def run_cycle(self):

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -49,6 +49,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ---------------------------------------------------------------------------
 # Soft‑optional dependencies (import‑time safe) ------------------------------
 # ---------------------------------------------------------------------------
@@ -239,8 +241,7 @@ class ManufacturingAgent(AgentBase):
     )
     def build_schedule(self, req_json: str) -> str:  # noqa: D401
         req = json.loads(req_json)
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._build_async(req))
+        return run_sync(self._build_async(req))
 
     @tool(
         description=(
@@ -250,8 +251,7 @@ class ManufacturingAgent(AgentBase):
     )
     def reschedule_delta(self, req_json: str) -> str:  # noqa: D401
         req = json.loads(req_json)
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._delta_async(req))
+        return run_sync(self._delta_async(req))
 
     @tool(description="Energy & CO₂ report for schedule. Arg JSON schedule object")
     def energy_report(self, sched_json: str) -> str:  # noqa: D401
@@ -262,8 +262,7 @@ class ManufacturingAgent(AgentBase):
     @tool(description='Monte‑Carlo what‑if. Arg JSON {"jobs_base": [...], "nbr_samples":int}')
     def what_if(self, req_json: str) -> str:  # noqa: D401
         req = json.loads(req_json)
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._what_if_async(req))
+        return run_sync(self._what_if_async(req))
 
     # ------------------------------------------------------------------
     # Public sync helpers ----------------------------------------------
@@ -272,8 +271,7 @@ class ManufacturingAgent(AgentBase):
     def schedule(self, jobs: List[List[Dict[str, Any]]], horizon: int) -> Dict[str, Any]:
         """Synchronous wrapper around :meth:`_build_async` returning a dict."""
         req = {"jobs": jobs, "horizon": horizon}
-        loop = asyncio.get_event_loop()
-        res = loop.run_until_complete(self._build_async(req))
+        res = run_sync(self._build_async(req))
         try:
             return json.loads(res)["payload"]
         except Exception:  # noqa: BLE001

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -51,6 +51,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ────────────────────────────────────────────────────────────────────────────
 # Soft‑optional deps (never crash at import)
 # ────────────────────────────────────────────────────────────────────────────
@@ -207,7 +209,7 @@ class _Retriever:
         self.texts: List[str] = []
         self.meta: List[Dict[str, Any]] = []  # keeps jurisdiction/version
         self.bm25: Optional[BM25Okapi] = None
-        asyncio.get_event_loop().run_until_complete(self._load())
+        run_sync(self._load())
 
     async def _load(self):
         if self.cfg.index_path.exists():

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -46,6 +46,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ---------------------------------------------------------------------------
 # Soft‑optional third‑party deps (guarded)  ----------------------------------
 # ---------------------------------------------------------------------------
@@ -255,13 +257,11 @@ class RetailDemandAgent(AgentBase):
 
     @tool(description="Return SKU‑level weekly demand forecast (mean & std dev) for the next horizon_weeks")
     def forecast(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._forecast_async())
+        return run_sync(self._forecast_async())
 
     @tool(description="Generate a reorder plan that meets the configured service level (>98 % by default)")
     def reorder_plan(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._plan_async())
+        return run_sync(self._plan_async())
 
     # ------------------------------------------------------------------
     # Orchestrator life‑cycle

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -48,6 +48,8 @@ from pathlib import Path
 from shlex import quote
 from typing import Any, Dict, List, Optional
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ---------------------------------------------------------------------------
 # Soft‑optional dependencies — import‑guarded to keep cold‑start <50 ms
 # ---------------------------------------------------------------------------
@@ -248,16 +250,14 @@ class SmartContractAgent(AgentBase):
         args = json.loads(contract_json)
         src: Optional[str] = args.get("source")
         addr: Optional[str] = args.get("address")
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._audit_async(src, addr))
+        return run_sync(self._audit_async(src, addr))
 
     @tool(description='Suggest gas‑saving refactors. Input: JSON {"source": str, "budget_gwei": int?}')
     def optimize_contract(self, src_json: str) -> str:  # noqa: D401
         args = json.loads(src_json)
         src = args.get("source", "")
         budget = int(args.get("budget_gwei", 50))
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._optimize_async(src, budget))
+        return run_sync(self._optimize_async(src, budget))
 
     @tool(
         description="Forecast gas price (gwei) and ETH cost for calldata length over next 12 blocks."
@@ -265,8 +265,7 @@ class SmartContractAgent(AgentBase):
     )
     def gas_forecast(self, args_json: str) -> str:  # noqa: D401
         blen = int(json.loads(args_json).get("bytes_len", 0))
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._gas_async(blen))
+        return run_sync(self._gas_async(blen))
 
     # ------------------------------------------------------------------
     # Orchestrator life‑cycle

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 try:
     import networkx as nx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dep
@@ -226,8 +228,7 @@ class SupplyChainAgent(AgentBase):  # noqa: D101
 
     @tool(description="Run an end‑to‑end supply‑chain replanning cycle and return JSON recommendations.")
     def replan(self) -> str:  # noqa: D401
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._plan_cycle())
+        return run_sync(self._plan_cycle())
 
     # ------------------------ orchestrator hook ----------------------- #
 

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -48,6 +48,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from alpha_factory_v1.backend.utils.sync import run_sync
+
 # ---------------------------------------------------------------------------
 # Optional dependencies (soft imports — never crash)                        |
 # ---------------------------------------------------------------------------
@@ -331,28 +333,24 @@ class TalentMatchAgent(AgentBase):
         args = json.loads(jd_json)
         jd = args.get("jd", "")
         topk = int(args.get("topk", 5))
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._recommend_async(jd, topk))
+        return run_sync(self._recommend_async(jd, topk))
 
     @tool(description='Similarity & skill gap between JD and resume. Arg: JSON {"jd":str, "resume":str}')
     def score_match(self, args_json: str) -> str:  # noqa: D401
         args = json.loads(args_json)
         jd, resume = args.get("jd", ""), args.get("resume", "")
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._score_async(jd, resume))
+        return run_sync(self._score_async(jd, resume))
 
     @tool(description="DEI diversity report given list of candidate IDs.")
     def diversity_report(self, ids_json: str) -> str:  # noqa: D401
         ids = json.loads(ids_json)
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._dei_async(ids))
+        return run_sync(self._dei_async(ids))
 
     @tool(description='Simulate hire probability vs compensation. Arg: JSON {"cid":str, "offer_usd":float}')
     def simulate_offer(self, args_json: str) -> str:  # noqa: D401
         args = json.loads(args_json)
         cid, offer = args.get("cid"), float(args.get("offer_usd", 0))
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._offer_async(cid, offer))
+        return run_sync(self._offer_async(cid, offer))
 
     # -------------------------------------------------------------
     #   Orchestrator lifecycle

--- a/alpha_factory_v1/backend/utils/sync.py
+++ b/alpha_factory_v1/backend/utils/sync.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Helper utilities for running async code synchronously."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Awaitable, TypeVar
+
+T = TypeVar("T")
+
+
+def run_sync(coro: Awaitable[T]) -> T:
+    """Run ``coro`` synchronously regardless of event loop state."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: list[T] = []
+
+    def _worker() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        task = loop.create_task(coro)
+        try:
+            result.append(loop.run_until_complete(task))
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join()
+    return result[0]


### PR DESCRIPTION
## Summary
- add `run_sync` helper for async wrappers
- use `run_sync` in biotech, smart contract, talent match, and other agents
- refactor energy agent to adopt `run_sync`

## Testing
- `pre-commit run --files alpha_factory_v1/backend/agents/biotech_agent.py alpha_factory_v1/backend/agents/climate_risk_agent.py alpha_factory_v1/backend/agents/cyber_threat_agent.py alpha_factory_v1/backend/agents/drug_design_agent.py alpha_factory_v1/backend/agents/energy_agent.py alpha_factory_v1/backend/agents/manufacturing_agent.py alpha_factory_v1/backend/agents/policy_agent.py alpha_factory_v1/backend/agents/retail_demand_agent.py alpha_factory_v1/backend/agents/smart_contract_agent.py alpha_factory_v1/backend/agents/supply_chain_agent.py alpha_factory_v1/backend/agents/talent_match_agent.py alpha_factory_v1/backend/utils/sync.py` *(fails: proto-verify and requirements lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_685aa276789883339375273dfca78e58