### PR TITLE
[alpha_factory] verify docs before pages deploy

### DIFF
--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -15,6 +15,10 @@ BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
 # Comprehensive environment checks
 python alpha_factory_v1/scripts/preflight.py
 node "$BROWSER_DIR/build/version_check.js"
+python scripts/check_python_deps.py
+python check_env.py --auto-install
+python scripts/verify_disclaimer_snippet.py
+python -m alpha_factory_v1.demos.validate_demos
 
 # Build the Insight docs and gallery
 npm --prefix "$BROWSER_DIR" run fetch-assets


### PR DESCRIPTION
## Summary
- verify optional Python packages and environment before building docs
- ensure disclaimers and demo validation run during `deploy_gallery_pages.sh`

## Testing
- `pre-commit run --files scripts/deploy_gallery_pages.sh` *(fails: proto-verify and requirements lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: interrupted)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686026265fc48333b11ce2366e8f9f0b