### PR TITLE
[alpha_factory] Update demo README with gallery link

### DIFF
--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -14,6 +14,10 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 > [Apache 2.0 license](../../LICENSE) and
 > [security policy](../../SECURITY.md) for details.
 
+Browse the **visual demo gallery** on GitHub Pages:
+<https://montrealai.github.io/AGI-Alpha-Agent-v0/gallery.html>
+or run `./scripts/open_gallery.sh` to open it automatically.
+
 Each demo package exposes its own ``__version__`` constant. These
 numbers indicate the demo revision and are independent from the
 main ``alpha_factory_v1`` package version.

--- a/scripts/open_gallery.sh
+++ b/scripts/open_gallery.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Open the Alpha-Factory demo gallery on GitHub Pages.
+set -euo pipefail
+
+remote=$(git config --get remote.origin.url)
+repo_path=${remote#*github.com[:/]}
+repo_path=${repo_path%.git}
+org="${repo_path%%/*}"
+repo="${repo_path##*/}"
+url="https://${org}.github.io/${repo}/gallery.html"
+
+echo "Opening $url"
+case "$(uname)" in
+  Darwin*) open "$url" ;;
+  Linux*) (xdg-open "$url" >/dev/null 2>&1 || echo "Browse to $url") ;;
+  MINGW*|MSYS*|CYGWIN*) start "$url" ;;
+  *) echo "Browse to $url" ;;
+esac


### PR DESCRIPTION
## Summary
- add helper script to open the GitHub Pages demo gallery
- link to the gallery from the demos README so users can explore visually

## Testing
- `pre-commit` *(fails: verify-meta_agentic_tree_search_v0 requirements lock)*
- `pytest -m 'not e2e'` *(fails: ModuleNotFoundError for alpha_factory_v1 demos)*

------
https://chatgpt.com/codex/tasks/task_e_686044e1f270833384cae6c7c05adff8