### PR TITLE
docs: add helper script to publish demo

### DIFF
--- a/scripts/publish_insight_pages.sh
+++ b/scripts/publish_insight_pages.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script builds the Insight demo and publishes the docs site to GitHub Pages.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+./scripts/build_insight_docs.sh
+
+# Deploy using mkdocs gh-deploy which relies on ghp-import under the hood
+mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- add convenience script `publish_insight_pages.sh` to build and deploy the Insight demo using `mkdocs gh-deploy`

## Testing
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-era-experience-requirements-lock,verify-mats-requirements-lock,verify-mats-demo-lock,verify-aiga-requirements-lock,verify-backend-requirements-lock,env-check,verify-disclaimer-helper pre-commit run --files scripts/publish_insight_pages.sh`
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685c8aabb51483338336358215cf43d9