### PR TITLE
[alpha_factory] add insight build notes

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -13,3 +13,21 @@ and navigate to <http://localhost:8000/>. Direct `file://` access is unsupported
 For details on publishing the site automatically, see [HOSTING_INSTRUCTIONS.md](../HOSTING_INSTRUCTIONS.md).
 
 The charts rely on synthetic data for illustration. Refer to the project disclaimer for important usage information.
+
+## One-Command Build
+
+Run the helper script to generate the Insight demo and the `site/` directory:
+
+```bash
+./scripts/build_insight_docs.sh
+```
+
+The script expects **Python ≥3.11**, **Node.js ≥20** and **MkDocs** to be installed. It installs Node dependencies, builds the browser bundle and runs `mkdocs build`.
+
+Preview the generated site locally with:
+
+```bash
+python -m http.server --directory site 8000
+```
+
+The `📚 Docs` workflow runs the same script and publishes the contents of `site/` to GitHub Pages on every push to `main`.


### PR DESCRIPTION
## Summary
- document building Insight docs with `scripts/build_insight_docs.sh`
- mention Python and Node requirements, local preview command and GitHub Pages workflow

## Testing
- `pre-commit run verify-disclaimer-snippet --files docs/alpha_agi_insight_v1/README.md`
- `pre-commit run verify-env-docs --files docs/alpha_agi_insight_v1/README.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError, 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c1b91cbf08333acfc1c6e978aded6