### PR TITLE
docs: add launch links for all demos

### DIFF
--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -3,6 +3,9 @@
 # 🌌 Algorithms That Invent Algorithms — <br>**AI‑GA Meta‑Evolution Demo**
 
 ![preview](../aiga_meta_evolution/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../aiga_meta_evolution/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_business_2_v1.md
+++ b/docs/demos/alpha_agi_business_2_v1.md
@@ -3,6 +3,9 @@
 # Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**
 
 ![preview](../alpha_agi_business_2_v1/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../alpha_agi_business_2_v1/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_business_3_v1.md
+++ b/docs/demos/alpha_agi_business_3_v1.md
@@ -3,6 +3,9 @@
 # 🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**
 
 ![preview](../alpha_agi_business_3_v1/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../alpha_agi_business_3_v1/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -3,6 +3,9 @@
 # Alpha Agi Business V1
 
 ![preview](../alpha_agi_business_v1/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../alpha_agi_business_v1/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_insight_v0.md
+++ b/docs/demos/alpha_agi_insight_v0.md
@@ -3,6 +3,9 @@
 # α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)
 
 ![preview](../alpha_agi_insight_v0/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../alpha_agi_insight_v0/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -3,6 +3,9 @@
 # Alpha Agi Marketplace V1
 
 ![preview](../alpha_agi_marketplace_v1/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../alpha_agi_marketplace_v1/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -3,6 +3,9 @@
 # Alpha Asi World Model
 
 ![preview](../alpha_asi_world_model/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../alpha_asi_world_model/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/cross_industry_alpha_factory.md
+++ b/docs/demos/cross_industry_alpha_factory.md
@@ -3,6 +3,9 @@
 # 👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo
 
 ![preview](../cross_industry_alpha_factory/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../cross_industry_alpha_factory/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 Current demo version: `1.0.0`.

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -3,6 +3,9 @@
 # Era Of Experience
 
 ![preview](../era_of_experience/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../era_of_experience/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/finance_alpha.md
+++ b/docs/demos/finance_alpha.md
@@ -3,6 +3,9 @@
 # Alpha‑Factory Demos 📊
 
 ![preview](../finance_alpha/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../finance_alpha/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/macro_sentinel.md
+++ b/docs/demos/macro_sentinel.md
@@ -3,6 +3,9 @@
 # 🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨
 
 ![preview](../macro_sentinel/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../macro_sentinel/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_agi.md
+++ b/docs/demos/meta_agentic_agi.md
@@ -3,6 +3,9 @@
 # Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**
 
 ![preview](../meta_agentic_agi/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../meta_agentic_agi/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_agi_v2.md
+++ b/docs/demos/meta_agentic_agi_v2.md
@@ -3,6 +3,9 @@
 # Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**
 
 ![preview](../meta_agentic_agi_v2/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../meta_agentic_agi_v2/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_agi_v3.md
+++ b/docs/demos/meta_agentic_agi_v3.md
@@ -3,6 +3,9 @@
 # **Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**
 
 ![preview](../meta_agentic_agi_v3/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../meta_agentic_agi_v3/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -3,6 +3,9 @@
 # Meta‑Agentic Tree Search (MATS) Demo — v0
 
 ![preview](../meta_agentic_tree_search_v0/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../meta_agentic_tree_search_v0/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/muzero_planning.md
+++ b/docs/demos/muzero_planning.md
@@ -3,6 +3,9 @@
 # 🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time
 
 ![preview](../muzero_planning/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../muzero_planning/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/muzeromctsllmagent_v0.md
+++ b/docs/demos/muzeromctsllmagent_v0.md
@@ -3,6 +3,9 @@
 # MuZero MCTS LLM Agent Demo
 
 ![preview](../muzeromctsllmagent_v0/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../muzeromctsllmagent_v0/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -3,6 +3,9 @@
 # OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)
 
 ![preview](../omni_factory_demo/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../omni_factory_demo/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/self_healing_repo.md
+++ b/docs/demos/self_healing_repo.md
@@ -3,6 +3,9 @@
 # 🔧 **Self‑Healing Repo** — when CI fails, agents patch
 
 ![preview](../self_healing_repo/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../self_healing_repo/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -3,6 +3,9 @@
 # Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]
 
 ![preview](../solving_agi_governance/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../solving_agi_governance/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/sovereign_agentic_agialpha_agent_v0.md
+++ b/docs/demos/sovereign_agentic_agialpha_agent_v0.md
@@ -3,6 +3,9 @@
 # Sovereign Agentic AGI Alpha Agent Demo
 
 ![preview](../sovereign_agentic_agialpha_agent_v0/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../sovereign_agentic_agialpha_agent_v0/){.md-button}
+
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 

--- a/docs/demos/utils.md
+++ b/docs/demos/utils.md
@@ -3,6 +3,9 @@
 # Demo Utilities
 
 ![preview](../utils/assets/preview.svg){.demo-preview}
+
+[Launch Demo](../utils/){.md-button}
+
 # Demo Utilities
 
 This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.


### PR DESCRIPTION
## Summary
- add **Launch Demo** links across all demo docs

## Testing
- `pre-commit run --files docs/demos/alpha_agi_business_v1.md` *(fails: hung or produced no output)*
- `pytest -m 'not e2e'` *(fails: 44 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68609b919c3483338a8f1e40bfcf3dee