### PR TITLE
Add gallery build helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 - [Advanced Demo Pages Sprint](CODEX_ADVANCED_DEMO_PAGES_SPRINT.md) – end‑to‑end tasks for the full demo gallery
 - [Edge‑of‑Knowledge Demo Sprint](EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md) – host every advanced demo via GitHub Pages
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
+- **Local Gallery Build** – run `./scripts/build_gallery_site.sh` to compile the full demo gallery under `site/` for offline review.
 
 ## Building the React Dashboard
 

--- a/scripts/build_gallery_site.sh
+++ b/scripts/build_gallery_site.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Build the full Alpha-Factory demo gallery locally.
+# This script regenerates all demo documentation, compiles the
+# MkDocs site and verifies the service worker hash.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
+
+# Verify core tools and optional packages
+python alpha_factory_v1/scripts/preflight.py
+node "$BROWSER_DIR/build/version_check.js"
+python scripts/check_python_deps.py
+python check_env.py --auto-install
+python scripts/verify_disclaimer_snippet.py
+python -m alpha_factory_v1.demos.validate_demos
+
+# Refresh browser assets and generate docs
+npm --prefix "$BROWSER_DIR" run fetch-assets
+npm --prefix "$BROWSER_DIR" ci
+"$SCRIPT_DIR/build_insight_docs.sh"
+python scripts/generate_demo_docs.py
+python scripts/generate_gallery_html.py
+
+# Build the static site and verify integrity
+mkdocs build --strict
+python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
+
+echo "Demo gallery built under $REPO_ROOT/site"


### PR DESCRIPTION
## Summary
- add a helper script to build the demo gallery locally
- document the script in README

## Testing
- `pre-commit run --files scripts/build_gallery_site.sh docs/README.md` *(fails: requirements.lock out of date)*
- `pytest -q` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686065b76e548333ae750f219e0251e6