### PR TITLE
refactor: unify agent registration

### DIFF
--- a/alpha_factory_v1/backend/agents/README.md
+++ b/alpha_factory_v1/backend/agents/README.md
@@ -314,6 +314,8 @@ super = my_pkg.super_agent:MySuperAgent
 ```
 
 Next boot, your agent auto‑registers & appears on `/capabilities`.
+Add `@register` above your `AgentBase` subclass to populate the
+global registry without touching `AGENT_REGISTRY` directly.
 
 ---
 

--- a/alpha_factory_v1/backend/agents/base.py
+++ b/alpha_factory_v1/backend/agents/base.py
@@ -316,7 +316,11 @@ class AgentBase(abc.ABC):
 # ░░░ 6. Tiny decorator to auto-register subclasses ░░░
 # ───────────────────────────────────────────────────────────────────────────────
 def register(cls: type[AgentBase]) -> type[AgentBase]:
-    """Register ``cls`` using :func:`register_agent` and return the class."""
+    """Return ``cls`` after adding it to :mod:`backend.agents` registry.
+
+    This helper wraps :func:`register_agent` so subclasses simply use
+    ``@register`` instead of touching ``AGENT_REGISTRY`` directly.
+    """
     # defer import to avoid circular refs
     from .registry import AgentMetadata, register_agent
 

--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -63,7 +63,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from alpha_factory_v1.backend.utils.sync import run_sync
 
 from backend.agents.base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent
+from backend.agents import register
 from backend.orchestrator import _publish  # pylint: disable=import-error
 from alpha_factory_v1.utils.env import _env_int
 
@@ -255,8 +255,10 @@ class _KG:
 
 
 # ────────────────────────────── Biotech Agent ───────────────────────────────
+@register
 class BiotechAgent(AgentBase):
     NAME = "biotech"
+    __version__ = "0.2.0"
     CAPABILITIES = ["nl_query", "experiment_design", "pathway_analysis", "alpha_dashboard"]
     COMPLIANCE_TAGS = ["gdpr_minimal", "sox_traceable"]
     REQUIRES_API_KEY = False
@@ -426,17 +428,5 @@ class BiotechAgent(AgentBase):
             logger.exception("Unexpected ADK registration error: %s", exc)
             raise
 
-
-# ───────────────────────────── registry hook ────────────────────────────────
-register_agent(
-    AgentMetadata(
-        name=BiotechAgent.NAME,
-        cls=BiotechAgent,
-        version="0.2.0",
-        capabilities=BiotechAgent.CAPABILITIES,
-        compliance_tags=BiotechAgent.COMPLIANCE_TAGS,
-        requires_api_key=BiotechAgent.REQUIRES_API_KEY,
-    )
-)
 
 __all__ = ["BiotechAgent"]

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -116,8 +116,8 @@ except Exception:  # pragma: no cover - optional
 # ────────────────────────────────────────────────────────────────────────────────
 # Alpha‑Factory locals (NO heavy deps)
 # ────────────────────────────────────────────────────────────────────────────────
-from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent
+from backend.agents.base import AgentBase  # pylint: disable=import-error
+from backend.agents import register
 from backend.orchestrator import _publish  # re‑use event bus
 from alpha_factory_v1.utils.env import _env_int
 
@@ -214,10 +214,12 @@ def _wrap_mcp(agent: str, payload: Any) -> Dict[str, Any]:
 # ────────────────────────────────────────────────────────────────────────────────
 
 
+@register
 class ClimateRiskAgent(AgentBase):
     """Physical‑risk α‑generator and adaptation planner."""
 
     NAME = "climate_risk"
+    __version__ = "0.5.0"
     CAPABILITIES = [
         "physical_risk_var",
         "adaptation_planning",
@@ -373,16 +375,4 @@ class ClimateRiskAgent(AgentBase):
 # ────────────────────────────────────────────────────────────────────────────────
 # Register with global agent registry
 # ────────────────────────────────────────────────────────────────────────────────
-
-register_agent(
-    AgentMetadata(
-        name=ClimateRiskAgent.NAME,
-        cls=ClimateRiskAgent,
-        version="0.5.0",
-        capabilities=ClimateRiskAgent.CAPABILITIES,
-        compliance_tags=ClimateRiskAgent.COMPLIANCE_TAGS,
-        requires_api_key=ClimateRiskAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["ClimateRiskAgent"]

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -115,8 +115,8 @@ except ModuleNotFoundError:  # pragma: no cover
 # ---------------------------------------------------------------------------
 # Alpha‑Factory locals (no heavy deps)
 # ---------------------------------------------------------------------------
-from backend.agent_base import AgentBase  # pylint: disable=import‑error
-from backend.agents.registry import AgentMetadata, register_agent
+from backend.agents.base import AgentBase  # pylint: disable=import‑error
+from backend.agents import register
 from backend.orchestrator import _publish  # reuse orchestrator event bus
 from alpha_factory_v1.utils.env import _env_int
 
@@ -205,10 +205,12 @@ class _GBMSurrogate:
 # ---------------------------------------------------------------------------
 
 
+@register
 class CyberThreatAgent(AgentBase):
     """Agent that converts threat intel into actionable risk‑reduction alpha."""
 
     NAME = "cyber_threat"
+    __version__ = "0.5.0"
     CAPABILITIES = [
         "cve_monitoring",
         "threat_intel_fusion",
@@ -433,16 +435,4 @@ class CyberThreatAgent(AgentBase):
 # ---------------------------------------------------------------------------
 # One‑time registration with global registry
 # ---------------------------------------------------------------------------
-
-register_agent(
-    AgentMetadata(
-        name=CyberThreatAgent.NAME,
-        cls=CyberThreatAgent,
-        version="0.5.0",
-        capabilities=CyberThreatAgent.CAPABILITIES,
-        compliance_tags=CyberThreatAgent.COMPLIANCE_TAGS,
-        requires_api_key=CyberThreatAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["CyberThreatAgent"]

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -124,7 +124,7 @@ except ModuleNotFoundError:  # pragma: no cover
 # Alpha‑Factory base imports (thin, always present) -------------------------
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent  # pylint: disable=import-error
+from backend.agents import register  # pylint: disable=import-error
 from backend.orchestrator import _publish  # pylint: disable=import-error
 from alpha_factory_v1.utils.env import _env_int
 
@@ -383,8 +383,10 @@ class _Planner:
 # ---------------------------------------------------------------------------
 
 
+@register
 class DrugDesignAgent(AgentBase):
     NAME = "drug_design"
+    __version__ = "0.2.0"
     CAPABILITIES = [
         "molecule_generation",
         "activity_prediction",
@@ -513,15 +515,4 @@ class DrugDesignAgent(AgentBase):
 # ---------------------------------------------------------------------------
 # Registry hook -------------------------------------------------------------
 # ---------------------------------------------------------------------------
-register_agent(
-    AgentMetadata(
-        name=DrugDesignAgent.NAME,
-        cls=DrugDesignAgent,
-        version="0.2.0",
-        capabilities=DrugDesignAgent.CAPABILITIES,
-        compliance_tags=DrugDesignAgent.COMPLIANCE_TAGS,
-        requires_api_key=DrugDesignAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["DrugDesignAgent"]

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -114,7 +114,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha-Factory core imports (lightweight, always available)
 # ---------------------------------------------------------------------------
 from backend.agents.base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent
+from backend.agents import register
 from backend.orchestrator import _publish  # reuse event-bus helper
 from alpha_factory_v1.utils.env import _env_int
 
@@ -223,8 +223,10 @@ def _battery_optim(prices: List[float], load: List[float]) -> Dict[str, Any]:
 
 # ---------------------------------------------------------------------------
 # EnergyAgent -----------------------------------------------------------------
+@register
 class EnergyAgent(AgentBase):
     NAME = "energy_markets"
+    __version__ = "0.4.0"
     CAPABILITIES = [
         "load_forecasting",
         "dispatch_optimisation",
@@ -360,15 +362,4 @@ class EnergyAgent(AgentBase):
 
 # ---------------------------------------------------------------------------
 # Registry hook --------------------------------------------------------------
-register_agent(
-    AgentMetadata(
-        name=EnergyAgent.NAME,
-        cls=EnergyAgent,
-        version="0.4.0",
-        capabilities=EnergyAgent.CAPABILITIES,
-        compliance_tags=EnergyAgent.COMPLIANCE_TAGS,
-        requires_api_key=EnergyAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["EnergyAgent"]

--- a/alpha_factory_v1/backend/agents/finance_agent.py
+++ b/alpha_factory_v1/backend/agents/finance_agent.py
@@ -81,7 +81,7 @@ if "tool" not in globals():  # offline stub
 
 # ─────────────────────── α-Factory imports ─────────────────────
 from backend.agent_base import AgentBase  # type: ignore
-from backend.agents.registry import AgentMetadata, register_agent  # type: ignore
+from backend.agents import register  # type: ignore
 from backend.orchestrator import _publish  # type: ignore
 from .. import risk
 from ..model_provider import ModelProvider
@@ -295,9 +295,11 @@ class _Planner:
 
 
 # ═════════════════════ main FinanceAgent ═══════════════════════
+@register
 class FinanceAgent(AgentBase):
     NAME = "finance"
     VERSION = "0.7.0"
+    __version__ = VERSION
 
     def __init__(
         self,
@@ -466,16 +468,7 @@ class FinanceAgent(AgentBase):
 
 
 # ═════════════════════ registry hook ═══════════════════════════
-register_agent(
-    AgentMetadata(
-        name=FinanceAgent.NAME,
-        cls=FinanceAgent,
-        version=FinanceAgent.VERSION,
-        capabilities=["alpha_generation", "risk_management", "trade_execution"],
-        compliance_tags=["sec_17a4", "sox_traceable"],
-        requires_api_key=False,
-    )
-)
+
 
 __all__: list[str] = [
     "FinanceAgent",

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -105,7 +105,7 @@ except Exception:  # pragma: no cover - optional
 # ---------------------------------------------------------------------------
 from backend.trace_ws import hub  # pylint: disable=import-error
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent  # pylint: disable=import-error
+from backend.agents import register  # pylint: disable=import-error
 from backend.orchestrator import _publish  # pylint: disable=import-error
 from alpha_factory_v1.utils.env import _env_int
 
@@ -197,10 +197,12 @@ class _GreedyPlanner:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 
+@register
 class ManufacturingAgent(AgentBase):
     """Hybrid CP‑SAT + RL manufacturing scheduler."""
 
     NAME = "manufacturing"
+    __version__ = "0.3.0"
     CAPABILITIES = [
         "scheduling",
         "scenario_analysis",
@@ -465,16 +467,4 @@ class ManufacturingAgent(AgentBase):
 # ---------------------------------------------------------------------------
 # Registry hook -------------------------------------------------------------
 # ---------------------------------------------------------------------------
-
-register_agent(
-    AgentMetadata(
-        name=ManufacturingAgent.NAME,
-        cls=ManufacturingAgent,
-        version="0.3.0",
-        capabilities=ManufacturingAgent.CAPABILITIES,
-        compliance_tags=ManufacturingAgent.COMPLIANCE_TAGS,
-        requires_api_key=ManufacturingAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["ManufacturingAgent"]

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -119,7 +119,7 @@ except ModuleNotFoundError:  # pragma: no cover
 # Alpha‑Factory internals
 # ────────────────────────────────────────────────────────────────────────────
 from backend.agent_base import AgentBase  # type: ignore
-from backend.agents.registry import AgentMetadata, register_agent  # type: ignore
+from backend.agents import register  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -271,8 +271,10 @@ class _Retriever:
 # ────────────────────────────────────────────────────────────────────────────
 # PolicyAgent class
 # ────────────────────────────────────────────────────────────────────────────
+@register
 class PolicyAgent(AgentBase):
     NAME = "policy"
+    __version__ = "0.2.0"
     CAPABILITIES = [
         "nl_query",
         "version_diff",
@@ -394,15 +396,4 @@ class PolicyAgent(AgentBase):
 # ────────────────────────────────────────────────────────────────────────────
 # Registry hook
 # ────────────────────────────────────────────────────────────────────────────
-register_agent(
-    AgentMetadata(
-        name=PolicyAgent.NAME,
-        cls=PolicyAgent,
-        version="0.2.0",
-        capabilities=PolicyAgent.CAPABILITIES,
-        compliance_tags=PolicyAgent.COMPLIANCE_TAGS,
-        requires_api_key=PolicyAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["PolicyAgent"]

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -105,7 +105,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha‑Factory lightweight core imports  ------------------------------------
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent
+from backend.agents import register
 from backend.orchestrator import _publish  # structured‑event helper
 from alpha_factory_v1.utils.env import _env_int
 
@@ -217,10 +217,12 @@ def _wrap_mcp(agent: str, payload: Any) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+@register
 class RetailDemandAgent(AgentBase):
     """Alpha‑grade demand‑sensing & replenishment planner."""
 
     NAME = "retail_demand"
+    __version__ = "0.4.0"
     CAPABILITIES = [
         "demand_forecasting",
         "reorder_optimisation",
@@ -379,16 +381,4 @@ class RetailDemandAgent(AgentBase):
 # ---------------------------------------------------------------------------
 # Static registry hook  ------------------------------------------------------
 # ---------------------------------------------------------------------------
-
-register_agent(
-    AgentMetadata(
-        name=RetailDemandAgent.NAME,
-        cls=RetailDemandAgent,
-        version="0.4.0",
-        capabilities=RetailDemandAgent.CAPABILITIES,
-        compliance_tags=RetailDemandAgent.COMPLIANCE_TAGS,
-        requires_api_key=RetailDemandAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["RetailDemandAgent"]

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -117,7 +117,7 @@ except ModuleNotFoundError:  # pragma: no cover
 # Alpha‑Factory local imports (never heavy)
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent
+from backend.agents import register
 from backend.orchestrator import _publish
 from alpha_factory_v1.utils.env import _env_int
 
@@ -197,10 +197,12 @@ class _VaRSurrogate:
 # ---------------------------------------------------------------------------
 
 
+@register
 class SmartContractAgent(AgentBase):
     """Analyse, optimise and forecast smart‑contract performance & risk."""
 
     NAME = "smart_contract"
+    __version__ = "1.0.0"
     CAPABILITIES = [
         "contract_audit",
         "gas_optimisation",
@@ -484,16 +486,6 @@ def _bootstrap_distribution(median: float, n: int = 12) -> List[float]:
 # Register agent in global registry
 # ---------------------------------------------------------------------------
 
-register_agent(
-    AgentMetadata(
-        name=SmartContractAgent.NAME,
-        cls=SmartContractAgent,
-        version="1.0.0",
-        capabilities=SmartContractAgent.CAPABILITIES,
-        compliance_tags=SmartContractAgent.COMPLIANCE_TAGS,
-        requires_api_key=SmartContractAgent.REQUIRES_API_KEY,
-    )
-)
 
 # ---------------------------------------------------------------------------
 # Doctest (quick smoke test)
@@ -505,3 +497,5 @@ if __name__ == "__main__":
         """pragma solidity ^0.8.25; contract Foo { function bar(uint a) external view returns(uint){return a+1;} }"""
     )
     print(agent.audit_contract(json.dumps({"source": sample_src}))[:200])
+
+__all__ = ["SmartContractAgent"]

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -115,7 +115,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha‑Factory local imports (lightweight, no heavy deps)
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import‑error
-from backend.agents.registry import AgentMetadata, register_agent  # pylint: disable=import‑error
+from backend.agents import register  # pylint: disable=import‑error
 from backend.orchestrator import _publish  # re‑use event bus hook
 
 logger = logging.getLogger(__name__)
@@ -203,8 +203,10 @@ class WorldModel:  # noqa: D101
 # ---------------------------------------------------------------------------
 # Supply‑Chain Agent implementation
 # ---------------------------------------------------------------------------
+@register
 class SupplyChainAgent(AgentBase):  # noqa: D101
     NAME = "supply_chain"
+    __version__ = "0.5.0"
     CAPABILITIES = [
         "demand_forecasting",
         "inventory_optimisation",
@@ -333,15 +335,4 @@ class SupplyChainAgent(AgentBase):  # noqa: D101
 # ---------------------------------------------------------------------------
 # Registry hook (executed at import‑time)
 # ---------------------------------------------------------------------------
-register_agent(
-    AgentMetadata(
-        name=SupplyChainAgent.NAME,
-        cls=SupplyChainAgent,
-        version="0.5.0",
-        capabilities=SupplyChainAgent.CAPABILITIES,
-        compliance_tags=SupplyChainAgent.COMPLIANCE_TAGS,
-        requires_api_key=SupplyChainAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["SupplyChainAgent"]

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -113,7 +113,7 @@ except Exception:  # pragma: no cover - optional
 # Alpha‑Factory light deps                                                  |
 # ---------------------------------------------------------------------------
 from backend.agent_base import AgentBase  # pylint: disable=import-error
-from backend.agents.registry import AgentMetadata, register_agent
+from backend.agents import register
 from backend.orchestrator import _publish
 from alpha_factory_v1.utils.env import _env_int
 
@@ -236,10 +236,12 @@ class _ANNIndex:
 # ==========================================================================
 
 
+@register
 class TalentMatchAgent(AgentBase):
     """Expert‑level talent recommendation and DEI analytics agent."""
 
     NAME = "talent_match"
+    __version__ = "0.4.0"
 
     CAPABILITIES = [
         "candidate_recommendation",
@@ -486,16 +488,4 @@ class TalentMatchAgent(AgentBase):
 # ==========================================================================
 # Registry hook                                                             |
 # ==========================================================================
-
-register_agent(
-    AgentMetadata(
-        name=TalentMatchAgent.NAME,
-        cls=TalentMatchAgent,
-        version="0.4.0",
-        capabilities=TalentMatchAgent.CAPABILITIES,
-        compliance_tags=TalentMatchAgent.COMPLIANCE_TAGS,
-        requires_api_key=TalentMatchAgent.REQUIRES_API_KEY,
-    )
-)
-
 __all__ = ["TalentMatchAgent"]


### PR DESCRIPTION
## Summary
- update `register` decorator to call `register_agent`
- use `@register` for all agents
- document the new decorator

## Testing
- `pre-commit` *(fails: verify-requirements-lock)*
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685abde1915883338ce48457af69698c