### PR TITLE
[alpha_factory] add demo-open helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build_web demo-setup demo-run compose-up loadtest \
-        gallery-build gallery-open gallery-deploy \
+        gallery-build gallery-open gallery-deploy demo-open \
         proto proto-verify benchmark
 
 build_web:
@@ -49,4 +49,7 @@ gallery-open:
 	bash scripts/open_gallery.sh
 
 gallery-deploy:
-	bash scripts/deploy_gallery_pages.sh
+        bash scripts/deploy_gallery_pages.sh
+
+demo-open:
+	bash scripts/open_demo.sh $(DEMO)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ make gallery-open
 Run `make gallery-build` to regenerate the site without deploying and open it
 in one step.
 
+Open an individual demo directly:
+
+```bash
+make demo-open DEMO=alpha_agi_business_v1
+```
+
 ### Edge-of-Human-Knowledge Sprint
 
 Run the wrapper to build and deploy the full GitHub Pages site with environment

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 - **Local Gallery Build** – run `./scripts/build_gallery_site.sh` to compile the full demo gallery under `site/` for offline review.
 - **Build & Open Gallery** – run `./scripts/build_open_gallery.sh` to regenerate the docs and open the gallery automatically.
+- **Open Individual Demo** – run `./scripts/open_demo.sh <demo_dir>` to open a single page from the gallery.
 - **Verify Disclaimer Snippet** – run `python scripts/verify_disclaimer_snippet.py` to ensure each file contains the disclaimer text once.
 
 ## Building the React Dashboard


### PR DESCRIPTION
## Summary
- add `demo-open` make target for opening a single demo
- document the new target in README
- mention `scripts/open_demo.sh` in docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files Makefile README.md docs/README.md` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6860a66ecc78833395d394b8c5c83bbc