### PR TITLE
[alpha_factory] Link Insight v1 demo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,8 +59,10 @@ available at the default Pages URL.
 
 `docs/alpha_agi_insight_v1` provides a self-contained HTML demo that
 visualises capability forecasts with Plotly. The GitHub Actions workflow
-copies this directory into the generated `site/` folder so the files are
-served on GitHub Pages.
+copies this directory into the generated `site/` folder, serves it on GitHub
+Pages and deploys the page automatically. Visit
+[the published demo](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
+to preview it.
 
 To update the charts, edit `forecast.json` and `population.json` and rebuild
 the site:


### PR DESCRIPTION
## Summary
- link to alpha_agi_insight_v1 GitHub Pages site
- mention automatic deployment in the docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files docs/README.md` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_685b03f6d9c48333b345c1ea063389e4