### PR TITLE
[alpha_factory] add browser quickstart link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@
 
 [Deployment Quickstart](DEPLOYMENT_QUICKSTART.md)
 
+- [Browser Quickstart](insight_browser_quickstart.pdf) – run `./scripts/publish_insight_pages.sh` for a one-command deployment
+
 ## Building the React Dashboard
 
 The React dashboard sources live under `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client`. Build the static assets before serving the API:


### PR DESCRIPTION
## Summary
- link insight_browser_quickstart.pdf in docs README
- mention one-command deployment script

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `./scripts/build_insight_docs.sh` *(fails: unable to fetch wasm_llm/wasm-gpt2.tar)*

------
https://chatgpt.com/codex/tasks/task_e_685e147630e48333956ea68ba0f33762