### PR TITLE
docs: add return link from Insight demo

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -75,11 +75,14 @@
       &copy; 2025 Montreal.AI — α‑AGI Insight v1 Demo. <br/>
       <small>For illustration purposes only; data is synthetic and for demonstration of concept.</small>
     </p>
-    <section class="snippet">
-      <a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a>
-      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
-    </section>
-  </footer>
+      <section class="snippet">
+        <a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a>
+        This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+      </section>
+      <p>
+        <a href="../index.html">Back to documentation</a>
+      </p>
+    </footer>
 
   <script src="script.js"></script>
 </body>

--- a/docs/alpha_agi_insight_v1/style.css
+++ b/docs/alpha_agi_insight_v1/style.css
@@ -91,3 +91,6 @@ footer {
   background: #f5f5f5;
   border-top: 1px solid #e0e0e0;
 }
+footer a {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- update Insight demo footer with back link
- style footer links

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/index.html docs/alpha_agi_insight_v1/style.css` *(all hooks skipped)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c1eaf1ea48333a0fb48d82a6fd7ba