### PR TITLE
[alpha_factory] Enhance gallery launcher

### DIFF
--- a/scripts/open_gallery.py
+++ b/scripts/open_gallery.py
@@ -4,7 +4,9 @@
 
 This helper mirrors ``open_gallery.sh`` but uses Python for portability.
 It attempts to open the published GitHub Pages gallery and falls back to a
-local build under ``site/`` when offline.
+local build under ``site/`` when offline. If the local build is missing,
+the script automatically runs ``scripts/build_gallery_site.sh`` to generate
+the site so non-technical users can access the demos with a single command.
 """
 from __future__ import annotations
 
@@ -13,6 +15,18 @@ import sys
 from pathlib import Path
 from urllib.request import Request, urlopen
 import webbrowser
+
+
+def _build_local_site(repo_root: Path) -> bool:
+    """Return ``True`` if the gallery was built successfully."""
+    script = repo_root / "scripts" / "build_gallery_site.sh"
+    if not script.is_file():
+        return False
+    try:
+        subprocess.run([str(script)], check=True)
+    except Exception:
+        return False
+    return True
 
 
 def _gallery_url() -> str:
@@ -41,12 +55,16 @@ def main() -> None:
         return
     repo_root = Path(__file__).resolve().parents[1]
     local_page = repo_root / "site" / "gallery.html"
-    if local_page.is_file():
-        print(f"Remote gallery unavailable. Opening local copy at {local_page}", file=sys.stderr)
-        webbrowser.open(local_page.as_uri())
-    else:
-        print("Gallery not found. Build it with ./scripts/build_gallery_site.sh", file=sys.stderr)
-        sys.exit(1)
+    if not local_page.is_file():
+        print("Remote gallery unavailable. Building local copy...", file=sys.stderr)
+        if not _build_local_site(repo_root) or not local_page.is_file():
+            print(
+                "Gallery not found. Build it with ./scripts/build_gallery_site.sh",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    print(f"Remote gallery unavailable. Opening local copy at {local_page}", file=sys.stderr)
+    webbrowser.open(local_page.as_uri())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `open_gallery.py` auto-build the gallery if no local copy is found

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.base_agent')*
- `pre-commit run --files scripts/open_gallery.py` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_686120f3a9608333b5be2b85e976ab45