### PR TITLE
[alpha_factory] implement mesh registration retries

### DIFF
--- a/alpha_factory_v1/backend/agents/biotech_agent.py
+++ b/alpha_factory_v1/backend/agents/biotech_agent.py
@@ -426,16 +426,30 @@ class BiotechAgent(AgentBase):
                 )
 
     # ── ADK mesh ────────────────────────────────────────────────────────
-    async def _register_mesh(self):
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"kg": str(self.cfg.kg_file)})
-            logger.info("[BT] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"kg": str(self.cfg.kg_file)})
+                logger.info("[BT] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 __all__ = ["BiotechAgent"]

--- a/alpha_factory_v1/backend/agents/climate_risk_agent.py
+++ b/alpha_factory_v1/backend/agents/climate_risk_agent.py
@@ -367,16 +367,30 @@ class ClimateRiskAgent(AgentBase):
     # ADK mesh heartbeat
     # ────────────────────────────────────────────────────────────────
 
-    async def _register_mesh(self):  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
-            logger.info("[CR] registered to ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
+                logger.info("[CR] registered to ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ────────────────────────────────────────────────────────────────────────────────

--- a/alpha_factory_v1/backend/agents/cyber_threat_agent.py
+++ b/alpha_factory_v1/backend/agents/cyber_threat_agent.py
@@ -429,16 +429,30 @@ class CyberThreatAgent(AgentBase):
     # ADK mesh registration (optional)
     # ------------------------------------------------------------------
 
-    async def _register_mesh(self):  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
-            logger.info("[CT] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
+                logger.info("[CT] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/energy_agent.py
+++ b/alpha_factory_v1/backend/agents/energy_agent.py
@@ -357,16 +357,30 @@ class EnergyAgent(AgentBase):
         return json.dumps(_mcp(self.NAME, hedge))
 
     # ---------------------- ADK mesh registration ------------------------ #
-    async def _register_mesh(self):
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
-            logger.info("[EN] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
+                logger.info("[EN] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/manufacturing_agent.py
+++ b/alpha_factory_v1/backend/agents/manufacturing_agent.py
@@ -460,16 +460,30 @@ class ManufacturingAgent(AgentBase):
     # ADK mesh ---------------------------------------------------------
     # ------------------------------------------------------------------
 
-    async def _register_mesh(self):  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"cp_sat": self._cp_available})
-            logger.info("[MF] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"cp_sat": self._cp_available})
+                logger.info("[MF] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/policy_agent.py
+++ b/alpha_factory_v1/backend/agents/policy_agent.py
@@ -391,16 +391,30 @@ class PolicyAgent(AgentBase):
         return tags or ["unknown"]
 
     # ── ADK mesh registration ──────────────────────────────────────────
-    async def _register_mesh(self):  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"corpus": str(self.cfg.corpus_dir)})
-            logger.info("[PL] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"corpus": str(self.cfg.corpus_dir)})
+                logger.info("[PL] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/alpha_factory_v1/backend/agents/retail_demand_agent.py
+++ b/alpha_factory_v1/backend/agents/retail_demand_agent.py
@@ -374,16 +374,30 @@ class RetailDemandAgent(AgentBase):
     # ADK mesh registration
     # ------------------------------------------------------------------
 
-    async def _register_mesh(self):  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
-            logger.info("[RD] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"runtime": "alpha_factory"})
+                logger.info("[RD] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/smart_contract_agent.py
+++ b/alpha_factory_v1/backend/agents/smart_contract_agent.py
@@ -442,15 +442,29 @@ class SmartContractAgent(AgentBase):
     # ------------------------------------------------------------------
 
     async def _register_mesh(self) -> None:  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME, metadata={"chain_id": self.cfg.chain_id})
-            logger.info("[SC] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME, metadata={"chain_id": self.cfg.chain_id})
+                logger.info("[SC] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/supply_chain_agent.py
+++ b/alpha_factory_v1/backend/agents/supply_chain_agent.py
@@ -329,16 +329,30 @@ class SupplyChainAgent(AgentBase):  # noqa: D101
 
     # -------------------- ADK mesh handshake ------------------------ #
 
-    async def _register_mesh(self):  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME)
-            logger.info("[SC] registered with ADK mesh as %s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME)
+                logger.info("[SC] registered with ADK mesh as %s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/backend/agents/talent_match_agent.py
+++ b/alpha_factory_v1/backend/agents/talent_match_agent.py
@@ -483,16 +483,30 @@ class TalentMatchAgent(AgentBase):
     #   ADK mesh
     # -------------------------------------------------------------
 
-    async def _register_mesh(self):  # noqa: D401
-        try:
-            client = adk.Client()
-            await client.register(node_type=self.NAME)
-            logger.info("[TM] registered in ADK mesh id=%s", client.node_id)
-        except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
-            logger.warning("ADK registration failed: %s", exc)
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.exception("Unexpected ADK registration error: %s", exc)
-            raise
+    async def _register_mesh(self) -> None:  # noqa: D401
+        max_attempts = 3
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                client = adk.Client()
+                await client.register(node_type=self.NAME)
+                logger.info("[TM] registered in ADK mesh id=%s", client.node_id)
+                return
+            except (AdkClientError, AiohttpClientError, asyncio.TimeoutError, OSError) as exc:
+                if attempt == max_attempts:
+                    logger.error("ADK registration failed after %d attempts: %s", max_attempts, exc)
+                    raise
+                logger.warning(
+                    "ADK registration attempt %d/%d failed: %s",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.exception("Unexpected ADK registration error: %s", exc)
+                raise
 
 
 # ==========================================================================

--- a/tests/test_register_mesh_backoff.py
+++ b/tests/test_register_mesh_backoff.py
@@ -1,0 +1,48 @@
+import asyncio
+import types
+import pytest
+
+from alpha_factory_v1.backend.agents import biotech_agent
+
+
+class StubClient:
+    def __init__(self):
+        self.calls = 0
+        self.node_id = "X"
+
+    async def register(self, *_, **__):
+        self.calls += 1
+        if self.calls < 3:
+            raise biotech_agent.AdkClientError("boom")
+
+
+async def no_sleep(_: float) -> None:
+    return None
+
+
+def test_register_mesh_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = StubClient()
+    fake_adk = types.SimpleNamespace(Client=lambda: client)
+    monkeypatch.setattr(biotech_agent, "adk", fake_adk)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    agent = biotech_agent.BiotechAgent()
+    asyncio.run(agent._register_mesh())
+    assert client.calls == 3
+
+
+def test_register_mesh_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FailClient(StubClient):
+        async def register(self, *_, **__):
+            self.calls += 1
+            raise biotech_agent.AdkClientError("boom")
+
+    client = FailClient()
+    fake_adk = types.SimpleNamespace(Client=lambda: client)
+    monkeypatch.setattr(biotech_agent, "adk", fake_adk)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    agent = biotech_agent.BiotechAgent()
+    with pytest.raises(biotech_agent.AdkClientError):
+        asyncio.run(agent._register_mesh())
+    assert client.calls == 3


### PR DESCRIPTION
## Summary
- add exponential backoff and final error for mesh registration
- test retry behaviour

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files alpha_factory_v1/backend/agents/biotech_agent.py alpha_factory_v1/backend/agents/climate_risk_agent.py alpha_factory_v1/backend/agents/cyber_threat_agent.py alpha_factory_v1/backend/agents/drug_design_agent.py alpha_factory_v1/backend/agents/energy_agent.py alpha_factory_v1/backend/agents/finance_agent.py alpha_factory_v1/backend/agents/manufacturing_agent.py alpha_factory_v1/backend/agents/policy_agent.py alpha_factory_v1/backend/agents/retail_demand_agent.py alpha_factory_v1/backend/agents/smart_contract_agent.py alpha_factory_v1/backend/agents/supply_chain_agent.py alpha_factory_v1/backend/agents/talent_match_agent.py tests/test_register_mesh_backoff.py` *(fails: proto-verify and requirements lock)*

------
https://chatgpt.com/codex/tasks/task_e_685ad95cc990833385cb6cc1b9874dc7