### PR TITLE
[alpha_factory] verify service worker in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,8 @@ jobs:
         run: pip install mkdocs mkdocs-material
       - name: Build Insight docs
         run: ./scripts/build_insight_docs.sh
+      - name: Verify service worker
+        run: python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- verify the site service worker hash during docs deployment

## Checks
- `pre-commit` *(fails: requirements.lock out of date)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685db9571ef08333902f08b6d3763898