### PR TITLE
[alpha_factory] Document automatic Docs workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 
+### Automatic Deployment
+
+Pushes to `main` trigger the [Docs workflow](.github/workflows/docs.yml), which
+runs [`scripts/build_insight_docs.sh`](scripts/build_insight_docs.sh) to rebuild
+the Insight demo and MkDocs site. The workflow publishes the result to GitHub
+Pages, so once it completes the live demo is available at
+<https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/> with no
+extra setup required.
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary
- explain that pushes to `main` run the Docs workflow via `scripts/build_insight_docs.sh`
- note that the Insight demo is served automatically once the workflow finishes

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files README.md` *(fails: proto-verify & requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685c6ac9e8b08333a4c318ee3484a4dd