### PR TITLE
chore: fetch assets during docs build

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -25,7 +25,8 @@ if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
     exit 0
 fi
 
-# Install Node dependencies and build the browser bundle
+# Fetch WASM assets then install Node dependencies and build the browser bundle
+npm --prefix "$BROWSER_DIR" run fetch-assets
 npm --prefix "$BROWSER_DIR" ci
 npm --prefix "$BROWSER_DIR" run build:dist
 


### PR DESCRIPTION
## Summary
- ensure `build_insight_docs.sh` downloads WASM assets before installing Node deps

## Testing
- `./scripts/build_insight_docs.sh` *(fails: Unable to retrieve wasm_llm/wasm-gpt2.tar)*
- `pre-commit run --files scripts/build_insight_docs.sh` *(failed to initialize semgrep environment)*

------
https://chatgpt.com/codex/tasks/task_e_685c49f3f36083339335ebab88873cee