### PR TITLE
fix: defer plotly script in docs

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Interactive forecast visualization of AGI-driven economic disruption" />
   <title>α‑AGI Insight v1 — Beyond Human Foresight</title>
   <!-- Plotly.js (minified) -->
-  <script src="plotly.min.js"></script>
+  <script src="plotly.min.js" defer></script>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -85,6 +85,6 @@
       </p>
     </footer>
 
-  <script src="script.js"></script>
+  <script src="script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Plotly asynchronously in `alpha_agi_insight_v1` demo
- defer the site script so Plotly is ready first

## Testing
- `python -m playwright install chromium`
- `python - <<'PY'
from playwright.sync_api import sync_playwright
url = 'http://localhost:8000/docs/alpha_agi_insight_v1/index.html'
with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto(url)
    page.wait_for_selector('#capability-chart .main-svg', timeout=10000)
    page.wait_for_selector('#timeline-chart .main-svg', timeout=10000)
    page.wait_for_selector('#pareto-chart .main-svg', timeout=10000)
    print('Charts loaded successfully with deferred script')
    browser.close()
PY

------
https://chatgpt.com/codex/tasks/task_e_685ca4a51e0c83338a06ce7682d90449