### PR TITLE
[alpha_factory] host insight demo under subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@ References to "AGI" and "superintelligence" describe aspirational goals and do n
 general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers
 accept no liability for losses incurred from using this software.
 
-**Ready to explore? [Launch the α‑AGI Insight demo](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/) to see it in action.**
+**Ready to explore? [Launch the α‑AGI Insight demo](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/) to see it in action.**
 
 See [HOSTING_INSTRUCTIONS](docs/HOSTING_INSTRUCTIONS.md) for build and deployment details. The [📚 Docs workflow](.github/workflows/docs.yml) runs automatically on every push to `main` and publishes the updated site to GitHub Pages.
 
 Full documentation: [https://montreal-ai.github.io/AGI-Alpha-Agent-v0/](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/) (use the **Docs** link in the navigation bar)
 
-The GitHub Pages root now hosts the interactive demo. Click **Docs** in the navigation bar for the full manual.
+The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1/` directory. Click **Docs** in the navigation bar for the full manual.
 
-**View the interactive demo here:** <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/>
+**View the interactive demo here:** <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>
 
-[![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/)
+[![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 
 ## Quickstart
 

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -37,7 +37,5 @@ unzip -q -o "$BROWSER_DIR/insight_browser.zip" -d "$DOCS_DIR"
 # Build the MkDocs site
 mkdocs build
 
-# Promote the demo output to the site root so the Insight dashboard
-# becomes the default landing page.
-cp -a site/alpha_agi_insight_v1/* site/
+
 


### PR DESCRIPTION
## Summary
- host α-AGI Insight demo under `alpha_agi_insight_v1/` instead of root
- note subdirectory in README

## Testing
- `python check_env.py --auto-install`
- `pytest -m smoke` *(fails: 44 errors during collection)*
- `pre-commit run --files README.md scripts/build_insight_docs.sh` *(failed: semgrep init interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685c406384fc833398529901ff96ee1a