### PR TITLE
[alpha_factory] remove duplicate disclaimers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -16,12 +16,6 @@ high‑stakes prod cluster right now.
 > **Definition**: An **α‑AGI Business** 👁️✨ (`<name>.a.agi.eth`) is an antifragile, self‑governing multi‑agent  👁️✨ (`<name>.a.agent.agi.eth`) enterprise that continuously hunts latent “**alpha**” opportunities across domains and transforms them into sustainable value under a secure, auditable governance framework.
 
 ---
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
-financial advice. MontrealAI and the maintainers accept no liability for losses
-incurred from using this software.
 
 ## 🛠 Requirements
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -1,12 +1,6 @@
 [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
- financial advice. MontrealAI and the maintainers accept no liability for losses
- incurred from using this software.
 
 # 🏭 Production Deployment Guide — Alpha‑AGI Business v1
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -4,7 +4,6 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 Documentation for the α‑AGI Insight demo.
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 Whenever `src/utils/a2a.proto` changes, regenerate the protocol stubs:
 

--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
@@ -4,12 +4,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 
 
 <!-- README.md — α‑AGI Marketplace Demo (v1.4‑production) -->
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
- financial advice. MontrealAI and the maintainers accept no liability for losses
- incurred from using this software.
 
 <h1 align="center">
   Large‑Scale α‑AGI Marketplace 👁️✨ <sup><code>$AGIALPHA</code></sup>

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
@@ -3,12 +3,6 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
- financial advice. MontrealAI and the maintainers accept no liability for losses
- incurred from using this software.
 
 # Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**
 

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
@@ -3,12 +3,6 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 
 
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
- financial advice. MontrealAI and the maintainers accept no liability for losses
- incurred from using this software.
 
 # **Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**
 


### PR DESCRIPTION
## Summary
- clean up README files with repeated disclaimer text
- keep only the first copy of the disclaimer snippet

## Testing
- `python scripts/verify_disclaimer_snippet.py`
- `pre-commit run --files alpha_factory_v1/demos/meta_agentic_agi_v2/README.md alpha_factory_v1/demos/meta_agentic_agi_v3/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6860ab463d348333aaec19016583aff5