### PR TITLE
[alpha_factory] refine docs and offline test

### DIFF
--- a/docs/INSIGHT_SPRINT_PLAN.md
+++ b/docs/INSIGHT_SPRINT_PLAN.md
@@ -1,4 +1,5 @@
 # Insight Demo GitHub Pages Sprint
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
 
 This document outlines the minimal tasks required to publish the **α‑AGI Insight v1** demo to GitHub Pages so that users can experience the full browser-based simulation, including the animated meta‑agentic tree search.
 
@@ -40,3 +41,8 @@ These steps keep the demo production-ready and easily reproducible for non‑tec
 - Load the GitHub Pages URL in a private browsing window to verify caching and service worker installation.
 - Search the page source for strings like `OPENAI_API_KEY` to ensure no secrets leaked.
 - Run `python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1` after each build.
+
+## 7. Confirm Meta-Agentic Animation
+- After deployment, open the live site and watch the **Meta-Agentic Tree Search Progress** panel.
+- Nodes should appear sequentially and the best path should highlight in red.
+- If no nodes appear within a few seconds, rebuild the site and ensure `tree.json` is valid.

--- a/scripts/verify_insight_offline.py
+++ b/scripts/verify_insight_offline.py
@@ -24,6 +24,7 @@ def main() -> int:
             context.set_offline(True)
             page.reload()
             page.wait_for_selector("body")
+            page.wait_for_selector("#tree-container .node", timeout=15000)
             browser.close()
         return 0
     except PlaywrightError as exc:


### PR DESCRIPTION
## Summary
- refine GitHub Pages sprint plan with disclaimer and animation checks
- ensure offline verification waits for tree search nodes

## Testing
- `pre-commit` *(failed: proto-verify hook)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: multiple import errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e9624c7788333a059db16b2b48c8d