### PR TITLE
Enhance disclaimer verification

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 - **Local Gallery Build** – run `./scripts/build_gallery_site.sh` to compile the full demo gallery under `site/` for offline review.
 - **Build & Open Gallery** – run `./scripts/build_open_gallery.sh` to regenerate the docs and open the gallery automatically.
+- **Verify Disclaimer Snippet** – run `python scripts/verify_disclaimer_snippet.py` to ensure each file contains the disclaimer text once.
 
 ## Building the React Dashboard
 

--- a/tests/test_verify_disclaimer_snippet.py
+++ b/tests/test_verify_disclaimer_snippet.py
@@ -1,0 +1,32 @@
+"""Tests for verify_disclaimer_snippet script."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from scripts import verify_disclaimer_snippet
+
+
+SNIPPET_PATH = Path("docs/DISCLAIMER_SNIPPET.md")
+SNIPPET_TEXT = SNIPPET_PATH.read_text(encoding="utf-8")
+
+
+def _create_repo(tmpdir: Path, content: str) -> Path:
+    docs = tmpdir / "docs"
+    docs.mkdir()
+    (docs / "DISCLAIMER_SNIPPET.md").write_text(SNIPPET_TEXT)
+    (tmpdir / "README.md").write_text(content)
+    return tmpdir
+
+
+def test_single_disclaimer_passes(tmp_path: Path) -> None:
+    repo = _create_repo(tmp_path, SNIPPET_TEXT)
+    missing, duplicates = verify_disclaimer_snippet.check_repo(repo)
+    assert missing == []
+    assert duplicates == []
+
+
+def test_duplicate_disclaimer_fails(tmp_path: Path) -> None:
+    repo = _create_repo(tmp_path, SNIPPET_TEXT + "\n" + SNIPPET_TEXT)
+    missing, duplicates = verify_disclaimer_snippet.check_repo(repo)
+    assert duplicates == [repo / "README.md"]


### PR DESCRIPTION
## Summary
- enforce unique disclaimer occurrences when verifying READMEs
- expose `check_repo()` for easier testing
- document new verify-disclaimer usage
- test single vs duplicate disclaimer handling

## Testing
- `pytest -q tests/test_verify_disclaimer_snippet.py`

------
https://chatgpt.com/codex/tasks/task_e_6860a3b6e6908333bd91ba6c2cdc7ceb