### PR TITLE
chore: verify Workbox hash after mkdocs build

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -102,5 +102,11 @@ fi
 # Build the MkDocs site
 mkdocs build
 
+# Verify the Workbox hash again in the generated site directory
+if ! python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1; then
+    echo "ERROR: Workbox hash verification failed for generated site" >&2
+    exit 1
+fi
+
 
 


### PR DESCRIPTION
## Summary
- ensure service worker integrity check covers generated site

## Testing
- `IPFS_GATEWAY=https://w3s.link/ipfs ./scripts/build_insight_docs.sh` *(failed: could not fetch wasm-gpt2.tar)*

------
https://chatgpt.com/codex/tasks/task_e_685eb64ca1e0833380a253fb319fb107