### PR TITLE
[alpha_factory] Use strict MkDocs builds

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -117,8 +117,8 @@ copy_assets
 python scripts/generate_demo_docs.py
 python scripts/generate_gallery_html.py
 
-# Build the MkDocs site
-mkdocs build
+# Build the MkDocs site with --strict so warnings fail the build
+mkdocs build --strict
 
 # Verify the Workbox hash again in the generated site directory
 if ! python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1; then

--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -25,8 +25,8 @@ npm --prefix "$BROWSER_DIR" run fetch-assets
 npm --prefix "$BROWSER_DIR" ci
 "$SCRIPT_DIR/build_insight_docs.sh"
 
-# Compile and verify the MkDocs site
-mkdocs build
+# Compile and verify the MkDocs site. Use --strict so warnings fail the build
+mkdocs build --strict
 python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 
 # Optional offline smoke test

--- a/scripts/gallery_sprint.sh
+++ b/scripts/gallery_sprint.sh
@@ -19,8 +19,8 @@ npm --prefix "$BROWSER_DIR" ci
 
 "$SCRIPT_DIR/build_insight_docs.sh"
 
-# Build and verify the site
-mkdocs build
+# Build and verify the site using strict mode so warnings fail
+mkdocs build --strict
 python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 
 # Optional offline smoke test if Playwright is available

--- a/scripts/publish_demo_gallery.sh
+++ b/scripts/publish_demo_gallery.sh
@@ -25,8 +25,8 @@ python -m alpha_factory_v1.demos.validate_demos
 # Build the Insight browser demo and refresh documentation
 "$SCRIPT_DIR/build_insight_docs.sh"
 
-# Compile the MkDocs site
-mkdocs build
+# Compile the MkDocs site in strict mode so warnings cause failure
+mkdocs build --strict
 python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 
 # Optional offline smoke test


### PR DESCRIPTION
## Summary
- enforce `mkdocs build --strict` across gallery deployment scripts
- document the strict build requirement in script comments

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install` *(failed to complete due to network issues)*
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68603ba8914c8333907a35ee60bd2566