### PR TITLE
[alpha_factory] Document insight deployment scripts

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -7,8 +7,15 @@ The generated site is hosted at <https://montreal-ai.github.io/AGI-Alpha-Agent-v
 
 ## Quick Deployment
 
-1. Run `./scripts/deploy_insight_demo.sh`.
-2. When it finishes, open the printed URL or push to `main` to trigger the “📚 Docs” workflow.
+`deploy_insight_demo.sh` downloads the Insight browser assets, installs the
+Node dependencies and then invokes `publish_insight_pages.sh`. The latter runs
+`build_insight_docs.sh` to refresh the MkDocs site and pushes the result to the
+`gh-pages` branch. When the script completes it prints the GitHub Pages URL.
+
+1. Fetch the assets:
+   `npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets`
+2. Run the build script with `./scripts/publish_insight_pages.sh` (or execute
+   `deploy_insight_demo.sh` to perform both steps automatically).
 3. Verify the page at `https://<org>.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- clarify how `deploy_insight_demo.sh` and `publish_insight_pages.sh` work
- show the minimal steps to build and verify the GitHub Pages demo

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent')*
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md` *(fails: proto-verify hook missing repo files)*

------
https://chatgpt.com/codex/tasks/task_e_685daabc00cc83338742151e586c3e9e