### PR TITLE
Add edge sprint deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ and docs with a single command:
 See [docs/GITHUB_PAGES_DEMO_TASKS.md](docs/GITHUB_PAGES_DEMO_TASKS.md) for a
 detailed walkthrough.
 
+### Edge-of-Human-Knowledge Sprint
+
+Run the wrapper to build and deploy the full GitHub Pages site with environment
+checks and offline validation:
+
+```bash
+./scripts/edge_human_knowledge_pages_sprint.sh
+```
+
+Ensure **Python 3.11+**, **Node 20+**, `mkdocs` and Playwright are installed. The
+script mirrors the [Docs workflow](.github/workflows/docs.yml) used for automatic
+deployment.
+
 ## Quickstart
 
 ```bash

--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -52,3 +52,14 @@ Verify the service worker caches assets for offline use and that the page includ
 - Re‑run the helper whenever demo docs or assets change.
 - Test with `mkdocs build --strict` before deploying.
 - Keep `pre-commit` hooks green so the gallery builds reproducibly.
+
+## 6. Edge-of-Human-Knowledge Sprint
+Run the wrapper to rebuild and publish the entire site in one step:
+
+```bash
+./scripts/edge_human_knowledge_pages_sprint.sh
+```
+
+Prerequisites: **Python 3.11+**, **Node.js 20+**, `mkdocs` and Playwright. This
+script mirrors the [Docs workflow](../.github/workflows/docs.yml) used for
+continuous deployment.


### PR DESCRIPTION
## Summary
- document `edge_human_knowledge_pages_sprint.sh`
- mention prerequisites and link to docs workflow

## Testing
- `pre-commit run --files README.md docs/GITHUB_PAGES_DEMO_TASKS.md` *(failed: could not initialize semgrep environment)*

------
https://chatgpt.com/codex/tasks/task_e_68601b961b7c83338e2883e69b294688