### PR TITLE
[alpha_factory] docs: add gallery helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ and docs with a single command:
 ```
 
 See [docs/GITHUB_PAGES_DEMO_TASKS.md](docs/GITHUB_PAGES_DEMO_TASKS.md) for a
-detailed walkthrough.
+detailed walkthrough. Once the build finishes, open the gallery locally with:
+
+```bash
+./scripts/open_gallery.sh
+```
+
+Run `./scripts/build_open_gallery.sh` to regenerate the site and open the page
+in one step.
 
 ### Edge-of-Human-Knowledge Sprint
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 - [Edge‑of‑Knowledge Demo Sprint](EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md) – host every advanced demo via GitHub Pages
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 - **Local Gallery Build** – run `./scripts/build_gallery_site.sh` to compile the full demo gallery under `site/` for offline review.
+- **Build & Open Gallery** – run `./scripts/build_open_gallery.sh` to regenerate the docs and open the gallery automatically.
 
 ## Building the React Dashboard
 

--- a/scripts/build_open_gallery.sh
+++ b/scripts/build_open_gallery.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Build the demo gallery and open it in the default browser.
+# This wrapper runs build_gallery_site.sh followed by open_gallery.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/build_gallery_site.sh"
+"$SCRIPT_DIR/open_gallery.sh"


### PR DESCRIPTION
## Summary
- add `build_open_gallery.sh` convenience wrapper
- document how to open the gallery after building

## Testing
- `pre-commit run --files README.md docs/README.md scripts/build_open_gallery.sh` *(fails: semgrep environment setup stalled)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -m 'not e2e' -q` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686072abba4c8333b2d71356d536f9e4