### PR TITLE
[alpha_factory] fix docs link

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -89,7 +89,7 @@
         This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
       </section>
       <p>
-        <a href="../index.html">Back to documentation</a>
+        <a href="../README/">⬅ Back to Documentation</a>
       </p>
     </footer>
 


### PR DESCRIPTION
## Summary
- correct the docs link in the insight demo

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/index.html` *(fails: proto-verify, verify-requirements-lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test suite fails during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d92bb93548333aaff7b3105a185ac