### PR TITLE
feat: deploy insight demo helper

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -7,8 +7,8 @@ The generated site is hosted at <https://montreal-ai.github.io/AGI-Alpha-Agent-v
 
 ## Quick Deployment
 
-1. Run `./scripts/build_insight_docs.sh`.
-2. Push to `main` or trigger the “📚 Docs” workflow.
+1. Run `./scripts/deploy_insight_demo.sh`.
+2. When it finishes, open the printed URL or push to `main` to trigger the “📚 Docs” workflow.
 3. Verify the page at `https://<org>.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
 
 ## Prerequisites

--- a/scripts/deploy_insight_demo.sh
+++ b/scripts/deploy_insight_demo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+# Deploy the Insight demo to GitHub Pages.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+
+node "$BROWSER_DIR/build/version_check.js"
+
+npm --prefix "$BROWSER_DIR" run fetch-assets
+npm --prefix "$BROWSER_DIR" ci
+
+"$SCRIPT_DIR/publish_insight_pages.sh"
+
+remote=$(git config --get remote.origin.url)
+repo_path=${remote#*github.com[:/]}
+repo_path=${repo_path%.git}
+org="${repo_path%%/*}"
+repo="${repo_path##*/}"
+url="https://${org}.github.io/${repo}/alpha_agi_insight_v1/"
+
+echo "Insight demo deployed to $url"


### PR DESCRIPTION
## Summary
- add deploy_insight_demo.sh to install assets, run npm and publish docs
- mention the new script in Quick Deployment instructions

## Testing
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-era-experience-requirements-lock,verify-mats-demo-lock,verify-mats-requirements-lock,verify-aiga-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,env-check,verify-disclaimer-snippet,verify-disclaimer-helper,py-compile,eslint-insight-browser pre-commit run --files scripts/deploy_insight_demo.sh docs/HOSTING_INSTRUCTIONS.md`
- `pytest -m smoke -q` *(fails: ModuleNotFoundError: No module named 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent')*

------
https://chatgpt.com/codex/tasks/task_e_685d7cb4ca008333852dc4482f6003ff