### PR TITLE
[alpha_factory] update service worker path

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
@@ -8,12 +8,12 @@ import {CacheFirst} from 'workbox-strategies';
 // replaced during build
 const CACHE_VERSION = '__CACHE_VERSION__';
 async function init() {
-  const res = await fetch('workbox-sw.js');
+  const res = await fetch('lib/workbox-sw.js');
   const buf = await res.arrayBuffer();
   const digest = await crypto.subtle.digest('SHA-384', buf);
   const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
   if (`sha384-${b64}` !== WORKBOX_SW_HASH) {
-    throw new Error('workbox-sw.js hash mismatch');
+    throw new Error('lib/workbox-sw.js hash mismatch');
   }
   importScripts(URL.createObjectURL(new Blob([buf], {type: 'application/javascript'})));
   workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -36,7 +36,7 @@ Run the helper script to build the Insight progressive web app (PWA) and generat
 ```
 
 The script installs Node dependencies, builds the browser bundle and runs `mkdocs build`. When executed in CI, it also publishes the resulting `site/` directory to GitHub Pages.
-The bundled site registers a service worker so the demo remains available offline once loaded. The PWA now ships with a fully functional service worker. Ensure both `workbox-sw.js` and `manifest.json` are present in the docs directory—these files enable caching. Serve the files with a simple HTTP server (e.g. `python -m http.server`) so the service worker can register; opening `index.html` directly with `file://` will not work.
+The bundled site registers a service worker so the demo remains available offline once loaded. The PWA now ships with a fully functional service worker. Ensure both `lib/workbox-sw.js` and `manifest.json` are present in the docs directory—these files enable caching. Serve the files with a simple HTTP server (e.g. `python -m http.server`) so the service worker can register; opening `index.html` directly with `file://` will not work.
 
 Preview the generated site locally with:
 
@@ -59,6 +59,6 @@ To verify that the PWA works without an internet connection:
 4. After the page loads, disable your network connection and reload.
    The demo should still display correctly.
 5. If the page does not load offline, open your browser's developer console
-   and inspect any service worker errors. Confirm `workbox-sw.js` and
+   and inspect any service worker errors. Confirm `lib/workbox-sw.js` and
    `manifest.json` are served next to `index.html`.
 Contributors are encouraged to run this check before publishing changes.

--- a/docs/alpha_agi_insight_v1/service-worker.js
+++ b/docs/alpha_agi_insight_v1/service-worker.js
@@ -8,12 +8,12 @@ import {CacheFirst} from 'workbox-strategies';
 // replaced during build
 const CACHE_VERSION = '0.1.0';
 async function init() {
-  const res = await fetch('workbox-sw.js');
+  const res = await fetch('lib/workbox-sw.js');
   const buf = await res.arrayBuffer();
   const digest = await crypto.subtle.digest('SHA-384', buf);
   const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
   if (`sha384-${b64}` !== WORKBOX_SW_HASH) {
-    throw new Error('workbox-sw.js hash mismatch');
+    throw new Error('lib/workbox-sw.js hash mismatch');
   }
   importScripts(URL.createObjectURL(new Blob([buf], {type: 'application/javascript'})));
   workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -53,6 +53,7 @@ unzip -q -o "$BROWSER_DIR/insight_browser.zip" -d "$DOCS_DIR"
 # Ensure the service worker and PWA files exist in the docs directory
 unzip -q -j "$BROWSER_DIR/insight_browser.zip" service-worker.js -d "$DOCS_DIR" || true
 unzip -q -j "$BROWSER_DIR/insight_browser.zip" manifest.json -d "$DOCS_DIR" || true
+mkdir -p "$DOCS_DIR/lib"
 unzip -q -j "$BROWSER_DIR/insight_browser.zip" lib/workbox-sw.js -d "$DOCS_DIR/lib" || true
 if [[ -n "$OLD_DOCS_TEMP" ]]; then
     while IFS= read -r -d '' file; do


### PR DESCRIPTION
## Summary
- load `workbox-sw.js` from `lib/` in Insight demo
- copy `lib/workbox-sw.js` when building docs
- note the new path in the docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js docs/alpha_agi_insight_v1/service-worker.js docs/alpha_agi_insight_v1/README.md scripts/build_insight_docs.sh` *(with hooks skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685d73533eb483338cb498fc136038ad