### PR TITLE
[alpha_factory] Fix docs link

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -89,7 +89,7 @@
         This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
       </section>
       <p>
-        <a href="../index.html">Back to documentation</a>
+        <a href="../README.html">Back to documentation</a>
       </p>
     </footer>
 


### PR DESCRIPTION
## Summary
- update the Insight demo footer to point to the docs homepage

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError and other import errors)*
- `pre-commit run --files docs/alpha_agi_insight_v1/index.html` *(fails: proto-verify, verify-requirements-lock)*
- `./scripts/build_insight_docs.sh` *(fails: could not fetch wasm_llm/wasm-gpt2.tar)*

------
https://chatgpt.com/codex/tasks/task_e_685cadcad8f48333bab8fd42ef82f4c9