### PR TITLE
[alpha_factory] copy service worker into docs

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -36,6 +36,7 @@ Run the helper script to build the Insight progressive web app (PWA) and generat
 ```
 
 The script installs Node dependencies, builds the browser bundle and runs `mkdocs build`. When executed in CI, it also publishes the resulting `site/` directory to GitHub Pages.
+The bundled site registers a service worker so the demo remains available offline once loaded.
 
 Preview the generated site locally with:
 

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -93,6 +93,13 @@
       </p>
     </footer>
 
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js').catch(() => {
+        console.warn('Service worker registration failed');
+      });
+    }
+  </script>
   <script src="script.js" defer></script>
 </body>
 </html>

--- a/docs/alpha_agi_insight_v1/service-worker.js
+++ b/docs/alpha_agi_insight_v1/service-worker.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-env serviceworker */
+const WORKBOX_SW_HASH = '__WORKBOX_SW_HASH__';
+import {precacheAndRoute} from 'workbox-precaching';
+import {registerRoute} from 'workbox-routing';
+import {CacheFirst} from 'workbox-strategies';
+
+// replaced during build
+const CACHE_VERSION = '__CACHE_VERSION__';
+async function init() {
+  const res = await fetch('workbox-sw.js');
+  const buf = await res.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-384', buf);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+  if (`sha384-${b64}` !== WORKBOX_SW_HASH) {
+    throw new Error('workbox-sw.js hash mismatch');
+  }
+  importScripts(URL.createObjectURL(new Blob([buf], {type: 'application/javascript'})));
+  workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});
+
+  // include translation JSON files in the precache
+  precacheAndRoute(self.__WB_MANIFEST);
+
+  registerRoute(
+    ({request, url}) =>
+      request.destination === 'script' ||
+      request.destination === 'worker' ||
+      request.destination === 'font' ||
+      url.pathname.endsWith('.wasm') ||
+      (url.pathname.includes('/ipfs/') && url.pathname.endsWith('.json')),
+    new CacheFirst({cacheName: `${CACHE_VERSION}-assets`})
+  );
+
+  self.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+      self.skipWaiting();
+    }
+  });
+
+  self.addEventListener('activate', (event) => {
+    event.waitUntil(
+      caches.keys().then((names) =>
+        Promise.all(
+          names.map((name) => {
+            if (!name.startsWith(CACHE_VERSION)) {
+              return caches.delete(name);
+            }
+            return undefined;
+          }),
+        ),
+      ),
+    );
+  });
+}
+
+init().catch((err) => {
+  console.error('Service worker failed to initialize', err);
+  self.registration.unregister();
+});

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -50,6 +50,8 @@ fi
 rm -rf "$DOCS_DIR"
 mkdir -p "$DOCS_DIR"
 unzip -q -o "$BROWSER_DIR/insight_browser.zip" -d "$DOCS_DIR"
+# Ensure the service worker exists in the docs directory
+unzip -q -j "$BROWSER_DIR/insight_browser.zip" service-worker.js -d "$DOCS_DIR" || true
 if [[ -n "$OLD_DOCS_TEMP" ]]; then
     while IFS= read -r -d '' file; do
         rel="${file#"$OLD_DOCS_TEMP"/}"

--- a/tests/test_docs_service_worker_present.py
+++ b/tests/test_docs_service_worker_present.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure service-worker.js is present in the built docs."""
+from pathlib import Path
+import re
+
+DOCS_DIR = Path("docs/alpha_agi_insight_v1")
+
+
+def test_docs_service_worker_present() -> None:
+    html = (DOCS_DIR / "index.html").read_text()
+    assert (DOCS_DIR / "service-worker.js").is_file()
+    assert re.search(r"service-worker.js", html)
+    assert "serviceWorker" in html


### PR DESCRIPTION
## Summary
- ensure service worker extracted into docs during build
- register `service-worker.js` in docs demo
- document offline PWA availability
- add regression test for docs service worker

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d5bfc77288333928593a937874c99