### PR TITLE
[alpha_factory] Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,6 @@ jobs:
         run: pip install mkdocs mkdocs-material
       - name: Build Insight docs
         run: ./scripts/build_insight_docs.sh
-      - name: Build site
-        run: mkdocs build --verbose
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- remove redundant `mkdocs build` step from the docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files .github/workflows/docs.yml` *(fails: could not install hooks)*

------
https://chatgpt.com/codex/tasks/task_e_685c3d8ed3fc83338f8426865950ac41