### PR TITLE
feat: auto-generate demo docs

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -113,6 +113,9 @@ copy_assets() {
 }
 copy_assets
 
+# Regenerate Markdown pages for each demo from their README files
+python scripts/generate_demo_docs.py
+
 # Build the MkDocs site
 mkdocs build
 

--- a/scripts/generate_demo_docs.py
+++ b/scripts/generate_demo_docs.py
@@ -51,18 +51,26 @@ def build_page(demo: Path) -> str:
     if not preview:
         preview = DEFAULT_PREVIEW
 
-    return "\n".join(
-        [
-            DISCLAIMER_LINK,
-            "",
-            f"# {title}",
-            "",
-            f"![preview]({preview}){{.demo-preview}}",
-            "",
-            f"[View README](../../alpha_factory_v1/demos/{demo.name}/README.md)",
-            "",
-        ]
-    )
+    readme_path = demo / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+    readme_lines = readme_text.splitlines()
+    if readme_lines and readme_lines[0].startswith("#"):
+        readme_text = "\n".join(readme_lines[1:])
+
+    content = [
+        DISCLAIMER_LINK,
+        "",
+        f"# {title}",
+        "",
+        f"![preview]({preview}){{.demo-preview}}",
+        "",
+        readme_text,
+        "",
+        f"[View README](../../alpha_factory_v1/demos/{demo.name}/README.md)",
+        "",
+    ]
+
+    return "\n".join(content)
 
 
 def generate_docs() -> None:


### PR DESCRIPTION
## Summary
- embed demo README contents directly in generated docs
- rebuild docs with regenerated demo pages

## Testing
- `pre-commit run --files scripts/generate_demo_docs.py scripts/build_insight_docs.sh` *(failed: command not found / interrupted)*
- `pytest -q` *(failed to finish due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fdd61d5c08333bf3f9426949b6c48