### PR TITLE
[alpha_factory] add headless capture helper

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -148,3 +148,16 @@ python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 ```
 
 This step catches missing or corrupted assets after deployment.
+
+## Capturing Demo Previews
+
+Use `scripts/capture_demo_preview.py` to generate short recordings for the
+documentation. The helper launches a demo inside a virtual display and captures
+the screen with `ffmpeg`.
+
+```bash
+python scripts/capture_demo_preview.py path/to/demo.sh -o demo.mp4
+```
+
+Supply a `.gif` output name to automatically convert the clip after recording.
+`--duration` and `--size` adjust the recording length and virtual display size.

--- a/scripts/capture_demo_preview.py
+++ b/scripts/capture_demo_preview.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+"""Record a short preview video of a demo using pyvirtualdisplay and ffmpeg."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import time
+from pathlib import Path
+
+from pyvirtualdisplay import Display
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Capture demo preview")
+    parser.add_argument(
+        "demo",
+        help="Path to the demo shell script or command to execute",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="Output file (.mp4 or .gif)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=15,
+        help="Duration to record in seconds (default: 15)",
+    )
+    parser.add_argument(
+        "--size",
+        default="1280x720",
+        help="Virtual display size WxH (default: 1280x720)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    width, height = (int(x) for x in args.size.split("x", maxsplit=1))
+    output = Path(args.output)
+
+    temp_mp4 = output if output.suffix != ".gif" else output.with_suffix(".mp4")
+
+    with Display(visible=False, size=(width, height)) as disp:
+        display_var = f":{disp.display}"
+        ffmpeg_cmd = [
+            "ffmpeg",
+            "-y",
+            "-video_size",
+            args.size,
+            "-f",
+            "x11grab",
+            "-i",
+            display_var,
+            "-codec:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(temp_mp4),
+        ]
+        # Start ffmpeg first so it captures the entire run
+        ffmpeg_proc = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        demo_proc = subprocess.Popen(args.demo, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        try:
+            time.sleep(args.duration)
+        finally:
+            demo_proc.terminate()
+            ffmpeg_proc.terminate()
+            demo_proc.wait()
+            ffmpeg_proc.wait()
+
+    if output.suffix == ".gif":
+        subprocess.run(["ffmpeg", "-y", "-i", str(temp_mp4), str(output)], check=True)
+        temp_mp4.unlink(missing_ok=True)
+
+    print(f"Saved preview to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `capture_demo_preview.py` to record a demo run with `pyvirtualdisplay` and `ffmpeg`
- document preview recording in `HOSTING_INSTRUCTIONS.md`

## Testing
- `pre-commit run --files scripts/capture_demo_preview.py docs/HOSTING_INSTRUCTIONS.md` *(skipped heavy hooks)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685ff02157f88333a0dd62c241d63728