### PR TITLE
[alpha_factory] Add workbox hash verification

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -83,6 +83,12 @@ if [[ ! -f "$DOCS_DIR/$ICON_FILE" && -f "$BROWSER_DIR/$ICON_FILE" ]]; then
     cp -a "$BROWSER_DIR/$ICON_FILE" "$DOCS_DIR/"
 fi
 
+# Validate the bundled workbox file before generating docs
+if ! python scripts/verify_workbox_hash.py "$DOCS_DIR"; then
+    echo "ERROR: Workbox hash verification failed" >&2
+    exit 1
+fi
+
 # Build the MkDocs site
 mkdocs build
 


### PR DESCRIPTION
## Summary
- validate service worker hash during docs build to prevent corrupted deployments

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files scripts/build_insight_docs.sh` *(fails: proto-verify / verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685de79d59b48333b3650d7aec0c8952