### PR TITLE
fix alpha agi insight disclaimer link

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -76,7 +76,7 @@
       <small>For illustration purposes only; data is synthetic and for demonstration of concept.</small>
     </p>
     <section class="snippet">
-      <a href="../disclaimer_snippet/">See docs/DISCLAIMER_SNIPPET.md</a>
+      <a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a>
       This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
     </section>
   </footer>


### PR DESCRIPTION
## Summary
- fix insight demo link to the disclaimer page

## Testing
- `mkdocs build -q`
- `pytest -k '' -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c0126466c83339decf47f7e88a77b