### PR TITLE
[alpha_factory] clarify Insight docs build

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -8,21 +8,29 @@ This directory hosts the static α‑AGI Insight demo used in the documentation.
 python -m http.server --directory docs/alpha_agi_insight_v1 8000
 ```
 
-and navigate to <http://localhost:8000/>. Direct `file://` access is unsupported due to browser security restrictions. You can also visit the [hosted page](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/).
+and navigate to <http://localhost:8000/>. Direct `file://` access is unsupported due to browser security restrictions.
+
+**Live demo:** <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>
 
 For details on publishing the site automatically, see [HOSTING_INSTRUCTIONS.md](../HOSTING_INSTRUCTIONS.md).
 
 The charts rely on synthetic data for illustration. Refer to the project disclaimer for important usage information.
 
+### Prerequisites
+
+* **Python ≥3.11**
+* **Node.js ≥20**
+* **MkDocs**
+
 ## One-Command Build
 
-Run the helper script to generate the Insight demo and the `site/` directory:
+Run the helper script to build the Insight progressive web app (PWA) and generate the `site/` directory:
 
 ```bash
 ./scripts/build_insight_docs.sh
 ```
 
-The script expects **Python ≥3.11**, **Node.js ≥20** and **MkDocs** to be installed. It installs Node dependencies, builds the browser bundle and runs `mkdocs build`.
+The script installs Node dependencies, builds the browser bundle and runs `mkdocs build`. When executed in CI, it also publishes the resulting `site/` directory to GitHub Pages.
 
 Preview the generated site locally with:
 
@@ -30,4 +38,4 @@ Preview the generated site locally with:
 python -m http.server --directory site 8000
 ```
 
-The `📚 Docs` workflow runs the same script and publishes the contents of `site/` to GitHub Pages on every push to `main`.
+The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same script and publishes the contents of `site/` to GitHub Pages on every push to `main`.


### PR DESCRIPTION
## Summary
- expand docs about the Insight demo
- link to the Docs workflow and live demo
- document prerequisites for building

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/README.md` *(fails: proto-verify, verify-requirements-lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a66ba90833399c79725db05ff45