### PR TITLE
[alpha_factory] Add Edge-of-Knowledge demo sprint doc

### DIFF
--- a/docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
+++ b/docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
@@ -1,0 +1,51 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Edge‑of‑Knowledge Demo Gallery Sprint for Codex
+
+This sprint distils how Codex can publish the entire **Alpha‑Factory v1** demo suite to GitHub Pages so that every showcase unfolds in real time and remains effortless for non‑technical users to explore.
+
+## 1. Environment Validation
+1. Install **Python 3.11+** and **Node.js 20+**.
+2. Run the preflight script:
+   ```bash
+   python alpha_factory_v1/scripts/preflight.py
+   ```
+3. Verify the Node version:
+   ```bash
+   node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+   ```
+4. Install optional Python packages so the verification tools succeed:
+   ```bash
+   python scripts/check_python_deps.py
+   python check_env.py --auto-install
+   ```
+
+## 2. Build and Verify the Gallery
+Execute the helper from the repository root:
+```bash
+./scripts/deploy_gallery_pages.sh
+```
+This command fetches browser assets, compiles the Insight demo, refreshes all documentation, runs integrity checks and, when Playwright is available, validates offline functionality.
+
+## 3. Preview Locally
+Serve the site to ensure each page loads smoothly:
+```bash
+python -m http.server --directory site 8000
+```
+Browse to <http://localhost:8000/> and click through `gallery.html`. Confirm that every demo README displays its preview media and that `alpha_agi_insight_v1/` animates the meta‑agent tree search progressively.
+
+## 4. Deploy to GitHub Pages
+Publish the gallery when satisfied:
+```bash
+mkdocs gh-deploy --force
+```
+The site becomes accessible at:
+```
+https://<org>.github.io/AGI-Alpha-Agent-v0/
+```
+The landing page redirects to `alpha_agi_insight_v1/` while the **Visual Demo Gallery** links to each README so users can watch every demo unfold organically.
+
+## 5. Maintenance Tips
+- Re‑run `./scripts/deploy_gallery_pages.sh` whenever demo docs or assets change.
+- Capture short GIFs or screenshots under `docs/<demo>/assets/` to keep the gallery highly visual.
+- Test with `mkdocs build --strict` before deploying and ensure `pre-commit` hooks pass.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [GH Pages Sprint](CODEX_INSIGHT_PAGES_SPRINT.md) – step‑by‑step tasks for Codex to publish the demo
 - [Demo Gallery Sprint](CODEX_DEMO_PAGES_SPRINT.md) – publish the entire gallery to GitHub Pages
 - [Advanced Demo Pages Sprint](CODEX_ADVANCED_DEMO_PAGES_SPRINT.md) – end‑to‑end tasks for the full demo gallery
+- [Edge‑of‑Knowledge Demo Sprint](EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md) – host every advanced demo via GitHub Pages
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 
 ## Building the React Dashboard


### PR DESCRIPTION
## Summary
- document how to publish all demos to GitHub Pages
- link new sprint from docs README

## Testing
- `pre-commit run --files docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md docs/README.md` *(with hooks skipped)*
- `pytest -q` *(fails: ModuleNotFoundError for alpha_agi_insight_v1 components)*

------
https://chatgpt.com/codex/tasks/task_e_685f2b31c7b08333b59b337e2e13f776