### PR TITLE
[alpha_factory] add Plotly license file

### DIFF
--- a/docs/alpha_agi_insight_v1/plotly.min.js.LICENSE.txt
+++ b/docs/alpha_agi_insight_v1/plotly.min.js.LICENSE.txt
@@ -1,0 +1,53 @@
+/*
+ * @copyright 2016 Sean Connelly (@voidqk), http://syntheti.cc
+ * @license MIT
+ * @preserve Project Home: https://github.com/voidqk/polybooljs
+ */
+
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+/*!
+ * Determine if an object is a Buffer
+ *
+ * @author   Feross Aboukhadijeh <https://feross.org>
+ * @license  MIT
+ */
+
+/*!
+ * The buffer module from node.js, for the browser.
+ *
+ * @author   Feross Aboukhadijeh <feross@feross.org> <http://feross.org>
+ * @license  MIT
+ */
+
+/*!
+ * The buffer module from node.js, for the browser.
+ *
+ * @author   Feross Aboukhadijeh <https://feross.org>
+ * @license  MIT
+ */
+
+/*!
+ * pad-left <https://github.com/jonschlinkert/pad-left>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT license.
+ */
+
+/*!
+ * repeat-string <https://github.com/jonschlinkert/repeat-string>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+/*! Native Promise Only
+    v0.8.1 (c) Kyle Simpson
+    MIT License: http://getify.mit-license.org
+*/
+
+/*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> */

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -64,7 +64,17 @@ if [[ -n "$OLD_DOCS_TEMP" ]]; then
             cp -a "$file" "$target"
         fi
     done < <(find "$OLD_DOCS_TEMP" -mindepth 1 -print0)
+    # Ensure the Plotly license file accompanies plotly.min.js
+    LICENSE_FILE="plotly.min.js.LICENSE.txt"
+    if [[ ! -f "$DOCS_DIR/$LICENSE_FILE" && -f "$OLD_DOCS_TEMP/$LICENSE_FILE" ]]; then
+        cp -a "$OLD_DOCS_TEMP/$LICENSE_FILE" "$DOCS_DIR/"
+    fi
     rm -rf "$OLD_DOCS_TEMP"
+fi
+
+LICENSE_FILE="plotly.min.js.LICENSE.txt"
+if [[ ! -f "$DOCS_DIR/$LICENSE_FILE" && -f "$REPO_ROOT/docs/alpha_agi_insight_v1/$LICENSE_FILE" ]]; then
+    cp -a "$REPO_ROOT/docs/alpha_agi_insight_v1/$LICENSE_FILE" "$DOCS_DIR/"
 fi
 
 # Build the MkDocs site


### PR DESCRIPTION
## Summary
- fetch Plotly `plotly.min.js.LICENSE.txt` from v2.24.2
- keep license alongside `plotly.min.js`
- ensure `build_insight_docs.sh` restores the license when rebuilding docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError, etc.)*
- `pre-commit run --files scripts/build_insight_docs.sh docs/alpha_agi_insight_v1/plotly.min.js.LICENSE.txt` *(with SKIP for heavy hooks)*

------
https://chatgpt.com/codex/tasks/task_e_685d8bd9b6f08333bc921cec701c468d