### PR TITLE
[alpha_factory] add demo gallery pages sprint

### DIFF
--- a/docs/CODEX_DEMO_PAGES_SPRINT.md
+++ b/docs/CODEX_DEMO_PAGES_SPRINT.md
@@ -1,0 +1,49 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Demo Gallery – GitHub Pages Sprint for Codex
+
+This short guide outlines how Codex can publish the full Alpha‑Factory demo gallery as a static site hosted on GitHub Pages. The steps build the α‑AGI Insight interface, include all Markdown documentation and ensure non‑technical users can explore the demos visually.
+
+## 1. Environment Setup
+
+1. Install **Python 3.11+** and **Node.js 20+**.
+2. Install `mkdocs` and `mkdocs-material` via `pip`:
+   ```bash
+   pip install mkdocs mkdocs-material
+   ```
+3. Verify Node version:
+   ```bash
+   node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+   ```
+4. Install optional Python packages:
+   ```bash
+   python scripts/check_python_deps.py
+   python check_env.py --auto-install
+   ```
+
+## 2. Build and Deploy the Gallery
+
+Run the helper from the repository root:
+
+```bash
+./scripts/gallery_sprint.sh
+```
+
+The script checks the environment, compiles the Insight browser bundle, refreshes `docs/alpha_agi_insight_v1`, builds the MkDocs site and publishes it to the `gh-pages` branch.
+
+Preview locally:
+
+```bash
+python -m http.server --directory site 8000
+```
+
+Browse to <http://localhost:8000/> and verify the index page links to the Insight demo and the full demo gallery.
+
+## 3. Verification Checklist
+
+- ✅ `docs/alpha_agi_insight_v1/` contains `index.html`, `manifest.json` and `lib/workbox-sw.js`.
+- ✅ `scripts/verify_workbox_hash.py site/alpha_agi_insight_v1` passes.
+- ✅ Landing page links to the Demo Gallery.
+- ✅ The GitHub Pages site loads without errors in an incognito window.
+
+Following these steps ensures the entire demo suite is accessible via GitHub Pages with a single command.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 
 - [Browser Quickstart](insight_browser_quickstart.pdf) – run `./scripts/deploy_insight_full.sh` for a verified one-command deployment
 - [GH Pages Sprint](CODEX_INSIGHT_PAGES_SPRINT.md) – step‑by‑step tasks for Codex to publish the demo
+- [Demo Gallery Sprint](CODEX_DEMO_PAGES_SPRINT.md) – publish the entire gallery to GitHub Pages
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 
 ## Building the React Dashboard

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
   <p>The Alpha-Factory project showcases experimental AGI research tools and demos.</p>
   <p>
     <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>
+    <a class="btn docs" href="DEMO_GALLERY/">Demo Gallery</a>
     <a class="btn docs" href="README/">View Documentation</a>
   </p>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
 - Policy Runbook: POLICY_RUNBOOK.md
 - dgm_ops: dgm_ops.md
 - Changelog: CHANGELOG.md
+- Demo Gallery Sprint: CODEX_DEMO_PAGES_SPRINT.md
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html
 - Demo Gallery:

--- a/scripts/gallery_sprint.sh
+++ b/scripts/gallery_sprint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This wrapper builds the demo gallery and publishes it to GitHub Pages.
+# It is a conceptual research prototype.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+
+# Environment checks
+python alpha_factory_v1/scripts/preflight.py
+node "$BROWSER_DIR/build/version_check.js"
+
+npm --prefix "$BROWSER_DIR" run fetch-assets
+npm --prefix "$BROWSER_DIR" ci
+
+"$SCRIPT_DIR/build_insight_docs.sh"
+
+# Build and verify the site
+mkdocs build
+python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+
+# Deploy using mkdocs
+mkdocs gh-deploy --force
+
+remote=$(git config --get remote.origin.url)
+repo_path=${remote#*github.com[:/]}
+repo_path=${repo_path%.git}
+org="${repo_path%%/*}"
+repo="${repo_path##*/}"
+url="https://${org}.github.io/${repo}/"
+
+echo "Demo gallery deployed to $url"


### PR DESCRIPTION
## Summary
- add CODEX_DEMO_PAGES_SPRINT guide
- link new sprint from README and mkdocs nav
- link demo gallery from landing page
- script to deploy demo gallery

## Testing
- `python scripts/check_python_deps.py` *(shows missing packages)*
- `ALPHA_FACTORY_FULL=0 python check_env.py --auto-install --skip-net-check`
- `pytest -q` *(fails: 44 errors)
- `pre-commit run --files docs/README.md docs/index.html mkdocs.yml docs/CODEX_DEMO_PAGES_SPRINT.md scripts/gallery_sprint.sh` *(fails: proto-verify and requirements lock)*

------
https://chatgpt.com/codex/tasks/task_e_685f0676e7a48333a308c72d53e1d588