### PR TITLE
[alpha_factory] add html landing pages

### DIFF
--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>🌌 Algorithms That Invent Algorithms — <br>**AI‑GA Meta‑Evolution Demo**</h1>
+<img class='preview' src='assets/preview.svg' alt='🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo'>
+
+<p><a href='../demos/aiga_meta_evolution.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – “Infinite Bloom 3.0”</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h1>
+<img class='preview' src='assets/preview.svg' alt='Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – “Infinite Bloom 3.0”'>
+
+<p><a href='../demos/alpha_agi_business_2_v1.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — Omega‑Grade Edition</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h1>
+<img class='preview' src='assets/preview.svg' alt='🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — Omega‑Grade Edition'>
+
+<p><a href='../demos/alpha_agi_business_3_v1.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Alpha Agi Business V1</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Alpha Agi Business V1</h1>
+<img class='preview' src='assets/preview.svg' alt='Alpha Agi Business V1'>
+
+<p><a href='../demos/alpha_agi_business_v1.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h1>
+<img class='preview' src='assets/preview.svg' alt='α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)'>
+
+<p><a href='../demos/alpha_agi_insight_v0.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Alpha Agi Marketplace V1</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Alpha Agi Marketplace V1</h1>
+<img class='preview' src='assets/preview.svg' alt='Alpha Agi Marketplace V1'>
+
+<p><a href='../demos/alpha_agi_marketplace_v1.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/alpha_asi_world_model/index.html
+++ b/docs/alpha_asi_world_model/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Alpha Asi World Model</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Alpha Asi World Model</h1>
+<img class='preview' src='assets/preview.svg' alt='Alpha Asi World Model'>
+
+<p><a href='../demos/alpha_asi_world_model.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>👁️ Alpha-Factory v1 — Cross-Industry AGENTIC α-AGI Demo</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h1>
+<img class='preview' src='assets/preview.svg' alt='👁️ Alpha-Factory v1 — Cross-Industry AGENTIC α-AGI Demo'>
+
+<p><a href='../demos/cross_industry_alpha_factory.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -20,117 +20,117 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="demos/aiga_meta_evolution/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
       <p class='demo-desc'>AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**" loading="lazy">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
       <p class='demo-desc'>**Global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. **Alpha‑Factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**" loading="lazy">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
       <p class='demo-desc'>**Alpha‑Factory v1 → Ω‑Lattice v0** _Transmuting cosmological free‑energy gradients into compounding cash‑flows._</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy">
       <h3>Alpha Agi Business V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
       <p class='demo-desc'>The **α‑AGI Insight** demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
       <p class='demo-desc'>🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy">
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
     </a>
-    <a class="demo-card" href="demos/alpha_asi_world_model/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
       <p class='demo-desc'>README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team</p>
     </a>
-    <a class="demo-card" href="demos/cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer">
       <img src="cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
       <p class='demo-desc'>Current demo version: `1.0.0`. *Out-learn • Out-think • Out-design • Out-strategise • Out-execute*</p>
     </a>
-    <a class="demo-card" href="demos/era_of_experience/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../era_of_experience/" target="_blank" rel="noopener noreferrer">
       <img src="era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy">
       <h3>Era Of Experience</h3>
       <p class='demo-desc'>Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
     </a>
-    <a class="demo-card" href="demos/finance_alpha/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../finance_alpha/" target="_blank" rel="noopener noreferrer">
       <img src="finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy">
       <h3>Alpha‑Factory Demos 📊</h3>
       <p class='demo-desc'>Welcome! These short demos let **anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the</p>
     </a>
-    <a class="demo-card" href="demos/macro_sentinel/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../macro_sentinel/" target="_blank" rel="noopener noreferrer">
       <img src="macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
       <p class='demo-desc'>*Cross‑asset macro risk radar powered by multi‑agent α‑AGI* **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../meta_agentic_agi/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>**Official definition – Meta-Agentic (adj.)** *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Identical to **v1** plus a statistical-physics wrapper that logs and minimises **Gibbs / variational free-energy** for each candidate agent during the evolutionary search. *Metric toggle*: `configs/default.yml → physics_metric: free_energy`</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_agi_v3/assets/preview.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**" loading="lazy">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
       <p class='demo-desc'>Identical to **v1** plus **two synergistic upgrades** 1. *Statistical‑physics wrapper* — logs &amp; minimises **Gibbs / variational free‑energy** for every candidate agent.</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
       <p class='demo-desc'>**Abstract:** We pioneer **Meta-Agentic Tree Search (MATS)**, a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through **recursive agent-to-agent interactions**. In this **second-order agentic** scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. **Status:** Experimental · Proof‑of‑Concept · Alpha</p>
     </a>
-    <a class="demo-card" href="demos/muzero_planning/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../muzero_planning/" target="_blank" rel="noopener noreferrer">
       <img src="muzero_planning/assets/preview.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time" loading="lazy">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
       <p class='demo-desc'>MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="demos/muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer">
       <img src="muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy">
       <h3>MuZero MCTS LLM Agent Demo</h3>
       <p class='demo-desc'>This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run `install_and_launch.sh` to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.</p>
     </a>
-    <a class="demo-card" href="demos/omni_factory_demo/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../omni_factory_demo/" target="_blank" rel="noopener noreferrer">
       <img src="omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb). To verify local prerequisites before launching the demo, run:</p>
     </a>
-    <a class="demo-card" href="demos/self_healing_repo/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../self_healing_repo/" target="_blank" rel="noopener noreferrer">
       <img src="self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
       <p class='demo-desc'>Self‑Healing Repo Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="demos/solving_agi_governance/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../solving_agi_governance/" target="_blank" rel="noopener noreferrer">
       <img src="solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
       <p class='demo-desc'>*Minimal Conditions for Stable, Antifragile Multi-Agent Order* **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI</p>
     </a>
-    <a class="demo-card" href="demos/sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer">
       <img src="sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
       <p class='demo-desc'>A minimal showcase of a self-directed agent with token-gated access. Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.</p>
     </a>
-    <a class="demo-card" href="demos/utils/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="../utils/" target="_blank" rel="noopener noreferrer">
       <img src="utils/assets/preview.svg" alt="Demo Utilities" loading="lazy">
       <h3>Demo Utilities</h3>
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.</p>

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Era Of Experience</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Era Of Experience</h1>
+<img class='preview' src='assets/preview.svg' alt='Era Of Experience'>
+
+<p><a href='../demos/era_of_experience.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Alpha‑Factory Demos 📊</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Alpha‑Factory Demos 📊</h1>
+<img class='preview' src='assets/preview.svg' alt='Alpha‑Factory Demos 📊'>
+
+<p><a href='../demos/finance_alpha.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -20,117 +20,117 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="demos/aiga_meta_evolution/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
       <p class='demo-desc'>AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**" loading="lazy">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
       <p class='demo-desc'>**Global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. **Alpha‑Factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**" loading="lazy">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
       <p class='demo-desc'>**Alpha‑Factory v1 → Ω‑Lattice v0** _Transmuting cosmological free‑energy gradients into compounding cash‑flows._</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy">
       <h3>Alpha Agi Business V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
       <p class='demo-desc'>The **α‑AGI Insight** demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
       <p class='demo-desc'>🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)</p>
     </a>
-    <a class="demo-card" href="demos/alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy">
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
     </a>
-    <a class="demo-card" href="demos/alpha_asi_world_model/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_asi_world_model/" target="_blank" rel="noopener noreferrer">
       <img src="alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
       <p class='demo-desc'>README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team</p>
     </a>
-    <a class="demo-card" href="demos/cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer">
       <img src="cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
       <p class='demo-desc'>Current demo version: `1.0.0`. *Out-learn • Out-think • Out-design • Out-strategise • Out-execute*</p>
     </a>
-    <a class="demo-card" href="demos/era_of_experience/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="era_of_experience/" target="_blank" rel="noopener noreferrer">
       <img src="era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy">
       <h3>Era Of Experience</h3>
       <p class='demo-desc'>Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
     </a>
-    <a class="demo-card" href="demos/finance_alpha/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="finance_alpha/" target="_blank" rel="noopener noreferrer">
       <img src="finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy">
       <h3>Alpha‑Factory Demos 📊</h3>
       <p class='demo-desc'>Welcome! These short demos let **anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the</p>
     </a>
-    <a class="demo-card" href="demos/macro_sentinel/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="macro_sentinel/" target="_blank" rel="noopener noreferrer">
       <img src="macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
       <p class='demo-desc'>*Cross‑asset macro risk radar powered by multi‑agent α‑AGI* **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_agi/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>**Official definition – Meta-Agentic (adj.)** *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Identical to **v1** plus a statistical-physics wrapper that logs and minimises **Gibbs / variational free-energy** for each candidate agent during the evolutionary search. *Metric toggle*: `configs/default.yml → physics_metric: free_energy`</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_agi_v3/assets/preview.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**" loading="lazy">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
       <p class='demo-desc'>Identical to **v1** plus **two synergistic upgrades** 1. *Statistical‑physics wrapper* — logs &amp; minimises **Gibbs / variational free‑energy** for every candidate agent.</p>
     </a>
-    <a class="demo-card" href="demos/meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer">
       <img src="meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
       <p class='demo-desc'>**Abstract:** We pioneer **Meta-Agentic Tree Search (MATS)**, a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through **recursive agent-to-agent interactions**. In this **second-order agentic** scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. **Status:** Experimental · Proof‑of‑Concept · Alpha</p>
     </a>
-    <a class="demo-card" href="demos/muzero_planning/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="muzero_planning/" target="_blank" rel="noopener noreferrer">
       <img src="muzero_planning/assets/preview.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time" loading="lazy">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
       <p class='demo-desc'>MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="demos/muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer">
       <img src="muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy">
       <h3>MuZero MCTS LLM Agent Demo</h3>
       <p class='demo-desc'>This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run `install_and_launch.sh` to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.</p>
     </a>
-    <a class="demo-card" href="demos/omni_factory_demo/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="omni_factory_demo/" target="_blank" rel="noopener noreferrer">
       <img src="omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb). To verify local prerequisites before launching the demo, run:</p>
     </a>
-    <a class="demo-card" href="demos/self_healing_repo/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="self_healing_repo/" target="_blank" rel="noopener noreferrer">
       <img src="self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
       <p class='demo-desc'>Self‑Healing Repo Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="demos/solving_agi_governance/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="solving_agi_governance/" target="_blank" rel="noopener noreferrer">
       <img src="solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
       <p class='demo-desc'>*Minimal Conditions for Stable, Antifragile Multi-Agent Order* **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI</p>
     </a>
-    <a class="demo-card" href="demos/sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer">
       <img src="sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
       <p class='demo-desc'>A minimal showcase of a self-directed agent with token-gated access. Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.</p>
     </a>
-    <a class="demo-card" href="demos/utils/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="utils/" target="_blank" rel="noopener noreferrer">
       <img src="utils/assets/preview.svg" alt="Demo Utilities" loading="lazy">
       <h3>Demo Utilities</h3>
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.</p>

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h1>
+<img class='preview' src='assets/preview.svg' alt='🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨'>
+
+<p><a href='../demos/macro_sentinel.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Meta‑Agentic α‑AGI 👁️✨ Demo – Production‑Grade v0.1.0</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h1>
+<img class='preview' src='assets/preview.svg' alt='Meta‑Agentic α‑AGI 👁️✨ Demo – Production‑Grade v0.1.0'>
+
+<p><a href='../demos/meta_agentic_agi.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – Production‑Grade v0.1.0</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h1>
+<img class='preview' src='assets/preview.svg' alt='Meta‑Agentic α‑AGI 👁️✨ Demo v2 – Production‑Grade v0.1.0'>
+
+<p><a href='../demos/meta_agentic_agi_v2.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h1>
+<img class='preview' src='assets/preview.svg' alt='Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)'>
+
+<p><a href='../demos/meta_agentic_agi_v3.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Meta‑Agentic Tree Search (MATS) Demo — v0</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Meta‑Agentic Tree Search (MATS) Demo — v0</h1>
+<img class='preview' src='assets/preview.svg' alt='Meta‑Agentic Tree Search (MATS) Demo — v0'>
+
+<p><a href='../demos/meta_agentic_tree_search_v0.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>🌟 Mastery Without a Rule‑Book — watch MuZero think in real time</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h1>
+<img class='preview' src='assets/preview.svg' alt='🌟 Mastery Without a Rule‑Book — watch MuZero think in real time'>
+
+<p><a href='../demos/muzero_planning.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>MuZero MCTS LLM Agent Demo</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>MuZero MCTS LLM Agent Demo</h1>
+<img class='preview' src='assets/preview.svg' alt='MuZero MCTS LLM Agent Demo'>
+
+<p><a href='../demos/muzeromctsllmagent_v0.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h1>
+<img class='preview' src='assets/preview.svg' alt='OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)'>
+
+<p><a href='../demos/omni_factory_demo.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/self_healing_repo/index.html
+++ b/docs/self_healing_repo/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>🔧 Self‑Healing Repo — when CI fails, agents patch</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h1>
+<img class='preview' src='assets/preview.svg' alt='🔧 Self‑Healing Repo — when CI fails, agents patch'>
+
+<p><a href='../demos/self_healing_repo.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/solving_agi_governance/index.html
+++ b/docs/solving_agi_governance/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Solving α-AGI Governance [![Open In Colab]][colab-notebook]</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h1>
+<img class='preview' src='assets/preview.svg' alt='Solving α-AGI Governance [![Open In Colab]][colab-notebook]'>
+
+<p><a href='../demos/solving_agi_governance.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Sovereign Agentic AGI Alpha Agent Demo</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Sovereign Agentic AGI Alpha Agent Demo</h1>
+<img class='preview' src='assets/preview.svg' alt='Sovereign Agentic AGI Alpha Agent Demo'>
+
+<p><a href='../demos/sovereign_agentic_agialpha_agent_v0.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Demo Utilities</title>
+<link rel='stylesheet' href='../stylesheets/cards.css'>
+<style>
+body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center; }
+.preview { max-width:80%; height:auto; margin-bottom:1rem; }
+.btn { display:inline-block; padding:0.5rem 1rem; margin:1rem 0; background:#4caf50; color:#fff; text-decoration:none; border-radius:4px; }
+</style>
+</head>
+<body>
+<h1>Demo Utilities</h1>
+<img class='preview' src='assets/preview.svg' alt='Demo Utilities'>
+
+<p><a href='../demos/utils.md'>Detailed instructions</a></p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -58,7 +58,11 @@ DEMOS_INDEX_FILE = REPO_ROOT / "docs" / "demos" / "index.html"
 
 
 def parse_page(md_file: Path) -> tuple[str, str, str, str]:
-    """Return ``(title, preview, link, summary)`` for ``md_file``."""
+    """Return ``(title, preview, link, summary)`` for ``md_file``.
+
+    If ``docs/<demo>/index.html`` exists, link directly to that page.
+    Otherwise fall back to the Markdown page under ``docs/demos``.
+    """
     title: str | None = None
     preview: str | None = None
     lines = md_file.read_text(encoding="utf-8").splitlines()
@@ -87,7 +91,11 @@ def parse_page(md_file: Path) -> tuple[str, str, str, str]:
                     break
     else:
         preview = "alpha_agi_insight_v1/favicon.svg"
-    link = f"demos/{md_file.stem}/"
+    demo_index = REPO_ROOT / "docs" / md_file.stem / "index.html"
+    if demo_index.is_file():
+        link = f"{md_file.stem}/"
+    else:
+        link = f"demos/{md_file.stem}/"
     summary = extract_summary(lines, title)
     return title, preview, link, summary
 
@@ -124,8 +132,9 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
   <div class=\"demo-grid\">"""
     lines = [head]
     for title, preview, link, summary in entries:
+        full_link = f"{disclaimer_prefix}{link}"
         lines.append(
-            f'    <a class="demo-card" href="{html.escape(link)}"' ' target="_blank" rel="noopener noreferrer">'
+            f'    <a class="demo-card" href="{html.escape(full_link)}" target="_blank" rel="noopener noreferrer">'
         )
         ext = Path(preview).suffix.lower()
         if ext in {".mp4", ".webm"}:


### PR DESCRIPTION
## Summary
- generate HTML landing pages for every demo under docs
- link gallery entries to these pages when available

## Testing
- `python scripts/generate_gallery_html.py`
- `bash scripts/edge_human_knowledge_pages_sprint.sh` *(fails: pre-commit missing)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68608b957ab48333980d3f6ebd5cba30