### PR TITLE
[alpha_factory] warn on missing optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,9 @@ Install these extras to unlock additional features:
 - `pip install openai-agents==0.0.17` – activates the official Agents runtime used for commentary.
 - `pip install google-adk` and set `ALPHA_FACTORY_ENABLE_ADK=true` – starts the Google ADK gateway for
   cross‑organisation agent exchange.
+- Install domain‑specific extras as needed (e.g. `httpx`, `feedparser`, `networkx`, `lightgbm`,
+  `kafka-python`, `tldextract`). Each agent logs a warning when a library is missing and continues in
+  degraded mode.
 
 Offline installations can omit these lines from the relevant `requirements.txt`
 files if the Agents SDK or ADK gateway are not needed.

--- a/alpha_factory_v1/backend/agents/aiga_evolver_agent.py
+++ b/alpha_factory_v1/backend/agents/aiga_evolver_agent.py
@@ -10,6 +10,8 @@ no-ops when optional heavy dependencies (torch/numpy) are absent.
 from __future__ import annotations
 
 import logging
+
+logger = logging.getLogger(__name__)
 import asyncio
 
 from backend.agents.registry import register, _agent_base
@@ -19,6 +21,7 @@ try:
     from alpha_factory_v1.demos.aiga_meta_evolution.meta_evolver import MetaEvolver
     from alpha_factory_v1.demos.aiga_meta_evolution.curriculum_env import CurriculumEnv
 except Exception:  # pragma: no cover - optional deps missing
+    logger.warning("AIGA meta-evolution demo unavailable – agent disabled")
     MetaEvolver = None  # type: ignore
     CurriculumEnv = None  # type: ignore
 

--- a/alpha_factory_v1/backend/agents/base.py
+++ b/alpha_factory_v1/backend/agents/base.py
@@ -58,17 +58,20 @@ from typing import Any, List, Mapping, MutableMapping, Optional
 try:  # -- Prometheus metrics
     from backend.agents.registry import Counter, Gauge  # type: ignore
 except Exception:  # pragma: no cover
+    logging.getLogger(__name__).warning("prometheus_client missing – metrics disabled")
     Counter = Gauge = None  # type: ignore
 
 try:  # -- Kafka producer for heart-beats
     from kafka import KafkaProducer  # type: ignore
     from kafka.errors import KafkaError
 except ModuleNotFoundError:  # pragma: no cover
+    logging.getLogger(__name__).warning("kafka-python missing – heartbeats disabled")
     KafkaProducer = None  # type: ignore
 
 try:  # -- Cron / RRULE scheduling helper
     import aiocron  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logging.getLogger(__name__).warning("aiocron not installed – scheduling disabled")
     aiocron = None  # type: ignore
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -74,32 +74,38 @@ try:
     import rdflib  # type: ignore
     from rdflib.namespace import RDF, RDFS  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("rdflib not installed – knowledge graph disabled")
     rdflib = RDF = RDFS = None  # type: ignore
 
 try:
     import faiss  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("faiss missing – similarity search disabled")
     faiss = None  # type: ignore
 
 try:
     from sentence_transformers import SentenceTransformer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("sentence-transformers missing – embeddings disabled")
     SentenceTransformer = None  # type: ignore
 
 try:
     import numpy as np  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("numpy not installed – vector ops disabled")
     np = None  # type: ignore
 
 try:
     import pandas as pd  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("pandas missing – CSV parsing disabled")
     pd = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_):  # type: ignore
@@ -112,16 +118,19 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event streaming disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – network fetch disabled")
     httpx = None  # type: ignore
 
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -55,6 +55,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import random
 from dataclasses import dataclass
@@ -70,23 +72,27 @@ from alpha_factory_v1.backend.utils.sync import run_sync
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – using cached datasets only")
     httpx = None  # type: ignore
 
 try:
     import torch  # type: ignore
     from torch import nn  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("torch missing – surrogate model disabled")
     torch = nn = None  # type: ignore
 
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event streaming disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
 
     def tool(fn=None, **_):  # type: ignore
         """Fallback when OpenAI Agents SDK unavailable."""
@@ -100,6 +106,7 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -47,6 +47,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -61,27 +63,32 @@ from alpha_factory_v1.backend.utils.sync import run_sync
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – falling back to offline mode")
     httpx = None  # type: ignore
 
 try:
     import feedparser  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("feedparser missing – RSS ingestion disabled")
     feedparser = None  # type: ignore
 
 try:
     import networkx as nx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("networkx unavailable – graph features disabled")
     nx = None  # type: ignore
 
 try:
     import lightgbm as lgb  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("lightgbm missing – ML model disabled")
     lgb = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_):  # type: ignore
@@ -94,6 +101,7 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore
@@ -110,6 +118,7 @@ except Exception:  # pragma: no cover - optional
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/discovery.py
+++ b/alpha_factory_v1/backend/agents/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import logging
 import os
 import pkgutil
 import sys
@@ -14,11 +15,13 @@ from typing import Optional
 try:  # ≥ Py 3.10 std-lib metadata
     import importlib.metadata as imetadata
 except ModuleNotFoundError:  # pragma: no cover
+    logging.getLogger(__name__).warning("importlib_metadata backport required on this Python")
     import importlib_metadata as imetadata  # type: ignore
 
 try:  # Google Agent Development Kit
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logging.getLogger(__name__).warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 
 from .registry import (

--- a/alpha_factory_v1/backend/agents/drug_design_agent.py
+++ b/alpha_factory_v1/backend/agents/drug_design_agent.py
@@ -39,6 +39,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import random
 import re
@@ -56,12 +58,14 @@ try:
     from rdkit import Chem  # type: ignore
     from rdkit.Chem import AllChem, rdMolDescriptors, Descriptors  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("rdkit not installed – chemical descriptors disabled")
     Chem = AllChem = rdMolDescriptors = Descriptors = None  # type: ignore
 
 try:
     import torch  # type: ignore
     from torch import nn  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("torch missing – neural nets disabled")
     torch = None  # type: ignore
     nn = None  # type: ignore
 
@@ -69,27 +73,32 @@ try:
     import torch_geometric.nn as tgnn  # type: ignore
     from torch_geometric.data import Data as TGData  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("torch-geometric missing – GNN features disabled")
     tgnn = TGData = None  # type: ignore
 
 try:
     import lightgbm as lgb  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("lightgbm missing – gradient boosting disabled")
     lgb = None  # type: ignore
 
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – dataset fetch disabled")
     httpx = None  # type: ignore
 
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_kw):  # type: ignore
@@ -102,6 +111,7 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore
@@ -118,6 +128,7 @@ except Exception:  # pragma: no cover - optional
 try:
     import selfies as sf  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("selfies not installed – SELFIES support disabled")
     sf = None  # type: ignore
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -45,6 +45,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import math
 import os
 import random
@@ -62,32 +64,38 @@ try:
     import pandas as pd  # type: ignore
     import numpy as np  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("numpy/pandas missing – data handling disabled")
     pd = np = None  # type: ignore
 
 try:
     import lightgbm as lgb  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("lightgbm missing – forecasting model disabled")
     lgb = None  # type: ignore
 
 try:
     import pulp  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("pulp not installed – optimisation disabled")
     pulp = None  # type: ignore
 
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – using offline datasets")
     httpx = None  # type: ignore
 
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_kw):  # type: ignore
@@ -97,6 +105,7 @@ except ModuleNotFoundError:  # pragma: no cover
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -43,6 +43,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import random
 from dataclasses import dataclass
@@ -57,27 +59,32 @@ from alpha_factory_v1.backend.utils.sync import run_sync
 try:
     import ortools.sat.python.cp_model as cp  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("OR-Tools missing – constraint solver disabled")
     cp = None  # type: ignore
 
 try:
     import numpy as np  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("numpy not installed – optimisation degraded")
     np = None  # type: ignore
 
 try:
     from backend.agents.registry import Gauge  # type: ignore
 except Exception:  # pragma: no cover
+    logger.warning("prometheus-client missing – metrics disabled")
     Gauge = None  # type: ignore
 
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_):  # type: ignore
@@ -87,6 +94,7 @@ except ModuleNotFoundError:  # pragma: no cover
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore

--- a/alpha_factory_v1/backend/agents/ping_agent.py
+++ b/alpha_factory_v1/backend/agents/ping_agent.py
@@ -80,14 +80,15 @@ try:
     _Prom.Histogram = Histogram
     _Prom.get_metric = _get_metric
 except ModuleNotFoundError:
-    pass  # Metrics disabled – agent still functions.
+    _log.warning("prometheus_client missing – metrics disabled")
+
 
 try:
     from opentelemetry import trace  # type: ignore
 
     _OTEL.tracer = trace.get_tracer(__name__)
 except ModuleNotFoundError:
-    pass  # Tracing disabled – agent still functions.
+    _log.warning("opentelemetry not installed – tracing disabled")
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Configuration helpers

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -44,6 +44,8 @@ import difflib
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import re
 from dataclasses import dataclass
@@ -59,22 +61,26 @@ from alpha_factory_v1.backend.utils.sync import run_sync
 try:
     import faiss  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("faiss missing – similarity search disabled")
     faiss = None  # type: ignore
 
 try:
     from sentence_transformers import SentenceTransformer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("sentence-transformers missing – embeddings disabled")
     SentenceTransformer = None  # type: ignore
 
 try:
     from rank_bm25 import BM25Okapi  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("rank_bm25 not installed – BM25 features disabled")
     BM25Okapi = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_):  # type: ignore
@@ -87,16 +93,19 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     from backend.agents.registry import Gauge  # type: ignore
 except Exception:  # pragma: no cover
+    logger.warning("prometheus-client missing – metrics disabled")
     Gauge = None  # type: ignore
 
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore
@@ -113,6 +122,7 @@ except Exception:  # pragma: no cover - optional
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – network fetch disabled")
     httpx = None  # type: ignore
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -37,6 +37,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import math
 import os
 import random
@@ -55,27 +57,32 @@ try:
     import pandas as pd  # type: ignore
     import numpy as np  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("numpy/pandas missing – data handling disabled")
     pd = np = None  # type: ignore
 
 try:
     import lightgbm as lgb  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("lightgbm missing – forecasting model disabled")
     lgb = None  # type: ignore
 
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – using cached datasets")
     httpx = None  # type: ignore
 
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
 
     def tool(fn=None, **_kw):  # type: ignore
         """No‑op decorator when OpenAI Agents SDK is missing."""
@@ -88,6 +95,7 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -38,6 +38,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import random
 import re
@@ -56,33 +58,39 @@ from alpha_factory_v1.backend.utils.sync import run_sync
 try:
     from web3 import Web3  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("web3 not installed – blockchain features disabled")
     Web3 = None  # type: ignore
 
 try:
-    import slither  # type: ignore  # noqa: F401  (import side effect registers entry‑point)
+    import slither  # type: ignore  # noqa: F401
     from slither.slither import Slither  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("slither missing – static analysis disabled")
     Slither = None  # type: ignore
 
 try:
     import lightgbm as lgb  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("lightgbm missing – scoring model disabled")
     lgb = None  # type: ignore
 
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – contract fetch disabled")
     httpx = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_):  # type: ignore
@@ -95,6 +103,7 @@ OPENAI_TIMEOUT_SEC = int(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore
@@ -111,6 +120,7 @@ except Exception:  # pragma: no cover - optional
 try:
     import solcx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("solcx not installed – compilation disabled")
     solcx = None  # type: ignore
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -34,6 +34,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import time
 from dataclasses import dataclass
@@ -45,6 +47,7 @@ from alpha_factory_v1.backend.utils.sync import run_sync
 try:
     import networkx as nx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dep
+    logger.warning("networkx not installed – graph model disabled")
 
     class _FakeGraph:
         def __init__(self) -> None:
@@ -65,6 +68,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dep
 try:
     import numpy as np  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("numpy not installed – numeric features disabled")
     np = None  # type: ignore
 
 # ---------------------------------------------------------------------------
@@ -73,22 +77,26 @@ except ModuleNotFoundError:  # pragma: no cover
 try:
     import pandas as pd  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("pandas missing – CSV parsing disabled")
     pd = None  # type: ignore
 
 try:
     import pulp  # Minimal‑cost flow MILP solver
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("pulp not installed – optimisation disabled")
     pulp = None  # type: ignore
 
 try:
     import httpx  # async HTTP client for open datasets
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – using cached datasets")
     httpx = None  # type: ignore
 
 try:
     import openai
     from openai.agents import tool
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
 
     def tool(fn=None, **_):  # type: ignore
         return (lambda f: f) if fn is None else fn  # no‑op decorator
@@ -98,6 +106,7 @@ except ModuleNotFoundError:  # pragma: no cover
 try:
     import adk  # Google Agent Development Kit
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -38,6 +38,8 @@ import asyncio
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import random
 import re
@@ -56,37 +58,44 @@ from alpha_factory_v1.backend.utils.sync import run_sync
 try:
     import numpy as np  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("numpy not installed – similarity search disabled")
     np = None  # type: ignore
 
 try:
     import pandas as pd  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("pandas missing – CSV parsing disabled")
     pd = None  # type: ignore
 
 try:
     import faiss  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("faiss missing – vector search disabled")
     faiss = None  # type: ignore
 
 try:
     from sentence_transformers import SentenceTransformer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("sentence-transformers missing – embeddings disabled")
     SentenceTransformer = None  # type: ignore
 
 try:
     from kafka import KafkaProducer  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("kafka-python missing – event bus disabled")
     KafkaProducer = None  # type: ignore
 
 try:
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("httpx unavailable – network fetch disabled")
     httpx = None  # type: ignore
 
 try:
     import openai  # type: ignore
     from openai.agents import tool  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("openai package not found – LLM features disabled")
     openai = None  # type: ignore
 
     def tool(fn=None, **_):  # type: ignore
@@ -96,6 +105,7 @@ except ModuleNotFoundError:  # pragma: no cover
 try:
     import adk  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+    logger.warning("google-adk not installed – mesh integration disabled")
     adk = None  # type: ignore
 try:
     from aiohttp import ClientError as AiohttpClientError  # type: ignore


### PR DESCRIPTION
## Summary
- log warnings when optional library imports fail
- document agent extras in README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kafka')*
- `pre-commit run --files README.md alpha_factory_v1/backend/agents/base.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac329a6e08333ba97ce734dd96106