### PR TITLE
[alpha_factory] add tests for docs generators

### DIFF
--- a/tests/test_generate_demo_docs.py
+++ b/tests/test_generate_demo_docs.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for generate_demo_docs.py."""
+from pathlib import Path
+
+from scripts import generate_demo_docs as gdd
+
+
+def test_generate_docs(tmp_path, monkeypatch):
+    repo = tmp_path
+    demos = repo / "alpha_factory_v1" / "demos" / "demo_a"
+    demos.mkdir(parents=True)
+    (demos / "README.md").write_text("# Demo A\nHello", encoding="utf-8")
+    assets = repo / "docs" / "demo_a" / "assets"
+    assets.mkdir(parents=True)
+    (assets / "preview.png").write_text("data", encoding="utf-8")
+    docs_demos = repo / "docs" / "demos"
+
+    monkeypatch.setattr(gdd, "REPO_ROOT", repo)
+    monkeypatch.setattr(gdd, "DEMOS_DIR", repo / "alpha_factory_v1" / "demos")
+    monkeypatch.setattr(gdd, "DOCS_DIR", docs_demos)
+
+    gdd.generate_docs()
+
+    page = docs_demos / "demo_a.md"
+    text = page.read_text(encoding="utf-8")
+    assert "# Demo A" in text
+    assert "![preview](../demo_a/assets/preview.png){.demo-preview}" in text
+    assert "[View README](../../alpha_factory_v1/demos/demo_a/README.md)" in text

--- a/tests/test_generate_gallery_html.py
+++ b/tests/test_generate_gallery_html.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for generate_gallery_html.py."""
+from pathlib import Path
+
+from scripts import generate_demo_docs as gdd
+from scripts import generate_gallery_html as ggh
+
+
+def test_gallery_html(tmp_path, monkeypatch):
+    repo = tmp_path
+    demos = repo / "alpha_factory_v1" / "demos" / "demo_b"
+    demos.mkdir(parents=True)
+    (demos / "README.md").write_text("# Demo B\nText", encoding="utf-8")
+    assets = repo / "docs" / "demo_b" / "assets"
+    assets.mkdir(parents=True)
+    (assets / "preview.png").write_text("data", encoding="utf-8")
+    docs_demos = repo / "docs" / "demos"
+
+    # generate docs
+    monkeypatch.setattr(gdd, "REPO_ROOT", repo)
+    monkeypatch.setattr(gdd, "DEMOS_DIR", repo / "alpha_factory_v1" / "demos")
+    monkeypatch.setattr(gdd, "DOCS_DIR", docs_demos)
+    gdd.generate_docs()
+
+    # build gallery
+    monkeypatch.setattr(ggh, "REPO_ROOT", repo)
+    monkeypatch.setattr(ggh, "DEMOS_DIR", docs_demos)
+    gallery = repo / "docs" / "gallery.html"
+    monkeypatch.setattr(ggh, "GALLERY_FILE", gallery)
+
+    html_text = ggh.build_html(ggh.collect_entries())
+    gallery.write_text(html_text, encoding="utf-8")
+
+    out = gallery.read_text(encoding="utf-8")
+    assert "Demo B" in out
+    assert "demo_b/assets/preview.png" in out
+    assert "href=\"demos/demo_b/\"" in out


### PR DESCRIPTION
## Summary
- test `generate_demo_docs.py` on sample demo README
- test `generate_gallery_html.py` on generated pages

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q tests/test_generate_demo_docs.py tests/test_generate_gallery_html.py`

------
https://chatgpt.com/codex/tasks/task_e_68602099b52c83339743037e0d1ac58b