### PR TITLE
feat: verify workbox integrity

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -125,3 +125,12 @@ push to `main` to trigger it. The initial run creates the `gh-pages` branch.
 After it finishes, browse to
 <https://montreal-ai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/> and
 check that the insight demo loads.
+
+Run the integrity check to make sure `lib/workbox-sw.js` matches the hash
+embedded in `service-worker.js`:
+
+```bash
+python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+```
+
+This step catches missing or corrupted assets after deployment.

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -67,3 +67,11 @@ To verify that the PWA works without an internet connection:
    and inspect any service worker errors. Confirm `lib/workbox-sw.js` and
    `manifest.json` are served next to `index.html`.
 Contributors are encouraged to run this check before publishing changes.
+After deployment, verify `lib/workbox-sw.js` matches the hash stored in
+`service-worker.js`:
+
+```bash
+python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+```
+
+This prevents caching issues caused by missing or corrupted assets.

--- a/scripts/verify_workbox_hash.py
+++ b/scripts/verify_workbox_hash.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Validate lib/workbox-sw.js against the hash in service-worker.js."""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import re
+from pathlib import Path
+
+
+def parse_expected_hash(service_worker: Path) -> str:
+    text = service_worker.read_text()
+    match = re.search(r"WORKBOX_SW_HASH\s*=\s*['\"]([^'\"]+)['\"]", text)
+    if not match:
+        raise ValueError("WORKBOX_SW_HASH not found")
+    return match.group(1)
+
+
+def compute_hash(workbox: Path) -> str:
+    data = workbox.read_bytes()
+    digest = hashlib.sha384(data).digest()
+    b64 = base64.b64encode(digest).decode()
+    return f"sha384-{b64}"
+
+
+def main(directory: Path) -> int:
+    service_worker = directory / "service-worker.js"
+    workbox = directory / "lib" / "workbox-sw.js"
+    if not service_worker.exists():
+        raise FileNotFoundError(service_worker)
+    if not workbox.exists():
+        raise FileNotFoundError(workbox)
+    expected = parse_expected_hash(service_worker)
+    actual = compute_hash(workbox)
+    if expected != actual:
+        print(f"Hash mismatch: expected {expected}, got {actual}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="docs/alpha_agi_insight_v1",
+        help="Directory containing service-worker.js and lib/workbox-sw.js",
+    )
+    args = parser.parse_args()
+    raise SystemExit(main(Path(args.path)))


### PR DESCRIPTION
## Summary
- add script to verify lib/workbox-sw.js integrity
- mention integrity check in Insight documentation

## Testing
- `python scripts/verify_workbox_hash.py docs/alpha_agi_insight_v1`
- `pre-commit run --files scripts/verify_workbox_hash.py docs/alpha_agi_insight_v1/README.md docs/HOSTING_INSTRUCTIONS.md`
- `python scripts/check_python_deps.py` *(fails: Missing packages: yaml)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent)*

------
https://chatgpt.com/codex/tasks/task_e_685dae56e7248333999ede79b5d54b55