### PR TITLE
docs: clarify service worker path

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -69,6 +69,7 @@ correctly:
 ```bash
 ls site/alpha_agi_insight_v1
 ```
+Ensure `lib/workbox-sw.js` resides under `site/alpha_agi_insight_v1/lib/` because the service worker expects the file relative to `index.html`.
 
 Serve the site locally to test it:
 

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -36,7 +36,7 @@ Run the helper script to build the Insight progressive web app (PWA) and generat
 ```
 
 The script installs Node dependencies, builds the browser bundle and runs `mkdocs build`. When executed in CI, it also publishes the resulting `site/` directory to GitHub Pages.
-The bundled site registers a service worker so the demo remains available offline once loaded. The PWA now ships with a fully functional service worker. Ensure both `lib/workbox-sw.js` and `manifest.json` are present in the docs directory—these files enable caching. Serve the files with a simple HTTP server (e.g. `python -m http.server`) so the service worker can register; opening `index.html` directly with `file://` will not work.
+The bundled site registers a service worker so the demo remains available offline once loaded. The PWA now ships with a fully functional service worker. Ensure both `lib/workbox-sw.js` and `manifest.json` are present in the docs directory—these files enable caching. The service worker fetches `lib/workbox-sw.js` relative to `index.html`, so keep the file under `lib/`. Serve the files with a simple HTTP server (e.g. `python -m http.server`) so the service worker can register; opening `index.html` directly with `file://` will not work.
 
 Preview the generated site locally with:
 


### PR DESCRIPTION
## Summary
- explain where the Insight demo service worker loads `workbox-sw.js`
- note the path in `HOSTING_INSTRUCTIONS.md`

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/README.md docs/HOSTING_INSTRUCTIONS.md` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685d77aeed0483338784fb58c8946338