### PR TITLE
[alpha_factory] add offline smoke test for docs

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -52,8 +52,13 @@ The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same scrip
 
 To verify that the PWA works without an internet connection:
 
-1. Build the documentation with `./scripts/build_insight_docs.sh`.
-2. Serve the `site/` directory locally:
+1. Run `./scripts/preview_insight_docs.sh`. The script builds the docs, starts a
+   local server and automatically launches a headless browser with Playwright.
+   It waits for the service worker to register, disables network access and
+   reloads the page. The command exits with an error if the page fails to load
+   offline.
+2. Alternatively, build the documentation with `./scripts/build_insight_docs.sh`
+   and serve the `site/` directory locally:
    `python -m http.server --directory site 8000`.
 3. Open <http://localhost:8000/> in a browser.
 4. After the page loads, disable your network connection and reload.

--- a/scripts/preview_insight_docs.sh
+++ b/scripts/preview_insight_docs.sh
@@ -10,6 +10,18 @@ cd "$REPO_ROOT"
 ./scripts/build_insight_docs.sh
 
 # Serve the site on localhost:8000
+python -m http.server --directory site 8000 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID' EXIT
+
+# Run a quick headless check to ensure the PWA loads offline
+sleep 2
+if ! python scripts/verify_insight_offline.py; then
+    echo "Offline check failed" >&2
+    kill $SERVER_PID
+    exit 1
+fi
+
 printf '\nServing Insight demo at http://localhost:8000/ (press Ctrl+C to stop)\n'
-python -m http.server --directory site 8000
+wait $SERVER_PID
 

--- a/scripts/verify_insight_offline.py
+++ b/scripts/verify_insight_offline.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+"""Smoke test that the Insight PWA loads offline."""
+
+from __future__ import annotations
+
+import sys
+from playwright.sync_api import sync_playwright, Error as PlaywrightError
+
+
+URL = "http://localhost:8000/alpha_agi_insight_v1/"
+
+
+def main() -> int:
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            page = context.new_page()
+            page.goto(URL)
+            page.wait_for_function("navigator.serviceWorker.ready")
+            page.wait_for_selector("body")
+            context.set_offline(True)
+            page.reload()
+            page.wait_for_selector("body")
+            browser.close()
+        return 0
+    except PlaywrightError as exc:
+        print(f"Playwright error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"Offline check failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- verify Insight PWA works offline from `preview_insight_docs.sh`
- document the automatic offline check in the Insight demo docs

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files scripts/preview_insight_docs.sh scripts/verify_insight_offline.py docs/alpha_agi_insight_v1/README.md` *(fails: proto-verify hook error)*

------
https://chatgpt.com/codex/tasks/task_e_685d7ff76d688333b6831a8b3d70485b