### PR TITLE
[alpha_factory] docs: outline edge-of-knowledge sprint

### DIFF
--- a/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -4,21 +4,26 @@
 
 This sprint condenses the steps required for Codex to expose every advanced demo under `alpha_factory_v1/demos/` on GitHub Pages. The goal is a polished subdirectory where each showcase unfolds in real time with smooth, highly visual interactions.
 
+Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for a one-command deployment.
+
 ## 1. Validate the Environment
 1. Install **Python 3.11+** and **Node.js 20+**.
 2. Run the preflight script:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
-   ```
 3. Verify the Node version:
    ```bash
    node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
-   ```
 4. Install optional packages so verification tools succeed:
    ```bash
    python scripts/check_python_deps.py
    python check_env.py --auto-install
-   ```
+```
+
+5. Validate the demo packages:
+```bash
+python -m alpha_factory_v1.demos.validate_demos
+```
 
 ## 2. Build the Insight Demo
 Execute the helper to compile the progressive web app and confirm the service worker hash:

--- a/scripts/edge_of_knowledge_sprint.sh
+++ b/scripts/edge_of_knowledge_sprint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Orchestrate the Edge-of-Knowledge demo gallery deployment.
+# This conceptual research script validates the environment,
+# verifies demo packages, builds the site and publishes it to GitHub Pages.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Ensure Python, Node and optional packages are present
+python alpha_factory_v1/scripts/preflight.py
+node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+python scripts/check_python_deps.py
+python check_env.py --auto-install
+
+# Validate demo directories for basic quality
+python -m alpha_factory_v1.demos.validate_demos
+
+# Build and deploy the full gallery
+"$SCRIPT_DIR/deploy_gallery_pages.sh"


### PR DESCRIPTION
## Summary
- add `edge_of_knowledge_sprint.sh` helper
- document one-command sprint in `AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent')*

------
https://chatgpt.com/codex/tasks/task_e_685f49dfd870833385fab6eae3f6f92c