### PR TITLE
[alpha_factory] host demo instructions

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -72,6 +72,18 @@ The "📚 Docs" workflow
 `scripts/build_insight_docs.sh`, builds the site and pushes the result to the
 `gh-pages` branch.
 
+### Manual Publish
+
+To trigger a one-off deployment outside of CI run:
+
+```bash
+./scripts/publish_insight_pages.sh
+```
+
+This wrapper script rebuilds the browser bundle, regenerates the MkDocs site and
+uses `mkdocs gh-deploy` to push the contents of `site/` to the `gh-pages` branch.
+Use it when testing changes locally or publishing from a personal fork.
+
 ## Publishing to GitHub Pages
 
 When changes land on `main` or a release is published, `docs.yml` pushes the


### PR DESCRIPTION
## Summary
- document manual publish workflow for GH Pages

## Testing
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md --hook-stage manual` *(fails: proto-verify, requirements lock)*
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685c8f2452a08333841d1972f2882a1a