### PR TITLE
[alpha_factory] fix footer link

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -89,7 +89,7 @@
         This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
       </section>
       <p>
-        <a href="../README/">Back to documentation</a>
+        <a href="../index.html">Back to documentation</a>
       </p>
     </footer>
 


### PR DESCRIPTION
## Summary
- tweak Insight demo footer link to point at root index

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files docs/alpha_agi_insight_v1/index.html` *(fails: proto-verify and verify-requirements-lock)*
- `./scripts/build_insight_docs.sh` *(fails to fetch wasm-gpt2.tar)*


------
https://chatgpt.com/codex/tasks/task_e_685d6422254c83339f7a4b2a3581f06e