### PR TITLE
docs: refine edge sprint

### DIFF
--- a/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -18,12 +18,16 @@ Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for a one-c
    ```bash
    python scripts/check_python_deps.py
    python check_env.py --auto-install
-```
+   ```
+5. Verify every README includes the standard disclaimer:
+   ```bash
+   python scripts/verify_disclaimer_snippet.py
+   ```
 
-5. Validate the demo packages:
-```bash
-python -m alpha_factory_v1.demos.validate_demos
-```
+6. Validate the demo packages:
+   ```bash
+   python -m alpha_factory_v1.demos.validate_demos
+   ```
 
 ## 2. Build the Insight Demo
 Execute the helper to compile the progressive web app and confirm the service worker hash:
@@ -45,6 +49,12 @@ Serve the result to ensure animations load smoothly:
 python -m http.server --directory site 8000
 ```
 Browse to <http://localhost:8000/> and step through `gallery.html`. Confirm that every README displays preview media so viewers can follow along in real time.
+
+Verify offline support:
+```bash
+python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+python scripts/verify_insight_offline.py
+```
 
 ## 5. Deploy to GitHub Pages
 Publish the gallery once satisfied:


### PR DESCRIPTION
## Summary
- verify disclaimers and triple-check offline support in edge sprint script
- document new verification steps in the edge-of-knowledge tasks sprint

## Testing
- `pre-commit run --files scripts/edge_of_knowledge_sprint.sh docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md` *(fails: proto-verify hook)*
- `pytest -q` *(fails: KeyboardInterrupt due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685f4f740cdc8333a06e0b0f75f54107