### PR TITLE
[alpha_factory] Fix disclaimer link in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <p>If you are not redirected, <a href="alpha_agi_insight_v1/index.html">click here to open the α‑AGI Insight demo</a>.</p>
-  <p class="snippet"><a href="DISCLAIMER_SNIPPET.md">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix the link to `DISCLAIMER_SNIPPET` in `docs/index.html`
- verify the generated site shows the corrected link

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*
- `pre-commit run --files docs/index.html` *(fails: proto-verify and requirements lock checks)*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_685c7469637883339837ebdb9e314c2a