### PR TITLE
[alpha_factory] fix path aliases for Insight browser

### DIFF
--- a/alpha_factory_v1/core/utils/llm.js
+++ b/alpha_factory_v1/core/utils/llm.js
@@ -1,2 +1,2 @@
 // SPDX-License-Identifier: Apache-2.0
-export * from '../../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.ts';
+export * from '../../demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.ts';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -62,7 +62,7 @@ try {
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), '..', '..', '..', '..');
-const aliasRoot = path.join(repoRoot, 'src');
+const aliasRoot = path.join(repoRoot, 'alpha_factory_v1', 'core');
 const quickstartPdf = path.join(repoRoot, manifest.quickstart_pdf);
 const aliasPlugin = {
   name: 'alias',

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ipfs/pinner.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { Web3Storage } from '../lib/bundle.esm.min.js';
+import { Web3Storage } from '../../lib/bundle.esm.min.js';
 
 declare global {
   interface Window {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/SimulatorPanel.ts
@@ -9,7 +9,7 @@ import { mutateEvaluator } from '../evaluator_genome.ts';
 import { pinFiles } from '../ipfs/pinner.ts';
 import { renderFrontier } from '../render/frontier.ts';
 import { detectColdZone } from '../utils/cluster.ts';
-import clone from '../../../../../../src/utils/clone.js';
+import clone from '../../../../../core/utils/clone.js';
 import type { Archive } from '../archive.ts';
 import type { PopulationFrame, SimulatorStatus, GpuToggleEvent } from './types.ts';
 import type { Selection } from 'd3';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "baseUrl": "./",
     "paths": {
-      "@insight-src/*": ["../../../../src/*"]
+      "@insight-src/*": ["../../../core/*"]
     },
     "allowJs": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary
- correct the module alias to point to the project core
- update imports for Web3Storage and clone helper

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm run build:dist` *(fails: checksum mismatch for pyodide.js)*
- `./scripts/build_insight_docs.sh` *(fails: checksum mismatch for pyodide.js)*

------
https://chatgpt.com/codex/tasks/task_e_685c15ee7f1883338df01f2c9bd23aa2