### PR TITLE
docs: refine edge-of-human-knowledge sprint

### DIFF
--- a/docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -6,6 +6,8 @@ This sprint describes how Codex can publish the **Alpha-Factory v1** demo galler
 
 Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for an automated workflow.
 
+The steps below triple-verify environment integrity, rebuild all assets and deploy a consistently beautiful gallery. Revisit them whenever the demos or documentation change.
+
 ## 1. Validate the Environment
 1. Install **Python 3.11+** and **Node.js 20+**.
 2. Execute the preflight script:
@@ -72,3 +74,5 @@ The landing page redirects to `alpha_agi_insight_v1/` while `gallery.html` links
 - Re-run the helper whenever demo docs or assets change.
 - Capture short GIFs or screenshots under `docs/<demo>/assets/` for a highly visual experience.
 - Test with `mkdocs build --strict` before deploying and ensure `pre-commit` hooks pass.
+- Run `pre-commit run --files <changed_files>` and `pytest -m 'not e2e'` to confirm formatting and basic tests before publishing.
+- Periodically verify every README still embeds the [disclaimer snippet](../docs/DISCLAIMER_SNIPPET.md).


### PR DESCRIPTION
## Summary
- clarify environment checks and deployment steps in the Edge-of-Human-Knowledge sprint guide
- document running pre-commit and pytest before publishing

## Testing
- `pre-commit run --files docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md`
- `pytest -m 'not e2e'` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f5ac5f3288333abc30489e02b9e3b