### PR TITLE
[alpha_factory] Document Static Insight demo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,3 +46,11 @@ A self-healing macro risk radar powered by multi-agent α‑AGI. The stack inges
 macro telemetry, runs Monte-Carlo simulations and exposes a Gradio dashboard.
 See the [alpha_factory_v1/demos/macro_sentinel/README.md](../alpha_factory_v1/demos/macro_sentinel/README.md)
 for full instructions.
+
+## Static Insight Demo
+
+GitHub Pages serves any files under `docs/` when the site is built from
+`mkdocs.yml`. To publish the static α‑AGI Insight demo, copy the contents of
+`static_insight/` into this directory and run `mkdocs build` if your workflow
+doesn't trigger it automatically. Pushing the updated files makes the demo
+available at the default Pages URL.


### PR DESCRIPTION
## Summary
- document how to deploy the static Insight demo

## Testing
- `pre-commit run --files docs/README.md` *(with many hooks skipped)*
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(interrupted: attempted network installs)*
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685af11eebbc83338c5763d09f2db0ad