### PR TITLE
[alpha_factory] add static insight page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,9 @@ jobs:
         run: pip install mkdocs mkdocs-material
       - name: Build site
         run: mkdocs build --verbose
+      - name: Copy static insight
+        run: |
+          cp -r docs/static_insight/* site/
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docs/static_insight/forecast.json
+++ b/docs/static_insight/forecast.json
@@ -1,0 +1,9 @@
+[
+  {"year": 1, "capability": 0.1},
+  {"year": 2, "capability": 0.15},
+  {"year": 3, "capability": 0.25},
+  {"year": 4, "capability": 0.4},
+  {"year": 5, "capability": 0.6},
+  {"year": 6, "capability": 0.8},
+  {"year": 7, "capability": 1.0}
+]

--- a/docs/static_insight/index.html
+++ b/docs/static_insight/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AGI Capability Insight</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.plot.ly/plotly-2.24.2.min.js"></script>
+</head>
+<body>
+  <header>
+    <h1>AGI Capability Insight</h1>
+  </header>
+  <main>
+    <section id="charts">
+      <div id="capability" class="chart"></div>
+      <div id="timeline" class="chart"></div>
+      <div id="pareto" class="chart"></div>
+    </section>
+    <section id="logs">
+      <h2>Agent Logs</h2>
+      <pre id="logPanel"></pre>
+    </section>
+  </main>
+  <footer>
+    <p class="snippet">This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/static_insight/population.json
+++ b/docs/static_insight/population.json
@@ -1,0 +1,7 @@
+[
+  {"effectiveness": 0.6, "risk": 0.4, "complexity": 0.2, "rank": 1},
+  {"effectiveness": 0.8, "risk": 0.3, "complexity": 0.4, "rank": 0},
+  {"effectiveness": 0.7, "risk": 0.5, "complexity": 0.3, "rank": 2},
+  {"effectiveness": 0.9, "risk": 0.6, "complexity": 0.5, "rank": 0},
+  {"effectiveness": 0.5, "risk": 0.2, "complexity": 0.1, "rank": 3}
+]

--- a/docs/static_insight/script.js
+++ b/docs/static_insight/script.js
@@ -1,0 +1,46 @@
+async function loadData() {
+  const forecast = await fetch('forecast.json').then(r => r.json());
+  const population = await fetch('population.json').then(r => r.json());
+
+  const years = forecast.map(p => p.year);
+  const capability = forecast.map(p => p.capability);
+
+  Plotly.newPlot('capability', [
+    { x: years, y: capability, mode: 'lines+markers', name: 'Capability' }
+  ], {
+    title: 'AGI Capability Curve',
+    xaxis: { title: 'Year' },
+    yaxis: { title: 'Capability' }
+  });
+
+  Plotly.newPlot('timeline', [
+    { x: years, y: capability, mode: 'lines+markers', name: 'Disruption' }
+  ], {
+    title: 'Sector Disruption Timeline',
+    xaxis: { title: 'Year' },
+    yaxis: { title: 'Energy Remaining' }
+  });
+
+  Plotly.newPlot("pareto", [{
+    x: population.map(p => p.effectiveness),
+    y: population.map(p => p.risk),
+    text: population.map(p => `Rank ${p.rank}`),
+    mode: "markers",
+    marker: { size: 12, color: population.map(p => p.rank) }
+  }], {
+    title: "Pareto Frontier",
+    xaxis: { title: "Effectiveness" },
+    yaxis: { title: "Risk" }
+  });
+
+  const logPanel = document.getElementById('logPanel');
+  function addLog(msg) {
+    const div = document.createElement('div');
+    div.textContent = msg;
+    logPanel.appendChild(div);
+    logPanel.scrollTop = logPanel.scrollHeight;
+  }
+  ['Simulation started', 'Year 1: minor disruption', 'Year 3: new breakthrough'].forEach(addLog);
+}
+
+window.addEventListener('load', loadData);

--- a/docs/static_insight/style.css
+++ b/docs/static_insight/style.css
@@ -1,0 +1,45 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+header {
+  background: #222;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+main {
+  flex: 1;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+#charts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.chart {
+  flex: 1 1 300px;
+  min-height: 300px;
+}
+#logs {
+  margin-top: 1rem;
+}
+#logPanel {
+  background: #f4f4f4;
+  padding: 1rem;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+}
+footer {
+  background: #eee;
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add static insight dashboard under docs/static_insight
- embed capability curve, sector disruption timeline and Pareto frontier
- display standard disclaimer text in the footer
- copy static assets during docs build

## Testing
- `pre-commit run --files docs/static_insight/index.html docs/static_insight/style.css docs/static_insight/script.js docs/static_insight/forecast.json docs/static_insight/population.json .github/workflows/docs.yml` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: import errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685ae9b2b8148333996c216f160f12f2