### PR TITLE
docs: add edge-of-human-knowledge pages sprint

### DIFF
--- a/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
+++ b/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
@@ -1,0 +1,22 @@
+[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+
+# Edge-of-Human-Knowledge Pages Sprint for Codex
+
+This sprint explains how Codex can publish the **Alpha-Factory** demo gallery to GitHub Pages so each showcase plays back organically with a single command. The wrapper script `scripts/edge_human_knowledge_pages_sprint.sh` calls the full deployment workflow and prints the final URL.
+
+## Quick Start
+1. Install **Python 3.11+** and **Node.js 20+**.
+2. Run the wrapper:
+   ```bash
+   ./scripts/edge_human_knowledge_pages_sprint.sh
+   ```
+   This triggers `edge_of_knowledge_sprint.sh` which performs environment validation, dependency checks, README disclaimer verification, asset builds, integrity tests and finally deploys the site via `mkdocs gh-deploy`.
+3. Visit the printed URL in an incognito window and ensure `gallery.html` links to every demo with preview media.
+
+## Maintenance
+- Re-run the wrapper whenever demo docs or assets change.
+- Validate formatting and basic tests before publishing:
+  ```bash
+  pre-commit run --files <changed_files>
+  pytest -m 'not e2e'
+  ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
 - Edge-of-Knowledge Demo Sprint: EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
 - Edge-of-Knowledge Demo Tasks Sprint: AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
 - Edge-of-Human-Knowledge Demo Tasks Sprint: AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+- Edge-of-Human-Knowledge Pages Sprint: EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html
 - Visual Demo Gallery: gallery.html

--- a/scripts/edge_human_knowledge_pages_sprint.sh
+++ b/scripts/edge_human_knowledge_pages_sprint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Thin wrapper orchestrating the Edge-of-Human-Knowledge Pages Sprint.
+# Executes edge_of_knowledge_sprint.sh to build and deploy the demo gallery.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/edge_of_knowledge_sprint.sh" "$@"


### PR DESCRIPTION
## Summary
- document an Edge-of-Human-Knowledge Pages Sprint
- wrap the existing gallery deployment script
- link the new guide from `mkdocs.yml`

## Testing
- `pre-commit` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685f6970c2788333859caea8db089ada