### PR TITLE
[alpha_factory] refresh insight tree during docs build

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -59,7 +59,9 @@ unzip -o insight_browser.zip -d ../../../docs/alpha_agi_insight_v1
 ```
 
 Generate `tree.json` from the latest run so the visualization reflects the
-current meta-agent state:
+current meta-agent state. `scripts/build_insight_docs.sh` automatically
+refreshes this file when `lineage/run.jsonl` is present, so the command below is
+only needed when running it manually:
 
 ```bash
 python alpha_factory_v1/demos/alpha_agi_insight_v1/tools/export_tree.py \

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -83,6 +83,16 @@ if [[ ! -f "$DOCS_DIR/$ICON_FILE" && -f "$BROWSER_DIR/$ICON_FILE" ]]; then
     cp -a "$BROWSER_DIR/$ICON_FILE" "$DOCS_DIR/"
 fi
 
+# Export the latest meta-agent tree when lineage data is available
+TREE_INPUT="lineage/run.jsonl"
+TREE_OUTPUT="$DOCS_DIR/tree.json"
+if [[ -f "$TREE_INPUT" ]]; then
+    python alpha_factory_v1/demos/alpha_agi_insight_v1/tools/export_tree.py \
+        "$TREE_INPUT" -o "$TREE_OUTPUT"
+else
+    echo "WARNING: $TREE_INPUT not found; skipping tree export" >&2
+fi
+
 # Validate the bundled workbox file before generating docs
 if ! python scripts/verify_workbox_hash.py "$DOCS_DIR"; then
     echo "ERROR: Workbox hash verification failed" >&2


### PR DESCRIPTION
## Summary
- export lineage tree when building Insight docs
- mention automatic tree refresh in hosting instructions

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages: yaml)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files scripts/build_insight_docs.sh docs/HOSTING_INSTRUCTIONS.md`

------
https://chatgpt.com/codex/tasks/task_e_685e98ae369c8333b7e630ace90715e5