### PR TITLE
docs: clarify Node version check for insight demo

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -16,6 +16,7 @@ The generated site is hosted at <https://montreal-ai.github.io/AGI-Alpha-Agent-v
 - **Python 3.11 or 3.12**
 - `mkdocs` and `mkdocs-material`
 - **Node.js 20+** *(optional, only for building the React dashboard)*
+- Run `node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js` to verify Node ≥20 before building
 - `unzip` to extract `insight_browser.zip`
 
 Install MkDocs:


### PR DESCRIPTION
## Summary
- remind users to run `version_check.js` before building the insight demo

## Testing
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685d960e95f48333bd83e45475c97da0