### PR TITLE
[alpha_factory] run health loops within asyncio

### DIFF
--- a/alpha_factory_v1/backend/agent_manager.py
+++ b/alpha_factory_v1/backend/agent_manager.py
@@ -23,9 +23,8 @@ class AgentManager:
         *,
         bus: EventBus | None = None,
     ) -> None:
-        from backend.agents import list_agents, start_background_tasks
+        from backend.agents import list_agents
 
-        start_background_tasks()
         avail = list_agents()
         names = [n for n in avail if not enabled or n in enabled]
         if not names:
@@ -40,6 +39,10 @@ class AgentManager:
 
     async def start(self) -> None:
         """Launch heartbeat and regression guard tasks."""
+        from backend.agents import start_background_tasks
+
+        await start_background_tasks()
+
         for r in self.runners.values():
             register = getattr(r.inst, "_register_mesh", None)
             if register:
@@ -57,6 +60,9 @@ class AgentManager:
         """Cancel helper tasks and wait for agent cycles to finish."""
 
         await self.bus.stop_consumer()
+        from backend.agents import stop_background_tasks
+
+        await stop_background_tasks()
         if self._hb_task:
             self._hb_task.cancel()
         if self._reg_task:

--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -145,7 +145,6 @@ if not logger.handlers:
 logger.setLevel(logging.INFO)
 
 
-
 ##############################################################################
 #                             public datatypes                               #
 ##############################################################################
@@ -312,6 +311,7 @@ def _agent_base():
 
 ##############################################################################
 
+
 ##############################################################################
 def _should_register(meta: AgentMetadata) -> bool:
     if meta.name.lower() in _DISABLED:
@@ -354,8 +354,6 @@ def _register(meta: AgentMetadata, *, overwrite: bool = False):
 
     logger.info("✓ agent %-18s caps=%s", meta.name, ",".join(meta.capabilities))
     _emit_kafka("agent.manifest", meta.to_json())
-
-
 
 
 ##############################################################################
@@ -418,7 +416,7 @@ def register_agent(meta: AgentMetadata, *, overwrite: bool = False):
 ##############################################################################
 #                         initial discovery pass                             #
 from .discovery import discover_local, discover_entrypoints, discover_hot_dir, discover_adk
-from .health import start_background_tasks
+from .health import start_background_tasks, stop_background_tasks
 
 ##############################################################################
 discover_local()
@@ -443,4 +441,5 @@ __all__ = [
     "capability_agents",
     "get_agent",
     "start_background_tasks",
+    "stop_background_tasks",
 ]

--- a/alpha_factory_v1/backend/agents/health.py
+++ b/alpha_factory_v1/backend/agents/health.py
@@ -2,8 +2,9 @@
 """Background health monitoring for agents."""
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
-import threading
 import time
 from queue import Empty
 
@@ -25,73 +26,95 @@ from . import (
 from .discovery import discover_hot_dir
 
 
-def _health_loop() -> None:
-    while True:
-        try:
-            name, latency_ms, ok = _HEALTH_Q.get(timeout=_HEARTBEAT_INT)
-        except Empty:
-            continue
+async def _health_loop() -> None:
+    """Consume heartbeat reports and handle quarantines."""
+    try:
+        while True:
+            try:
+                name, latency_ms, ok = await asyncio.to_thread(_HEALTH_Q.get, timeout=_HEARTBEAT_INT)
+            except Empty:
+                continue
 
-        quarantine = False
-        stub_meta: AgentMetadata | None = None
-        with _REGISTRY_LOCK:
-            meta = AGENT_REGISTRY.get(name)
-            if meta and not ok:
-                if Counter:
-                    _err_counter.labels(agent=name).inc()  # type: ignore[attr-defined]
-                object.__setattr__(meta, "err_count", meta.err_count + 1)
-                if meta.err_count >= _ERR_THRESHOLD:  # type: ignore[name-defined]
-                    logger.error(
-                        "\N{NO ENTRY SIGN} Quarantining agent '%s' after %d consecutive errors",
-                        name,
-                        meta.err_count,
-                    )
-                    stub_meta = AgentMetadata(
-                        name=meta.name,
-                        cls=StubAgent,
-                        version=meta.version + "+stub",
-                        capabilities=meta.capabilities,
-                        compliance_tags=meta.compliance_tags,
-                    )
-                    quarantine = True
+            quarantine = False
+            stub_meta: AgentMetadata | None = None
+            with _REGISTRY_LOCK:
+                meta = AGENT_REGISTRY.get(name)
+                if meta and not ok:
+                    if Counter:
+                        _err_counter.labels(agent=name).inc()  # type: ignore[attr-defined]
+                    object.__setattr__(meta, "err_count", meta.err_count + 1)
+                    if meta.err_count >= _ERR_THRESHOLD:  # type: ignore[name-defined]
+                        logger.error(
+                            "\N{NO ENTRY SIGN} Quarantining agent '%s' after %d consecutive errors",
+                            name,
+                            meta.err_count,
+                        )
+                        stub_meta = AgentMetadata(
+                            name=meta.name,
+                            cls=StubAgent,
+                            version=meta.version + "+stub",
+                            capabilities=meta.capabilities,
+                            compliance_tags=meta.compliance_tags,
+                        )
+                        quarantine = True
 
-        if quarantine and stub_meta:
-            _register(stub_meta, overwrite=True)
+            if quarantine and stub_meta:
+                _register(stub_meta, overwrite=True)
 
-        logger.debug(
-            "heartbeat: %s ok=%s latency=%.1fms",
-            name,
-            ok,
-            latency_ms,
-        )
-        _emit_kafka(  # type: ignore[name-defined]
-            "agent.heartbeat",
-            json.dumps({"name": name, "latency_ms": latency_ms, "ok": ok, "ts": time.time()}),
-        )
+            logger.debug(
+                "heartbeat: %s ok=%s latency=%.1fms",
+                name,
+                ok,
+                latency_ms,
+            )
+            _emit_kafka(  # type: ignore[name-defined]
+                "agent.heartbeat",
+                json.dumps({"name": name, "latency_ms": latency_ms, "ok": ok, "ts": time.time()}),
+            )
+    except asyncio.CancelledError:
+        pass
 
 
-
-def _rescan_loop() -> None:  # pragma: no cover
-    while True:
-        try:
-            discover_hot_dir()
-        except Exception:  # noqa: BLE001
-            logger.exception("Hot-dir rescan failed")
-        time.sleep(_RESCAN_SEC)
+async def _rescan_loop() -> None:  # pragma: no cover
+    try:
+        while True:
+            try:
+                discover_hot_dir()
+            except Exception:  # noqa: BLE001
+                logger.exception("Hot-dir rescan failed")
+            await asyncio.sleep(_RESCAN_SEC)
+    except asyncio.CancelledError:
+        pass
 
 
 _bg_started = False
-_health_thread: threading.Thread | None = None
-_rescan_thread: threading.Thread | None = None
+_health_task: asyncio.Task[None] | None = None
+_rescan_task: asyncio.Task[None] | None = None
 
 
-def start_background_tasks() -> None:
+async def start_background_tasks() -> None:
     """Launch health monitor and rescan loops exactly once."""
-    global _bg_started, _health_thread, _rescan_thread
+    global _bg_started, _health_task, _rescan_task
     if _bg_started:
         return
     _bg_started = True
-    _health_thread = threading.Thread(target=_health_loop, daemon=True, name="agent-health")
-    _rescan_thread = threading.Thread(target=_rescan_loop, daemon=True, name="agent-rescan")
-    _health_thread.start()
-    _rescan_thread.start()
+    loop = asyncio.get_running_loop()
+    _health_task = loop.create_task(_health_loop(), name="agent-health")
+    _rescan_task = loop.create_task(_rescan_loop(), name="agent-rescan")
+
+
+async def stop_background_tasks() -> None:
+    """Cancel background health and rescan loops."""
+    global _bg_started, _health_task, _rescan_task
+    if not _bg_started:
+        return
+    _bg_started = False
+    tasks = [_health_task, _rescan_task]
+    for t in tasks:
+        if t:
+            t.cancel()
+    for t in tasks:
+        if t:
+            with contextlib.suppress(asyncio.CancelledError):
+                await t
+    _health_task = _rescan_task = None

--- a/tests/test_agent_manager_consumer.py
+++ b/tests/test_agent_manager_consumer.py
@@ -37,7 +37,7 @@ def test_manager_starts_and_stops_bus_consumer(monkeypatch: pytest.MonkeyPatch) 
         assert name == "dummy"
         return DummyAgent()
 
-    def start_background_tasks() -> None:
+    async def start_background_tasks() -> None:
         pass
 
     monkeypatch.setattr("alpha_factory_v1.backend.agent_manager.EventBus", DummyBus)

--- a/tests/test_backend_orchestrator_dev.py
+++ b/tests/test_backend_orchestrator_dev.py
@@ -20,6 +20,7 @@ from alpha_factory_v1.backend.agents import (
     AGENT_REGISTRY,
     StubAgent,
     start_background_tasks,
+    stop_background_tasks,
 )
 from alpha_factory_v1.backend.agents.base import AgentBase
 
@@ -41,7 +42,7 @@ class FailingAgent(AgentBase):  # type: ignore[misc]
 
 
 @pytest.fixture()  # type: ignore[misc]
-def dev_orchestrator(monkeypatch: pytest.MonkeyPatch) -> orch_mod.Orchestrator:
+async def dev_orchestrator(monkeypatch: pytest.MonkeyPatch) -> orch_mod.Orchestrator:
     monkeypatch.setenv("DEV_MODE", "true")
     monkeypatch.setenv("API_TOKEN", "test-token")
     monkeypatch.setenv("AGENT_ERR_THRESHOLD", "1")
@@ -76,10 +77,11 @@ def dev_orchestrator(monkeypatch: pytest.MonkeyPatch) -> orch_mod.Orchestrator:
     monkeypatch.setattr("alpha_factory_v1.backend.agents.list_agents", list_agents)
     monkeypatch.setattr("alpha_factory_v1.backend.agents.get_agent", get_agent)
     monkeypatch.setattr("alpha_factory_v1.backend.agent_runner.get_agent", get_agent)
-    start_background_tasks()
+    await start_background_tasks()
 
     orch = orch_mod.Orchestrator()
     yield orch
+    await stop_background_tasks()
 
 
 def _mem_stub() -> object:

--- a/tests/test_orchestrator_lifecycle.py
+++ b/tests/test_orchestrator_lifecycle.py
@@ -45,7 +45,7 @@ async def test_orchestrator_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     agents_stub = types.ModuleType("backend.agents")
     setattr(agents_stub, "list_agents", lambda _detail=False: ["dummy"])
     setattr(agents_stub, "get_agent", lambda name: DummyAgent())
-    setattr(agents_stub, "start_background_tasks", lambda: None)
+    setattr(agents_stub, "start_background_tasks", lambda: asyncio.sleep(0))
 
     fin_stub = types.ModuleType("alpha_factory_v1.backend.agents.finance_agent")
     setattr(fin_stub, "metrics_asgi_app", lambda: None)


### PR DESCRIPTION
## Summary
- run `_health_loop` and `_rescan_loop` as asyncio tasks
- expose `stop_background_tasks` API
- start/stop health tasks from `AgentManager`
- update orchestrator and manager tests

## Testing
- `pre-commit run --files alpha_factory_v1/backend/agent_manager.py alpha_factory_v1/backend/agents/__init__.py alpha_factory_v1/backend/agents/health.py tests/test_agent_manager_consumer.py tests/test_agents_registry.py tests/test_backend_orchestrator_dev.py tests/test_orchestrator_lifecycle.py` *(fails: proto-verify, verify-requirements-lock)*
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install`
- `pytest -q` *(errors: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685ab0de4d9883338df959a1d0c84777