### PR TITLE
[alpha_factory] moving-average regression guard

### DIFF
--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -24,7 +24,7 @@ def test_regression_guard(monkeypatch) -> None:
     async def drive() -> float:
         guard = asyncio.create_task(orchestrator.regression_guard(runners, alerts.append))
         start = time.time()
-        for v in [1.0, 0.7, 0.5, 0.3]:
+        for v in [1.0, 0.95, 0.6]:
             metrics.dgm_best_score.set(v)
             await asyncio.sleep(0.2)
         await asyncio.sleep(0.5)


### PR DESCRIPTION
## Summary
- simplify regression guard to rely on moving average
- adjust governance test for new moving-average logic

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/backend/agent_runner.py tests/test_governance.py` *(failed: environment setup was interrupted)*
- `pytest -q` *(failed: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685acec0ea048333870c88bbe5e81002