### PR TITLE
Add docs deployment quickstart

### DIFF
--- a/docs/DEPLOYMENT_QUICKSTART.md
+++ b/docs/DEPLOYMENT_QUICKSTART.md
@@ -1,0 +1,47 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Deployment Quickstart
+
+This guide summarizes how to publish the **α‑AGI Insight** demo using GitHub Pages.
+
+## Prerequisites
+
+- **Python ≥3.11** with `mkdocs` installed
+- **Node.js ≥20**
+
+Verify Node:
+
+```bash
+node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+```
+
+## Build and Publish
+
+1. Fetch the browser assets:
+   ```bash
+   npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
+   ```
+2. Build the PWA and deploy to GitHub Pages:
+   ```bash
+   ./scripts/publish_insight_pages.sh
+   ```
+
+The script compiles the PWA, runs `mkdocs gh-deploy` and pushes the `site/` directory to `gh-pages`.
+Visit:
+
+```
+https://<org>.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/
+```
+
+after the workflow finishes.
+
+## Troubleshooting
+
+- Check your Node version if the build fails:
+  ```bash
+  node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+  ```
+- Confirm the service worker includes the correct Workbox hash after publishing:
+  ```bash
+  python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+  ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 [α‑AGI Insight Demo](alpha_agi_insight_v1/index.html)
 
+[Deployment Quickstart](DEPLOYMENT_QUICKSTART.md)
+
 ## Building the React Dashboard
 
 The React dashboard sources live under `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client`. Build the static assets before serving the API:


### PR DESCRIPTION
## Summary
- document quick steps to publish Alpha AGI docs via GitHub Pages
- link the new guide from docs/README.md

## Testing
- `pre-commit run --files docs/README.md docs/DEPLOYMENT_QUICKSTART.md` *(fails: KeyboardInterrupt cloning semgrep)*

------
https://chatgpt.com/codex/tasks/task_e_685de4e771dc8333811070faf456e9ab