### PR TITLE
docs: mention unzip requirement

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -9,6 +9,7 @@ This project uses [MkDocs](https://www.mkdocs.org/) to build the static document
 - **Python 3.11 or 3.12**
 - `mkdocs` and `mkdocs-material`
 - **Node.js 20+** *(optional, only for building the React dashboard)*
+- `unzip` to extract `insight_browser.zip`
 
 Install MkDocs:
 


### PR DESCRIPTION
## Summary
- note that `unzip` is needed to extract `insight_browser.zip` in hosting instructions

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md` *(fails: verify-era-experience-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685c09aa3264833388193e4bf742c3c0