### PR TITLE
[alpha_factory] Edge demo pages sprint

### DIFF
--- a/docs/EDGE_DEMO_PAGES_SPRINT.md
+++ b/docs/EDGE_DEMO_PAGES_SPRINT.md
@@ -1,0 +1,49 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Edge Demo Pages Sprint for Codex
+
+This short guide details how Codex can expose every Alpha‑Factory demo via GitHub Pages. The goal is a beautiful subdirectory that plays each showcase in real time and remains trivial for non‑technical users to publish.
+
+## 1. Prepare the Environment
+
+1. Install **Python 3.11+** and **Node.js 20+**.
+2. Run the preflight script:
+   ```bash
+   python alpha_factory_v1/scripts/preflight.py
+   ```
+3. Verify Node version:
+   ```bash
+   node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+   ```
+4. Install optional packages:
+   ```bash
+   python scripts/check_python_deps.py
+   python check_env.py --auto-install
+   ```
+
+## 2. Build and Verify
+
+Execute the new helper from the repository root:
+
+```bash
+./scripts/deploy_gallery_pages.sh
+```
+
+The script fetches browser assets, compiles the Insight demo, regenerates documentation and runs integrity checks. If Playwright is available, it opens a local server and verifies the PWA works offline.
+
+## 3. Deploy
+
+Upon successful validation the helper publishes the MkDocs site to the `gh-pages` branch using `mkdocs gh-deploy`. The final URL typically resembles:
+
+```
+https://<org>.github.io/AGI-Alpha-Agent-v0/
+```
+
+The root `index.html` redirects to `alpha_agi_insight_v1/` while `gallery.html` links to every README so users can watch each demo unfold organically and elegantly.
+
+## 4. Ongoing Maintenance
+
+- Re‑run `./scripts/deploy_gallery_pages.sh` whenever demo assets or docs change.
+- Test the site locally with `mkdocs build --strict` before deploying.
+- Ensure `pre-commit` passes so the page builds reproducibly.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
 - Changelog: CHANGELOG.md
 - Demo Gallery Sprint: CODEX_DEMO_PAGES_SPRINT.md
 - Demo Access Sprint: DEMO_ACCESS_SPRINT.md
+- Edge Demo Pages Sprint: EDGE_DEMO_PAGES_SPRINT.md
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html
 - Visual Demo Gallery: gallery.html

--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Orchestrate the full demo gallery deployment sprint.
+# This wrapper ensures the Insight demo assets build correctly, the
+# MkDocs site passes integrity checks and the final result deploys to
+# GitHub Pages. Designed for Codex automation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+
+# Comprehensive environment checks
+python alpha_factory_v1/scripts/preflight.py
+node "$BROWSER_DIR/build/version_check.js"
+
+# Build the Insight docs and gallery
+npm --prefix "$BROWSER_DIR" run fetch-assets
+npm --prefix "$BROWSER_DIR" ci
+"$SCRIPT_DIR/build_insight_docs.sh"
+
+# Compile and verify the MkDocs site
+mkdocs build
+python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+
+# Optional offline smoke test
+if python - "import importlib,sys;sys.exit(0 if importlib.util.find_spec('playwright') else 1)"; then
+  python -m http.server --directory site 8000 &
+  SERVER_PID=$!
+  trap 'kill $SERVER_PID' EXIT
+  sleep 2
+  python scripts/verify_insight_offline.py
+  kill $SERVER_PID
+  trap - EXIT
+else
+  echo "Playwright not found; skipping offline check" >&2
+fi
+
+# Deploy to GitHub Pages
+mkdocs gh-deploy --force
+


### PR DESCRIPTION
## Summary
- add script `deploy_gallery_pages.sh`
- document Edge Demo Pages sprint
- register doc in mkdocs navigation

## Testing
- `pre-commit run --files mkdocs.yml docs/EDGE_DEMO_PAGES_SPRINT.md scripts/deploy_gallery_pages.sh` *(with hooks skipped)*
- `pytest -q` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685f1949df6c8333b9ae5f41368d0ac1