### PR TITLE
[alpha_factory] fix service worker placeholders

### DIFF
--- a/docs/alpha_agi_insight_v1/service-worker.js
+++ b/docs/alpha_agi_insight_v1/service-worker.js
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 /* eslint-env serviceworker */
-const WORKBOX_SW_HASH = '__WORKBOX_SW_HASH__';
+const WORKBOX_SW_HASH = 'sha384-R7RXlLLrbRAy0JWTwv62SHZwpjwwc7C0wjnLGa5bRxm6YCl5zw87IRvhlleSM5zd';
 import {precacheAndRoute} from 'workbox-precaching';
 import {registerRoute} from 'workbox-routing';
 import {CacheFirst} from 'workbox-strategies';
 
 // replaced during build
-const CACHE_VERSION = '__CACHE_VERSION__';
+const CACHE_VERSION = '0.1.0';
 async function init() {
   const res = await fetch('workbox-sw.js');
   const buf = await res.arrayBuffer();


### PR DESCRIPTION
## Summary
- remove __WORKBOX_SW_HASH__ and __CACHE_VERSION__ placeholders from `docs/alpha_agi_insight_v1/service-worker.js`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files docs/alpha_agi_insight_v1/service-worker.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json` *(fails: proto-verify, verify-requirements-lock)*
- `./scripts/build_insight_docs.sh` *(fails: Checksum mismatch for pyodide.js)*

------
https://chatgpt.com/codex/tasks/task_e_685d5f66be648333a064af4957723371