### PR TITLE
feat: auto-build gallery on open

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
 - **Build & Open Gallery** – run `./scripts/build_open_gallery.sh` to regenerate the docs and open the gallery automatically.
 - **Preview Gallery Locally** – run `./scripts/preview_gallery.sh` to build the full gallery and serve it on <http://localhost:8000/>.
 - **Open Gallery (Python)** – run `./scripts/open_gallery.py` for a cross-platform way to launch the published gallery, falling back to the local build when offline.
+- **Open Gallery (Shell)** – run `./scripts/open_gallery.sh` to open the gallery in your browser. It automatically builds a fresh local copy when the remote site isn't available.
 - **Open Individual Demo** – run `./scripts/open_demo.sh <demo_dir>` to open a single page from the gallery.
 - **Verify Disclaimer Snippet** – run `python scripts/verify_disclaimer_snippet.py` to ensure each file contains the disclaimer text once.
 

--- a/scripts/open_gallery.sh
+++ b/scripts/open_gallery.sh
@@ -29,15 +29,18 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 local_page="$REPO_ROOT/site/gallery.html"
-if [[ -f "$local_page" ]]; then
-  echo "Remote gallery unavailable. Opening local copy at $local_page" >&2
-  case "$(uname)" in
-    Darwin*) open "$local_page" ;;
-    Linux*) (xdg-open "$local_page" >/dev/null 2>&1 || echo "Browse to $local_page") ;;
-    MINGW*|MSYS*|CYGWIN*) start "$local_page" ;;
-    *) echo "Browse to $local_page" ;;
-  esac
-else
-  echo "Gallery not found. Build it with ./scripts/build_open_gallery.sh" >&2
-  exit 1
+if [[ ! -f "$local_page" ]]; then
+  echo "Gallery not found locally. Building a fresh copy..." >&2
+  "$REPO_ROOT/scripts/build_gallery_site.sh" || {
+    echo "Failed to build the gallery" >&2
+    exit 1
+  }
 fi
+
+echo "Remote gallery unavailable. Opening local copy at $local_page" >&2
+case "$(uname)" in
+  Darwin*) open "$local_page" ;;
+  Linux*) (xdg-open "$local_page" >/dev/null 2>&1 || echo "Browse to $local_page") ;;
+  MINGW*|MSYS*|CYGWIN*) start "$local_page" ;;
+  *) echo "Browse to $local_page" ;;
+esac


### PR DESCRIPTION
## Summary
- automatically build a local gallery when opening with `open_gallery.sh`
- document new behaviour in project docs

## Testing
- `pre-commit run --files docs/README.md scripts/open_gallery.sh` *(fails: proto-verify and requirements lock)*
- `pytest -m 'not e2e'` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68613426eed483338ed58e2a0e5b7c0c