### PR TITLE
[alpha_factory] Run version check before doc build

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -25,6 +25,12 @@ if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
     exit 0
 fi
 
+# Ensure the correct Node.js version before running npm
+if ! node "$BROWSER_DIR/build/version_check.js"; then
+    echo "ERROR: Node.js 20+ is required to build the Insight docs." >&2
+    exit 1
+fi
+
 # Fetch WASM assets then install Node dependencies and build the browser bundle
 npm --prefix "$BROWSER_DIR" run fetch-assets
 npm --prefix "$BROWSER_DIR" ci


### PR DESCRIPTION
## Summary
- ensure Node 20 is installed before running npm in `build_insight_docs.sh`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files scripts/build_insight_docs.sh` *(fails: proto-verify hook error)*

------
https://chatgpt.com/codex/tasks/task_e_685c7f6fdf5c833397d8bcd649570ff3