### PR TITLE
Fix duplicate disclaimer on docs landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,6 @@
   </style>
 </head>
 <body>
-  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
   <p>The Alpha-Factory project showcases experimental AGI research tools and demos.</p>
   <p>
     <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>


### PR DESCRIPTION
[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

# Summary
- remove the repeated disclaimer from `docs/index.html`

# Checks
- [x] I ran `pre-commit run --files docs/index.html` *(skipping env dependent hooks)*
- [x] I ran `python check_env.py --auto-install`
- [x] I ran `pytest -q` *(tests failed: 44 errors)*

# Testing
- `pre-commit run --files docs/index.html` *(with SKIP env var)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 44 errors during collection)*
- `scripts/build_insight_docs.sh` *(fails to fetch wasm asset)*

------
https://chatgpt.com/codex/tasks/task_e_6860a16df81c83339b1376ad43eaa8e8