### PR TITLE
[alpha_factory] add demo preview assets

### DIFF
--- a/docs/aiga_meta_evolution/assets/preview.svg
+++ b/docs/aiga_meta_evolution/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/alpha_agi_business_2_v1/assets/preview.svg
+++ b/docs/alpha_agi_business_2_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/alpha_agi_business_3_v1/assets/preview.svg
+++ b/docs/alpha_agi_business_3_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/alpha_agi_business_v1/assets/preview.svg
+++ b/docs/alpha_agi_business_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/alpha_agi_insight_v0/assets/preview.svg
+++ b/docs/alpha_agi_insight_v0/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/alpha_agi_marketplace_v1/assets/preview.svg
+++ b/docs/alpha_agi_marketplace_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/alpha_asi_world_model/assets/preview.svg
+++ b/docs/alpha_asi_world_model/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/cross_industry_alpha_factory/assets/preview.svg
+++ b/docs/cross_industry_alpha_factory/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -2,7 +2,7 @@
 
 # 🌌 Algorithms That Invent Algorithms — <br>**AI‑GA Meta‑Evolution Demo**
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../aiga_meta_evolution/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/alpha_agi_business_2_v1.md
+++ b/docs/demos/alpha_agi_business_2_v1.md
@@ -2,7 +2,7 @@
 
 # Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../alpha_agi_business_2_v1/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/alpha_agi_business_3_v1.md
+++ b/docs/demos/alpha_agi_business_3_v1.md
@@ -2,7 +2,7 @@
 
 # 🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../alpha_agi_business_3_v1/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -2,7 +2,7 @@
 
 # Alpha Agi Business V1
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../alpha_agi_business_v1/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/alpha_agi_insight_v0.md
+++ b/docs/demos/alpha_agi_insight_v0.md
@@ -2,7 +2,7 @@
 
 # α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../alpha_agi_insight_v0/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -2,7 +2,7 @@
 
 # α‑AGI Insight v1 — Beyond Human Foresight
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../alpha_agi_insight_v1/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -2,7 +2,7 @@
 
 # Alpha Agi Marketplace V1
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../alpha_agi_marketplace_v1/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -2,7 +2,7 @@
 
 # Alpha Asi World Model
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../alpha_asi_world_model/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/cross_industry_alpha_factory.md
+++ b/docs/demos/cross_industry_alpha_factory.md
@@ -2,7 +2,7 @@
 
 # 👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../cross_industry_alpha_factory/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -2,7 +2,7 @@
 
 # Era Of Experience
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../era_of_experience/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/finance_alpha.md
+++ b/docs/demos/finance_alpha.md
@@ -2,7 +2,7 @@
 
 # Alpha‑Factory Demos 📊
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../finance_alpha/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/macro_sentinel.md
+++ b/docs/demos/macro_sentinel.md
@@ -2,7 +2,7 @@
 
 # 🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../macro_sentinel/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/meta_agentic_agi.md
+++ b/docs/demos/meta_agentic_agi.md
@@ -2,7 +2,7 @@
 
 # Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../meta_agentic_agi/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/meta_agentic_agi_v2.md
+++ b/docs/demos/meta_agentic_agi_v2.md
@@ -2,7 +2,7 @@
 
 # Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../meta_agentic_agi_v2/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/meta_agentic_agi_v3.md
+++ b/docs/demos/meta_agentic_agi_v3.md
@@ -2,7 +2,7 @@
 
 # **Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../meta_agentic_agi_v3/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -2,7 +2,7 @@
 
 # Meta‑Agentic Tree Search (MATS) Demo — v0
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../meta_agentic_tree_search_v0/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/muzero_planning.md
+++ b/docs/demos/muzero_planning.md
@@ -2,7 +2,7 @@
 
 # 🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../muzero_planning/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/muzeromctsllmagent_v0.md
+++ b/docs/demos/muzeromctsllmagent_v0.md
@@ -2,7 +2,7 @@
 
 # MuZero MCTS LLM Agent Demo
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../muzeromctsllmagent_v0/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -2,7 +2,7 @@
 
 # OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../omni_factory_demo/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/self_healing_repo.md
+++ b/docs/demos/self_healing_repo.md
@@ -2,7 +2,7 @@
 
 # 🔧 **Self‑Healing Repo** — when CI fails, agents patch
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../self_healing_repo/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -2,7 +2,7 @@
 
 # Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../solving_agi_governance/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/sovereign_agentic_agialpha_agent_v0.md
+++ b/docs/demos/sovereign_agentic_agialpha_agent_v0.md
@@ -2,7 +2,7 @@
 
 # Sovereign Agentic AGI Alpha Agent Demo
 
-![preview](../alpha_agi_insight_v1/favicon.svg){.demo-preview}
+![preview](../sovereign_agentic_agialpha_agent_v0/assets/preview.svg){.demo-preview}
 
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/docs/demos/utils.md
+++ b/docs/demos/utils.md
@@ -1,0 +1,15 @@
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+
+# Demo Utilities
+
+![preview](../utils/assets/preview.svg){.demo-preview}
+
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Demo Utilities
+
+This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.
+
+
+[View README](../../alpha_factory_v1/demos/utils/README.md)

--- a/docs/era_of_experience/assets/preview.svg
+++ b/docs/era_of_experience/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/finance_alpha/assets/preview.svg
+++ b/docs/finance_alpha/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -19,92 +19,96 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <div class="demo-grid">
     <a class="demo-card" href="demos/aiga_meta_evolution/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy">
+      <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**" loading="lazy">
+      <img src="alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**" loading="lazy">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**" loading="lazy">
+      <img src="alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**" loading="lazy">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Business V1" loading="lazy">
+      <img src="alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy">
       <h3>Alpha Agi Business V1</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy">
+      <img src="alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy">
+      <img src="alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
     </a>
     <a class="demo-card" href="demos/alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Agi Marketplace V1" loading="lazy">
+      <img src="alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy">
       <h3>Alpha Agi Marketplace V1</h3>
     </a>
     <a class="demo-card" href="demos/alpha_asi_world_model/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha Asi World Model" loading="lazy">
+      <img src="alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
     </a>
     <a class="demo-card" href="demos/cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
+      <img src="cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
     </a>
     <a class="demo-card" href="demos/era_of_experience/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Era Of Experience" loading="lazy">
+      <img src="era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy">
       <h3>Era Of Experience</h3>
     </a>
     <a class="demo-card" href="demos/finance_alpha/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha‑Factory Demos 📊" loading="lazy">
+      <img src="finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy">
       <h3>Alpha‑Factory Demos 📊</h3>
     </a>
     <a class="demo-card" href="demos/macro_sentinel/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy">
+      <img src="macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_agi/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**" loading="lazy">
+      <img src="meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**" loading="lazy">
+      <img src="meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**" loading="lazy">
+      <img src="meta_agentic_agi_v3/assets/preview.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**" loading="lazy">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
     </a>
     <a class="demo-card" href="demos/meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy">
+      <img src="meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
     </a>
     <a class="demo-card" href="demos/muzero_planning/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time" loading="lazy">
+      <img src="muzero_planning/assets/preview.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time" loading="lazy">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
     </a>
     <a class="demo-card" href="demos/muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy">
+      <img src="muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy">
       <h3>MuZero MCTS LLM Agent Demo</h3>
     </a>
     <a class="demo-card" href="demos/omni_factory_demo/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy">
+      <img src="omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
     </a>
     <a class="demo-card" href="demos/self_healing_repo/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
+      <img src="self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
     </a>
     <a class="demo-card" href="demos/solving_agi_governance/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
+      <img src="solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
     </a>
     <a class="demo-card" href="demos/sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
+      <img src="sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
+    </a>
+    <a class="demo-card" href="demos/utils/" target="_blank" rel="noopener noreferrer">
+      <img src="utils/assets/preview.svg" alt="Demo Utilities" loading="lazy">
+      <h3>Demo Utilities</h3>
     </a>
   </div>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>

--- a/docs/macro_sentinel/assets/preview.svg
+++ b/docs/macro_sentinel/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/meta_agentic_agi/assets/preview.svg
+++ b/docs/meta_agentic_agi/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/meta_agentic_agi_v2/assets/preview.svg
+++ b/docs/meta_agentic_agi_v2/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/meta_agentic_agi_v3/assets/preview.svg
+++ b/docs/meta_agentic_agi_v3/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/meta_agentic_tree_search_v0/assets/preview.svg
+++ b/docs/meta_agentic_tree_search_v0/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/muzero_planning/assets/preview.svg
+++ b/docs/muzero_planning/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/muzeromctsllmagent_v0/assets/preview.svg
+++ b/docs/muzeromctsllmagent_v0/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/omni_factory_demo/assets/preview.svg
+++ b/docs/omni_factory_demo/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/self_healing_repo/assets/preview.svg
+++ b/docs/self_healing_repo/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/solving_agi_governance/assets/preview.svg
+++ b/docs/solving_agi_governance/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/sovereign_agentic_agialpha_agent_v0/assets/preview.svg
+++ b/docs/sovereign_agentic_agialpha_agent_v0/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/utils/assets/preview.svg
+++ b/docs/utils/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>


### PR DESCRIPTION
## Summary
- add preview.svg placeholder to every demo
- regenerate demo docs and gallery

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files $(cat /tmp/changed_files.txt)` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_686014b713748333b2187f9de1f9c71f