### PR TITLE
[alpha_factory] add offline docs check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,13 @@ jobs:
         run: pip install mkdocs mkdocs-material
       - name: Build Insight docs
         run: ./scripts/build_insight_docs.sh
+      - name: Verify Insight offline
+        run: |
+          python -m http.server --directory site 8000 &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID' EXIT
+          sleep 2
+          python scripts/verify_insight_offline.py
       - name: Verify service worker
         run: python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
       - name: Deploy


### PR DESCRIPTION
## Summary
- verify Insight PWA offline in docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError and others)*
- `pre-commit run --files .github/workflows/docs.yml` *(fails: requirements.lock outdated)*

------
https://chatgpt.com/codex/tasks/task_e_685e05a176c08333a5956721b8d2ccef