### PR TITLE
docs: add home links to demo gallery

### DIFF
--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -136,6 +136,7 @@
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.</p>
     </a>
   </div>
+  <p><a href="../index.html">⬅️ Back to Home</a></p>
   <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
   <script>
     const input = document.getElementById('search-input');

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -136,6 +136,7 @@
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.</p>
     </a>
   </div>
+  <p><a href="index.html">⬅️ Back to Home</a></p>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
   <script>
     const input = document.getElementById('search-input');

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -50,6 +50,7 @@ def extract_summary(lines: list[str], title: str) -> str:
             break
     return " ".join(paragraph).strip()
 
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEMOS_DIR = REPO_ROOT / "docs" / "demos"
 GALLERY_FILE = REPO_ROOT / "docs" / "gallery.html"
@@ -139,6 +140,8 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
             lines.append(f"      <p class='demo-desc'>{html.escape(summary)}</p>")
         lines.append("    </a>")
     lines.append("  </div>")
+    home_link = f"{disclaimer_prefix}index.html"
+    lines.append(f'  <p><a href="{home_link}">\u2b05\ufe0f Back to Home</a></p>')
     lines.append(
         f'  <p class="snippet"><a href="{disclaimer_prefix}DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>'
     )
@@ -163,11 +166,7 @@ def main() -> None:
     GALLERY_FILE.write_text(gallery_html, encoding="utf-8")
     demos_html = build_html(entries, disclaimer_prefix="../")
     DEMOS_INDEX_FILE.write_text(demos_html, encoding="utf-8")
-    print(
-        "Wrote"
-        f" {GALLERY_FILE.relative_to(REPO_ROOT)} and"
-        f" {DEMOS_INDEX_FILE.relative_to(REPO_ROOT)}"
-    )
+    print("Wrote" f" {GALLERY_FILE.relative_to(REPO_ROOT)} and" f" {DEMOS_INDEX_FILE.relative_to(REPO_ROOT)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update `generate_gallery_html.py` to include a Home link
- regenerate gallery and demos index with the new link

## Testing
- `pre-commit run --files docs/gallery.html docs/demos/index.html scripts/generate_gallery_html.py` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_686060cc63e48333b9a3b30c2bd4da0b