### PR TITLE
[alpha_factory] add insight sprint wrapper

### DIFF
--- a/scripts/insight_sprint.sh
+++ b/scripts/insight_sprint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This wrapper orchestrates the full α-AGI Insight deployment sprint.
+# It performs environment checks, builds the demo, verifies offline
+# functionality and publishes the site to GitHub Pages.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+"$SCRIPT_DIR/deploy_insight_full.sh"


### PR DESCRIPTION
## Summary
- add `scripts/insight_sprint.sh` helper

## Testing
- `pre-commit run --files scripts/insight_sprint.sh` *(fails: proto-verify, verify-requirements-lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685edc99acac83339940a71b150b1e1d