### PR TITLE
ci: verify Node 20 before docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+      - name: Verify Node.js version
+        working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+        run: node build/version_check.js
       - name: Install MkDocs
         run: pip install mkdocs mkdocs-material
       - name: Build Insight docs

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -24,7 +24,7 @@ The charts rely on synthetic data for illustration. Refer to the project disclai
 ### Prerequisites
 
 * **Python ≥3.11**
-* **Node.js ≥20**
+* **Node.js ≥20** (checked via `node build/version_check.js`)
 * **MkDocs**
 
 ## One-Command Build

--- a/scripts/publish_insight_pages.sh
+++ b/scripts/publish_insight_pages.sh
@@ -7,6 +7,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+if ! node "$BROWSER_DIR/build/version_check.js"; then
+    echo "ERROR: Node.js 20+ is required to publish the Insight docs." >&2
+    exit 1
+fi
+
 ./scripts/build_insight_docs.sh
 
 # Deploy using mkdocs gh-deploy which relies on ghp-import under the hood


### PR DESCRIPTION
## Summary
- make docs workflow check `node build/version_check.js`
- verify Node 20 in `publish_insight_pages.sh`
- note the Node version check in the Insight docs

## Testing
- `pre-commit run --files .github/workflows/docs.yml scripts/publish_insight_pages.sh docs/alpha_agi_insight_v1/README.md` *(fails: network access required)*
- `pytest -q` *(fails: KeyboardInterrupt during environment check)*

------
https://chatgpt.com/codex/tasks/task_e_685d3b614e708333a0a043722e68436e