### PR TITLE
[alpha_factory] docs: redirect to insight demo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>α‑AGI Insight</title>
+  <meta http-equiv="refresh" content="0; url=alpha_agi_insight_v1/" />
+  <script>
+    window.location.href = "alpha_agi_insight_v1/";
+  </script>
   <style>
     body { font-family: sans-serif; text-align: center; margin-top: 4rem; }
     .btn { display: inline-block; padding: 1em 2em; margin: 1em; font-size: 1.2em; text-decoration: none; border-radius: 4px; }


### PR DESCRIPTION
## Summary
- redirect docs index to the insight demo

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent')*
- `pre-commit run --files docs/index.html` *(fails: hook proto-verify and verify-requirements-lock)*
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_685d4fbed5d88333b21077c8c8f99cbd