### PR TITLE
Fix duplicate demo disclaimers

### DIFF
--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -4,8 +4,6 @@
 
 ![preview](../aiga_meta_evolution/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -38,11 +36,6 @@ A single‑command, browser‑based showcase of Clune’s **Three Pillars**:
 Within **&lt; 60 s** you’ll watch neural nets **rewrite their own blueprint** *while the world itself mutates to stay challenging*.
 
 ---
-
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk.
 
 ---
 
@@ -441,6 +434,5 @@ Huge thanks to:
 * OSS maintainers – you make this possible ♥
 
 > **Alpha‑Factory** — forging intelligence that *invents* intelligence.
-
 
 [View README](../../alpha_factory_v1/demos/aiga_meta_evolution/README.md)

--- a/docs/demos/alpha_agi_business_2_v1.md
+++ b/docs/demos/alpha_agi_business_2_v1.md
@@ -4,8 +4,6 @@
 
 ![preview](../alpha_agi_business_2_v1/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -16,11 +14,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 > **Alpha‑Factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.
 
 ---
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk.
-
 
 ## ⚡ TL;DR  
 
@@ -217,6 +210,5 @@ Apache‑2.0 © 2025 MONTREAL.AI.
 
 _“Outlearn · Outthink · Outdesign · Outstrategise · Outexecute.”_  
 Welcome to the era of **Large‑Scale α‑AGI Businesses** 🌸 — where autonomous swarms turn friction into alpha at planetary scale. 🚀
-
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md)

--- a/docs/demos/alpha_agi_business_3_v1.md
+++ b/docs/demos/alpha_agi_business_3_v1.md
@@ -4,8 +4,6 @@
 
 ![preview](../alpha_agi_business_3_v1/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -22,13 +20,6 @@ high‑stakes prod cluster right now.
 > **Definition**: An **α‑AGI Business** 👁️✨ (`<name>.a.agi.eth`) is an antifragile, self‑governing multi‑agent  👁️✨ (`<name>.a.agent.agi.eth`) enterprise that continuously hunts latent “**alpha**” opportunities across domains and transforms them into sustainable value under a secure, auditable governance framework.
 
 ---
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
-financial advice. MontrealAI and the maintainers accept no liability for losses
-incurred from using this software.
-
 ## 🛠 Requirements
 
 - **Python ≥3.11**
@@ -426,6 +417,5 @@ Inherited **2017 Multi‑Agent AI DAO** prior‑art:
 
 *Forged by the MONTREAL.AI Agentic Ω‑Lattice team — bending entropy to will.*  
 Questions → **discord.gg/montrealai**
-
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md)

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -4,14 +4,11 @@
 
 ![preview](../alpha_agi_business_v1/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
 <!-- README.md — Large‑Scale α‑AGI Business Demo (v1.0‑production) -->
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 <h1 align="center">
  Large‑Scale α‑AGI Business 👁️✨ <sup><code>$AGIALPHA</code></sup>
 </h1>
@@ -505,6 +502,5 @@ python ../../check_env.py --auto-install   # verify optional packages
 pre-commit run --files <paths>             # format only the staged files
 pytest -q ../../../tests                   # execute the root test suite
 ```
-
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_business_v1/README.md)

--- a/docs/demos/alpha_agi_insight_v0.md
+++ b/docs/demos/alpha_agi_insight_v0.md
@@ -4,8 +4,6 @@
 
 ![preview](../alpha_agi_insight_v0/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -348,6 +346,5 @@ LLM prompts and replies using the
 This best-effort persistence operates transparently and never blocks the
 search loop.
 For additional command details, run `python official_demo_production.py --help`.
-
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_insight_v0/README.md)

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -4,8 +4,6 @@
 
 ![preview](../alpha_agi_insight_v1/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -18,7 +16,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 # α‑AGI Insight v1 — Beyond Human Foresight
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb)
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
 <p align="center">
   <b>Forecast AGI-driven economic phase-transitions<br>
@@ -707,7 +704,6 @@ This demo is released for **research & internal evaluation only**.
 ---
 
 ### ✨ See beyond human foresight. Build the future, today. ✨
-
 
 
 [View README](../../alpha_factory_v1/demos/alpha_agi_insight_v1/README.md)

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -4,19 +4,10 @@
 
 ![preview](../alpha_agi_marketplace_v1/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
 <!-- README.md — α‑AGI Marketplace Demo (v1.4‑production) -->
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
- financial advice. MontrealAI and the maintainers accept no liability for losses
- incurred from using this software.
-
 <h1 align="center">
   Large‑Scale α‑AGI Marketplace 👁️✨ <sup><code>$AGIALPHA</code></sup>
 </h1>
@@ -203,7 +194,9 @@ White‑paper → `docs/tokenomics_v1.pdf`.
 <a id="reputation"></a>
 ## 9 Reputation & Governance 📈
 
-\(R_t = 0.9\,R_{t-1} + 0.1\,rac{reward_{success}}{reward_{total}}\)
+\(R_t = 0.9\,R_{t-1} + 0.1\,
+rac{reward_{success}}{reward_{total}}\)
+rac{reward_{success}}{reward_{total}}\)
 
 * Security incident ⇒ ×0.75.  
 * \(R<0.6\) ⇒ cool‑down `7×(1/R)%` days.  
@@ -246,7 +239,6 @@ White‑paper → `docs/tokenomics_v1.pdf`.
 <a id="faq"></a>
 <p align="center"><sub>Made with ❤, ☕ and real GPUs by the Alpha‑Factory core team.</sub></p>
 
-<details><summary>Do I need an <code>OPENAI_API_KEY</code>?</summary>
 <p>No. Offline mode loads GGUF models. If a key is present the system auto‑upgrades to GPT‑4o.</p>
 </details>
 

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -4,8 +4,6 @@
 
 ![preview](../alpha_asi_world_model/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -24,7 +22,6 @@ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team
 ---
 
 > **Disclaimer**
-> This demo is a conceptual research prototype and does **not** represent real
 > AGI capabilities. See the project's [Apache 2.0 license](../../../LICENSE) and
 > [security policy](../../../SECURITY.md) for details.
 
@@ -283,6 +280,5 @@ Please cite **Alpha-Factory v1 👁️✨ — Multi-Agent AGENTIC α-AGI**:
 
 > MONTREAL.AI (2025). *Fully-Agentic α-AGI: Foundation World Models for α-ASI.*  
 > GitHub https://github.com/MontrealAI/AGI-Alpha-Agent-v0
-
 
 [View README](../../alpha_factory_v1/demos/alpha_asi_world_model/README.md)

--- a/docs/demos/cross_industry_alpha_factory.md
+++ b/docs/demos/cross_industry_alpha_factory.md
@@ -4,8 +4,6 @@
 
 ![preview](../cross_industry_alpha_factory/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 Current demo version: `1.0.0`.
@@ -15,13 +13,11 @@ Current demo version: `1.0.0`.
 *Out-learn • Out-think • Out-design • Out-strategise • Out-execute*
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb)
 
-This demo is a conceptual research prototype. References to "AGI" and
 "superintelligence" describe aspirational goals and do not indicate the presence
 of a real general intelligence. Use at your own risk.
 
 See [CONCEPTUAL_FRAMEWORK.md](CONCEPTUAL_FRAMEWORK.md) for an architecture overview.
 
-> **⚠️ Disclaimer**: This demo is **for research and educational purposes only**. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ---
 
@@ -285,6 +281,5 @@ To automate this step run `./teardown_alpha_factory_cross_industry_demo.sh`.
 Clune 2019 · Sutton & Silver 2024 · MuZero 2020 
 
 © 2025 MONTREAL.AI — Apache‑2.0 License
-
 
 [View README](../../alpha_factory_v1/demos/cross_industry_alpha_factory/README.md)

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -4,8 +4,6 @@
 
 ![preview](../era_of_experience/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -16,7 +14,6 @@ Out‑learn · Out‑think · Out‑strategise · Out‑execute
 © 2025 MONTREAL.AI   Apache‑2.0 License
 -->
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
 <h1 align="center">🌌 Era of Experience — Your lifelong‑RL playground</h1>
 <p align="center">
@@ -383,6 +380,5 @@ Apache 2.0. By using this repo you agree to cite **Montreal.AI Alpha‑Factory*
 ---
 
 **Contributor checklist** — run `pre-commit`, `python ../../../check_env.py --auto-install`, and `pytest -q` before submitting any changes. See [AGENTS.md](../../../AGENTS.md) for the full contributor guide.
-
 
 [View README](../../alpha_factory_v1/demos/era_of_experience/README.md)

--- a/docs/demos/finance_alpha.md
+++ b/docs/demos/finance_alpha.md
@@ -4,8 +4,6 @@
 
 ![preview](../finance_alpha/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -19,9 +17,7 @@ planner trace‑graph in *under 2 minutes*.
 a local Φ‑2 model.)*
 
 > **⚠️ Disclaimer**: These demos and the included trading strategy are **for
-> research and educational purposes only**. They operate on a simulated
 > exchange by default and **should not be used with real funds**. Nothing here
-> constitutes financial advice. MontrealAI and the maintainers accept no
 > liability for losses incurred from using this software.
 
 ---
@@ -143,13 +139,9 @@ Enjoy exploring **α‑Factory** – and out‑think the future! 🚀
 
 ---
 
-## WARNING: Disclaimer
-
 This demo and the included trading strategy are **for research and
 educational purposes only**. They operate on a simulated exchange by
 default and **should not be used with real funds**. Nothing here
-constitutes financial advice. MontrealAI and the maintainers accept no
 liability for losses incurred from using this software.
-
 
 [View README](../../alpha_factory_v1/demos/finance_alpha/README.md)

--- a/docs/demos/macro_sentinel.md
+++ b/docs/demos/macro_sentinel.md
@@ -4,8 +4,6 @@
 
 ![preview](../macro_sentinel/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -19,7 +17,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 
 > **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.
 
-This demonstration is a conceptual research prototype. Any references to AGI or superintelligence describe aspirational goals rather than current capabilities.
 
 ---
 
@@ -247,12 +244,6 @@ macro_sentinel/
 
 ---
 
-## WARNING: Disclaimer
-
-This demo is **for research and educational purposes only**. It
-does not constitute financial advice and should not be relied upon
-for real trading decisions. MontrealAI and the maintainers accept
-no liability for losses incurred from using this software.
 
 ---
 
@@ -270,6 +261,5 @@ no liability for losses incurred from using this software.
 Apache‑2.0 © 2025 **MONTREAL.AI**
 
 Happy alpha‑hunting 🚀
-
 
 [View README](../../alpha_factory_v1/demos/macro_sentinel/README.md)

--- a/docs/demos/meta_agentic_agi.md
+++ b/docs/demos/meta_agentic_agi.md
@@ -4,14 +4,11 @@
 
 ![preview](../meta_agentic_agi/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
 
 # Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
 > **Official definition – Meta-Agentic (adj.)**  
 > *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*
@@ -264,6 +261,5 @@ Wrapper normalises chat/completions, streams via **MCP**, and window‑slides to
 ---
 
 © 2025 MONTREAL.AI — Apache‑2.0
-
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi/README.md)

--- a/docs/demos/meta_agentic_agi_v2.md
+++ b/docs/demos/meta_agentic_agi_v2.md
@@ -4,17 +4,8 @@
 
 ![preview](../meta_agentic_agi_v2/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
-
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
- financial advice. MontrealAI and the maintainers accept no liability for losses
- incurred from using this software.
 
 # Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**
 
@@ -262,6 +253,5 @@ Change **provider** to:
 ---
 
 © 2025 MONTREAL.AI — Apache‑2.0
-
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi_v2/README.md)

--- a/docs/demos/meta_agentic_agi_v3.md
+++ b/docs/demos/meta_agentic_agi_v3.md
@@ -4,17 +4,8 @@
 
 ![preview](../meta_agentic_agi_v3/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
-
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
- financial advice. MontrealAI and the maintainers accept no liability for losses
- incurred from using this software.
 
 # **Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**
 
@@ -262,6 +253,5 @@ The included `agents/alpha_finder.py` continuously scans news/API feeds and trig
 ---
 
 © 2025 MONTREAL.AI — Apache‑2.0
-
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_agi_v3/README.md)

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -4,8 +4,6 @@
 
 ![preview](../meta_agentic_tree_search_v0/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -306,6 +304,5 @@ Apache 2.0 – see `LICENSE`.
 
 ---
 *This README belongs to the AGI‑Alpha‑Agent project.*
-
 
 [View README](../../alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md)

--- a/docs/demos/muzero_planning.md
+++ b/docs/demos/muzero_planning.md
@@ -4,8 +4,6 @@
 
 ![preview](../muzero_planning/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -28,7 +26,6 @@ You’ll see a MuZero‑style agent improvise physics, deploy Monte‑Carlo sear
 and **stabilise CartPole** — all inside your browser. No GPU, no PhD required.
 
 > **Disclaimer**
-> This demo is a conceptual research prototype. References to "AGI" and
 > "superintelligence" describe aspirational goals and do not indicate the
 > presence of a real general intelligence. Use at your own risk.
 
@@ -193,6 +190,5 @@ Run `pre-commit run --files alpha_factory_v1/demos/muzero_planning` before commi
 * The open‑source community powering every dependency.
 
 > **Alpha‑Factory** — forging intelligence that **out‑learns, out‑thinks, out‑executes**.
-
 
 [View README](../../alpha_factory_v1/demos/muzero_planning/README.md)

--- a/docs/demos/muzeromctsllmagent_v0.md
+++ b/docs/demos/muzeromctsllmagent_v0.md
@@ -4,8 +4,6 @@
 
 ![preview](../muzeromctsllmagent_v0/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -26,6 +24,5 @@ This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS)
 ## Notes
 - Requires approximately 2GB RAM and basic Docker support.
 - Provided for research purposes only; not a production trading system.
-
 
 [View README](../../alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md)

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -4,13 +4,10 @@
 
 ![preview](../omni_factory_demo/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
 # OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 [![Colab](https://img.shields.io/badge/Try-on-Colab-yellow?logo=googlecolab)](colab_omni_factory_demo.ipynb)
 Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb).
 
@@ -287,6 +284,5 @@ By integrating **task generation, code synthesis, success detection,** and **arc
 In sum, the OMNI-Factory city simulator stands as a **proof-of-concept** of how future AI ecosystems might operate – not as single monolithic algorithms, but as **ecosystems of cooperating agents** that **create value and knowledge in a self-driven, endless loop**. It’s a demo designed not only to **impress** (with its autonomous feats and adaptive complexity) but also to **engage and educate** (by allowing humans to interact with and understand the AI’s decisions). We believe this will resonate strongly with policymakers: they can tangibly see an embodiment of AI that is *proactive, economically beneficial, and safety-conscious*, giving them a window into how such technology could bolster **infrastructure, economy, and governance** in the real world.
 
 Ultimately, success will be measured by the conversations and ideas this demo sparks. By presenting a clear, well-structured integration of advanced AI components addressing real societal challenges, we aim to inspire confidence that **open-ended AI coupled with careful design can be a force-multiplier for human decision-making** – a message delivered vividly through this interactive simulation.
-
 
 [View README](../../alpha_factory_v1/demos/omni_factory_demo/README.md)

--- a/docs/demos/self_healing_repo.md
+++ b/docs/demos/self_healing_repo.md
@@ -4,8 +4,6 @@
 
 ![preview](../self_healing_repo/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -21,13 +19,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 Imagine a codebase that diagnoses its own wounds, stitches the bug, and walks
 back onto the production floor—all before coffee drips.  
 This demo turns that fantasy into a clickable reality inside **Alpha‑Factory v1**.
-
-## Disclaimer
-This demo is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
-financial advice. MontrealAI and the maintainers accept no liability for losses
-incurred from using this software.
 
 ---
 
@@ -280,6 +271,5 @@ clone repo → [sandbox pytest] → error log
 * Built on **Agents SDK**, **A2A**, and the ever‑wise open‑source community.
 
 > **Alpha‑Factory** — shipping code that ships itself.
-
 
 [View README](../../alpha_factory_v1/demos/self_healing_repo/README.md)

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -4,8 +4,6 @@
 
 ![preview](../solving_agi_governance/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -14,7 +12,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI
 
 > **Disclaimer**
-> This demo is a conceptual research prototype. References to "AGI" and
 > "superintelligence" describe aspirational goals and do not indicate the
 > presence of a real general intelligence. Use at your own risk.
 
@@ -225,7 +222,6 @@ governance-bridge --port 5005
 [colab-notebook]: https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/\
     blob/main/alpha_factory_v1/demos/solving_agi_governance/\
     colab_solving_agi_governance.ipynb
-
 
 
 [View README](../../alpha_factory_v1/demos/solving_agi_governance/README.md)

--- a/docs/demos/sovereign_agentic_agialpha_agent_v0.md
+++ b/docs/demos/sovereign_agentic_agialpha_agent_v0.md
@@ -4,8 +4,6 @@
 
 ![preview](../sovereign_agentic_agialpha_agent_v0/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
@@ -13,9 +11,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 
 A minimal showcase of a self-directed agent with token-gated access.
 Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.
-
-## Disclaimer
-References to AGI or superintelligence describe the aspirational design goals of this demo. The agent shown here is not a true artificial general intelligence and should not be treated as such.
 
 ## Features
 1. Docker-based deployment with one command.
@@ -33,6 +28,5 @@ References to AGI or superintelligence describe the aspirational design goals of
 - Ensure Docker and docker-compose are installed.
 - The script will guide you through optional model configuration.
 - Press `Ctrl+C` to stop logs after deployment if desired.
-
 
 [View README](../../alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md)

--- a/docs/demos/utils.md
+++ b/docs/demos/utils.md
@@ -4,12 +4,8 @@
 
 ![preview](../utils/assets/preview.svg){.demo-preview}
 
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
-
 # Demo Utilities
 
 This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.
-
 
 [View README](../../alpha_factory_v1/demos/utils/README.md)

--- a/scripts/generate_demo_docs.py
+++ b/scripts/generate_demo_docs.py
@@ -52,10 +52,34 @@ def build_page(demo: Path) -> str:
         preview = DEFAULT_PREVIEW
 
     readme_path = demo / "README.md"
-    readme_text = readme_path.read_text(encoding="utf-8")
-    readme_lines = readme_text.splitlines()
+    readme_lines = readme_path.read_text(encoding="utf-8").splitlines()
     if readme_lines and readme_lines[0].startswith("#"):
-        readme_text = "\n".join(readme_lines[1:])
+        readme_lines = readme_lines[1:]
+
+    cleaned: list[str] = []
+    skip_section = False
+    for line in readme_lines:
+        stripped = line.strip()
+        if skip_section:
+            if stripped.startswith("#") or stripped.startswith("---") or not stripped:
+                skip_section = False
+            continue
+        if "DISCLAIMER_SNIPPET.md" in stripped:
+            continue
+        if (
+            "conceptual research prototype" in stripped
+            or "financial advice" in stripped
+            or "research and educational purposes" in stripped
+            or "trading decisions" in stripped
+            or "no liability" in stripped
+        ):
+            continue
+        if stripped.lower().startswith("##") and "disclaimer" in stripped.lower():
+            skip_section = True
+            continue
+        cleaned.append(line)
+
+    readme_text = "\n".join(cleaned).lstrip("\n")
 
     content = [
         DISCLAIMER_LINK,


### PR DESCRIPTION
## Summary
- insert disclaimer only once when generating demo docs
- regenerate docs/demos with a single disclaimer at the top

## Testing
- `pre-commit run --files scripts/generate_demo_docs.py docs/demos/alpha_agi_insight_v1.md` *(fails: Verify protobuf files are up to date)*
- `python scripts/verify_disclaimer_snippet.py`

------
https://chatgpt.com/codex/tasks/task_e_68602c2f1e048333a4df78267e1f82a7