### PR TITLE
[alpha_factory] improve GH Pages docs

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -89,6 +89,9 @@ Use it when testing changes locally or publishing from a personal fork.
 When changes land on `main` or a release is published, `docs.yml` pushes the
 `site/` directory to the `gh-pages` branch. GitHub Pages serves the result at
 `https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
+The repository’s `docs/index.html` file redirects to this path so that opening
+`https://montreal-ai.github.io/AGI-Alpha-Agent-v0/` automatically loads the
+demo.
 The standard [project disclaimer](DISCLAIMER_SNIPPET.md) applies.
 
 ## Verifying Deployment

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -12,6 +12,11 @@ and navigate to <http://localhost:8000/>. Direct `file://` access is unsupported
 
 **Live demo:** <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>
 
+The project’s GitHub Pages site redirects its root URL to this directory for
+convenience. Non‑technical users can simply open
+<https://montreal-ai.github.io/AGI-Alpha-Agent-v0/> and they will be forwarded
+to the demo automatically.
+
 For details on publishing the site automatically, see [HOSTING_INSTRUCTIONS.md](../HOSTING_INSTRUCTIONS.md).
 
 The charts rely on synthetic data for illustration. Refer to the project disclaimer for important usage information.


### PR DESCRIPTION
## Summary
- document automatic redirect from GitHub Pages root to the Insight demo

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c3f77808333acd71e9dd6281bf3