### PR TITLE
[alpha_factory] add demo docs generator

### DIFF
--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Aiga Meta Evolution
+# 🌌 Algorithms That Invent Algorithms — <br>**AI‑GA Meta‑Evolution Demo**
 
-Agents *evolve* new agents; genetic tests auto‑score fitness.
-
-![screenshot](../aiga_meta_evolution/bridge_overview.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/aiga_meta_evolution/README.md)

--- a/docs/demos/alpha_agi_business_2_v1.md
+++ b/docs/demos/alpha_agi_business_2_v1.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Alpha Agi Business 2 V1
+# Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**
 
-Iterates business model with live market data RAG.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md)

--- a/docs/demos/alpha_agi_business_3_v1.md
+++ b/docs/demos/alpha_agi_business_3_v1.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Alpha Agi Business 3 V1
+# 🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**
 
-Financial forecasting & fundraising agent swarm.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md)

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -2,10 +2,6 @@
 
 # Alpha Agi Business V1
 
-Auto‑incorporates a digital‑first company end‑to‑end.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_v1/README.md)

--- a/docs/demos/alpha_agi_insight_v0.md
+++ b/docs/demos/alpha_agi_insight_v0.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Alpha Agi Insight V0
+# α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)
 
-Zero‑data search ranking AGI‑disrupted sectors.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_insight_v0/README.md)

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Alpha Agi Insight V1
+# α‑AGI Insight v1 — Beyond Human Foresight
 
-Beyond Human Foresight insight demo with web UI.
-
-![screenshot](../alpha_agi_insight_v1/favicon.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_insight_v1/README.md)

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -2,10 +2,6 @@
 
 # Alpha Agi Marketplace V1
 
-Peer‑to‑peer agent marketplace simulating price discovery.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md)

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -2,10 +2,6 @@
 
 # Alpha Asi World Model
 
-Scales MuZero‑style world‑model to an open‑ended grid‑world.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/alpha_asi_world_model/README.md)

--- a/docs/demos/cross_industry_alpha_factory.md
+++ b/docs/demos/cross_industry_alpha_factory.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Cross Industry Alpha Factory
+# 👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo
 
-Full pipeline: ingest → plan → act across 4 verticals.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/cross_industry_alpha_factory/README.md)

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -2,10 +2,6 @@
 
 # Era Of Experience
 
-Streams of life events build autobiographical memory‑graph tutor.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/era_of_experience/README.md)

--- a/docs/demos/finance_alpha.md
+++ b/docs/demos/finance_alpha.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Finance Alpha
+# Alpha‑Factory Demos 📊
 
-Live momentum + risk‑parity bot on Binance test‑net.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/finance_alpha/README.md)

--- a/docs/demos/macro_sentinel.md
+++ b/docs/demos/macro_sentinel.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Macro Sentinel
+# 🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨
 
-GPT‑RAG news scanner auto‑hedges with CTA futures.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/macro_sentinel/README.md)

--- a/docs/demos/meta_agentic_agi.md
+++ b/docs/demos/meta_agentic_agi.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Meta Agentic Agi
+# Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**
 
-Production-grade meta-agentic AGI stack demo.
-
-![screenshot](../meta_agentic_agi/assets/logo.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi/README.md)

--- a/docs/demos/meta_agentic_agi_v2.md
+++ b/docs/demos/meta_agentic_agi_v2.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Meta Agentic Agi V2
+# Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**
 
-Adds a physics-based free-energy metric to meta-agentic AGI search.
-
-![screenshot](../meta_agentic_agi_v2/assets/logo.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi_v2/README.md)

--- a/docs/demos/meta_agentic_agi_v3.md
+++ b/docs/demos/meta_agentic_agi_v3.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Meta Agentic Agi V3
+# **Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**
 
-AZR-powered meta-agentic AGI demo version 3.
-
-![screenshot](../meta_agentic_agi_v3/assets/logo.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi_v3/README.md)

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Meta Agentic Tree Search V0
+# Meta‑Agentic Tree Search (MATS) Demo — v0
 
-Recursive agent rewrites via best‑first search.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md)

--- a/docs/demos/muzero_planning.md
+++ b/docs/demos/muzero_planning.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Muzero Planning
+# 🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time
 
-MuZero in 60 s; online world‑model with MCTS.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/muzero_planning/README.md)

--- a/docs/demos/muzeromctsllmagent_v0.md
+++ b/docs/demos/muzeromctsllmagent_v0.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Muzeromctsllmagent V0
+# MuZero MCTS LLM Agent Demo
 
-MuZero MCTS LLM agent example.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md)

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Omni Factory Demo
+# OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)
 
-Open-ended multi-agent simulation for smart city resilience.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/omni_factory_demo/README.md)

--- a/docs/demos/self_healing_repo.md
+++ b/docs/demos/self_healing_repo.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Self Healing Repo
+# 🔧 **Self‑Healing Repo** — when CI fails, agents patch
 
-CI fails → agent crafts patch ⇒ PR green again.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/self_healing_repo/README.md)

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Solving Agi Governance
+# Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]
 
-Demonstrates an α-AGI governance framework.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/solving_agi_governance/README.md)

--- a/docs/demos/sovereign_agentic_agialpha_agent_v0.md
+++ b/docs/demos/sovereign_agentic_agialpha_agent_v0.md
@@ -1,11 +1,7 @@
 [See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
-# Sovereign Agentic Agialpha Agent V0
+# Sovereign Agentic AGI Alpha Agent Demo
 
-Sovereign agentic AGI Alpha Agent showcase.
-
-![screenshot](https://colab.research.google.com/assets/colab-badge.svg)
-![preview](https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif){.demo-preview}
-
+![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
 
 [View README](../../alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md)

--- a/scripts/generate_demo_docs.py
+++ b/scripts/generate_demo_docs.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Generate documentation pages for each demo in docs/demos.
+
+This utility scans the ``alpha_factory_v1/demos`` directory for subpackages
+containing ``README.md`` files and creates matching Markdown pages under
+``docs/demos``. Each generated page embeds the project disclaimer,
+links back to the original README and optionally displays a preview
+image found under ``docs/<demo>/assets/preview.*``.
+
+Run this script whenever a new demo is added or READMEs change so the
+GitHub Pages gallery stays up to date.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMOS_DIR = REPO_ROOT / "alpha_factory_v1" / "demos"
+DOCS_DIR = REPO_ROOT / "docs" / "demos"
+DEFAULT_PREVIEW = "../alpha_agi_insight_v1/favicon.svg"
+DISCLAIMER_LINK = "[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)"
+
+TITLE_RE = re.compile(r"^#(?!#)\s*(.+)")
+
+
+def extract_title(readme: Path) -> str:
+    """Return a reasonable title for the given README."""
+    lines = readme.read_text(encoding="utf-8").splitlines()
+    # Search the first 50 lines for a level-one heading
+    for line in lines[:50]:
+        m = TITLE_RE.match(line.strip())
+        if m:
+            return m.group(1).strip()
+    # Fallback to folder name if no heading found early in the file
+    return readme.parent.name.replace("_", " ").title()
+
+
+def build_page(demo: Path) -> str:
+    """Return Markdown text for the given demo subdirectory."""
+    title = extract_title(demo / "README.md")
+    assets_dir = REPO_ROOT / "docs" / demo.name / "assets"
+    preview = None
+    if assets_dir.is_dir():
+        for ext in ("gif", "png", "jpg", "jpeg", "svg"):
+            candidate = assets_dir / f"preview.{ext}"
+            if candidate.exists():
+                preview = f"../{demo.name}/assets/{candidate.name}"
+                break
+    if not preview:
+        preview = DEFAULT_PREVIEW
+
+    return "\n".join(
+        [
+            DISCLAIMER_LINK,
+            "",
+            f"# {title}",
+            "",
+            f"![preview]({preview}){{.demo-preview}}",
+            "",
+            f"[View README](../../alpha_factory_v1/demos/{demo.name}/README.md)",
+            "",
+        ]
+    )
+
+
+def generate_docs() -> None:
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    for entry in sorted(DEMOS_DIR.iterdir()):
+        if not entry.is_dir() or entry.name.startswith(("__", ".")):
+            continue
+        readme = entry / "README.md"
+        if not readme.is_file():
+            continue
+        page_content = build_page(entry)
+        output = DOCS_DIR / f"{entry.name}.md"
+        output.write_text(page_content, encoding="utf-8")
+        print(f"Generated {output.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    generate_docs()


### PR DESCRIPTION
## Summary
- generate docs from demo READMEs with `generate_demo_docs.py`
- regenerate `docs/demos/*` with consistent layout

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -m 'not e2e'` *(fails: 44 errors during collection)*
- `pre-commit run --files scripts/generate_demo_docs.py docs/demos/alpha_agi_business_v1.md` *(interrupted during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_685fd296058083339a5b903947160b8b