### PR TITLE
[alpha_factory] refactor: split agent registry

### DIFF
--- a/alpha_factory_v1/backend/agent_manager.py
+++ b/alpha_factory_v1/backend/agent_manager.py
@@ -23,7 +23,7 @@ class AgentManager:
         *,
         bus: EventBus | None = None,
     ) -> None:
-        from backend.agents import list_agents
+        from backend.agents.registry import list_agents
 
         avail = list_agents()
         names = [n for n in avail if not enabled or n in enabled]
@@ -39,7 +39,7 @@ class AgentManager:
 
     async def start(self) -> None:
         """Launch heartbeat and regression guard tasks."""
-        from backend.agents import start_background_tasks
+        from backend.agents.health import start_background_tasks
 
         await start_background_tasks()
 
@@ -60,7 +60,7 @@ class AgentManager:
         """Cancel helper tasks and wait for agent cycles to finish."""
 
         await self.bus.stop_consumer()
-        from backend.agents import stop_background_tasks
+        from backend.agents.health import stop_background_tasks
 
         await stop_background_tasks()
         if self._hb_task:

--- a/alpha_factory_v1/backend/agent_runner.py
+++ b/alpha_factory_v1/backend/agent_runner.py
@@ -15,7 +15,7 @@ from collections import deque
 from typing import Any, Callable, Dict, Optional
 import os
 
-from backend.agents import get_agent
+from backend.agents.registry import get_agent
 from alpha_factory_v1.core.monitoring import metrics
 
 from .telemetry import MET_LAT, MET_ERR, MET_UP, tracer

--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -1,431 +1,52 @@
 # SPDX-License-Identifier: Apache-2.0
-"""
-alpha_factory_v1.backend.agents
-================================
-Alpha-Factory v1 👁️✨ — Multi-Agent AGENTIC α-AGI
------------------------------------------------------------------
-Dynamic **agent discovery, registry, governance, telemetry & health**.
-
-Key guarantees
---------------
-✅ *Backward-compatibility* — every public symbol of the original file
-   (`AGENT_REGISTRY`, `list_agents`, `get_agent`, …) is preserved.
-
-✅ *Zero hard-fail* — **all optional deps are wrapped** so a bare-bones
-   Python install still imports (& degrades to in-memory no-ops).
-
-✅ *Extensible* — discovery paths:
-      • Local `*_agent.py` modules
-      • PEP-621 entry-points (`alpha_factory.agents`)
-      • Google ADK / A2A streamed wheels
-      • “Hot-drop” wheel folder (`$AGENT_HOT_DIR`)
-
-✅ Kafka • Prometheus • OpenTelemetry emit hooks
-   (transparently disabled if libs missing).
-
-✅ Live “hot-reload” — a wheel dropped into `$AGENT_HOT_DIR` is picked up
-   within `$AGENT_RESCAN_SEC` (default 60 s) **without** restarting the
-   Orchestrator.
-
-✅ **Health heartbeat** loop → quarantines / stub-swaps any agent after
-   `$AGENT_ERR_THRESHOLD` consecutive exceptions (default 3).
-
-This file is the *single source of truth* for every domain-agent that
-participates in Alpha-Factory.
-"""
-
-##############################################################################
-#                             standard-library                               #
-##############################################################################
+"""Agent discovery, health monitoring and registry."""
 from __future__ import annotations
 
-import asyncio
-import inspect
-import json
-import logging
-import os
-import base64
-import queue
-import threading
-import time
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Dict, List, Optional, Type
-
-##############################################################################
-#                      optional heavy deps — never hard-fail                 #
-##############################################################################
-try:  # ≥ Py 3.10 std-lib metadata
-    import importlib.metadata as imetadata
-except ModuleNotFoundError:  # pragma: no cover
-    import importlib_metadata as imetadata  # type: ignore
-
-try:  # Kafka telemetry
-    from kafka import KafkaProducer  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover
-    KafkaProducer = None  # type: ignore
-
-try:  # Prometheus metrics
-    from prometheus_client import (
-        Counter as _Counter,
-        Gauge as _Gauge,
-        Histogram as _Histogram,
-        CollectorRegistry,
-    )  # type: ignore
-    from alpha_factory_v1.backend.metrics_registry import get_metric as _reg_metric
-
-    def _get_metric(cls, name: str, desc: str, labels=None):
-        return _reg_metric(cls, name, desc, labels)
-
-    def Counter(name: str, desc: str, labels=None):  # type: ignore[misc]
-        return _get_metric(_Counter, name, desc, labels)
-
-    def Gauge(name: str, desc: str, labels=None):  # type: ignore[misc]
-        return _get_metric(_Gauge, name, desc, labels)
-
-    def Histogram(name: str, desc: str, labels=None):  # type: ignore[misc]
-        return _get_metric(_Histogram, name, desc, labels)
-
-except ModuleNotFoundError:  # pragma: no cover
-    Counter = Gauge = Histogram = CollectorRegistry = None  # type: ignore
-
-try:  # Google Agent Development Kit
-    import adk  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover
-    adk = None  # type: ignore
-
-try:
-    from cryptography.hazmat.primitives.asymmetric import ed25519
-    from cryptography.exceptions import InvalidSignature
-except ModuleNotFoundError:  # pragma: no cover
-    ed25519 = None  # type: ignore
-    InvalidSignature = Exception  # type: ignore
-
-try:
-    from packaging.version import parse as _parse_version  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover
-
-    def _parse_version(v: str):
-        return tuple(int(p) for p in v.split(".") if p.isdigit())
-
-
-##############################################################################
-#                             configuration                                  #
-##############################################################################
-_OPENAI_READY = bool(os.getenv("OPENAI_API_KEY"))
-_KAFKA_BROKER = os.getenv("ALPHA_KAFKA_BROKER")
-_DISABLED = {x.strip().lower() for x in os.getenv("DISABLED_AGENTS", "").split(",") if x.strip()}
-_ERR_THRESHOLD = int(os.getenv("AGENT_ERR_THRESHOLD", 3))
-_HOT_DIR = Path(os.getenv("AGENT_HOT_DIR", "~/.alpha_agents")).expanduser()
-_HEARTBEAT_INT = int(os.getenv("AGENT_HEARTBEAT_SEC", 10))
-_RESCAN_SEC = int(os.getenv("AGENT_RESCAN_SEC", 60))
-
-# Agent wheel signature trust configuration
-# ----------------------------------------
-# ``_WHEEL_PUBKEY`` is the base64-encoded ED25519 public key used to verify
-# signed wheels. ``_WHEEL_SIGS`` maps wheel filenames to their expected
-# base64-encoded signatures. Only wheels present in this mapping and
-# successfully verified will load.
-_WHEEL_PUBKEY = os.getenv(
-    "AGENT_WHEEL_PUBKEY",
-    "vGX59ownuBM9Z6e4tXesOv8+xhPf4dC7b8P6kp9hPJo=",
+from .registry import (
+    AGENT_REGISTRY,
+    CAPABILITY_GRAPH,
+    AgentMetadata,
+    StubAgent,
+    Counter,
+    Gauge,
+    Histogram,
+    CollectorRegistry,
+    ed25519,
+    InvalidSignature,
+    _ERR_THRESHOLD,
+    _HEALTH_Q,
+    _REGISTRY_LOCK,
+    _HEARTBEAT_INT,
+    _RESCAN_SEC,
+    _WHEEL_PUBKEY,
+    _WHEEL_SIGS,
+    logger,
+    _emit_kafka,
+    register_agent,
+    register,
+    list_capabilities,
+    list_agents,
+    capability_agents,
+    get_agent,
 )
-_WHEEL_SIGS: Dict[str, str] = {
-    "example_agent.whl": ("XKyQtzeUaE2EkbB0Up4teNr+i6gRSNE3Gcy6q605jQogZXjjp4pfxkGko/VDvJCGJgHD5X0fo30Mk+ESwQC9Q==")
-}
-
-##############################################################################
-#                                logging                                     #
-##############################################################################
-logger = logging.getLogger("alpha_factory.agents")
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(logging.Formatter("%(asctime)s  %(levelname)-8s  %(name)s: %(message)s"))
-    logger.addHandler(_h)
-logger.setLevel(logging.INFO)
-
-
-##############################################################################
-#                             public datatypes                               #
-##############################################################################
-@dataclass(frozen=True)
-class AgentMetadata:
-    """Lightweight manifest describing an agent implementation."""
-
-    name: str
-    cls: Type
-    version: str = "0.1.0"
-    capabilities: List[str] = field(default_factory=list)
-    compliance_tags: List[str] = field(default_factory=list)
-    requires_api_key: bool = False
-    err_count: int = 0  # mutated via object.__setattr__
-
-    # ---------- helpers ----------
-    def as_dict(self) -> Dict:
-        return {
-            "name": self.name,
-            "version": self.version,
-            "capabilities": self.capabilities,
-            "compliance": self.compliance_tags,
-            "requires_api_key": self.requires_api_key,
-        }
-
-    def to_json(self) -> str:
-        return json.dumps(self.as_dict(), separators=(",", ":"))
-
-    def instantiate(self, **kw):
-        return self.cls(**kw)  # type: ignore[arg-type]
-
-
-class CapabilityGraph(Dict[str, List[str]]):
-    """capability → [agent names]"""
-
-    def add(self, capability: str, agent_name: str):
-        self.setdefault(capability, []).append(agent_name)
-
-
-##############################################################################
-#                           stub fallback agent                              #
-##############################################################################
-class StubAgent:  # pragma: no cover
-    """Inert replacement for quarantined / unavailable agents."""
-
-    NAME = "stub"
-    CAPABILITIES: List[str] = []
-    COMPLIANCE_TAGS: List[str] = []
-    REQUIRES_API_KEY = False
-    SLEEP = 3600
-
-    async def step(self):
-        await asyncio.sleep(self.SLEEP)
-
-
-##############################################################################
-#                           internal state                                   #
-##############################################################################
-AGENT_REGISTRY: Dict[str, AgentMetadata] = {}
-CAPABILITY_GRAPH: CapabilityGraph = CapabilityGraph()
-_HEALTH_Q: "queue.Queue[tuple[str,float,bool]]" = queue.Queue()
-_REGISTRY_LOCK = threading.Lock()
-
-if Counter is not None:
-    _err_counter = Counter(
-        "af_agent_exceptions_total",
-        "Exceptions raised by agents",
-        ["agent"],
-    )
-
-
-##############################################################################
-#                          helper — Kafka producer                           #
-##############################################################################
-def _kafka_producer() -> Optional[KafkaProducer]:
-    if not _KAFKA_BROKER or KafkaProducer is None:
-        return None
-    try:
-        return KafkaProducer(
-            bootstrap_servers=_KAFKA_BROKER,
-            value_serializer=lambda v: v.encode() if isinstance(v, str) else v,
-        )
-    except Exception:  # noqa: BLE001
-        logger.exception("Kafka producer init failed")
-        return None
-
-
-_PRODUCER = _kafka_producer()
-
-
-def _emit_kafka(topic: str, payload: str):
-    if _PRODUCER is None:
-        return
-    try:
-        _PRODUCER.send(topic, payload)
-        _PRODUCER.flush()
-    except Exception:  # noqa: BLE001
-        logger.exception("Kafka emit failed (topic=%s)", topic)
-
-
-##############################################################################
-#                   unified decorator (optional nicety)                      #
-##############################################################################
-def register(cls=None, *, condition=True):  # type: ignore
-    """Decorator adding an :class:`AgentBase` subclass to the registry.
-
-    ``condition`` may be a boolean or a callable returning ``True``/``False``.
-    When ``False`` the decorated class is returned but not registered.  Usage::
-
-        @register
-        class MyAgent(AgentBase):
-            ...
-
-        @register(condition=lambda: os.getenv("ENABLE_X") == "1")
-        class OptionalAgent(AgentBase):
-            ...
-    """
-
-    def decorator(inner_cls):
-        from_backend_base = _agent_base()
-        if not issubclass(inner_cls, from_backend_base):
-            raise TypeError("register() only allowed on AgentBase subclasses")
-
-        cond_result = condition() if callable(condition) else bool(condition)
-        if cond_result:
-            meta = AgentMetadata(
-                name=getattr(inner_cls, "NAME", inner_cls.__name__),
-                cls=inner_cls,
-                version=getattr(inner_cls, "__version__", "0.1.0"),
-                capabilities=list(getattr(inner_cls, "CAPABILITIES", [])),
-                compliance_tags=list(getattr(inner_cls, "COMPLIANCE_TAGS", [])),
-                requires_api_key=getattr(inner_cls, "REQUIRES_API_KEY", False),
-            )
-            _register(meta, overwrite=False)
-        else:
-            logger.info(
-                "Agent %s not registered (condition=false)",
-                getattr(inner_cls, "NAME", inner_cls.__name__),
-            )
-        return inner_cls
-
-    return decorator(cls) if cls is not None else decorator
-
-
-##############################################################################
-#               internal — utility to import the master AgentBase            #
-##############################################################################
-def _agent_base():
-    """Return the canonical AgentBase implementation.
-
-    The lightweight ``backend.agents.base`` module is preferred.  We
-    fall back to the legacy ``backend.agent_base`` variant when the new
-    path is unavailable for full backward compatibility.
-    """
-    try:
-        from backend.agents.base import AgentBase  # type: ignore
-
-        return AgentBase
-    except ModuleNotFoundError:  # pragma: no cover - legacy only
-        from backend.agent_base import AgentBase  # type: ignore
-
-        return AgentBase
-
-
-##############################################################################
-
-
-##############################################################################
-def _should_register(meta: AgentMetadata) -> bool:
-    if meta.name.lower() in _DISABLED:
-        logger.info("Agent %s disabled via env", meta.name)
-        return False
-    if meta.name == "ping" and os.getenv("AF_DISABLE_PING_AGENT", "").lower() in ("1", "true"):
-        logger.info("Ping agent disabled via AF_DISABLE_PING_AGENT")
-        return False
-    if meta.requires_api_key and not _OPENAI_READY:
-        logger.warning("Skipping %s (needs OpenAI key)", meta.name)
-        return False
-    return True
-
-
-def _register(meta: AgentMetadata, *, overwrite: bool = False):
-    if not _should_register(meta):
-        return
-    with _REGISTRY_LOCK:
-        if meta.name in AGENT_REGISTRY and not overwrite:
-            existing = AGENT_REGISTRY[meta.name]
-            try:
-                if _parse_version(meta.version) > _parse_version(existing.version):
-                    logger.info(
-                        "Overriding agent %s with newer version %s > %s",
-                        meta.name,
-                        meta.version,
-                        existing.version,
-                    )
-                    overwrite = True
-                else:
-                    logger.error("Duplicate agent name '%s' ignored", meta.name)
-                    return
-            except Exception:  # pragma: no cover - version parse failed
-                logger.error("Duplicate agent name '%s' ignored", meta.name)
-                return
-
-        AGENT_REGISTRY[meta.name] = meta
-        for cap in meta.capabilities:
-            CAPABILITY_GRAPH.add(cap, meta.name)
-
-    logger.info("✓ agent %-18s caps=%s", meta.name, ",".join(meta.capabilities))
-    _emit_kafka("agent.manifest", meta.to_json())
-
-
-##############################################################################
-#                          public convenience API                            #
-##############################################################################
-def list_agents(detail: bool = False):
-    with _REGISTRY_LOCK:
-        metas = sorted(AGENT_REGISTRY.values(), key=lambda m: m.name)
-    return [m.as_dict() if detail else m.name for m in metas]
-
-
-def capability_agents(capability: str):
-    """Return list of agent names exposing *capability*."""
-    with _REGISTRY_LOCK:
-        return CAPABILITY_GRAPH.get(capability, []).copy()
-
-
-def list_capabilities():
-    """Return sorted list of all capabilities currently registered."""
-    with _REGISTRY_LOCK:
-        return sorted(CAPABILITY_GRAPH.keys())
-
-
-def get_agent(name: str, **kwargs):
-    """
-    Instantiate agent by *name* and wrap its async `step()` coroutine
-    with a heartbeat probe so failures auto-quarantine.
-    """
-    with _REGISTRY_LOCK:
-        meta = AGENT_REGISTRY[name]
-    agent = meta.instantiate(**kwargs)
-
-    if hasattr(agent, "step") and inspect.iscoroutinefunction(agent.step):
-        orig = agent.step
-
-        async def _wrapped(*a, **kw):  # type: ignore[no-untyped-def]
-            t0 = time.perf_counter()
-            ok = True
-            try:
-                return await orig(*a, **kw)  # type: ignore[misc]
-            except Exception:  # noqa: BLE001
-                ok = False
-                raise
-            finally:
-                _HEALTH_Q.put((meta.name, (time.perf_counter() - t0) * 1000, ok))
-
-        agent.step = _wrapped  # type: ignore[assignment]
-
-    return agent
-
-
-def register_agent(meta: AgentMetadata, *, overwrite: bool = False):
-    """
-    Public hook for dynamically-generated agents (e.g. a Meta-Agent
-    evolving new agent code at runtime) to self-register.
-    """
-    _register(meta, overwrite=overwrite)
-
-
-##############################################################################
-#                         initial discovery pass                             #
-from .discovery import discover_local, discover_entrypoints, discover_hot_dir, discover_adk
+from .discovery import (
+    discover_local,
+    discover_entrypoints,
+    discover_hot_dir,
+    discover_adk,
+    _HOT_DIR,
+)
+from .discovery import discover_local as _discover_local
 from .health import start_background_tasks, stop_background_tasks
 
-##############################################################################
+# Perform initial discovery on import
 discover_local()
 discover_entrypoints()
 discover_hot_dir()
 discover_adk()
 
 logger.info(
-    "🚀 Agent registry ready – %3d agents, %3d distinct capabilities",
+    "\U0001f680 Agent registry ready \u2013 %3d agents, %3d distinct capabilities",
     len(AGENT_REGISTRY),
     len(CAPABILITY_GRAPH),
 )

--- a/alpha_factory_v1/backend/agents/aiga_evolver_agent.py
+++ b/alpha_factory_v1/backend/agents/aiga_evolver_agent.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import asyncio
 
-from backend.agents import register, _agent_base
+from backend.agents.registry import register, _agent_base
 from backend.orchestrator import _publish
 
 try:

--- a/alpha_factory_v1/backend/agents/base.py
+++ b/alpha_factory_v1/backend/agents/base.py
@@ -56,7 +56,7 @@ from typing import Any, List, Mapping, MutableMapping, Optional
 # ░░░ 2. Optional, best-effort 3rd-party imports ░░░
 # ───────────────────────────────────────────────────────────────────────────────
 try:  # -- Prometheus metrics
-    from backend.agents import Counter, Gauge  # type: ignore
+    from backend.agents.registry import Counter, Gauge  # type: ignore
 except Exception:  # pragma: no cover
     Counter = Gauge = None  # type: ignore
 
@@ -318,7 +318,7 @@ class AgentBase(abc.ABC):
 def register(cls: type[AgentBase]) -> type[AgentBase]:
     """Register ``cls`` using :func:`register_agent` and return the class."""
     # defer import to avoid circular refs
-    from . import AgentMetadata, register_agent
+    from .registry import AgentMetadata, register_agent
 
     meta = AgentMetadata(
         name=getattr(cls, "NAME", cls.__name__),

--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -63,7 +63,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from alpha_factory_v1.backend.utils.sync import run_sync
 
 from backend.agents.base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent
+from backend.agents.registry import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # pylint: disable=import-error
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -117,7 +117,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha‑Factory locals (NO heavy deps)
 # ────────────────────────────────────────────────────────────────────────────────
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent
+from backend.agents.registry import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # re‑use event bus
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -116,7 +116,7 @@ except ModuleNotFoundError:  # pragma: no cover
 # Alpha‑Factory locals (no heavy deps)
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import‑error
-from backend.agents import AgentMetadata, register_agent
+from backend.agents.registry import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # reuse orchestrator event bus
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/discovery.py
+++ b/alpha_factory_v1/backend/agents/discovery.py
@@ -11,16 +11,25 @@ from pathlib import Path
 from types import ModuleType
 from typing import Optional
 
-from . import (
+try:  # ≥ Py 3.10 std-lib metadata
+    import importlib.metadata as imetadata
+except ModuleNotFoundError:  # pragma: no cover
+    import importlib_metadata as imetadata  # type: ignore
+
+try:  # Google Agent Development Kit
+    import adk  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    adk = None  # type: ignore
+
+from .registry import (
     AGENT_REGISTRY,
     AgentMetadata,
-    adk,
-    imetadata,
     logger,
-    _HOT_DIR,
     _register,
     _agent_base,
 )
+
+_HOT_DIR = Path(os.getenv("AGENT_HOT_DIR", "~/.alpha_agents")).expanduser()
 from .plugins import verify_wheel, install_wheel
 
 

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -124,7 +124,7 @@ except ModuleNotFoundError:  # pragma: no cover
 # Alpha‑Factory base imports (thin, always present) -------------------------
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent  # pylint: disable=import-error
+from backend.agents.registry import AgentMetadata, register_agent  # pylint: disable=import-error
 from backend.orchestrator import _publish  # pylint: disable=import-error
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -114,7 +114,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha-Factory core imports (lightweight, always available)
 # ---------------------------------------------------------------------------
 from backend.agents.base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent
+from backend.agents.registry import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # reuse event-bus helper
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/finance_agent.py
+++ b/alpha_factory_v1/backend/agents/finance_agent.py
@@ -42,7 +42,7 @@ with contextlib.suppress(ModuleNotFoundError):
 with contextlib.suppress(ModuleNotFoundError):
     from scipy.special import erfcinv  # type: ignore
 with contextlib.suppress(Exception):
-    from backend.agents import Gauge  # type: ignore
+    from backend.agents.registry import Gauge  # type: ignore
     from prometheus_client import make_asgi_app  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
     from binance import Client as _BnClient  # type: ignore
@@ -81,7 +81,7 @@ if "tool" not in globals():  # offline stub
 
 # ─────────────────────── α-Factory imports ─────────────────────
 from backend.agent_base import AgentBase  # type: ignore
-from backend.agents import AgentMetadata, register_agent  # type: ignore
+from backend.agents.registry import AgentMetadata, register_agent  # type: ignore
 from backend.orchestrator import _publish  # type: ignore
 from .. import risk
 from ..model_provider import ModelProvider

--- a/alpha_factory_v1/backend/agents/health.py
+++ b/alpha_factory_v1/backend/agents/health.py
@@ -8,7 +8,7 @@ import json
 import time
 from queue import Empty
 
-from . import (
+from .registry import (
     _HEALTH_Q,
     _HEARTBEAT_INT,
     _RESCAN_SEC,

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -65,7 +65,7 @@ except ModuleNotFoundError:  # pragma: no cover
     np = None  # type: ignore
 
 try:
-    from backend.agents import Gauge  # type: ignore
+    from backend.agents.registry import Gauge  # type: ignore
 except Exception:  # pragma: no cover
     Gauge = None  # type: ignore
 
@@ -105,7 +105,7 @@ except Exception:  # pragma: no cover - optional
 # ---------------------------------------------------------------------------
 from backend.trace_ws import hub  # pylint: disable=import-error
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent  # pylint: disable=import-error
+from backend.agents.registry import AgentMetadata, register_agent  # pylint: disable=import-error
 from backend.orchestrator import _publish  # pylint: disable=import-error
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -52,7 +52,7 @@ from typing import Any, Mapping, Optional
 # ──────────────────────────────────────────────────────────────────────────────
 # Alpha-Factory internal imports
 # ──────────────────────────────────────────────────────────────────────────────
-from backend.agents import register, _agent_base
+from backend.agents.registry import register, _agent_base
 
 # Ensure compatibility with both legacy and new AgentBase locations
 AgentBase = _agent_base()

--- a/alpha_factory_v1/backend/agents/plugins.py
+++ b/alpha_factory_v1/backend/agents/plugins.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Optional
 
-from . import _WHEEL_PUBKEY, _WHEEL_SIGS, ed25519, InvalidSignature, logger
+from .registry import _WHEEL_PUBKEY, _WHEEL_SIGS, ed25519, InvalidSignature, logger
 
 
 def verify_wheel(path: Path) -> bool:

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -90,7 +90,7 @@ except ModuleNotFoundError:  # pragma: no cover
     KafkaProducer = None  # type: ignore
 
 try:
-    from backend.agents import Gauge  # type: ignore
+    from backend.agents.registry import Gauge  # type: ignore
 except Exception:  # pragma: no cover
     Gauge = None  # type: ignore
 
@@ -119,7 +119,7 @@ except ModuleNotFoundError:  # pragma: no cover
 # Alpha‑Factory internals
 # ────────────────────────────────────────────────────────────────────────────
 from backend.agent_base import AgentBase  # type: ignore
-from backend.agents import AgentMetadata, register_agent  # type: ignore
+from backend.agents.registry import AgentMetadata, register_agent  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/alpha_factory_v1/backend/agents/registry.py
+++ b/alpha_factory_v1/backend/agents/registry.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Agent registry, metadata and public APIs."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Type
+
+try:  # ≥ Py 3.10 std-lib metadata
+    import importlib.metadata as imetadata
+except ModuleNotFoundError:  # pragma: no cover
+    import importlib_metadata as imetadata  # type: ignore
+
+try:  # Kafka telemetry
+    from kafka import KafkaProducer  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    KafkaProducer = None  # type: ignore
+
+try:  # Prometheus metrics
+    from prometheus_client import (
+        Counter as _Counter,
+        Gauge as _Gauge,
+        Histogram as _Histogram,
+        CollectorRegistry,
+    )  # type: ignore
+    from alpha_factory_v1.backend.metrics_registry import get_metric as _reg_metric
+
+    def _get_metric(cls, name: str, desc: str, labels=None):
+        return _reg_metric(cls, name, desc, labels)
+
+    def Counter(name: str, desc: str, labels=None):  # type: ignore[misc]
+        return _get_metric(_Counter, name, desc, labels)
+
+    def Gauge(name: str, desc: str, labels=None):  # type: ignore[misc]
+        return _get_metric(_Gauge, name, desc, labels)
+
+    def Histogram(name: str, desc: str, labels=None):  # type: ignore[misc]
+        return _get_metric(_Histogram, name, desc, labels)
+
+except ModuleNotFoundError:  # pragma: no cover
+    Counter = Gauge = Histogram = CollectorRegistry = None  # type: ignore
+
+try:
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+    from cryptography.exceptions import InvalidSignature
+except ModuleNotFoundError:  # pragma: no cover
+    ed25519 = None  # type: ignore
+    InvalidSignature = Exception  # type: ignore
+
+try:
+    from packaging.version import parse as _parse_version  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+
+    def _parse_version(v: str):
+        return tuple(int(p) for p in v.split(".") if p.isdigit())
+
+
+# ---------------------------------------------------------------------------
+# configuration
+# ---------------------------------------------------------------------------
+_OPENAI_READY = bool(os.getenv("OPENAI_API_KEY"))
+_KAFKA_BROKER = os.getenv("ALPHA_KAFKA_BROKER")
+_DISABLED = {x.strip().lower() for x in os.getenv("DISABLED_AGENTS", "").split(",") if x.strip()}
+_ERR_THRESHOLD = int(os.getenv("AGENT_ERR_THRESHOLD", 3))
+_HEARTBEAT_INT = int(os.getenv("AGENT_HEARTBEAT_SEC", 10))
+_RESCAN_SEC = int(os.getenv("AGENT_RESCAN_SEC", 60))
+_WHEEL_PUBKEY = os.getenv(
+    "AGENT_WHEEL_PUBKEY",
+    "vGX59ownuBM9Z6e4tXesOv8+xhPf4dC7b8P6kp9hPJo=",
+)
+_WHEEL_SIGS: Dict[str, str] = {
+    "example_agent.whl": ("XKyQtzeUaE2EkbB0Up4teNr+i6gRSNE3Gcy6q605jQogZXjjp4pfxkGko/VDvJCGJgHD5X0fo30Mk+ESwQC9Q==")
+}
+
+# ---------------------------------------------------------------------------
+# logging
+# ---------------------------------------------------------------------------
+logger = logging.getLogger("alpha_factory.agents")
+if not logger.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("%(asctime)s  %(levelname)-8s  %(name)s: %(message)s"))
+    logger.addHandler(_h)
+logger.setLevel(logging.INFO)
+
+
+# ---------------------------------------------------------------------------
+# datatypes
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class AgentMetadata:
+    """Lightweight manifest describing an agent implementation."""
+
+    name: str
+    cls: Type
+    version: str = "0.1.0"
+    capabilities: List[str] = field(default_factory=list)
+    compliance_tags: List[str] = field(default_factory=list)
+    requires_api_key: bool = False
+    err_count: int = 0  # mutated via object.__setattr__
+
+    def as_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "capabilities": self.capabilities,
+            "compliance": self.compliance_tags,
+            "requires_api_key": self.requires_api_key,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), separators=(",", ":"))
+
+    def instantiate(self, **kw):
+        return self.cls(**kw)  # type: ignore[arg-type]
+
+
+class CapabilityGraph(Dict[str, List[str]]):
+    """capability → [agent names]."""
+
+    def add(self, capability: str, agent_name: str) -> None:
+        self.setdefault(capability, []).append(agent_name)
+
+
+class StubAgent:  # pragma: no cover
+    """Inert replacement for quarantined or unavailable agents."""
+
+    NAME = "stub"
+    CAPABILITIES: List[str] = []
+    COMPLIANCE_TAGS: List[str] = []
+    REQUIRES_API_KEY = False
+    SLEEP = 3600
+
+    async def step(self) -> None:
+        await asyncio.sleep(self.SLEEP)
+
+
+# ---------------------------------------------------------------------------
+# internal state
+# ---------------------------------------------------------------------------
+AGENT_REGISTRY: Dict[str, AgentMetadata] = {}
+CAPABILITY_GRAPH: CapabilityGraph = CapabilityGraph()
+_HEALTH_Q: "queue.Queue[tuple[str, float, bool]]" = queue.Queue()
+_REGISTRY_LOCK = threading.Lock()
+
+if Counter is not None:
+    _err_counter = Counter(
+        "af_agent_exceptions_total",
+        "Exceptions raised by agents",
+        ["agent"],
+    )
+else:  # pragma: no cover - metrics disabled
+    _err_counter = None
+
+# ---------------------------------------------------------------------------
+# helper – Kafka producer
+# ---------------------------------------------------------------------------
+
+
+def _kafka_producer() -> Optional[KafkaProducer]:
+    if not _KAFKA_BROKER or KafkaProducer is None:
+        return None
+    try:
+        return KafkaProducer(
+            bootstrap_servers=_KAFKA_BROKER,
+            value_serializer=lambda v: v.encode() if isinstance(v, str) else v,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Kafka producer init failed")
+        return None
+
+
+_PRODUCER = _kafka_producer()
+
+
+def _emit_kafka(topic: str, payload: str) -> None:
+    if _PRODUCER is None:
+        return
+    try:
+        _PRODUCER.send(topic, payload)
+        _PRODUCER.flush()
+    except Exception:  # noqa: BLE001
+        logger.exception("Kafka emit failed (topic=%s)", topic)
+
+
+# ---------------------------------------------------------------------------
+# unified decorator
+# ---------------------------------------------------------------------------
+
+
+def register(cls=None, *, condition=True):  # type: ignore
+    """Decorator adding an :class:`AgentBase` subclass to the registry."""
+
+    def decorator(inner_cls):
+        from_backend_base = _agent_base()
+        if not issubclass(inner_cls, from_backend_base):
+            raise TypeError("register() only allowed on AgentBase subclasses")
+
+        cond_result = condition() if callable(condition) else bool(condition)
+        if cond_result:
+            meta = AgentMetadata(
+                name=getattr(inner_cls, "NAME", inner_cls.__name__),
+                cls=inner_cls,
+                version=getattr(inner_cls, "__version__", "0.1.0"),
+                capabilities=list(getattr(inner_cls, "CAPABILITIES", [])),
+                compliance_tags=list(getattr(inner_cls, "COMPLIANCE_TAGS", [])),
+                requires_api_key=getattr(inner_cls, "REQUIRES_API_KEY", False),
+            )
+            _register(meta, overwrite=False)
+        else:
+            logger.info(
+                "Agent %s not registered (condition=false)",
+                getattr(inner_cls, "NAME", inner_cls.__name__),
+            )
+        return inner_cls
+
+    return decorator(cls) if cls is not None else decorator
+
+
+# ---------------------------------------------------------------------------
+# utility to import the master AgentBase
+# ---------------------------------------------------------------------------
+
+
+def _agent_base():
+    """Return the canonical AgentBase implementation."""
+
+    try:
+        from backend.agents.base import AgentBase  # type: ignore
+
+        return AgentBase
+    except ModuleNotFoundError:  # pragma: no cover - legacy only
+        from backend.agent_base import AgentBase  # type: ignore
+
+        return AgentBase
+
+
+# ---------------------------------------------------------------------------
+
+
+def _should_register(meta: AgentMetadata) -> bool:
+    if meta.name.lower() in _DISABLED:
+        logger.info("Agent %s disabled via env", meta.name)
+        return False
+    if meta.name == "ping" and os.getenv("AF_DISABLE_PING_AGENT", "").lower() in ("1", "true"):
+        logger.info("Ping agent disabled via AF_DISABLE_PING_AGENT")
+        return False
+    if meta.requires_api_key and not _OPENAI_READY:
+        logger.warning("Skipping %s (needs OpenAI key)", meta.name)
+        return False
+    return True
+
+
+def _register(meta: AgentMetadata, *, overwrite: bool = False) -> None:
+    if not _should_register(meta):
+        return
+    with _REGISTRY_LOCK:
+        if meta.name in AGENT_REGISTRY and not overwrite:
+            existing = AGENT_REGISTRY[meta.name]
+            try:
+                if _parse_version(meta.version) > _parse_version(existing.version):
+                    logger.info(
+                        "Overriding agent %s with newer version %s > %s",
+                        meta.name,
+                        meta.version,
+                        existing.version,
+                    )
+                    overwrite = True
+                else:
+                    logger.error("Duplicate agent name '%s' ignored", meta.name)
+                    return
+            except Exception:  # pragma: no cover - version parse failed
+                logger.error("Duplicate agent name '%s' ignored", meta.name)
+                return
+
+        AGENT_REGISTRY[meta.name] = meta
+        for cap in meta.capabilities:
+            CAPABILITY_GRAPH.add(cap, meta.name)
+
+    logger.info("\u2713 agent %-18s caps=%s", meta.name, ",".join(meta.capabilities))
+    _emit_kafka("agent.manifest", meta.to_json())
+
+
+# ---------------------------------------------------------------------------
+# public convenience API
+# ---------------------------------------------------------------------------
+
+
+def list_agents(detail: bool = False):
+    with _REGISTRY_LOCK:
+        metas = sorted(AGENT_REGISTRY.values(), key=lambda m: m.name)
+    return [m.as_dict() if detail else m.name for m in metas]
+
+
+def capability_agents(capability: str):
+    """Return list of agent names exposing *capability*."""
+    with _REGISTRY_LOCK:
+        return CAPABILITY_GRAPH.get(capability, []).copy()
+
+
+def list_capabilities():
+    """Return sorted list of all capabilities currently registered."""
+    with _REGISTRY_LOCK:
+        return sorted(CAPABILITY_GRAPH.keys())
+
+
+def get_agent(name: str, **kwargs):
+    """Instantiate agent by *name* and wrap its async ``step`` coroutine."""
+    with _REGISTRY_LOCK:
+        meta = AGENT_REGISTRY[name]
+    agent = meta.instantiate(**kwargs)
+
+    if hasattr(agent, "step") and inspect.iscoroutinefunction(agent.step):
+        orig = agent.step
+
+        async def _wrapped(*a, **kw):  # type: ignore[no-untyped-def]
+            t0 = time.perf_counter()
+            ok = True
+            try:
+                return await orig(*a, **kw)  # type: ignore[misc]
+            except Exception:  # noqa: BLE001
+                ok = False
+                raise
+            finally:
+                _HEALTH_Q.put((meta.name, (time.perf_counter() - t0) * 1000, ok))
+
+        agent.step = _wrapped  # type: ignore[assignment]
+
+    return agent
+
+
+def register_agent(meta: AgentMetadata, *, overwrite: bool = False) -> None:
+    """Public hook for dynamically-generated agents to self-register."""
+    _register(meta, overwrite=overwrite)
+
+
+__all__ = [
+    "AgentMetadata",
+    "AGENT_REGISTRY",
+    "CAPABILITY_GRAPH",
+    "register_agent",
+    "register",
+    "list_capabilities",
+    "list_agents",
+    "capability_agents",
+    "get_agent",
+]

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -105,7 +105,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha‑Factory lightweight core imports  ------------------------------------
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent
+from backend.agents.registry import AgentMetadata, register_agent
 from backend.orchestrator import _publish  # structured‑event helper
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -117,7 +117,7 @@ except ModuleNotFoundError:  # pragma: no cover
 # Alpha‑Factory local imports (never heavy)
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent
+from backend.agents.registry import AgentMetadata, register_agent
 from backend.orchestrator import _publish
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -115,7 +115,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha‑Factory local imports (lightweight, no heavy deps)
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import‑error
-from backend.agents import AgentMetadata, register_agent  # pylint: disable=import‑error
+from backend.agents.registry import AgentMetadata, register_agent  # pylint: disable=import‑error
 from backend.orchestrator import _publish  # re‑use event bus hook
 
 logger = logging.getLogger(__name__)

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -113,7 +113,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha‑Factory light deps                                                  |
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents import AgentMetadata, register_agent
+from backend.agents.registry import AgentMetadata, register_agent
 from backend.orchestrator import _publish
 from alpha_factory_v1.utils.env import _env_int
 

--- a/alpha_factory_v1/backend/memory_graph.py
+++ b/alpha_factory_v1/backend/memory_graph.py
@@ -64,7 +64,7 @@ except Exception:  # pragma: no cover
     _HAS_NX = False
 
 try:
-    from backend.agents import Counter, Gauge, Histogram  # type: ignore
+    from backend.agents.registry import Counter, Gauge, Histogram  # type: ignore
 
     _PM = True
 except Exception:  # pragma: no cover

--- a/alpha_factory_v1/backend/memory_vector.py
+++ b/alpha_factory_v1/backend/memory_vector.py
@@ -111,7 +111,7 @@ except ModuleNotFoundError:  # pragma: no cover
     _HAS_FAISS = False
 
 try:  # Prometheus metrics
-    from backend.agents import Counter, Gauge  # type: ignore
+    from backend.agents.registry import Counter, Gauge  # type: ignore
 
     _MET_ADD = Counter("af_mem_add_total", "Memories added", ["backend"])
     _MET_QRY = Counter("af_mem_query_total", "Vector queries", ["backend"])
@@ -122,11 +122,9 @@ except Exception:  # pragma: no cover
         def labels(self, *_a):  # noqa: D401
             return self
 
-        def inc(self, *_a):
-            ...
+        def inc(self, *_a): ...
 
-        def set(self, *_a):
-            ...
+        def set(self, *_a): ...
 
     _MET_ADD = _MET_QRY = _MET_SZ = _Noop()
 

--- a/alpha_factory_v1/backend/world_model.py
+++ b/alpha_factory_v1/backend/world_model.py
@@ -46,7 +46,7 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 with contextlib.suppress(ModuleNotFoundError):
     from llama_cpp import Llama
 with contextlib.suppress(Exception):
-    from backend.agents import Gauge  # type: ignore
+    from backend.agents.registry import Gauge  # type: ignore
 with contextlib.suppress(ModuleNotFoundError):
     from confluent_kafka import Producer
 
@@ -235,11 +235,9 @@ if PROM_ENABLED and "Gauge" in globals():
 else:
 
     class _Dummy(float):
-        def observe(self, *a: Any, **kw: Any) -> None:
-            ...
+        def observe(self, *a: Any, **kw: Any) -> None: ...
 
-        def set(self, *a: Any, **kw: Any) -> None:
-            ...
+        def set(self, *a: Any, **kw: Any) -> None: ...
 
     PLAN_LAT = RISK_SCR = _Dummy()
 

--- a/tests/test_agent_manager_consumer.py
+++ b/tests/test_agent_manager_consumer.py
@@ -41,9 +41,9 @@ def test_manager_starts_and_stops_bus_consumer(monkeypatch: pytest.MonkeyPatch) 
         pass
 
     monkeypatch.setattr("alpha_factory_v1.backend.agent_manager.EventBus", DummyBus)
-    monkeypatch.setattr("backend.agents.list_agents", list_agents)
-    monkeypatch.setattr("backend.agents.get_agent", get_agent)
-    monkeypatch.setattr("backend.agents.start_background_tasks", start_background_tasks)
+    monkeypatch.setattr("backend.agents.registry.list_agents", list_agents)
+    monkeypatch.setattr("backend.agents.registry.get_agent", get_agent)
+    monkeypatch.setattr("backend.agents.health.start_background_tasks", start_background_tasks)
     monkeypatch.setattr("alpha_factory_v1.backend.agent_runner.get_agent", get_agent)
 
     mgr = AgentManager({"dummy"}, True, None, 60, 30)

--- a/tests/test_agents_integrity.py
+++ b/tests/test_agents_integrity.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 import unittest
 
-from alpha_factory_v1.backend.agents import list_agents, get_agent, AGENT_REGISTRY, list_capabilities
+from alpha_factory_v1.backend.agents.registry import (
+    list_agents,
+    get_agent,
+    AGENT_REGISTRY,
+    list_capabilities,
+)
 
 
 class TestAgentsIntegrity(unittest.TestCase):

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -8,7 +8,7 @@ import os
 import sys
 import subprocess
 
-from alpha_factory_v1.backend.agents import (
+from alpha_factory_v1.backend.agents.registry import (
     AGENT_REGISTRY,
     CAPABILITY_GRAPH,
     AgentMetadata,
@@ -165,7 +165,7 @@ class TestRegisterDecorator(unittest.TestCase):
         AGENT_REGISTRY.update(self._registry_backup)
 
     def test_condition_false(self):
-        from alpha_factory_v1.backend.agents import register, _agent_base
+        from alpha_factory_v1.backend.agents.registry import register, _agent_base
 
         Base = _agent_base()
 
@@ -179,7 +179,7 @@ class TestRegisterDecorator(unittest.TestCase):
         self.assertNotIn("skip", AGENT_REGISTRY)
 
     def test_condition_true(self):
-        from alpha_factory_v1.backend.agents import register, _agent_base
+        from alpha_factory_v1.backend.agents.registry import register, _agent_base
 
         Base = _agent_base()
 
@@ -203,10 +203,12 @@ class TestHealthQuarantine(unittest.TestCase):
         AGENT_REGISTRY.update(self._registry_backup)
 
     def test_stub_after_errors(self):
-        from alpha_factory_v1.backend.agents import (
+        from alpha_factory_v1.backend.agents.registry import (
             _HEALTH_Q,
             StubAgent,
             _ERR_THRESHOLD,
+        )
+        from alpha_factory_v1.backend.agents.health import (
             start_background_tasks,
             stop_background_tasks,
         )

--- a/tests/test_backend_orchestrator_dev.py
+++ b/tests/test_backend_orchestrator_dev.py
@@ -16,9 +16,8 @@ except ModuleNotFoundError:  # pragma: no cover - optional dep
 
 from alpha_factory_v1.backend import orchestrator as orch_mod
 from alpha_factory_v1.backend.api_server import build_rest
-from alpha_factory_v1.backend.agents import (
-    AGENT_REGISTRY,
-    StubAgent,
+from alpha_factory_v1.backend.agents.registry import AGENT_REGISTRY, StubAgent
+from alpha_factory_v1.backend.agents.health import (
     start_background_tasks,
     stop_background_tasks,
 )
@@ -47,7 +46,7 @@ async def dev_orchestrator(monkeypatch: pytest.MonkeyPatch) -> orch_mod.Orchestr
     monkeypatch.setenv("API_TOKEN", "test-token")
     monkeypatch.setenv("AGENT_ERR_THRESHOLD", "1")
 
-    from alpha_factory_v1.backend.agents import _HEALTH_Q
+    from alpha_factory_v1.backend.agents.registry import _HEALTH_Q
     import inspect
     import time
 
@@ -74,8 +73,8 @@ async def dev_orchestrator(monkeypatch: pytest.MonkeyPatch) -> orch_mod.Orchestr
             agent.step = _wrapped
         return agent
 
-    monkeypatch.setattr("alpha_factory_v1.backend.agents.list_agents", list_agents)
-    monkeypatch.setattr("alpha_factory_v1.backend.agents.get_agent", get_agent)
+    monkeypatch.setattr("alpha_factory_v1.backend.agents.registry.list_agents", list_agents)
+    monkeypatch.setattr("alpha_factory_v1.backend.agents.registry.get_agent", get_agent)
     monkeypatch.setattr("alpha_factory_v1.backend.agent_runner.get_agent", get_agent)
     await start_background_tasks()
 


### PR DESCRIPTION
## Summary
- create `registry.py` with agent registry and public APIs
- move discovery constants and imports
- refactor health loop imports
- update imports across modules and tests

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_685ab98c65948333af6ce62cd53d540b