### PR TITLE
Add hosting instructions for insight demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ extraordinary economic advantages tomorrow.
 * **Precision Forecasting** — Identify and proactively engage critical sectors before AGI disruption.  
 * **First‑Mover Advantage** — Maximize returns through strategic foresight and superior positioning.
 A static demo is available via [GitHub Pages](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/).
+See [docs/HOSTING_INSTRUCTIONS.md](docs/HOSTING_INSTRUCTIONS.md) for guidance on building the docs and publishing your own copy.
 
 ### 🎖️ α‑AGI Sovereign 👁️✨ — Autonomous Economic Transformation
 Meta‑Agentic mastery at global scale. α‑AGI Sovereign represents a revolutionary class of autonomous, blockchain‑based

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -1,0 +1,36 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Hosting Instructions
+
+This project uses [MkDocs](https://www.mkdocs.org/) to build the static documentation.
+
+## Prerequisites
+
+- **Python 3.11 or 3.12**
+- `mkdocs` and `mkdocs-material`
+- **Node.js 20+** *(optional, only for building the React dashboard)*
+
+Install MkDocs:
+
+```bash
+pip install mkdocs mkdocs-material
+```
+
+## Building the Site
+
+Run the following from the repository root:
+
+```bash
+mkdocs build
+```
+
+This generates the HTML under `site/`. The workflow
+[`.github/workflows/docs.yml`](../.github/workflows/docs.yml) runs the same
+command, copies `docs/alpha_agi_insight_v1` into `site/` and then deploys.
+
+## Publishing to GitHub Pages
+
+When changes land on `main` or a release is published, `docs.yml` pushes the
+`site/` directory to the `gh-pages` branch. GitHub Pages serves the result at
+`https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
+The standard [project disclaimer](DISCLAIMER_SNIPPET.md) applies.

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -4,4 +4,6 @@
 
 This directory hosts the static α‑AGI Insight demo used in the documentation. Build the docs with `mkdocs build` and open `alpha_agi_insight_v1/index.html` from the generated `site/` folder, or visit the [hosted page](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/).
 
+For details on publishing the site automatically, see [HOSTING_INSTRUCTIONS.md](../HOSTING_INSTRUCTIONS.md).
+
 The charts rely on synthetic data for illustration. Refer to the project disclaimer for important usage information.


### PR DESCRIPTION
## Summary
- document how to host the docs with MkDocs and GitHub Pages
- cross-link new hosting guide from the insight demo README and main README

## Testing
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md docs/alpha_agi_insight_v1/README.md README.md` *(with verification hooks skipped)*
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685b6bc2a2d88333aecaa2c725705797