### PR TITLE
[alpha_factory] add script to open demo pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 
 **View the interactive demo here:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>
 
+**Browse the visual demo gallery:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/gallery.html>
+
 **Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)

--- a/scripts/open_demo.sh
+++ b/scripts/open_demo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Open a specific demo page from the published GitHub Pages site.
+# Falls back to a local build under ./site/ if the remote page is unavailable.
+set -euo pipefail
+
+usage() { echo "Usage: $0 <demo_name>" >&2; exit 1; }
+[[ $# -eq 1 ]] || usage
+DEMO="$1"
+
+remote=$(git config --get remote.origin.url)
+repo_path=${remote#*github.com[:/]}
+repo_path=${repo_path%.git}
+org="${repo_path%%/*}"
+repo="${repo_path##*/}"
+url="https://${org}.github.io/${repo}/${DEMO}/"
+
+check_remote() {
+  local status
+  status=$(curl -fsIL "$url" 2>/dev/null | head -n1 | awk '{print $2}') || return 1
+  [[ "$status" == "200" ]]
+}
+
+if check_remote; then
+  echo "Opening $url"
+  case "$(uname)" in
+    Darwin*) open "$url" ;;
+    Linux*) (xdg-open "$url" >/dev/null 2>&1 || echo "Browse to $url") ;;
+    MINGW*|MSYS*|CYGWIN*) start "$url" ;;
+    *) echo "Browse to $url" ;;
+  esac
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+local_page="$REPO_ROOT/site/${DEMO}/index.html"
+if [[ -f "$local_page" ]]; then
+  echo "Remote page unavailable. Opening local copy at $local_page" >&2
+  case "$(uname)" in
+    Darwin*) open "$local_page" ;;
+    Linux*) (xdg-open "$local_page" >/dev/null 2>&1 || echo "Browse to $local_page") ;;
+    MINGW*|MSYS*|CYGWIN*) start "$local_page" ;;
+    *) echo "Browse to $local_page" ;;
+  esac
+else
+  echo "Demo $DEMO not found. Build the gallery with ./scripts/build_gallery_site.sh" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `open_demo.sh` to open any demo page locally or on GitHub Pages
- link to the visual demo gallery from the main README

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files README.md scripts/open_demo.sh` *(fails: proto-verify hook and verify-requirements-lock)*
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68607f468fe48333aa2d65762f281750