### PR TITLE
[alpha_factory] Add GitHub Pages demo tasks

### DIFF
--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -1,0 +1,51 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# GitHub Pages Demo Tasks Sprint
+
+This short sprint guides Codex through publishing the entire **Alpha‑Factory v1** demo gallery to GitHub Pages. The goal is a polished subdirectory that showcases every demo in real time and remains effortless for non‑technical users to deploy.
+
+## 1. Environment Checks
+1. Install **Python 3.11+** and **Node.js 20+**.
+2. Run the preflight script:
+   ```bash
+   python alpha_factory_v1/scripts/preflight.py
+   ```
+3. Confirm the Node version:
+   ```bash
+   node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+   ```
+4. Install optional packages so the verification tools work:
+   ```bash
+   python scripts/check_python_deps.py
+   python check_env.py --auto-install
+   ```
+
+## 2. Build the Demo Gallery
+Execute the helper from the repository root:
+```bash
+./scripts/deploy_gallery_pages.sh
+```
+This command fetches browser assets, compiles the α‑AGI Insight interface, runs integrity checks and builds the MkDocs site under `site/`. If Playwright is installed the script also verifies offline functionality.
+
+## 3. Preview Locally
+Start a quick HTTP server to examine the result:
+```bash
+python -m http.server --directory site 8000
+```
+Open <http://localhost:8000/> in a browser. Ensure the landing page redirects to `alpha_agi_insight_v1/` and that `gallery.html` links to each demo README with preview images or GIFs.
+
+## 4. Deploy to GitHub Pages
+When satisfied, publish the site:
+```bash
+mkdocs gh-deploy --force
+```
+Alternatively rerun `./scripts/deploy_gallery_pages.sh` which performs the same step automatically. The final URL typically resembles:
+```
+https://<org>.github.io/AGI-Alpha-Agent-v0/
+```
+Verify the service worker caches assets for offline use and that the page includes the project disclaimer.
+
+## 5. Maintenance Tips
+- Re‑run the helper whenever demo docs or assets change.
+- Test with `mkdocs build --strict` before deploying.
+- Keep `pre-commit` hooks green so the gallery builds reproducibly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
 - Changelog: CHANGELOG.md
 - Demo Gallery Sprint: CODEX_DEMO_PAGES_SPRINT.md
 - Demo Access Sprint: DEMO_ACCESS_SPRINT.md
+- GitHub Pages Demo Tasks: GITHUB_PAGES_DEMO_TASKS.md
 - Edge Demo Pages Sprint: EDGE_DEMO_PAGES_SPRINT.md
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html


### PR DESCRIPTION
## Summary
- document how to publish demos to GitHub Pages via `deploy_gallery_pages.sh`
- add navigation entry in `mkdocs.yml`

## Testing
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install`
- `pre-commit run --files mkdocs.yml docs/GITHUB_PAGES_DEMO_TASKS.md` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685f223b1b508333aca826c800f4f184