### PR TITLE
[alpha_factory] Implement gallery asset verifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,6 +108,11 @@ repos:
         entry: python scripts/verify_disclaimer_helper.py
         language: python
         pass_filenames: false
+      - id: verify-gallery-assets
+        name: Verify demo gallery preview assets exist
+        entry: python scripts/verify_gallery_assets.py
+        language: python
+        pass_filenames: false
       - id: py-compile
         name: Validate Python syntax with py_compile
         entry: python -m py_compile

--- a/scripts/verify_gallery_assets.py
+++ b/scripts/verify_gallery_assets.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+"""Verify each demo page references an existing preview asset."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PREVIEW_RE = re.compile(r"!\[preview\]\(([^)]+)\)")
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    demos_dir = repo_root / "docs" / "demos"
+    missing: list[str] = []
+
+    for md_file in sorted(demos_dir.glob("*.md")):
+        text = md_file.read_text(encoding="utf-8")
+        m = PREVIEW_RE.search(text)
+        if not m:
+            missing.append(f"{md_file.relative_to(repo_root)}: missing preview")
+            continue
+        rel = Path(m.group(1).split("#", 1)[0])
+        target = (md_file.parent / rel).resolve()
+        expected_dir = repo_root / "docs" / md_file.stem / "assets"
+        if not target.is_file() or not target.is_relative_to(expected_dir):
+            missing.append(f"{md_file.relative_to(repo_root)}: {target.relative_to(repo_root)}")
+
+    if missing:
+        print("Missing preview assets:", file=sys.stderr)
+        for item in missing:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- ensure docs/demos pages link to existing preview assets
- add verify-gallery-assets hook to pre-commit

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent')*
- `pre-commit run --files scripts/verify_gallery_assets.py docs/demos/aiga_meta_evolution.md` *(fails: proto-verify)*

------
https://chatgpt.com/codex/tasks/task_e_6860995031cc8333b3c83bc3a0b4fc11