### PR TITLE
Mirror demo gallery in subdir

### DIFF
--- a/docs/alpha_factory_v1/demos/index.html
+++ b/docs/alpha_factory_v1/demos/index.html
@@ -20,124 +20,124 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
+    <a class="demo-card" href="../../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
       <p class='demo-desc'>AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="../alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer" data-summary="**global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. **alpha‑factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.">
+    <a class="demo-card" href="../../alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer" data-summary="**global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. **alpha‑factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.">
       <img src="alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**" loading="lazy">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
       <p class='demo-desc'>**Global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. **Alpha‑Factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.</p>
     </a>
-    <a class="demo-card" href="../alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer" data-summary="**alpha‑factory v1 → ω‑lattice v0** _transmuting cosmological free‑energy gradients into compounding cash‑flows._">
+    <a class="demo-card" href="../../alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer" data-summary="**alpha‑factory v1 → ω‑lattice v0** _transmuting cosmological free‑energy gradients into compounding cash‑flows._">
       <img src="alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**" loading="lazy">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
       <p class='demo-desc'>**Alpha‑Factory v1 → Ω‑Lattice v0** _Transmuting cosmological free‑energy gradients into compounding cash‑flows._</p>
     </a>
-    <a class="demo-card" href="../alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi business 👁️✨ $agialpha using alpha‑factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.">
+    <a class="demo-card" href="../../alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi business 👁️✨ $agialpha using alpha‑factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.">
       <img src="alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy">
       <h3>Alpha Agi Business V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.</p>
     </a>
-    <a class="demo-card" href="../alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer" data-summary="the **α‑agi insight** demo predicts which industry sector is most likely to be transformed by artificial general intelligence. it runs a small">
+    <a class="demo-card" href="../../alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer" data-summary="the **α‑agi insight** demo predicts which industry sector is most likely to be transformed by artificial general intelligence. it runs a small">
       <img src="alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
       <p class='demo-desc'>The **α‑AGI Insight** demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small</p>
     </a>
-    <a class="demo-card" href="../alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer" data-summary="🎖️ α-agi insight 👁️✨ — beyond human foresight version 1.1 (2025-07-15)">
+    <a class="demo-card" href="../../alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer" data-summary="🎖️ α-agi insight 👁️✨ — beyond human foresight version 1.1 (2025-07-15)">
       <img src="alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
       <p class='demo-desc'>🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)</p>
     </a>
-    <a class="demo-card" href="../alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi marketplace 👁️✨ $agialpha hunt exploitable alpha 🎯 and convert it into tangible value 💎.">
+    <a class="demo-card" href="../../alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi marketplace 👁️✨ $agialpha hunt exploitable alpha 🎯 and convert it into tangible value 💎.">
       <img src="alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy">
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
     </a>
-    <a class="demo-card" href="../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨ last updated 2025-04-25   maintainer → montreal.ai core agi team">
+    <a class="demo-card" href="../../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨ last updated 2025-04-25   maintainer → montreal.ai core agi team">
       <img src="alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
       <p class='demo-desc'>README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team</p>
     </a>
-    <a class="demo-card" href="../cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="current demo version: `1.0.0`. *out-learn • out-think • out-design • out-strategise • out-execute*">
+    <a class="demo-card" href="../../cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="current demo version: `1.0.0`. *out-learn • out-think • out-design • out-strategise • out-execute*">
       <img src="cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
       <p class='demo-desc'>Current demo version: `1.0.0`. *Out-learn • Out-think • Out-design • Out-strategise • Out-execute*</p>
     </a>
-    <a class="demo-card" href="../era_of_experience/" target="_blank" rel="noopener noreferrer" data-summary="era‑of‑experience demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi">
+    <a class="demo-card" href="../../era_of_experience/" target="_blank" rel="noopener noreferrer" data-summary="era‑of‑experience demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi">
       <img src="era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy">
       <h3>Era Of Experience</h3>
       <p class='demo-desc'>Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
     </a>
-    <a class="demo-card" href="../finance_alpha/" target="_blank" rel="noopener noreferrer" data-summary="welcome! these short demos let **anyone – even if you’ve never touched a terminal – spin up alpha‑factory, watch a live trade, and explore the">
+    <a class="demo-card" href="../../finance_alpha/" target="_blank" rel="noopener noreferrer" data-summary="welcome! these short demos let **anyone – even if you’ve never touched a terminal – spin up alpha‑factory, watch a live trade, and explore the">
       <img src="finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy">
       <h3>Alpha‑Factory Demos 📊</h3>
       <p class='demo-desc'>Welcome! These short demos let **anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the</p>
     </a>
-    <a class="demo-card" href="../macro_sentinel/" target="_blank" rel="noopener noreferrer" data-summary="*cross‑asset macro risk radar powered by multi‑agent α‑agi* **tl;dr**   spin up a self‑healing stack that ingests macro telemetry, runs a monte‑carlo risk engine, sizes an es hedge, and explains its reasoning—all behind a gradio dashboard.">
+    <a class="demo-card" href="../../macro_sentinel/" target="_blank" rel="noopener noreferrer" data-summary="*cross‑asset macro risk radar powered by multi‑agent α‑agi* **tl;dr**   spin up a self‑healing stack that ingests macro telemetry, runs a monte‑carlo risk engine, sizes an es hedge, and explains its reasoning—all behind a gradio dashboard.">
       <img src="macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
       <p class='demo-desc'>*Cross‑asset macro risk radar powered by multi‑agent α‑AGI* **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.</p>
     </a>
-    <a class="demo-card" href="../meta_agentic_agi/" target="_blank" rel="noopener noreferrer" data-summary="**official definition – meta-agentic (adj.)** *describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*">
+    <a class="demo-card" href="../../meta_agentic_agi/" target="_blank" rel="noopener noreferrer" data-summary="**official definition – meta-agentic (adj.)** *describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*">
       <img src="meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>**Official definition – Meta-Agentic (adj.)** *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*</p>
     </a>
-    <a class="demo-card" href="../meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer" data-summary="identical to **v1** plus a statistical-physics wrapper that logs and minimises **gibbs / variational free-energy** for each candidate agent during the evolutionary search. *metric toggle*: `configs/default.yml → physics_metric: free_energy`">
+    <a class="demo-card" href="../../meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer" data-summary="identical to **v1** plus a statistical-physics wrapper that logs and minimises **gibbs / variational free-energy** for each candidate agent during the evolutionary search. *metric toggle*: `configs/default.yml → physics_metric: free_energy`">
       <img src="meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Identical to **v1** plus a statistical-physics wrapper that logs and minimises **Gibbs / variational free-energy** for each candidate agent during the evolutionary search. *Metric toggle*: `configs/default.yml → physics_metric: free_energy`</p>
     </a>
-    <a class="demo-card" href="../meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer" data-summary="identical to **v1** plus **two synergistic upgrades** 1. *statistical‑physics wrapper* — logs &amp; minimises **gibbs / variational free‑energy** for every candidate agent.">
+    <a class="demo-card" href="../../meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer" data-summary="identical to **v1** plus **two synergistic upgrades** 1. *statistical‑physics wrapper* — logs &amp; minimises **gibbs / variational free‑energy** for every candidate agent.">
       <img src="meta_agentic_agi_v3/assets/preview.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**" loading="lazy">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
       <p class='demo-desc'>Identical to **v1** plus **two synergistic upgrades** 1. *Statistical‑physics wrapper* — logs &amp; minimises **Gibbs / variational free‑energy** for every candidate agent.</p>
     </a>
-    <a class="demo-card" href="../meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer" data-summary="**abstract:** we pioneer **meta-agentic tree search (mats)**, a novel framework for autonomous multi-agent decision optimization in complex strategic domains. mats enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through **recursive agent-to-agent interactions**. in this **second-order agentic** scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. this recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. **status:** experimental · proof‑of‑concept · alpha">
+    <a class="demo-card" href="../../meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer" data-summary="**abstract:** we pioneer **meta-agentic tree search (mats)**, a novel framework for autonomous multi-agent decision optimization in complex strategic domains. mats enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through **recursive agent-to-agent interactions**. in this **second-order agentic** scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. this recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. **status:** experimental · proof‑of‑concept · alpha">
       <img src="meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
       <p class='demo-desc'>**Abstract:** We pioneer **Meta-Agentic Tree Search (MATS)**, a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through **recursive agent-to-agent interactions**. In this **second-order agentic** scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. **Status:** Experimental · Proof‑of‑Concept · Alpha</p>
     </a>
-    <a class="demo-card" href="../muzero_planning/" target="_blank" rel="noopener noreferrer" data-summary="muzero planning demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
+    <a class="demo-card" href="../../muzero_planning/" target="_blank" rel="noopener noreferrer" data-summary="muzero planning demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
       <img src="muzero_planning/assets/preview.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time" loading="lazy">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
       <p class='demo-desc'>MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="../muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer" data-summary="this folder contains a prototype integration of a monte carlo tree search (mcts) agent with language model guidance. run `install_and_launch.sh` to build the environment and start the demo in your browser. 1. ensure python 3.9+ is installed.">
+    <a class="demo-card" href="../../muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer" data-summary="this folder contains a prototype integration of a monte carlo tree search (mcts) agent with language model guidance. run `install_and_launch.sh` to build the environment and start the demo in your browser. 1. ensure python 3.9+ is installed.">
       <img src="muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy">
       <h3>MuZero MCTS LLM Agent Demo</h3>
       <p class='demo-desc'>This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run `install_and_launch.sh` to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.</p>
     </a>
-    <a class="demo-card" href="../omni_factory_demo/" target="_blank" rel="noopener noreferrer" data-summary="run the full demo interactively in [google colab](colab_omni_factory_demo.ipynb). to verify local prerequisites before launching the demo, run:">
+    <a class="demo-card" href="../../omni_factory_demo/" target="_blank" rel="noopener noreferrer" data-summary="run the full demo interactively in [google colab](colab_omni_factory_demo.ipynb). to verify local prerequisites before launching the demo, run:">
       <img src="omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb). To verify local prerequisites before launching the demo, run:</p>
     </a>
-    <a class="demo-card" href="../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="self‑healing repo demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
+    <a class="demo-card" href="../../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="self‑healing repo demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
       <img src="self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
       <p class='demo-desc'>Self‑Healing Repo Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="*minimal conditions for stable, antifragile multi-agent order* **author :** vincent boucher — president, montreal.ai · quebec.ai">
+    <a class="demo-card" href="../../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="*minimal conditions for stable, antifragile multi-agent order* **author :** vincent boucher — president, montreal.ai · quebec.ai">
       <img src="solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
       <p class='demo-desc'>*Minimal Conditions for Stable, Antifragile Multi-Agent Order* **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI</p>
     </a>
-    <a class="demo-card" href="../sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="a minimal showcase of a self-directed agent with token-gated access. run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.">
+    <a class="demo-card" href="../../sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="a minimal showcase of a self-directed agent with token-gated access. run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.">
       <img src="sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
       <p class='demo-desc'>A minimal showcase of a self-directed agent with token-gated access. Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.</p>
     </a>
-    <a class="demo-card" href="../utils/" target="_blank" rel="noopener noreferrer" data-summary="this directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.">
+    <a class="demo-card" href="../../utils/" target="_blank" rel="noopener noreferrer" data-summary="this directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.">
       <img src="utils/assets/preview.svg" alt="Demo Utilities" loading="lazy">
       <h3>Demo Utilities</h3>
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.</p>
     </a>
   </div>
-  <p><a href="../index.html">⬅️ Back to Home</a></p>
-  <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
+  <p><a href="../../index.html">⬅️ Back to Home</a></p>
+  <p class="snippet"><a href="../../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
   <script>
     const input = document.getElementById('search-input');
     const cards = document.querySelectorAll('.demo-card');

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -20,117 +20,117 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
       <p class='demo-desc'>AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer" data-summary="**global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. **alpha‑factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.">
       <img src="alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**" loading="lazy">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
       <p class='demo-desc'>**Global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. **Alpha‑Factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.</p>
     </a>
-    <a class="demo-card" href="alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer" data-summary="**alpha‑factory v1 → ω‑lattice v0** _transmuting cosmological free‑energy gradients into compounding cash‑flows._">
       <img src="alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**" loading="lazy">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
       <p class='demo-desc'>**Alpha‑Factory v1 → Ω‑Lattice v0** _Transmuting cosmological free‑energy gradients into compounding cash‑flows._</p>
     </a>
-    <a class="demo-card" href="alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi business 👁️✨ $agialpha using alpha‑factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.">
       <img src="alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy">
       <h3>Alpha Agi Business V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.</p>
     </a>
-    <a class="demo-card" href="alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer" data-summary="the **α‑agi insight** demo predicts which industry sector is most likely to be transformed by artificial general intelligence. it runs a small">
       <img src="alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
       <p class='demo-desc'>The **α‑AGI Insight** demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small</p>
     </a>
-    <a class="demo-card" href="alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer" data-summary="🎖️ α-agi insight 👁️✨ — beyond human foresight version 1.1 (2025-07-15)">
       <img src="alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
       <p class='demo-desc'>🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)</p>
     </a>
-    <a class="demo-card" href="alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi marketplace 👁️✨ $agialpha hunt exploitable alpha 🎯 and convert it into tangible value 💎.">
       <img src="alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy">
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
     </a>
-    <a class="demo-card" href="alpha_asi_world_model/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨ last updated 2025-04-25   maintainer → montreal.ai core agi team">
       <img src="alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
       <p class='demo-desc'>README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team</p>
     </a>
-    <a class="demo-card" href="cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="current demo version: `1.0.0`. *out-learn • out-think • out-design • out-strategise • out-execute*">
       <img src="cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
       <p class='demo-desc'>Current demo version: `1.0.0`. *Out-learn • Out-think • Out-design • Out-strategise • Out-execute*</p>
     </a>
-    <a class="demo-card" href="era_of_experience/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="era_of_experience/" target="_blank" rel="noopener noreferrer" data-summary="era‑of‑experience demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi">
       <img src="era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy">
       <h3>Era Of Experience</h3>
       <p class='demo-desc'>Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
     </a>
-    <a class="demo-card" href="finance_alpha/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="finance_alpha/" target="_blank" rel="noopener noreferrer" data-summary="welcome! these short demos let **anyone – even if you’ve never touched a terminal – spin up alpha‑factory, watch a live trade, and explore the">
       <img src="finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy">
       <h3>Alpha‑Factory Demos 📊</h3>
       <p class='demo-desc'>Welcome! These short demos let **anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the</p>
     </a>
-    <a class="demo-card" href="macro_sentinel/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="macro_sentinel/" target="_blank" rel="noopener noreferrer" data-summary="*cross‑asset macro risk radar powered by multi‑agent α‑agi* **tl;dr**   spin up a self‑healing stack that ingests macro telemetry, runs a monte‑carlo risk engine, sizes an es hedge, and explains its reasoning—all behind a gradio dashboard.">
       <img src="macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
       <p class='demo-desc'>*Cross‑asset macro risk radar powered by multi‑agent α‑AGI* **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.</p>
     </a>
-    <a class="demo-card" href="meta_agentic_agi/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_agi/" target="_blank" rel="noopener noreferrer" data-summary="**official definition – meta-agentic (adj.)** *describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*">
       <img src="meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>**Official definition – Meta-Agentic (adj.)** *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*</p>
     </a>
-    <a class="demo-card" href="meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer" data-summary="identical to **v1** plus a statistical-physics wrapper that logs and minimises **gibbs / variational free-energy** for each candidate agent during the evolutionary search. *metric toggle*: `configs/default.yml → physics_metric: free_energy`">
       <img src="meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**" loading="lazy">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Identical to **v1** plus a statistical-physics wrapper that logs and minimises **Gibbs / variational free-energy** for each candidate agent during the evolutionary search. *Metric toggle*: `configs/default.yml → physics_metric: free_energy`</p>
     </a>
-    <a class="demo-card" href="meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer" data-summary="identical to **v1** plus **two synergistic upgrades** 1. *statistical‑physics wrapper* — logs &amp; minimises **gibbs / variational free‑energy** for every candidate agent.">
       <img src="meta_agentic_agi_v3/assets/preview.svg" alt="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**" loading="lazy">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
       <p class='demo-desc'>Identical to **v1** plus **two synergistic upgrades** 1. *Statistical‑physics wrapper* — logs &amp; minimises **Gibbs / variational free‑energy** for every candidate agent.</p>
     </a>
-    <a class="demo-card" href="meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer" data-summary="**abstract:** we pioneer **meta-agentic tree search (mats)**, a novel framework for autonomous multi-agent decision optimization in complex strategic domains. mats enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through **recursive agent-to-agent interactions**. in this **second-order agentic** scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. this recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. **status:** experimental · proof‑of‑concept · alpha">
       <img src="meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
       <p class='demo-desc'>**Abstract:** We pioneer **Meta-Agentic Tree Search (MATS)**, a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through **recursive agent-to-agent interactions**. In this **second-order agentic** scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. **Status:** Experimental · Proof‑of‑Concept · Alpha</p>
     </a>
-    <a class="demo-card" href="muzero_planning/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="muzero_planning/" target="_blank" rel="noopener noreferrer" data-summary="muzero planning demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
       <img src="muzero_planning/assets/preview.svg" alt="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time" loading="lazy">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
       <p class='demo-desc'>MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer" data-summary="this folder contains a prototype integration of a monte carlo tree search (mcts) agent with language model guidance. run `install_and_launch.sh` to build the environment and start the demo in your browser. 1. ensure python 3.9+ is installed.">
       <img src="muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy">
       <h3>MuZero MCTS LLM Agent Demo</h3>
       <p class='demo-desc'>This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run `install_and_launch.sh` to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.</p>
     </a>
-    <a class="demo-card" href="omni_factory_demo/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="omni_factory_demo/" target="_blank" rel="noopener noreferrer" data-summary="run the full demo interactively in [google colab](colab_omni_factory_demo.ipynb). to verify local prerequisites before launching the demo, run:">
       <img src="omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb). To verify local prerequisites before launching the demo, run:</p>
     </a>
-    <a class="demo-card" href="self_healing_repo/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="self‑healing repo demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
       <img src="self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
       <p class='demo-desc'>Self‑Healing Repo Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
     </a>
-    <a class="demo-card" href="solving_agi_governance/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="*minimal conditions for stable, antifragile multi-agent order* **author :** vincent boucher — president, montreal.ai · quebec.ai">
       <img src="solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
       <p class='demo-desc'>*Minimal Conditions for Stable, Antifragile Multi-Agent Order* **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI</p>
     </a>
-    <a class="demo-card" href="sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="a minimal showcase of a self-directed agent with token-gated access. run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.">
       <img src="sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
       <p class='demo-desc'>A minimal showcase of a self-directed agent with token-gated access. Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.</p>
     </a>
-    <a class="demo-card" href="utils/" target="_blank" rel="noopener noreferrer">
+    <a class="demo-card" href="utils/" target="_blank" rel="noopener noreferrer" data-summary="this directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.">
       <img src="utils/assets/preview.svg" alt="Demo Utilities" loading="lazy">
       <h3>Demo Utilities</h3>
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.</p>
@@ -144,8 +144,8 @@
     input.addEventListener('input', () => {
       const term = input.value.toLowerCase();
       cards.forEach(c => {
-        const t = c.querySelector('h3').textContent.toLowerCase();
-        c.style.display = t.includes(term) ? 'block' : 'none';
+        const text = c.querySelector('h3').textContent.toLowerCase() + ' ' + (c.dataset.summary || '');
+        c.style.display = text.includes(term) ? 'block' : 'none';
       });
     });
   </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
   <p>
     <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>
     <a class="btn docs" href="gallery.html">Visual Demo Gallery</a>
+    <a class="btn docs" href="alpha_factory_v1/demos/">Gallery Mirror</a>
     <a class="btn docs" href="DEMO_GALLERY/">Demo Table</a>
     <a class="btn docs" href="README/">View Documentation</a>
   </p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
 - Disclaimer: DISCLAIMER_SNIPPET.md
 - Alpha AGI Insight Demo: alpha_agi_insight_v1/index.html
 - Visual Demo Gallery: gallery.html
+- Gallery Mirror: alpha_factory_v1/demos/index.html
 - Demo Gallery:
   - Overview: DEMO_GALLERY.md
   - Aiga Meta Evolution: demos/aiga_meta_evolution.md

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -55,6 +55,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEMOS_DIR = REPO_ROOT / "docs" / "demos"
 GALLERY_FILE = REPO_ROOT / "docs" / "gallery.html"
 DEMOS_INDEX_FILE = REPO_ROOT / "docs" / "demos" / "index.html"
+SUBDIR_GALLERY_FILE = REPO_ROOT / "docs" / "alpha_factory_v1" / "demos" / "index.html"
 
 
 def parse_page(md_file: Path) -> tuple[str, str, str, str]:
@@ -135,10 +136,10 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
         full_link = f"{disclaimer_prefix}{link}"
         summary_attr = html.escape(summary.lower()) if summary else ""
         lines.append(
-            "    <a class=\"demo-card\" "
+            '    <a class="demo-card" '
             f'href="{html.escape(full_link)}" target="_blank" '
             'rel="noopener noreferrer" '
-            f'data-summary="{summary_attr}">' 
+            f'data-summary="{summary_attr}">'
         )
         ext = Path(preview).suffix.lower()
         if ext in {".mp4", ".webm"}:
@@ -164,7 +165,9 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
     lines.append("    input.addEventListener('input', () => {")
     lines.append("      const term = input.value.toLowerCase();")
     lines.append("      cards.forEach(c => {")
-    lines.append("        const text = c.querySelector('h3').textContent.toLowerCase() + ' ' + (c.dataset.summary || '');")
+    lines.append(
+        "        const text = c.querySelector('h3').textContent.toLowerCase() + ' ' + (c.dataset.summary || '');"
+    )
     lines.append("        c.style.display = text.includes(term) ? 'block' : 'none';")
     lines.append("      });")
     lines.append("    });")
@@ -179,7 +182,15 @@ def main() -> None:
     GALLERY_FILE.write_text(gallery_html, encoding="utf-8")
     demos_html = build_html(entries, disclaimer_prefix="../")
     DEMOS_INDEX_FILE.write_text(demos_html, encoding="utf-8")
-    print("Wrote" f" {GALLERY_FILE.relative_to(REPO_ROOT)} and" f" {DEMOS_INDEX_FILE.relative_to(REPO_ROOT)}")
+    subdir_html = build_html(entries, disclaimer_prefix="../../")
+    SUBDIR_GALLERY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SUBDIR_GALLERY_FILE.write_text(subdir_html, encoding="utf-8")
+    print(
+        "Wrote"
+        f" {GALLERY_FILE.relative_to(REPO_ROOT)},"
+        f" {DEMOS_INDEX_FILE.relative_to(REPO_ROOT)} and"
+        f" {SUBDIR_GALLERY_FILE.relative_to(REPO_ROOT)}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- generate a gallery mirror under `alpha_factory_v1/demos/`
- link to the mirror from the home page and docs navigation

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files scripts/generate_gallery_html.py docs/gallery.html docs/demos/index.html docs/index.html mkdocs.yml docs/alpha_factory_v1/demos/index.html` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68614a67e43083338f035062a64a6067