### PR TITLE
[alpha_factory] support video previews in gallery

### DIFF
--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -18,92 +18,92 @@
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <div class="demo-grid">
-    <a class="demo-card" href="demos/aiga_meta_evolution/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
+    <a class="demo-card" href="demos/aiga_meta_evolution/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_2_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**">
+    <a class="demo-card" href="demos/alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**" loading="lazy">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_3_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**">
+    <a class="demo-card" href="demos/alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**" loading="lazy">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Business V1">
+    <a class="demo-card" href="demos/alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Business V1" loading="lazy">
       <h3>Alpha Agi Business V1</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_insight_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)">
+    <a class="demo-card" href="demos/alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_insight_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight">
+    <a class="demo-card" href="demos/alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_marketplace_v1/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Marketplace V1">
+    <a class="demo-card" href="demos/alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Marketplace V1" loading="lazy">
       <h3>Alpha Agi Marketplace V1</h3>
     </a>
-    <a class="demo-card" href="demos/alpha_asi_world_model/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Asi World Model">
+    <a class="demo-card" href="demos/alpha_asi_world_model/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
     </a>
-    <a class="demo-card" href="demos/cross_industry_alpha_factory/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo">
+    <a class="demo-card" href="demos/cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
     </a>
-    <a class="demo-card" href="demos/era_of_experience/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Era Of Experience">
+    <a class="demo-card" href="demos/era_of_experience/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Era Of Experience" loading="lazy">
       <h3>Era Of Experience</h3>
     </a>
-    <a class="demo-card" href="demos/finance_alpha/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha‑Factory Demos 📊">
+    <a class="demo-card" href="demos/finance_alpha/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha‑Factory Demos 📊" loading="lazy">
       <h3>Alpha‑Factory Demos 📊</h3>
     </a>
-    <a class="demo-card" href="demos/macro_sentinel/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨">
+    <a class="demo-card" href="demos/macro_sentinel/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**">
+    <a class="demo-card" href="demos/meta_agentic_agi/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi_v2/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**">
+    <a class="demo-card" href="demos/meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi_v3/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**">
+    <a class="demo-card" href="demos/meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**" loading="lazy">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_tree_search_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0">
+    <a class="demo-card" href="demos/meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
     </a>
-    <a class="demo-card" href="demos/muzero_planning/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time">
+    <a class="demo-card" href="demos/muzero_planning/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time" loading="lazy">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
     </a>
-    <a class="demo-card" href="demos/muzeromctsllmagent_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="MuZero MCTS LLM Agent Demo">
+    <a class="demo-card" href="demos/muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy">
       <h3>MuZero MCTS LLM Agent Demo</h3>
     </a>
-    <a class="demo-card" href="demos/omni_factory_demo/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)">
+    <a class="demo-card" href="demos/omni_factory_demo/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
     </a>
-    <a class="demo-card" href="demos/self_healing_repo/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch">
+    <a class="demo-card" href="demos/self_healing_repo/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
     </a>
-    <a class="demo-card" href="demos/solving_agi_governance/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]">
+    <a class="demo-card" href="demos/solving_agi_governance/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
     </a>
-    <a class="demo-card" href="demos/sovereign_agentic_agialpha_agent_v0/">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Sovereign Agentic AGI Alpha Agent Demo">
+    <a class="demo-card" href="demos/sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer">
+      <img src="alpha_agi_insight_v1/favicon.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
     </a>
   </div>

--- a/docs/stylesheets/cards.css
+++ b/docs/stylesheets/cards.css
@@ -16,6 +16,7 @@
   width: 100%;
   height: auto;
   border-radius: 4px;
+  display: block;
 }
 @media (max-width: 600px) {
   .demo-card {
@@ -27,4 +28,5 @@ video.demo-preview {
   width: 100%;
   height: auto;
   border-radius: 8px;
+  display: block;
 }

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -41,6 +41,14 @@ def parse_page(md_file: Path) -> tuple[str, str, str]:
         title = md_file.stem.replace("_", " ").title()
     if preview:
         preview = preview.lstrip("./").lstrip("../")
+        # Automatically switch to a corresponding video preview when available
+        candidate = REPO_ROOT / "docs" / preview
+        if candidate.suffix.lower() not in {".mp4", ".webm"}:
+            for ext in (".mp4", ".webm"):
+                alt = candidate.with_suffix(ext)
+                if alt.is_file():
+                    preview = str(Path(preview).with_suffix(ext))
+                    break
     else:
         preview = "alpha_agi_insight_v1/favicon.svg"
     link = f"demos/{md_file.stem}/"


### PR DESCRIPTION
## Summary
- allow generating video tags when mp4/webm previews exist
- ensure videos display like images in the gallery
- rebuild gallery.html

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68600ddb11e88333a5e9ca085a06a72a