### PR TITLE
docs: add local preview helper

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -43,4 +43,6 @@ Preview the generated site locally with:
 python -m http.server --directory site 8000
 ```
 
+For convenience, run `./scripts/preview_insight_docs.sh` to build the demo and immediately serve it on `http://localhost:8000/`.
+
 The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same script and publishes the contents of `site/` to GitHub Pages on every push to `main`.

--- a/scripts/preview_insight_docs.sh
+++ b/scripts/preview_insight_docs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script builds the Insight demo then serves the generated site locally.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Build the Insight browser bundle and docs
+./scripts/build_insight_docs.sh
+
+# Serve the site on localhost:8000
+printf '\nServing Insight demo at http://localhost:8000/ (press Ctrl+C to stop)\n'
+python -m http.server --directory site 8000
+


### PR DESCRIPTION
## Summary
- add a script to build and serve the Insight demo for local testing
- document the preview script in the demo README

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/README.md scripts/preview_insight_docs.sh` *(with heavy hooks skipped)*
- `python check_env.py --auto-install`


------
https://chatgpt.com/codex/tasks/task_e_685c9dc6a75083339024a3382da38c31