### PR TITLE
[alpha_factory] highlight one-command deployment script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 
 - [Browser Quickstart](insight_browser_quickstart.pdf) – run `./scripts/deploy_insight_full.sh` for a verified one-command deployment
 - [GH Pages Sprint](CODEX_INSIGHT_PAGES_SPRINT.md) – step‑by‑step tasks for Codex to publish the demo
+- **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 
 ## Building the React Dashboard
 


### PR DESCRIPTION
## Summary
- document `insight_sprint.sh` in the docs README for easier GH Pages deployments

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install`
- `pre-commit run --files docs/README.md` *(fails: missing proto files, requirement lock checks)*
- `pytest -q` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_685eebd1ac7083339f81f909427069d7