### PR TITLE
[alpha_factory] Add advanced demo pages sprint

### DIFF
--- a/docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
+++ b/docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
@@ -1,0 +1,58 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Advanced Demo Pages Sprint for Codex
+
+This sprint outlines a robust sequence to publish the **Alpha‑Factory** demo gallery on GitHub Pages. It builds upon the existing automation scripts so each showcase unfolds organically and remains trivial to deploy by non‑technical users.
+
+## 1. Environment Validation
+1. Install **Python 3.11+** and **Node.js 20+**.
+2. Run the preflight check:
+   ```bash
+   python alpha_factory_v1/scripts/preflight.py
+   ```
+3. Confirm Node version:
+   ```bash
+   node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+   ```
+4. Install optional packages so verification tools work:
+   ```bash
+   python scripts/check_python_deps.py
+   python check_env.py --auto-install
+   ```
+
+## 2. Build the Insight Demo
+Execute the bundled helper:
+```bash
+./scripts/build_insight_docs.sh
+```
+This compiles the Insight PWA, exports `tree.json` when logs are present and verifies the service worker hash.
+
+## 3. Generate the Demo Gallery
+From the repository root:
+```bash
+./scripts/deploy_gallery_pages.sh
+```
+The script fetches assets, refreshes documentation and builds the MkDocs site under `site/`.
+
+## 4. Preview Locally
+Serve the site to verify every page:
+```bash
+python -m http.server --directory site 8000
+```
+Navigate to <http://localhost:8000/> and ensure each demo README loads with its preview media. The **Meta‑Agentic Tree Search** animation should play smoothly.
+
+## 5. Publish to GitHub Pages
+Deploy the site when satisfied:
+```bash
+mkdocs gh-deploy --force
+```
+The gallery becomes available at:
+```
+https://<org>.github.io/AGI-Alpha-Agent-v0/
+```
+Confirm the landing page redirects to `alpha_agi_insight_v1/` and that offline access works after the first visit.
+
+## 6. Maintenance
+- Rerun `./scripts/deploy_gallery_pages.sh` whenever demo docs or assets change.
+- Test with `mkdocs build --strict` before deploying.
+- Keep `pre-commit` hooks green so the gallery builds reproducibly.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 - [Browser Quickstart](insight_browser_quickstart.pdf) – run `./scripts/deploy_insight_full.sh` for a verified one-command deployment
 - [GH Pages Sprint](CODEX_INSIGHT_PAGES_SPRINT.md) – step‑by‑step tasks for Codex to publish the demo
 - [Demo Gallery Sprint](CODEX_DEMO_PAGES_SPRINT.md) – publish the entire gallery to GitHub Pages
+- [Advanced Demo Pages Sprint](CODEX_ADVANCED_DEMO_PAGES_SPRINT.md) – end‑to‑end tasks for the full demo gallery
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 
 ## Building the React Dashboard


### PR DESCRIPTION
## Summary
- document a new advanced sprint for publishing GitHub Pages
- link from the docs README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `pre-commit run --files docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md docs/README.md`

------
https://chatgpt.com/codex/tasks/task_e_685f266fb0708333bd73a806fa8b9a62