### PR TITLE
docs: add full deployment helper

### DIFF
--- a/docs/CODEX_INSIGHT_PAGES_SPRINT.md
+++ b/docs/CODEX_INSIGHT_PAGES_SPRINT.md
@@ -50,10 +50,12 @@ Navigate to <http://localhost:8000/alpha_agi_insight_v1/> and confirm:
 
 ## 3. Deploy to GitHub Pages
 
-Use the deployment helper to publish the docs:
+Use the deployment helper to publish the docs. The new `deploy_insight_full.sh`
+script performs additional environment checks and runs a quick offline test
+before pushing to GitHub Pages:
 
 ```bash
-./scripts/deploy_insight_demo.sh
+./scripts/deploy_insight_full.sh
 ```
 
 The script rebuilds the site and pushes `site/` to the `gh-pages` branch via `mkdocs gh-deploy`. It prints the final URL upon completion, typically:

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -12,6 +12,10 @@ Node dependencies and then invokes `publish_insight_pages.sh`. The latter runs
 `build_insight_docs.sh` to refresh the MkDocs site and pushes the result to the
 `gh-pages` branch. When the script completes it prints the GitHub Pages URL.
 
+For an end‑to‑end build **with verification** use `deploy_insight_full.sh`. This
+wrapper script runs the environment preflight checks, builds the PWA, verifies
+offline functionality and then publishes the docs in one step.
+
 1. Fetch the assets:
    `npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets`
 2. Run the build script with `./scripts/publish_insight_pages.sh` (or execute

--- a/docs/INSIGHT_ACCESS_SPRINT.md
+++ b/docs/INSIGHT_ACCESS_SPRINT.md
@@ -48,10 +48,11 @@ Open <http://localhost:8000/alpha_agi_insight_v1/> and confirm:
 
 ## 3. Deploy to GitHub Pages
 
-To publish the site, run:
+To publish the site, run the helper below. It performs preflight checks,
+builds the PWA, verifies offline access and deploys everything in one step:
 
 ```bash
-./scripts/deploy_insight_demo.sh
+./scripts/deploy_insight_full.sh
 ```
 
 The script builds the docs and pushes them to the `gh-pages` branch via `mkdocs gh-deploy`. When it finishes, it prints the final URL, typically:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 [Deployment Quickstart](DEPLOYMENT_QUICKSTART.md)
 
-- [Browser Quickstart](insight_browser_quickstart.pdf) – run `./scripts/publish_insight_pages.sh` for a one-command deployment
+- [Browser Quickstart](insight_browser_quickstart.pdf) – run `./scripts/deploy_insight_full.sh` for a verified one-command deployment
 - [GH Pages Sprint](CODEX_INSIGHT_PAGES_SPRINT.md) – step‑by‑step tasks for Codex to publish the demo
 
 ## Building the React Dashboard

--- a/scripts/deploy_insight_full.sh
+++ b/scripts/deploy_insight_full.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script performs environment checks, builds the Insight demo,
+# verifies offline functionality and deploys the site to GitHub Pages.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+
+# Comprehensive preflight checks
+python alpha_factory_v1/scripts/preflight.py
+# Ensure required Node version
+node "$BROWSER_DIR/build/version_check.js"
+
+npm --prefix "$BROWSER_DIR" run fetch-assets
+npm --prefix "$BROWSER_DIR" ci
+
+"$SCRIPT_DIR/build_insight_docs.sh"
+
+# Verify the generated site integrity
+python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+
+# Optional offline smoke test if Playwright is available
+if python - "import importlib,sys;sys.exit(0 if importlib.util.find_spec('playwright') else 1)"; then
+  python -m http.server --directory site 8000 &
+  SERVER_PID=$!
+  trap 'kill $SERVER_PID' EXIT
+  sleep 2
+  python scripts/verify_insight_offline.py
+  kill $SERVER_PID
+  trap - EXIT
+else
+  echo "Playwright not found; skipping offline check" >&2
+fi
+
+# Deploy using mkdocs
+mkdocs gh-deploy --force
+
+remote=$(git config --get remote.origin.url)
+repo_path=${remote#*github.com[:/]}
+repo_path=${repo_path%.git}
+org="${repo_path%%/*}"
+repo="${repo_path##*/}"
+url="https://${org}.github.io/${repo}/alpha_agi_insight_v1/"
+
+echo "Insight demo deployed to $url"


### PR DESCRIPTION
## Summary
- add `deploy_insight_full.sh` for one-step verified deployment
- update docs to reference the new helper script

## Testing
- `pre-commit run --files docs/CODEX_INSIGHT_PAGES_SPRINT.md docs/HOSTING_INSTRUCTIONS.md docs/INSIGHT_ACCESS_SPRINT.md docs/README.md scripts/deploy_insight_full.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ebfa3f248833385424689dab586bb