### PR TITLE
docs: add demo access sprint

### DIFF
--- a/docs/DEMO_ACCESS_SPRINT.md
+++ b/docs/DEMO_ACCESS_SPRINT.md
@@ -1,0 +1,67 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Demo Access Sprint for Codex
+
+This short sprint distills how Codex can publish the **Alpha‑Factory v1** demo suite to GitHub Pages so every showcase is accessible from a single, beautiful subdirectory. The process mirrors the existing demo gallery script while emphasising verification and a smooth real‑time experience.
+
+## 1. Verify the Environment
+
+1. Install **Python 3.11+** and **Node.js 20+**.
+2. Run the preflight check:
+   ```bash
+   python alpha_factory_v1/scripts/preflight.py
+   ```
+3. Confirm the Node version:
+   ```bash
+   node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+   ```
+4. Install optional dependencies:
+   ```bash
+   python scripts/check_python_deps.py
+   python check_env.py --auto-install
+   ```
+
+## 2. Build the Insight Demo
+
+The Insight browser bundle powers many visualisations. Refresh it with:
+```bash
+./scripts/build_insight_docs.sh
+```
+This regenerates `docs/alpha_agi_insight_v1/` and verifies the service worker hash. The directory contains everything needed for offline access and the animated Meta‑Agentic Tree Search.
+
+## 3. Generate the Demo Gallery
+
+Run the gallery helper:
+```bash
+./scripts/gallery_sprint.sh
+```
+It compiles the docs, copies preview assets for every demo and builds the MkDocs site under `site/`.
+
+## 4. Preview Locally
+
+Start a simple HTTP server:
+```bash
+python -m http.server --directory site 8000
+```
+Open <http://localhost:8000/> and navigate through the gallery. Ensure each page loads its screenshots or GIFs and that `alpha_agi_insight_v1/` animates the tree search in real time.
+
+## 5. Deploy to GitHub Pages
+
+Publish the site:
+```bash
+mkdocs gh-deploy --force
+```
+Upon completion, GitHub Pages serves the gallery at:
+```
+https://<org>.github.io/AGI-Alpha-Agent-v0/
+```
+The root `index.html` already redirects to `alpha_agi_insight_v1/`, while `gallery.html` links to every demo README.
+
+## 6. Verify the Live Site
+
+1. Load the URL in an incognito window.
+2. Check that `alpha_agi_insight_v1/` works offline after the first visit (disable network and reload).
+3. Confirm each demo page includes preview media and instructions to run locally.
+4. Search the page source for secrets to ensure none leaked.
+
+Following this sprint yields a polished, user‑friendly GitHub Pages deployment showcasing all demos in a single subdirectory.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
 - dgm_ops: dgm_ops.md
 - Changelog: CHANGELOG.md
 - Demo Gallery Sprint: CODEX_DEMO_PAGES_SPRINT.md
+- Demo Access Sprint: DEMO_ACCESS_SPRINT.md
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html
 - Visual Demo Gallery: gallery.html


### PR DESCRIPTION
## Summary
- outline steps for Codex to publish the demo gallery to GitHub Pages
- link new doc from mkdocs navigation

## Testing
- `pre-commit run --files docs/DEMO_ACCESS_SPRINT.md mkdocs.yml`

------
https://chatgpt.com/codex/tasks/task_e_685f1409ef1c8333ba2b5e8365b7afb8