### PR TITLE
fix: robust local demo opener

### DIFF
--- a/scripts/open_demo.sh
+++ b/scripts/open_demo.sh
@@ -34,6 +34,14 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 local_page="$REPO_ROOT/site/${DEMO}/index.html"
+if [[ ! -f "$local_page" ]]; then
+  echo "Local page missing. Building gallery..." >&2
+  "$REPO_ROOT/scripts/build_gallery_site.sh" || {
+    echo "Failed to build the gallery" >&2
+    exit 1
+  }
+fi
+
 if [[ -f "$local_page" ]]; then
   echo "Remote page unavailable. Opening local copy at $local_page" >&2
   case "$(uname)" in


### PR DESCRIPTION
## Summary
- build local gallery automatically when opening a demo if not present

## Testing
- `python check_env.py --auto-install`
- `pre-commit run shellcheck --files scripts/open_demo.sh`
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686137bb7a048333ae0c86265a24ea52