### PR TITLE
[alpha_factory] Fix docs link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
   <p>The Alpha-Factory project showcases experimental AGI research tools and demos.</p>
   <p>
     <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>
-    <a class="btn docs" href="README.html">View Documentation</a>
+    <a class="btn docs" href="README/">View Documentation</a>
   </p>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>


### PR DESCRIPTION
## Summary
- update docs index link to use directory-style URL

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: yaml)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `SKIP=proto-verify,verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-era-experience-requirements-lock,verify-mats-demo-lock,verify-mats-requirements-lock,verify-aiga-requirements-lock,verify-backend-requirements-lock,verify-env-docs,dp-scrub,env-check,verify-disclaimer-snippet,verify-disclaimer-helper,eslint-insight-browser pre-commit run --files docs/index.html`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_685d83f9afd08333b63833991a2f6975