### PR TITLE
docs: link Edge-of-Knowledge sprint

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
 - Demo Access Sprint: DEMO_ACCESS_SPRINT.md
 - GitHub Pages Demo Tasks: GITHUB_PAGES_DEMO_TASKS.md
 - Edge Demo Pages Sprint: EDGE_DEMO_PAGES_SPRINT.md
+- Edge-of-Knowledge Demo Sprint: EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html
 - Visual Demo Gallery: gallery.html


### PR DESCRIPTION
## Summary
- add Edge-of-Knowledge demo sprint to MkDocs navigation

## Checks
- `python check_env.py --auto-install`
- `pre-commit run --files mkdocs.yml` *(fails: verify-requirements-lock)*
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685f3291e858833391c858694dfc6b98