### PR TITLE
[alpha_factory] add async init hook

### DIFF
--- a/alpha_factory_v1/backend/agent_manager.py
+++ b/alpha_factory_v1/backend/agent_manager.py
@@ -44,6 +44,10 @@ class AgentManager:
             register = getattr(r.inst, "_register_mesh", None)
             if register:
                 asyncio.create_task(register())
+        for r in self.runners.values():
+            init_async = getattr(r.inst, "init_async", None)
+            if init_async:
+                await init_async()
 
         self._hb_task = asyncio.create_task(hb_watch(self.runners))
         self._reg_task = asyncio.create_task(regression_guard(self.runners))

--- a/alpha_factory_v1/backend/agents/base.py
+++ b/alpha_factory_v1/backend/agents/base.py
@@ -169,6 +169,10 @@ class AgentBase(abc.ABC):
         """One-time async initialization (DB warm-up, model load…)."""
         return None
 
+    async def init_async(self) -> None:  # pragma: no cover - optional hook
+        """Launch background tasks once the event loop is running."""
+        return None
+
     @abc.abstractmethod
     async def step(self) -> None:  # noqa: D401
         """The agent's main unit of work.  MUST be overridden."""

--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -269,7 +269,6 @@ class BiotechAgent(AgentBase):
 
         self.store = _EmbedStore(self.cfg)
         self.kg = _KG(self.cfg, self.store)
-        asyncio.create_task(self.kg.load())
 
         self._latest_alpha: List[Dict[str, Any]] = []
 
@@ -284,6 +283,10 @@ class BiotechAgent(AgentBase):
         if self.cfg.adk_mesh and adk:
             # registration scheduled by orchestrator after loop start
             pass
+
+    async def init_async(self) -> None:
+        """Launch background tasks after instantiation."""
+        asyncio.create_task(self.kg.load())
 
     # ── OpenAI Agents SDK tools ──────────────────────────────────────────
     @tool(description="Ask a biotech-related question; returns answer with citations.")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,7 @@ For more details see `docs/DESIGN.md` and the module docstrings within
 
 Agents are instantiated synchronously so their constructors **must not** schedule
 asynchronous tasks. The orchestrator invokes each agent's optional
-`_register_mesh()` coroutine once the event loop is running and calls the
-`setup()` coroutine for heavy initialisation. This allows agents to be created in
-standard blocking code without errors about missing event loops.
+`_register_mesh()` coroutine once the event loop is running, awaits the
+`init_async()` hook for background setup and calls the `setup()` coroutine for
+heavy initialisation. This allows agents to be created in standard blocking
+code without errors about missing event loops.


### PR DESCRIPTION
## Summary
- add optional `init_async` coroutine in `AgentBase`
- run `init_async` from `AgentManager.start`
- move BiotechAgent KG load into new hook
- clarify constructor behaviour in documentation

## Testing
- `pre-commit run --files alpha_factory_v1/backend/agent_manager.py alpha_factory_v1/backend/agents/base.py alpha_factory_v1/backend/agents/biotech_agent.py docs/ARCHITECTURE.md` *(fails: flake8, mypy)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685aaa6d82e88333a2fe2b15f9c8d385