### PR TITLE
[alpha_factory] docs update

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -18,6 +18,13 @@ Install MkDocs:
 pip install mkdocs mkdocs-material
 ```
 
+Before building the demo, ensure optional Python packages are available:
+
+```bash
+python scripts/check_python_deps.py
+python check_env.py --auto-install
+```
+
 ## Build the Insight Demo
 
 The static browser bundle lives under


### PR DESCRIPTION
## Summary
- mention `check_env.py` step in HOSTING_INSTRUCTIONS

## Testing
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md` *(fails: proto-verify; see log)*
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685c9970f29c8333b12c293125911e6f