### PR TITLE
[alpha_factory] feat: auto build gallery

### DIFF
--- a/docs/ADVANCED_GITHUB_PAGES_DEMO_SPRINT.md
+++ b/docs/ADVANCED_GITHUB_PAGES_DEMO_SPRINT.md
@@ -35,7 +35,9 @@ Regenerate the progressive web app and check the service worker hash:
 ```bash
 ./scripts/build_insight_docs.sh
 ```
-This step exports `tree.json` when lineage logs are present so the meta‑agent tree search animates organically.
+This step exports `tree.json` when lineage logs are present,
+regenerates `docs/gallery.html` via `scripts/generate_gallery_html.py` and ensures
+the meta‑agent tree search animates organically.
 
 ## 3. Generate the Demo Gallery
 Compile all documentation and build the MkDocs site:

--- a/docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -46,7 +46,9 @@ Compile the progressive web app and verify the service worker hash:
 ```bash
 ./scripts/build_insight_docs.sh
 ```
-If lineage logs are available, this exports `tree.json` so the **Meta-Agentic Tree Search** animates organically.
+If lineage logs are available this exports `tree.json`, updates
+`docs/gallery.html` via `scripts/generate_gallery_html.py` and ensures the
+**Meta-Agentic Tree Search** animates organically.
 
 ## 3. Generate the Demo Gallery
 From the repository root run:

--- a/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -34,7 +34,9 @@ Execute the helper to compile the progressive web app and confirm the service wo
 ```bash
 ./scripts/build_insight_docs.sh
 ```
-When lineage logs are present this exports `tree.json` so the **Meta‑Agentic Tree Search** plays back organically.
+When lineage logs are present this exports `tree.json`, refreshes
+`docs/gallery.html` via `scripts/generate_gallery_html.py` and ensures the
+**Meta‑Agentic Tree Search** plays back organically.
 
 ## 3. Generate the Demo Gallery
 From the repository root:

--- a/docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
+++ b/docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
@@ -25,7 +25,9 @@ Execute the bundled helper:
 ```bash
 ./scripts/build_insight_docs.sh
 ```
-This compiles the Insight PWA, exports `tree.json` when logs are present and verifies the service worker hash.
+This compiles the Insight PWA, exports `tree.json` when logs are present,
+regenerates `docs/gallery.html` via `scripts/generate_gallery_html.py` and
+verifies the service worker hash.
 
 ## 3. Generate the Demo Gallery
 From the repository root:

--- a/docs/CODEX_DEMO_PAGES_SPRINT.md
+++ b/docs/CODEX_DEMO_PAGES_SPRINT.md
@@ -29,7 +29,10 @@ Run the helper from the repository root:
 ./scripts/gallery_sprint.sh
 ```
 
-The script checks the environment, compiles the Insight browser bundle, refreshes `docs/alpha_agi_insight_v1`, builds the MkDocs site and publishes it to the `gh-pages` branch.
+The script checks the environment, compiles the Insight browser bundle, refreshes
+`docs/alpha_agi_insight_v1` and builds the MkDocs site. It also calls
+`scripts/generate_gallery_html.py` so `docs/gallery.html` always lists the latest
+demos before publishing to the `gh-pages` branch.
 
 Preview locally:
 

--- a/docs/CODEX_SUPER_DEMO_PAGES_SPRINT.md
+++ b/docs/CODEX_SUPER_DEMO_PAGES_SPRINT.md
@@ -30,8 +30,9 @@ The Insight browser bundle powers the animated tree search. Refresh it with:
 ```bash
 ./scripts/build_insight_docs.sh
 ```
-This step exports `tree.json` when lineage logs exist and verifies the service
-worker hash for offline support.
+This step exports `tree.json` when lineage logs exist, regenerates
+`docs/gallery.html` via `scripts/generate_gallery_html.py` and verifies the
+service worker hash for offline support.
 
 ## 3. Generate the Demo Gallery
 

--- a/docs/DEMO_ACCESS_SPRINT.md
+++ b/docs/DEMO_ACCESS_SPRINT.md
@@ -27,7 +27,10 @@ The Insight browser bundle powers many visualisations. Refresh it with:
 ```bash
 ./scripts/build_insight_docs.sh
 ```
-This regenerates `docs/alpha_agi_insight_v1/` and verifies the service worker hash. The directory contains everything needed for offline access and the animated Meta‑Agentic Tree Search.
+This regenerates `docs/alpha_agi_insight_v1/`, refreshes `docs/gallery.html` via
+`scripts/generate_gallery_html.py` and verifies the service worker hash. The
+directory contains everything needed for offline access and the animated
+Meta‑Agentic Tree Search.
 
 ## 3. Generate the Demo Gallery
 

--- a/docs/EDGE_DEMO_PAGES_SPRINT.md
+++ b/docs/EDGE_DEMO_PAGES_SPRINT.md
@@ -30,6 +30,8 @@ Execute the new helper from the repository root:
 ```
 
 The script fetches browser assets, compiles the Insight demo, regenerates documentation and runs integrity checks. If Playwright is available, it opens a local server and verifies the PWA works offline.
+`scripts/generate_gallery_html.py` runs as part of the helper so `docs/gallery.html`
+always lists the current demos.
 
 ## 3. Deploy
 

--- a/docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
+++ b/docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
@@ -26,6 +26,8 @@ Execute the helper from the repository root:
 ./scripts/deploy_gallery_pages.sh
 ```
 This command fetches browser assets, compiles the Insight demo, refreshes all documentation, runs integrity checks and, when Playwright is available, validates offline functionality.
+The helper also invokes `scripts/generate_gallery_html.py` so `docs/gallery.html`
+tracks new demos automatically.
 
 ## 3. Preview Locally
 Serve the site to ensure each page loads smoothly:

--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -25,7 +25,10 @@ Execute the helper from the repository root:
 ```bash
 ./scripts/deploy_gallery_pages.sh
 ```
-This command fetches browser assets, compiles the α‑AGI Insight interface, runs integrity checks and builds the MkDocs site under `site/`. If Playwright is installed the script also verifies offline functionality.
+This command fetches browser assets, compiles the α‑AGI Insight interface, runs
+integrity checks and builds the MkDocs site under `site/`. It also runs
+`scripts/generate_gallery_html.py` to refresh `docs/gallery.html`. If Playwright
+is installed the script also verifies offline functionality.
 
 ## 3. Preview Locally
 Start a quick HTTP server to examine the result:

--- a/docs/USER_FRIENDLY_DEMO_PAGES_SPRINT.md
+++ b/docs/USER_FRIENDLY_DEMO_PAGES_SPRINT.md
@@ -25,7 +25,9 @@ Execute the bundled helper to compile the progressive web app and verify its ser
 ```bash
 ./scripts/build_insight_docs.sh
 ```
-This step exports `tree.json` when lineage logs exist and ensures offline support works as expected.
+This step exports `tree.json` when lineage logs exist, rebuilds
+`docs/gallery.html` via `scripts/generate_gallery_html.py` and ensures offline
+support works as expected.
 
 ## 3. Generate the Demo Gallery
 From the repository root, build the complete gallery and documentation:

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -115,6 +115,7 @@ copy_assets
 
 # Regenerate Markdown pages for each demo from their README files
 python scripts/generate_demo_docs.py
+python scripts/generate_gallery_html.py
 
 # Build the MkDocs site
 mkdocs build

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+"""Generate ``docs/gallery.html`` from the Markdown pages under ``docs/demos``.
+
+The helper extracts each page's title (first level‑one heading) and preview image
+with the alt text ``preview``. It outputs a simple HTML grid linking to the
+corresponding demo page so the gallery stays up to date whenever documentation is
+rebuilt.
+"""
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMOS_DIR = REPO_ROOT / "docs" / "demos"
+GALLERY_FILE = REPO_ROOT / "docs" / "gallery.html"
+
+H1_RE = re.compile(r"^#\s+(.*)")
+PREVIEW_RE = re.compile(r"!\[preview\]\(([^)]+)\)")
+
+
+def parse_page(md_file: Path) -> tuple[str, str, str]:
+    """Return ``(title, preview, link)`` for ``md_file``."""
+    title: str | None = None
+    preview: str | None = None
+    for line in md_file.read_text(encoding="utf-8").splitlines():
+        if title is None:
+            m = H1_RE.match(line.strip())
+            if m:
+                title = m.group(1).strip()
+        if preview is None:
+            m = PREVIEW_RE.search(line)
+            if m:
+                preview = m.group(1).strip()
+        if title and preview:
+            break
+    if not title:
+        title = md_file.stem.replace("_", " ").title()
+    if preview:
+        preview = preview.lstrip("./").lstrip("../")
+    else:
+        preview = "alpha_agi_insight_v1/favicon.svg"
+    link = f"demos/{md_file.stem}/"
+    return title, preview, link
+
+
+def collect_entries() -> list[tuple[str, str, str]]:
+    entries: list[tuple[str, str, str]] = []
+    for page in sorted(DEMOS_DIR.glob("*.md")):
+        entries.append(parse_page(page))
+    return entries
+
+
+def build_html(entries: list[tuple[str, str, str]]) -> str:
+    head = """<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"UTF-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>Alpha‑Factory Demo Gallery</title>
+  <link rel=\"stylesheet\" href=\"stylesheets/cards.css\">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background: #f7f7f7; }
+    h1 { text-align: center; margin-bottom: 1rem; }
+    p.subtitle { text-align: center; margin-bottom: 2rem; }
+    a.demo-card { text-decoration: none; color: inherit; }
+    .demo-card h3 { margin-top: 0.5rem; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Alpha‑Factory Demo Gallery</h1>
+  <p class=\"subtitle\">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
+  <div class=\"demo-grid\">"""
+    lines = [head]
+    for title, preview, link in entries:
+        lines.append(f'    <a class="demo-card" href="{html.escape(link)}">')
+        lines.append(f'      <img src="{html.escape(preview)}" alt="{html.escape(title)}">')
+        lines.append(f"      <h3>{html.escape(title)}</h3>")
+        lines.append("    </a>")
+    lines.append("  </div>")
+    lines.append('  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>')
+    lines.append("</body>\n</html>\n")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    html_text = build_html(collect_entries())
+    GALLERY_FILE.write_text(html_text, encoding="utf-8")
+    print(f"Wrote {GALLERY_FILE.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate `docs/gallery.html` from Markdown files
- refresh gallery when building Insight docs
- reference `generate_gallery_html.py` in build instructions

## Testing
- `pre-commit run --files scripts/generate_gallery_html.py scripts/build_insight_docs.sh docs/DEMO_ACCESS_SPRINT.md docs/CODEX_DEMO_PAGES_SPRINT.md docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md docs/CODEX_SUPER_DEMO_PAGES_SPRINT.md docs/ADVANCED_GITHUB_PAGES_DEMO_SPRINT.md docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md docs/EDGE_DEMO_PAGES_SPRINT.md docs/GITHUB_PAGES_DEMO_TASKS.md docs/USER_FRIENDLY_DEMO_PAGES_SPRINT.md docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md` *(fails: requirements lock and proto verification)*
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fe696de608333a3d380dffe5221c5