### PR TITLE
[alpha_factory] Add Quick Deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Non-technical users can try the project with zero setup. Simply visit
 browser. The [README](docs/README.md#α‑agi-insight-v1-demo) explains how this
 demo is built and deployed.
 
-See [HOSTING_INSTRUCTIONS](docs/HOSTING_INSTRUCTIONS.md) for build and deployment details. The [📚 Docs workflow](.github/workflows/docs.yml) runs automatically on every push to `main` and publishes the updated site to GitHub Pages.
+See [Quick Deployment](docs/HOSTING_INSTRUCTIONS.md#quick-deployment) for build and deployment details. The [📚 Docs workflow](.github/workflows/docs.yml) runs automatically on every push to `main` and publishes the updated site to GitHub Pages.
 
 Full documentation: [https://montreal-ai.github.io/AGI-Alpha-Agent-v0/](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/) (use the **Docs** link in the navigation bar)
 
@@ -123,7 +123,7 @@ extraordinary economic advantages tomorrow.
 * **Precision Forecasting** — Identify and proactively engage critical sectors before AGI disruption.  
 * **First‑Mover Advantage** — Maximize returns through strategic foresight and superior positioning.
 A static demo is available via [GitHub Pages](https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/).
-See [docs/HOSTING_INSTRUCTIONS.md](docs/HOSTING_INSTRUCTIONS.md) for guidance on building the docs and publishing your own copy.
+See [Quick Deployment](docs/HOSTING_INSTRUCTIONS.md#quick-deployment) for guidance on building the docs and publishing your own copy.
 
 ### 🎖️ α‑AGI Sovereign 👁️✨ — Autonomous Economic Transformation
 Meta‑Agentic mastery at global scale. α‑AGI Sovereign represents a revolutionary class of autonomous, blockchain‑based

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -5,6 +5,12 @@
 This project uses [MkDocs](https://www.mkdocs.org/) to build the static documentation.
 The generated site is hosted at <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>.
 
+## Quick Deployment
+
+1. Run `./scripts/build_insight_docs.sh`.
+2. Push to `main` or trigger the “📚 Docs” workflow.
+3. Verify the page at `https://<org>.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
+
 ## Prerequisites
 
 - **Python 3.11 or 3.12**

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -17,7 +17,7 @@ convenience. Non‑technical users can simply open
 <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/> and they will be forwarded
 to the demo automatically.
 
-For details on publishing the site automatically, see [HOSTING_INSTRUCTIONS.md](../HOSTING_INSTRUCTIONS.md).
+For details on publishing the site automatically, see [Quick Deployment](../HOSTING_INSTRUCTIONS.md#quick-deployment).
 
 The charts rely on synthetic data for illustration. Refer to the project disclaimer for important usage information.
 


### PR DESCRIPTION
## Summary
- provide a short "Quick Deployment" section in docs/HOSTING_INSTRUCTIONS
- cross-link the new guide from docs/alpha_agi_insight_v1/README and README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError in tests)*
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md docs/alpha_agi_insight_v1/README.md README.md` *(fails: proto-verify and verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685cafad4eb8833383f14cbaee9bc375