### PR TITLE
[alpha_factory] Add gallery development server

### DIFF
--- a/scripts/serve_gallery_dev.sh
+++ b/scripts/serve_gallery_dev.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+# Live-reload the demo gallery using MkDocs.
+# Rebuilds demo docs before launching the development server.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+
+# Basic environment checks
+python alpha_factory_v1/scripts/preflight.py
+node "$BROWSER_DIR/build/version_check.js"
+
+# Rebuild browser bundle and docs
+npm --prefix "$BROWSER_DIR" run fetch-assets
+npm --prefix "$BROWSER_DIR" ci
+"$SCRIPT_DIR/build_insight_docs.sh"
+python scripts/generate_demo_docs.py
+python scripts/generate_gallery_html.py
+
+# Launch MkDocs with live reload
+mkdocs serve --dev-addr 0.0.0.0:8000


### PR DESCRIPTION
## Summary
- add `serve_gallery_dev.sh` to rebuild demos and run MkDocs live server

## Testing
- `python scripts/check_python_deps.py` *(reports missing packages)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*
- `pre-commit run --files scripts/serve_gallery_dev.sh` *(setup interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_686041caeeb08333b6235e0a1879c248