### PR TITLE
docs: deploy docs on push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: "\ud83d\udcda Docs"
 
 on:
+  push:
+    branches: ["main"]
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary
- trigger docs build on pushes to main

## Testing
- `pre-commit run --files .github/workflows/docs.yml` *(with many hooks skipped)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685b0a7f6f648333ad4d90e7f05d57a4