### PR TITLE
[alpha_factory] improve gallery script

### DIFF
--- a/scripts/open_gallery.sh
+++ b/scripts/open_gallery.sh
@@ -10,10 +10,34 @@ org="${repo_path%%/*}"
 repo="${repo_path##*/}"
 url="https://${org}.github.io/${repo}/gallery.html"
 
-echo "Opening $url"
-case "$(uname)" in
-  Darwin*) open "$url" ;;
-  Linux*) (xdg-open "$url" >/dev/null 2>&1 || echo "Browse to $url") ;;
-  MINGW*|MSYS*|CYGWIN*) start "$url" ;;
-  *) echo "Browse to $url" ;;
-esac
+check_remote() {
+  local status
+  status=$(curl -fsIL "$url" 2>/dev/null | head -n1 | awk '{print $2}') || return 1
+  [[ "$status" == "200" ]]
+}
+
+if check_remote; then
+  echo "Opening $url"
+  case "$(uname)" in
+    Darwin*) open "$url" ;;
+    Linux*) (xdg-open "$url" >/dev/null 2>&1 || echo "Browse to $url") ;;
+    MINGW*|MSYS*|CYGWIN*) start "$url" ;;
+    *) echo "Browse to $url" ;;
+  esac
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+local_page="$REPO_ROOT/site/gallery.html"
+if [[ -f "$local_page" ]]; then
+  echo "Remote gallery unavailable. Opening local copy at $local_page" >&2
+  case "$(uname)" in
+    Darwin*) open "$local_page" ;;
+    Linux*) (xdg-open "$local_page" >/dev/null 2>&1 || echo "Browse to $local_page") ;;
+    MINGW*|MSYS*|CYGWIN*) start "$local_page" ;;
+    *) echo "Browse to $local_page" ;;
+  esac
+else
+  echo "Gallery not found. Build it with ./scripts/build_open_gallery.sh" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- enhance gallery opener with remote check and offline fallback

## Checks
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install`
- `pre-commit run --files scripts/open_gallery.sh` *(failed: proto-verify and verify-requirements-lock)*
- `pytest -q` *(failed: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68607bf4a704833396e43ba043f2f658