### PR TITLE
feat: add video support to gallery

### DIFF
--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -7,104 +7,104 @@
   <title>Alpha‑Factory Demo Gallery</title>
   <link rel="stylesheet" href="stylesheets/cards.css">
   <style>
-    body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background:#f7f7f7; }
+    body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background: #f7f7f7; }
     h1 { text-align: center; margin-bottom: 1rem; }
-    p.subtitle { text-align: center; margin-bottom:2rem; }
-    a.demo-card { text-decoration:none; color:inherit; }
-    .demo-card h3 { margin-top:0.5rem; text-align:center; }
+    p.subtitle { text-align: center; margin-bottom: 2rem; }
+    a.demo-card { text-decoration: none; color: inherit; }
+    .demo-card h3 { margin-top: 0.5rem; text-align: center; }
   </style>
 </head>
 <body>
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <div class="demo-grid">
-    <a class="demo-card" href="demos/alpha_agi_business_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha AGI Business V1">
-      <h3>Alpha AGI Business V1</h3>
+    <a class="demo-card" href="demos/aiga_meta_evolution/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
+      <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_business_2_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha AGI Business 2 V1">
-      <h3>Alpha AGI Business 2 V1</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**">
+      <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_business_3_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha AGI Business 3 V1">
-      <h3>Alpha AGI Business 3 V1</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**">
+      <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_marketplace_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Marketplace V1">
-      <h3>Alpha AGI Marketplace V1</h3>
-    </a>
-    <a class="demo-card" href="alpha_agi_insight_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Insight V1">
-      <h3>Alpha AGI Insight V1</h3>
-    </a>
-    <a class="demo-card" href="demos/alpha_asi_world_model/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="ASI World Model">
-      <h3>Alpha ASI World Model</h3>
-    </a>
-    <a class="demo-card" href="demos/cross_industry_alpha_factory/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Cross Industry Alpha">
-      <h3>Cross Industry Alpha</h3>
-    </a>
-    <a class="demo-card" href="demos/era_of_experience/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Era of Experience">
-      <h3>Era of Experience</h3>
-    </a>
-    <a class="demo-card" href="demos/finance_alpha/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Finance Alpha">
-      <h3>Finance Alpha</h3>
-    </a>
-    <a class="demo-card" href="demos/macro_sentinel/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Macro Sentinel">
-      <h3>Macro Sentinel</h3>
-    </a>
-    <a class="demo-card" href="demos/muzero_planning/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="MuZero Planning">
-      <h3>MuZero Planning</h3>
-    </a>
-    <a class="demo-card" href="demos/self_healing_repo/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Self Healing Repo">
-      <h3>Self Healing Repo</h3>
-    </a>
-    <a class="demo-card" href="demos/aiga_meta_evolution/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Aiga Meta Evolution">
-      <h3>Aiga Meta Evolution</h3>
+    <a class="demo-card" href="demos/alpha_agi_business_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Business V1">
+      <h3>Alpha Agi Business V1</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_insight_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha AGI Insight V0">
-      <h3>Alpha AGI Insight V0</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)">
+      <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
+    </a>
+    <a class="demo-card" href="demos/alpha_agi_insight_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight">
+      <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
+    </a>
+    <a class="demo-card" href="demos/alpha_agi_marketplace_v1/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Marketplace V1">
+      <h3>Alpha Agi Marketplace V1</h3>
+    </a>
+    <a class="demo-card" href="demos/alpha_asi_world_model/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Asi World Model">
+      <h3>Alpha Asi World Model</h3>
+    </a>
+    <a class="demo-card" href="demos/cross_industry_alpha_factory/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo">
+      <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
+    </a>
+    <a class="demo-card" href="demos/era_of_experience/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Era Of Experience">
+      <h3>Era Of Experience</h3>
+    </a>
+    <a class="demo-card" href="demos/finance_alpha/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha‑Factory Demos 📊">
+      <h3>Alpha‑Factory Demos 📊</h3>
+    </a>
+    <a class="demo-card" href="demos/macro_sentinel/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨">
+      <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_agi/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta Agentic AGI">
-      <h3>Meta Agentic AGI</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**">
+      <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_agi_v2/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta Agentic AGI V2">
-      <h3>Meta Agentic AGI V2</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**">
+      <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_agi_v3/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta Agentic AGI V3">
-      <h3>Meta Agentic AGI V3</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**">
+      <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_tree_search_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta Agentic Tree Search V0">
-      <h3>Meta Agentic Tree Search V0</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0">
+      <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
+    </a>
+    <a class="demo-card" href="demos/muzero_planning/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time">
+      <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
     </a>
     <a class="demo-card" href="demos/muzeromctsllmagent_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Muzeromctsllmagent V0">
-      <h3>Muzeromctsllmagent V0</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="MuZero MCTS LLM Agent Demo">
+      <h3>MuZero MCTS LLM Agent Demo</h3>
     </a>
     <a class="demo-card" href="demos/omni_factory_demo/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Omni Factory Demo">
-      <h3>Omni Factory Demo</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)">
+      <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
+    </a>
+    <a class="demo-card" href="demos/self_healing_repo/">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch">
+      <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
     </a>
     <a class="demo-card" href="demos/solving_agi_governance/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Solving AGI Governance">
-      <h3>Solving AGI Governance</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]">
+      <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
     </a>
     <a class="demo-card" href="demos/sovereign_agentic_agialpha_agent_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Sovereign Agentic Agialpha Agent V0">
-      <h3>Sovereign Agentic Agialpha Agent V0</h3>
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Sovereign Agentic AGI Alpha Agent Demo">
+      <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
     </a>
   </div>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>

--- a/docs/stylesheets/cards.css
+++ b/docs/stylesheets/cards.css
@@ -22,7 +22,8 @@
     flex-basis: 100%;
   }
 }
-.demo-preview {
+.demo-preview,
+video.demo-preview {
   width: 100%;
   height: auto;
   border-radius: 8px;

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -78,7 +78,11 @@ def build_html(entries: list[tuple[str, str, str]]) -> str:
     lines = [head]
     for title, preview, link in entries:
         lines.append(f'    <a class="demo-card" href="{html.escape(link)}">')
-        lines.append(f'      <img src="{html.escape(preview)}" alt="{html.escape(title)}">')
+        ext = Path(preview).suffix.lower()
+        if ext in {".mp4", ".webm"}:
+            lines.append(f'      <video src="{html.escape(preview)}" autoplay loop muted playsinline></video>')
+        else:
+            lines.append(f'      <img src="{html.escape(preview)}" alt="{html.escape(title)}">')
         lines.append(f"      <h3>{html.escape(title)}</h3>")
         lines.append("    </a>")
     lines.append("  </div>")


### PR DESCRIPTION
## Summary
- update gallery generator to emit `<video>` tags when `.mp4` or `.webm` previews exist
- style videos in the demo gallery
- regenerate the `docs/gallery.html` page

## Testing
- `pre-commit run --files scripts/generate_gallery_html.py docs/stylesheets/cards.css docs/gallery.html` *(fails: proto-verify and requirements checks)*

------
https://chatgpt.com/codex/tasks/task_e_685ff736bdd88333a18f2f68fe32c8fb