### PR TITLE
[alpha_factory] add gallery make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: build_web demo-setup demo-run compose-up loadtest proto proto-verify benchmark
+.PHONY: build_web demo-setup demo-run compose-up loadtest \
+        gallery-build gallery-open gallery-deploy \
+        proto proto-verify benchmark
 
 build_web:
 	pnpm --dir src/interface/web_client install
@@ -37,3 +39,14 @@ proto-verify:
 
 benchmark:
 	python benchmarks/docker_runner.py > bench_results.json
+
+# Demo gallery helpers
+
+gallery-build:
+	bash scripts/build_gallery_site.sh
+
+gallery-open:
+	bash scripts/open_gallery.sh
+
+gallery-deploy:
+	bash scripts/deploy_gallery_pages.sh

--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ Ensure **Python 3.11+** and **Node 20+** are installed, then deploy the galler
 and docs with a single command:
 
 ```bash
-./scripts/deploy_gallery_pages.sh
+make gallery-deploy
 ```
 
 See [docs/GITHUB_PAGES_DEMO_TASKS.md](docs/GITHUB_PAGES_DEMO_TASKS.md) for a
 detailed walkthrough. Once the build finishes, open the gallery locally with:
 
 ```bash
-./scripts/open_gallery.sh
+make gallery-open
 ```
 
-Run `./scripts/build_open_gallery.sh` to regenerate the site and open the page
+Run `make gallery-build` to regenerate the site without deploying and open it
 in one step.
 
 ### Edge-of-Human-Knowledge Sprint


### PR DESCRIPTION
## Summary
- add gallery-* commands to Makefile
- document new make targets for publishing demo gallery

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files Makefile README.md` *(fails: proto-verify)*
- `make gallery-deploy` *(fails: Preflight checks failed)*

------
https://chatgpt.com/codex/tasks/task_e_68609272b73c833387e205d5050b8741