### PR TITLE
[alpha_factory] Update docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,12 +17,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
       - name: Install MkDocs
         run: pip install mkdocs mkdocs-material
+      - name: Build Insight docs
+        run: ./scripts/build_insight_docs.sh
       - name: Build site
         run: mkdocs build --verbose
-      - name: Copy insight demo
-        run: cp -r docs/alpha_agi_insight_v1 site/
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- use `actions/setup-node@v3`
- build insight docs with `build_insight_docs.sh`
- keep docs published to `gh-pages`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*
- `pre-commit run --files .github/workflows/docs.yml` *(fails: verify requirements.lock)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d85a9908333bb5a2fe590fccb6e