### PR TITLE
[alpha_factory] open demo gallery after deploy

### DIFF
--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -45,3 +45,18 @@ fi
 # Deploy to GitHub Pages
 mkdocs gh-deploy --force
 
+remote=$(git config --get remote.origin.url)
+repo_path=${remote#*github.com[:/]}
+repo_path=${repo_path%.git}
+org="${repo_path%%/*}"
+repo="${repo_path##*/}"
+url="https://${org}.github.io/${repo}/"
+echo "Demo gallery deployed to $url"
+case "$(uname)" in
+  Darwin*) open "$url" ;;
+  Linux*) (xdg-open "$url" >/dev/null 2>&1 || echo "Browse to $url") ;;
+  MINGW*|MSYS*|CYGWIN*) start "$url" ;;
+  *) echo "Browse to $url" ;;
+esac
+
+


### PR DESCRIPTION
## Summary
- open the deployed GitHub Pages site at the end of `deploy_gallery_pages.sh`

## Testing
- `pre-commit run --files scripts/deploy_gallery_pages.sh` *(with several hooks skipped)*
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68604d560a588333af0ddd63b515cb82