### PR TITLE
Improve demo gallery docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build_web demo-setup demo-run compose-up loadtest \
-        gallery-build gallery-open gallery-deploy demo-open \
+        gallery-build gallery-open subdir-gallery-open gallery-deploy demo-open \
         proto proto-verify benchmark
 
 build_web:
@@ -46,7 +46,10 @@ gallery-build:
 	bash scripts/build_gallery_site.sh
 
 gallery-open:
-	python scripts/open_gallery.py
+        python scripts/open_gallery.py
+
+subdir-gallery-open:
+	python scripts/open_subdir_gallery.py
 
 gallery-deploy:
         bash scripts/deploy_gallery_pages.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 - **Open Gallery (Python)** – run `./scripts/open_gallery.py` for a cross-platform way to launch the published gallery, falling back to the local build when offline.
 - **Open Gallery (Shell)** – run `./scripts/open_gallery.sh` to open the gallery in your browser. It automatically builds a fresh local copy when the remote site isn't available.
 - **Open Individual Demo** – run `./scripts/open_demo.sh <demo_dir>` to open a single page from the gallery.
+- **Open Subdirectory Gallery** – run `./scripts/open_subdir_gallery.py` to launch the mirror under `alpha_factory_v1/demos/`.
 - **Verify Disclaimer Snippet** – run `python scripts/verify_disclaimer_snippet.py` to ensure each file contains the disclaimer text once.
 
 ## Building the React Dashboard


### PR DESCRIPTION
## Summary
- mention the subdirectory gallery helper in docs
- add `subdir-gallery-open` target in Makefile

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pre-commit run --files docs/README.md Makefile` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68615a6d74b48333a195bec4a3416725