### PR TITLE
[alpha_factory] track failed agent imports

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -25,7 +25,7 @@ from .registry import (
     register_agent,
     register,
     list_capabilities,
-    list_agents,
+    list_agents as _list_agents,
     capability_agents,
     get_agent,
 )
@@ -35,6 +35,7 @@ from .discovery import (
     discover_hot_dir,
     discover_adk,
     _HOT_DIR,
+    FAILED_AGENTS,
 )
 from .discovery import discover_local as _discover_local
 from .health import start_background_tasks, stop_background_tasks
@@ -50,6 +51,16 @@ logger.info(
     len(AGENT_REGISTRY),
     len(CAPABILITY_GRAPH),
 )
+
+
+def list_agents(detail: bool = False):
+    """Return agent registry entries and failed imports when ``detail`` is ``True``."""
+    entries = _list_agents(detail=detail)
+    if not detail:
+        return entries
+    failed = [{"name": name, "status": "error", "message": msg} for name, msg in sorted(FAILED_AGENTS.items())]
+    return entries + failed
+
 
 __all__ = [
     "AGENT_REGISTRY",

--- a/tests/test_failed_agent_discovery.py
+++ b/tests/test_failed_agent_discovery.py
@@ -1,0 +1,36 @@
+"""Tests for failed agent discovery handling."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from unittest import TestCase, mock
+
+from alpha_factory_v1.backend import agents
+from alpha_factory_v1.backend.agents import discovery
+
+
+class TestFailedAgentDiscovery(TestCase):
+    def setUp(self) -> None:
+        self._reg_backup = agents.AGENT_REGISTRY.copy()
+        agents.AGENT_REGISTRY.clear()
+        self._fail_backup = discovery.FAILED_AGENTS.copy()
+        discovery.FAILED_AGENTS.clear()
+
+    def tearDown(self) -> None:
+        agents.AGENT_REGISTRY.clear()
+        agents.AGENT_REGISTRY.update(self._reg_backup)
+        discovery.FAILED_AGENTS.clear()
+        discovery.FAILED_AGENTS.update(self._fail_backup)
+
+    def test_failed_local_import_recorded(self) -> None:
+        with (
+            mock.patch.object(pkgutil, "iter_modules", return_value=[(None, "bad_agent", False)]),
+            mock.patch.object(importlib, "import_module", side_effect=ImportError("boom")),
+        ):
+            discovery.discover_local()
+
+        self.assertIn("bad_agent", discovery.FAILED_AGENTS)
+        self.assertEqual(discovery.FAILED_AGENTS["bad_agent"], "boom")
+        detail = agents.list_agents(detail=True)
+        self.assertIn({"name": "bad_agent", "status": "error", "message": "boom"}, detail)


### PR DESCRIPTION
## Summary
- record discovery failures
- surface failed imports via `list_agents(detail=True)`
- test that failed modules are included

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q tests/test_failed_agent_discovery.py`

------
https://chatgpt.com/codex/tasks/task_e_685ac82bff7883338a75ca6e0dcef20e