### PR TITLE
[alpha_factory] update disclaimer links

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.html)
 
 # α-AGI Insight v1
 

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -95,7 +95,7 @@
       <small>For illustration purposes only; data is synthetic and for demonstration of concept.</small>
     </p>
       <section class="snippet">
-        <a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a>
+        <a href="../DISCLAIMER_SNIPPET.html">See docs/DISCLAIMER_SNIPPET.md</a>
         This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
       </section>
       <p>


### PR DESCRIPTION
## Summary
- update README and demo footer links to point to `../DISCLAIMER_SNIPPET.html`

## Testing
- `python scripts/check_python_deps.py --help`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `scripts/build_insight_docs.sh` *(fails: could not fetch wasm asset)*
- `python scripts/verify_workbox_hash.py docs/alpha_agi_insight_v1`

------
https://chatgpt.com/codex/tasks/task_e_685e0c79f00483338898352f15437d27