### PR TITLE
[alpha_factory] update insight instructions

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -2,7 +2,13 @@
 
 # α-AGI Insight v1
 
-This directory hosts the static α‑AGI Insight demo used in the documentation. Build the docs with `mkdocs build` and open `alpha_agi_insight_v1/index.html` from the generated `site/` folder, or visit the [hosted page](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/).
+This directory hosts the static α‑AGI Insight demo used in the documentation. Build the docs with `mkdocs build` and open `alpha_agi_insight_v1/index.html` from the generated `site/` folder. To preview the files directly from the repository, run:
+
+```bash
+python -m http.server --directory docs/alpha_agi_insight_v1 8000
+```
+
+and navigate to <http://localhost:8000/>. Direct `file://` access is unsupported due to browser security restrictions. You can also visit the [hosted page](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/).
 
 For details on publishing the site automatically, see [HOSTING_INSTRUCTIONS.md](../HOSTING_INSTRUCTIONS.md).
 


### PR DESCRIPTION
## Summary
- clarify how to run a local web server for α‑AGI Insight demo
- note that `file://` access isn't supported

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files docs/alpha_agi_insight_v1/README.md`

------
https://chatgpt.com/codex/tasks/task_e_685be77d6f5c8333bfea8889830b35a3