### PR TITLE
[alpha_factory] Improve docs landing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,12 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=alpha_agi_insight_v1/index.html">
-  <title>α‑AGI Insight Demo Redirect</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>α‑AGI Insight</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; margin-top: 4rem; }
+    .btn { display: inline-block; padding: 1em 2em; margin: 1em; font-size: 1.2em; text-decoration: none; border-radius: 4px; }
+    .demo { background: #4caf50; color: #fff; }
+    .docs { background: #2196f3; color: #fff; }
+  </style>
 </head>
 <body>
-  <p>If you are not redirected, <a href="alpha_agi_insight_v1/index.html">click here to open the α‑AGI Insight demo</a>.</p>
+  <p>The Alpha-Factory project showcases experimental AGI research tools and demos.</p>
+  <p>
+    <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>
+    <a class="btn docs" href="README.html">View Documentation</a>
+  </p>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a simple docs landing page with demo and docs links

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent)*
- `pre-commit run --files docs/index.html --show-diff-on-failure` *(fails: proto-verify missing src/utils/a2a_pb2.py)*

------
https://chatgpt.com/codex/tasks/task_e_685d4205dad08333812ab6ab5eba22af