### PR TITLE
[alpha_factory] add disclaimer page to docs site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 # Project Documentation
 
+[α‑AGI Insight Demo](alpha_agi_insight_v1/index.html)
 
 ## Building the React Dashboard
 

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -1,0 +1,7 @@
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+
+# α-AGI Insight v1
+
+This directory hosts the static α‑AGI Insight demo used in the documentation. Build the docs with `mkdocs build` and open `alpha_agi_insight_v1/index.html` from the generated `site/` folder, or visit the [hosted page](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/).
+
+The charts rely on synthetic data for illustration. Refer to the project disclaimer for important usage information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,4 +19,5 @@ nav:
   - Policy Runbook: POLICY_RUNBOOK.md
   - dgm_ops: dgm_ops.md
   - Changelog: CHANGELOG.md
+  - Disclaimer: DISCLAIMER_SNIPPET.md
   - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html


### PR DESCRIPTION
## Summary
- add page for DISCLAIMER_SNIPPET.md to mkdocs nav so it gets built
- insert direct link to Alpha AGI Insight demo on the docs homepage
- provide README for the alpha_agi_insight_v1 demo

## Testing
- `mkdocs build -q`
- `pre-commit run verify-disclaimer-snippet --files docs/alpha_agi_insight_v1/README.md docs/README.md mkdocs.yml`


------
https://chatgpt.com/codex/tasks/task_e_685b6911062483339e8161d9c5cd843f