### PR TITLE
[alpha_factory] Cross-platform gallery launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ gallery-build:
 	bash scripts/build_gallery_site.sh
 
 gallery-open:
-	bash scripts/open_gallery.sh
+	python scripts/open_gallery.py
 
 gallery-deploy:
         bash scripts/deploy_gallery_pages.sh

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -16,7 +16,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 Browse the **visual demo gallery** on GitHub Pages:
 <https://montrealai.github.io/AGI-Alpha-Agent-v0/gallery.html>
-or run `./scripts/open_gallery.sh` to open it automatically.
+Run `./scripts/open_gallery.py` for a cross-platform launcher that opens the published gallery when online and falls back to the local build. Alternatively, `./scripts/open_gallery.sh` offers a Bash implementation.
 
 Each demo package exposes its own ``__version__`` constant. These
 numbers indicate the demo revision and are independent from the

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 - **Local Gallery Build** – run `./scripts/build_gallery_site.sh` to compile the full demo gallery under `site/` for offline review.
 - **Build & Open Gallery** – run `./scripts/build_open_gallery.sh` to regenerate the docs and open the gallery automatically.
+- **Open Gallery (Python)** – run `./scripts/open_gallery.py` for a cross-platform way to launch the published gallery, falling back to the local build when offline.
 - **Open Individual Demo** – run `./scripts/open_demo.sh <demo_dir>` to open a single page from the gallery.
 - **Verify Disclaimer Snippet** – run `python scripts/verify_disclaimer_snippet.py` to ensure each file contains the disclaimer text once.
 

--- a/scripts/build_open_gallery.sh
+++ b/scripts/build_open_gallery.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Build the demo gallery and open it in the default browser.
-# This wrapper runs build_gallery_site.sh followed by open_gallery.sh.
+# This wrapper runs build_gallery_site.sh followed by the cross-platform
+# open_gallery.py helper.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 "$SCRIPT_DIR/build_gallery_site.sh"
-"$SCRIPT_DIR/open_gallery.sh"
+python "$SCRIPT_DIR/open_gallery.py"

--- a/scripts/open_gallery.py
+++ b/scripts/open_gallery.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Open the Alpha-Factory demo gallery in a web browser.
+
+This helper mirrors ``open_gallery.sh`` but uses Python for portability.
+It attempts to open the published GitHub Pages gallery and falls back to a
+local build under ``site/`` when offline.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from urllib.request import Request, urlopen
+import webbrowser
+
+
+def _gallery_url() -> str:
+    remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
+    repo_path = remote.split("github.com")[-1].lstrip(":/")
+    repo_path = repo_path.removesuffix(".git")
+    org, repo = repo_path.split("/", 1)
+    return f"https://{org}.github.io/{repo}/gallery.html"
+
+
+def _remote_available(url: str) -> bool:
+    try:
+        req = Request(url, method="HEAD")
+        with urlopen(req, timeout=3) as resp:
+            status = getattr(resp, "status", None)
+        return bool(status and 200 <= int(status) < 300)
+    except Exception:
+        return False
+
+
+def main() -> None:
+    url = _gallery_url()
+    if _remote_available(url):
+        print(f"Opening {url}")
+        webbrowser.open(url)
+        return
+    repo_root = Path(__file__).resolve().parents[1]
+    local_page = repo_root / "site" / "gallery.html"
+    if local_page.is_file():
+        print(f"Remote gallery unavailable. Opening local copy at {local_page}", file=sys.stderr)
+        webbrowser.open(local_page.as_uri())
+    else:
+        print("Gallery not found. Build it with ./scripts/build_gallery_site.sh", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `open_gallery.py` for cross-platform GitHub Pages launcher
- reference new Python helper in docs and gallery build script
- use Python helper from Makefile

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files scripts/open_gallery.py docs/README.md alpha_factory_v1/demos/README.md scripts/build_open_gallery.sh Makefile` *(failed: requirements.lock outdated)*
- `pytest -q` *(failed: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860affcc00483339570651bbe82adc0