### PR TITLE
[alpha_factory] Update docs homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=alpha_agi_insight_v1/index.html">
+  <title>α‑AGI Insight Demo Redirect</title>
+</head>
+<body>
+  <p>If you are not redirected, <a href="alpha_agi_insight_v1/index.html">click here to open the α‑AGI Insight demo</a>.</p>
+  <p class="snippet"><a href="DISCLAIMER_SNIPPET.md">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,8 @@ docs_dir: docs
 theme:
   name: material
 nav:
-  - Home: README.md
+  - Home: index.html
+  - Documentation Overview: README.md
   - Quickstart: quickstart.md
   - Getting Started: INTRO.md
   - Project Overview: OVERVIEW.md


### PR DESCRIPTION
## Summary
- add docs/index.html redirecting to alpha_agi_insight_v1
- make MkDocs use the new index

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `bash scripts/build_insight_docs.sh` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_685c53aab23083338829e6fbee15d723