### PR TITLE
[alpha_factory] Add demo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Full documentation: [https://montreal-ai.github.io/AGI-Alpha-Agent-v0/](https://
 
 **View the interactive demo here:** <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>
 
+[![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/index.html)
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary
- add badge pointing to Insight demo on GitHub Pages

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors)*
- `pre-commit run --files README.md` *(fails to finish: environment install interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685bfec77ef4833395e4563e378cda32