### PR TITLE
[alpha_factory] add top-level disclaimers to HTML pages

### DIFF
--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -15,6 +15,7 @@
   </style>
 </head>
 <body>
+  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <div class="demo-grid">

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,7 @@
   </style>
 </head>
 <body>
+  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
   <p>The Alpha-Factory project showcases experimental AGI research tools and demos.</p>
   <p>
     <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>


### PR DESCRIPTION
## Summary
- show the disclaimer snippet at the top of `gallery.html`
- show the full disclaimer paragraph before any links on the main `index.html`

## Testing
- `pre-commit run --files docs/gallery.html docs/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6860332fc8248333aa37b37728fde6f1