### PR TITLE
[alpha_factory] docs: demo previews

### DIFF
--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -5,5 +5,7 @@
 Agents *evolve* new agents; genetic tests auto‑score fitness.
 
 ![screenshot](../aiga_meta_evolution/bridge_overview.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/aiga_meta_evolution/README.md)

--- a/docs/demos/alpha_agi_business_2_v1.md
+++ b/docs/demos/alpha_agi_business_2_v1.md
@@ -5,5 +5,7 @@
 Iterates business model with live market data RAG.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md)

--- a/docs/demos/alpha_agi_business_3_v1.md
+++ b/docs/demos/alpha_agi_business_3_v1.md
@@ -5,5 +5,7 @@
 Financial forecasting & fundraising agent swarm.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md)

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -5,5 +5,7 @@
 Auto‑incorporates a digital‑first company end‑to‑end.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_v1/README.md)

--- a/docs/demos/alpha_agi_insight_v0.md
+++ b/docs/demos/alpha_agi_insight_v0.md
@@ -5,5 +5,7 @@
 Zero‑data search ranking AGI‑disrupted sectors.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_insight_v0/README.md)

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -5,5 +5,7 @@
 Beyond Human Foresight insight demo with web UI.
 
 ![screenshot](../alpha_agi_insight_v1/favicon.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_insight_v1/README.md)

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -5,5 +5,7 @@
 Peer‑to‑peer agent marketplace simulating price discovery.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md)

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -5,5 +5,7 @@
 Scales MuZero‑style world‑model to an open‑ended grid‑world.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/alpha_asi_world_model/README.md)

--- a/docs/demos/cross_industry_alpha_factory.md
+++ b/docs/demos/cross_industry_alpha_factory.md
@@ -5,5 +5,7 @@
 Full pipeline: ingest → plan → act across 4 verticals.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/cross_industry_alpha_factory/README.md)

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -5,5 +5,7 @@
 Streams of life events build autobiographical memory‑graph tutor.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/era_of_experience/README.md)

--- a/docs/demos/finance_alpha.md
+++ b/docs/demos/finance_alpha.md
@@ -5,5 +5,7 @@
 Live momentum + risk‑parity bot on Binance test‑net.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/finance_alpha/README.md)

--- a/docs/demos/macro_sentinel.md
+++ b/docs/demos/macro_sentinel.md
@@ -5,5 +5,7 @@
 GPT‑RAG news scanner auto‑hedges with CTA futures.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/macro_sentinel/README.md)

--- a/docs/demos/meta_agentic_agi.md
+++ b/docs/demos/meta_agentic_agi.md
@@ -5,5 +5,7 @@
 Production-grade meta-agentic AGI stack demo.
 
 ![screenshot](../meta_agentic_agi/assets/logo.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi/README.md)

--- a/docs/demos/meta_agentic_agi_v2.md
+++ b/docs/demos/meta_agentic_agi_v2.md
@@ -5,5 +5,7 @@
 Adds a physics-based free-energy metric to meta-agentic AGI search.
 
 ![screenshot](../meta_agentic_agi_v2/assets/logo.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi_v2/README.md)

--- a/docs/demos/meta_agentic_agi_v3.md
+++ b/docs/demos/meta_agentic_agi_v3.md
@@ -5,5 +5,7 @@
 AZR-powered meta-agentic AGI demo version 3.
 
 ![screenshot](../meta_agentic_agi_v3/assets/logo.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi_v3/README.md)

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -5,5 +5,7 @@
 Recursive agent rewrites via best‑first search.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md)

--- a/docs/demos/muzero_planning.md
+++ b/docs/demos/muzero_planning.md
@@ -5,5 +5,7 @@
 MuZero in 60 s; online world‑model with MCTS.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/muzero_planning/README.md)

--- a/docs/demos/muzeromctsllmagent_v0.md
+++ b/docs/demos/muzeromctsllmagent_v0.md
@@ -5,5 +5,7 @@
 MuZero MCTS LLM agent example.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md)

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -5,5 +5,7 @@
 Open-ended multi-agent simulation for smart city resilience.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/omni_factory_demo/README.md)

--- a/docs/demos/self_healing_repo.md
+++ b/docs/demos/self_healing_repo.md
@@ -5,5 +5,7 @@
 CI fails → agent crafts patch ⇒ PR green again.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/self_healing_repo/README.md)

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -5,5 +5,7 @@
 Demonstrates an α-AGI governance framework.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/solving_agi_governance/README.md)

--- a/docs/demos/sovereign_agentic_agialpha_agent_v0.md
+++ b/docs/demos/sovereign_agentic_agialpha_agent_v0.md
@@ -5,5 +5,7 @@
 Sovereign agentic AGI Alpha Agent showcase.
 
 ![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
+![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
+
 
 [View README](../../alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md)

--- a/docs/stylesheets/cards.css
+++ b/docs/stylesheets/cards.css
@@ -1,0 +1,29 @@
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+.demo-card {
+  flex: 1 1 280px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  padding: 1rem;
+  background-color: var(--md-default-bg-color);
+}
+.demo-card img,
+.demo-card video {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+@media (max-width: 600px) {
+  .demo-card {
+    flex-basis: 100%;
+  }
+}
+.demo-preview {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,10 @@ repo_url: https://github.com/MontrealAI/AGI-Alpha-Agent-v0
 docs_dir: docs
 theme:
   name: material
+extra_css:
+  - stylesheets/cards.css
+markdown_extensions:
+  - attr_list
 nav:
 - Home: index.html
 - Documentation Overview: README.md


### PR DESCRIPTION
## Summary
- add responsive card/grid CSS
- embed preview gifs on demo pages
- include the stylesheet via MkDocs config

## Testing
- `python check_env.py --auto-install` *(fails: Missing core packages)*
- `pytest -q` *(fails: network install aborted)*
- `pre-commit run --files mkdocs.yml docs/demos/aiga_meta_evolution.md` *(failed: KeyboardInterrupt)*
- `mkdocs build`
- `curl -I http://localhost:8000`

------
https://chatgpt.com/codex/tasks/task_e_685f043932c08333851a497b48fa0992