### PR TITLE
[alpha_factory] Fix insight disclaimer link

### DIFF
--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.html)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 
 # α-AGI Insight v1
 


### PR DESCRIPTION
## Summary
- fix path to disclaimer snippet in docs

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/README.md` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68609036b3848333955c0708dae14d1f