### PR TITLE
feat: add local gallery preview helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 - **Local Gallery Build** – run `./scripts/build_gallery_site.sh` to compile the full demo gallery under `site/` for offline review.
 - **Build & Open Gallery** – run `./scripts/build_open_gallery.sh` to regenerate the docs and open the gallery automatically.
+- **Preview Gallery Locally** – run `./scripts/preview_gallery.sh` to build the full gallery and serve it on <http://localhost:8000/>.
 - **Open Gallery (Python)** – run `./scripts/open_gallery.py` for a cross-platform way to launch the published gallery, falling back to the local build when offline.
 - **Open Individual Demo** – run `./scripts/open_demo.sh <demo_dir>` to open a single page from the gallery.
 - **Verify Disclaimer Snippet** – run `python scripts/verify_disclaimer_snippet.py` to ensure each file contains the disclaimer text once.

--- a/scripts/preview_gallery.sh
+++ b/scripts/preview_gallery.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Build the full demo gallery then serve it locally.
+# This is a convenience wrapper for non-technical users.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+"$SCRIPT_DIR/build_gallery_site.sh"
+
+python -m http.server --directory site 8000 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID' EXIT
+sleep 2
+
+if command -v python >/dev/null 2>&1; then
+    python - <<'PY'
+import webbrowser, pathlib
+webbrowser.open((pathlib.Path('site/gallery.html').resolve()).as_uri())
+PY
+fi
+
+echo "Serving demo gallery at http://localhost:8000/ (Ctrl+C to stop)"
+wait $SERVER_PID


### PR DESCRIPTION
## Summary
- add script to build and serve the demo gallery locally
- document new helper in docs README

## Checks
- `pre-commit run --files scripts/preview_gallery.sh docs/README.md` *(failed: proto-verify, verify-requirements-lock)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68611113a9dc833395cd2f3d369c3be7