### PR TITLE
[alpha_factory] Unify disclaimer text in insight pages

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/dist/index.html
+++ b/alpha_factory_v1/core/interface/web_client/dist/index.html
@@ -12,7 +12,7 @@
   <body>
     <div id="root"></div>
     <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align: center;">
-      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
     </footer>
     
     

--- a/alpha_factory_v1/core/interface/web_client/index.html
+++ b/alpha_factory_v1/core/interface/web_client/index.html
@@ -11,7 +11,7 @@
   <body>
     <div id="root"></div>
     <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align: center;">
-      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
     </footer>
     <script type="module" src="/src/main.tsx"></script>
     <script type="module">

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -41,7 +41,7 @@
     <div id="legend" role="region" aria-label="Legend"></div>
     <div id="depth-legend" role="region" aria-label="Depth Legend"></div>
     <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;">
-      This repository is a conceptual research prototype describing aspirational goals and does not contain real general intelligence. Use at your own risk.
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
     </footer>
     <script
       src="d3.v7.min.js"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/i18n/en.json
@@ -37,5 +37,5 @@
   ,"pin_failed": "pin failed"
   ,"worker_error": "worker error"
   ,"error_unknown": "unknown error"
-  ,"disclaimer": "This repository is a conceptual research prototype describing aspirational goals and does not contain real general intelligence. Use at your own risk."
+  ,"disclaimer": "This repository is a conceptual research prototype. References to 'AGI' and 'superintelligence' describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software."
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html
@@ -14,5 +14,8 @@
   </head>
   <body>
     <div id="root"></div>
+    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align: center;">
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+    </footer>
   </body>
 </html>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html
@@ -13,6 +13,9 @@
   </head>
   <body>
     <div id="root"></div>
+    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align: center;">
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+    </footer>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- use the full disclaimer snippet in Insight browser templates
- update generated dist files with matching text
- update Insight browser i18n entry

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/core/interface/web_client/index.html alpha_factory_v1/core/interface/web_client/dist/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/src/i18n/en.json alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/index.html` *(fails: proto-verify)*
- `pytest -q` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685da1ca729c833381e0ac3e5ca8d530