### PR TITLE
[alpha_factory] Add visual demo gallery page

### DIFF
--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -1,0 +1,72 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Alpha‑Factory Demo Gallery</title>
+  <link rel="stylesheet" href="stylesheets/cards.css">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background:#f7f7f7; }
+    h1 { text-align: center; margin-bottom: 1rem; }
+    p.subtitle { text-align: center; margin-bottom:2rem; }
+    a.demo-card { text-decoration:none; color:inherit; }
+    .demo-card h3 { margin-top:0.5rem; text-align:center; }
+  </style>
+</head>
+<body>
+  <h1>Alpha‑Factory Demo Gallery</h1>
+  <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
+  <div class="demo-grid">
+    <a class="demo-card" href="demos/alpha_agi_business_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha AGI Business V1">
+      <h3>Alpha AGI Business V1</h3>
+    </a>
+    <a class="demo-card" href="demos/alpha_agi_business_2_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha AGI Business 2 V1">
+      <h3>Alpha AGI Business 2 V1</h3>
+    </a>
+    <a class="demo-card" href="demos/alpha_agi_business_3_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha AGI Business 3 V1">
+      <h3>Alpha AGI Business 3 V1</h3>
+    </a>
+    <a class="demo-card" href="demos/alpha_agi_marketplace_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Marketplace V1">
+      <h3>Alpha AGI Marketplace V1</h3>
+    </a>
+    <a class="demo-card" href="alpha_agi_insight_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Insight V1">
+      <h3>Alpha AGI Insight V1</h3>
+    </a>
+    <a class="demo-card" href="demos/alpha_asi_world_model/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="ASI World Model">
+      <h3>Alpha ASI World Model</h3>
+    </a>
+    <a class="demo-card" href="demos/cross_industry_alpha_factory/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Cross Industry Alpha">
+      <h3>Cross Industry Alpha</h3>
+    </a>
+    <a class="demo-card" href="demos/era_of_experience/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Era of Experience">
+      <h3>Era of Experience</h3>
+    </a>
+    <a class="demo-card" href="demos/finance_alpha/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Finance Alpha">
+      <h3>Finance Alpha</h3>
+    </a>
+    <a class="demo-card" href="demos/macro_sentinel/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Macro Sentinel">
+      <h3>Macro Sentinel</h3>
+    </a>
+    <a class="demo-card" href="demos/muzero_planning/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="MuZero Planning">
+      <h3>MuZero Planning</h3>
+    </a>
+    <a class="demo-card" href="demos/self_healing_repo/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Self Healing Repo">
+      <h3>Self Healing Repo</h3>
+    </a>
+  </div>
+  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,8 @@
   <p>The Alpha-Factory project showcases experimental AGI research tools and demos.</p>
   <p>
     <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>
-    <a class="btn docs" href="DEMO_GALLERY/">Demo Gallery</a>
+    <a class="btn docs" href="gallery.html">Visual Demo Gallery</a>
+    <a class="btn docs" href="DEMO_GALLERY/">Demo Table</a>
     <a class="btn docs" href="README/">View Documentation</a>
   </p>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
 - Demo Gallery Sprint: CODEX_DEMO_PAGES_SPRINT.md
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html
+- Visual Demo Gallery: gallery.html
 - Demo Gallery:
   - Overview: DEMO_GALLERY.md
   - Aiga Meta Evolution: demos/aiga_meta_evolution.md


### PR DESCRIPTION
## Summary
- add a simple HTML gallery to showcase demos visually
- link to the gallery from the landing page
- expose the page through `mkdocs.yml`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files docs/index.html docs/gallery.html mkdocs.yml` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_685f104ac85c8333acb84de8f901965b