### PR TITLE
[alpha_factory] fix: include favicon in insight docs

### DIFF
--- a/docs/alpha_agi_insight_v1/favicon.svg
+++ b/docs/alpha_agi_insight_v1/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -77,6 +77,12 @@ if [[ ! -f "$DOCS_DIR/$LICENSE_FILE" && -f "$REPO_ROOT/docs/alpha_agi_insight_v1
     cp -a "$REPO_ROOT/docs/alpha_agi_insight_v1/$LICENSE_FILE" "$DOCS_DIR/"
 fi
 
+# Ensure the favicon survives extraction
+ICON_FILE="favicon.svg"
+if [[ ! -f "$DOCS_DIR/$ICON_FILE" && -f "$BROWSER_DIR/$ICON_FILE" ]]; then
+    cp -a "$BROWSER_DIR/$ICON_FILE" "$DOCS_DIR/"
+fi
+
 # Build the MkDocs site
 mkdocs build
 


### PR DESCRIPTION
## Summary
- add favicon.svg to docs bundle
- ensure build script restores favicon after extracting Insight build

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent', 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d8edfc12083338489b940a0923c45