### PR TITLE
docs: add subdirectory index for demo gallery

### DIFF
--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -1,0 +1,20 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Alpha‑Factory Visual Demo Gallery</title>
+  <meta http-equiv="refresh" content="0; url=../gallery.html">
+  <script>window.location.href='../gallery.html';</script>
+  <link rel="stylesheet" href="../stylesheets/cards.css">
+  <style>
+    body { font-family: Arial, sans-serif; text-align: center; margin-top: 4rem; }
+    a { color: #2196f3; }
+  </style>
+</head>
+<body>
+  <p>If you are not redirected automatically, <a href="../gallery.html">open the Visual Demo Gallery</a>.</p>
+  <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>


### PR DESCRIPTION
[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

# Summary
- add `docs/demos/index.html` redirecting to `gallery.html` so demos are reachable from a subdirectory

# Checks
- [ ] I ran `pre-commit run --files docs/demos/index.html`
- [ ] I ran `python check_env.py --auto-install`
- [ ] I ran `pytest -q` and documented any failures below

# Testing
- `pre-commit run --files docs/demos/index.html` *(fails: proto-verify & verify-requirements-lock)*
- `python check_env.py --auto-install` *(interrupted after some installs)*
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685ff9acaaa883338450ae421b8eb2dd