### PR TITLE
[alpha_factory] docs: demo launch links

### DIFF
--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -3,7 +3,6 @@
 # 🌌 Algorithms That Invent Algorithms — <br>**AI‑GA Meta‑Evolution Demo**
 
 ![preview](../aiga_meta_evolution/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_business_2_v1.md
+++ b/docs/demos/alpha_agi_business_2_v1.md
@@ -3,7 +3,6 @@
 # Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**
 
 ![preview](../alpha_agi_business_2_v1/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_business_3_v1.md
+++ b/docs/demos/alpha_agi_business_3_v1.md
@@ -3,7 +3,6 @@
 # 🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**
 
 ![preview](../alpha_agi_business_3_v1/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -3,7 +3,6 @@
 # Alpha Agi Business V1
 
 ![preview](../alpha_agi_business_v1/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_insight_v0.md
+++ b/docs/demos/alpha_agi_insight_v0.md
@@ -3,7 +3,6 @@
 # α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)
 
 ![preview](../alpha_agi_insight_v0/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -4,6 +4,8 @@
 
 ![preview](../alpha_agi_insight_v1/assets/preview.svg){.demo-preview}
 
+[Launch Demo](../alpha_agi_insight_v1/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -3,7 +3,6 @@
 # Alpha Agi Marketplace V1
 
 ![preview](../alpha_agi_marketplace_v1/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -3,7 +3,6 @@
 # Alpha Asi World Model
 
 ![preview](../alpha_asi_world_model/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/cross_industry_alpha_factory.md
+++ b/docs/demos/cross_industry_alpha_factory.md
@@ -3,7 +3,6 @@
 # 👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo
 
 ![preview](../cross_industry_alpha_factory/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 Current demo version: `1.0.0`.

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -3,7 +3,6 @@
 # Era Of Experience
 
 ![preview](../era_of_experience/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/finance_alpha.md
+++ b/docs/demos/finance_alpha.md
@@ -3,7 +3,6 @@
 # Alpha‑Factory Demos 📊
 
 ![preview](../finance_alpha/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/macro_sentinel.md
+++ b/docs/demos/macro_sentinel.md
@@ -3,7 +3,6 @@
 # 🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨
 
 ![preview](../macro_sentinel/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_agi.md
+++ b/docs/demos/meta_agentic_agi.md
@@ -3,7 +3,6 @@
 # Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**
 
 ![preview](../meta_agentic_agi/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_agi_v2.md
+++ b/docs/demos/meta_agentic_agi_v2.md
@@ -3,7 +3,6 @@
 # Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**
 
 ![preview](../meta_agentic_agi_v2/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_agi_v3.md
+++ b/docs/demos/meta_agentic_agi_v3.md
@@ -3,7 +3,6 @@
 # **Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**
 
 ![preview](../meta_agentic_agi_v3/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -3,7 +3,6 @@
 # Meta‑Agentic Tree Search (MATS) Demo — v0
 
 ![preview](../meta_agentic_tree_search_v0/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/muzero_planning.md
+++ b/docs/demos/muzero_planning.md
@@ -3,7 +3,6 @@
 # 🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time
 
 ![preview](../muzero_planning/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/muzeromctsllmagent_v0.md
+++ b/docs/demos/muzeromctsllmagent_v0.md
@@ -3,7 +3,6 @@
 # MuZero MCTS LLM Agent Demo
 
 ![preview](../muzeromctsllmagent_v0/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -3,7 +3,6 @@
 # OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)
 
 ![preview](../omni_factory_demo/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/self_healing_repo.md
+++ b/docs/demos/self_healing_repo.md
@@ -3,7 +3,6 @@
 # 🔧 **Self‑Healing Repo** — when CI fails, agents patch
 
 ![preview](../self_healing_repo/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -3,7 +3,6 @@
 # Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]
 
 ![preview](../solving_agi_governance/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/sovereign_agentic_agialpha_agent_v0.md
+++ b/docs/demos/sovereign_agentic_agialpha_agent_v0.md
@@ -3,7 +3,6 @@
 # Sovereign Agentic AGI Alpha Agent Demo
 
 ![preview](../sovereign_agentic_agialpha_agent_v0/assets/preview.svg){.demo-preview}
-
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/utils.md
+++ b/docs/demos/utils.md
@@ -3,7 +3,6 @@
 # Demo Utilities
 
 ![preview](../utils/assets/preview.svg){.demo-preview}
-
 # Demo Utilities
 
 This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.

--- a/scripts/generate_demo_docs.py
+++ b/scripts/generate_demo_docs.py
@@ -51,6 +51,11 @@ def build_page(demo: Path) -> str:
     if not preview:
         preview = DEFAULT_PREVIEW
 
+    launch_link = None
+    demo_index = REPO_ROOT / "docs" / demo.name / "index.html"
+    if demo_index.is_file():
+        launch_link = f"[Launch Demo](../{demo.name}/){{.md-button}}"
+
     readme_path = demo / "README.md"
     readme_lines = readme_path.read_text(encoding="utf-8").splitlines()
     if readme_lines and readme_lines[0].startswith("#"):
@@ -87,12 +92,15 @@ def build_page(demo: Path) -> str:
         f"# {title}",
         "",
         f"![preview]({preview}){{.demo-preview}}",
-        "",
+    ]
+    if launch_link:
+        content.extend(["", launch_link, ""])
+    content.extend([
         readme_text,
         "",
         f"[View README](../../alpha_factory_v1/demos/{demo.name}/README.md)",
         "",
-    ]
+    ])
 
     return "\n".join(content)
 


### PR DESCRIPTION
## Summary
- update `generate_demo_docs.py` to add 'Launch Demo' link when a built demo page exists
- regenerate demo documentation pages

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860523237888333bb10a961ce99bb39