### PR TITLE
[alpha_factory] Add doc build helper script

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -35,6 +35,10 @@ its contents into `docs/alpha_agi_insight_v1` so MkDocs can include the files:
 unzip -o insight_browser.zip -d ../../../docs/alpha_agi_insight_v1
 ```
 
+The helper script `scripts/build_insight_docs.sh` automates the steps above.
+Run it from the repository root to build the bundle, refresh
+`docs/alpha_agi_insight_v1` and generate the site.
+
 
 ## Building the Site
 

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+# Build the Insight demo and documentation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+DOCS_DIR="docs/alpha_agi_insight_v1"
+
+usage() {
+    cat <<USAGE
+Usage: $0
+
+Build the Insight browser bundle, refresh $DOCS_DIR
+and generate the mkdocs site.
+USAGE
+}
+
+if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
+    usage
+    exit 0
+fi
+
+# Install Node dependencies and build the browser bundle
+npm --prefix "$BROWSER_DIR" ci
+npm --prefix "$BROWSER_DIR" run build:dist
+
+# Refresh docs directory with the new bundle
+rm -rf "$DOCS_DIR"
+mkdir -p "$DOCS_DIR"
+unzip -q -o "$BROWSER_DIR/insight_browser.zip" -d "$DOCS_DIR"
+
+# Build the MkDocs site
+mkdocs build
+


### PR DESCRIPTION
## Summary
- add POSIX shell script to build Insight docs
- document how to use it in HOSTING_INSTRUCTIONS

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files scripts/build_insight_docs.sh docs/HOSTING_INSTRUCTIONS.md` *(failed to complete due to environment setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd346a748333820c1f09184396c5