### PR TITLE
Add demo utils README

### DIFF
--- a/alpha_factory_v1/demos/utils/README.md
+++ b/alpha_factory_v1/demos/utils/README.md
@@ -1,0 +1,6 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Demo Utilities
+
+This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.


### PR DESCRIPTION
## Summary
- document helper utilities in `alpha_factory_v1/demos/utils`
- include standard disclaimer

## Testing
- `python -m alpha_factory_v1.demos.validate_demos | head -n 5`
- `python -m py_compile alpha_factory_v1/demos/utils/__init__.py alpha_factory_v1/demos/utils/disclaimer.py`
- `pre-commit run --files alpha_factory_v1/demos/utils/README.md alpha_factory_v1/demos/utils/__init__.py alpha_factory_v1/demos/utils/disclaimer.py` *(fails: Could not download semgrep)*


------
https://chatgpt.com/codex/tasks/task_e_686003d41bec8333b1755d7602f8879f