### PR TITLE
Fix gallery disclaimer links

### DIFF
--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo'>
 
 <p><a href='../demos/aiga_meta_evolution.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – “Infinite Bloom 3.0”'>
 
 <p><a href='../demos/alpha_agi_business_2_v1.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — Omega‑Grade Edition'>
 
 <p><a href='../demos/alpha_agi_business_3_v1.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Alpha Agi Business V1'>
 
 <p><a href='../demos/alpha_agi_business_v1.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)'>
 
 <p><a href='../demos/alpha_agi_insight_v0.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -95,7 +95,7 @@
       <small>For illustration purposes only; data is synthetic and for demonstration of concept.</small>
     </p>
       <section class="snippet">
-        <a href="../DISCLAIMER_SNIPPET.html">See docs/DISCLAIMER_SNIPPET.md</a>
+        <a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a>
         This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
       </section>
       <p>

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Alpha Agi Marketplace V1'>
 
 <p><a href='../demos/alpha_agi_marketplace_v1.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/alpha_asi_world_model/index.html
+++ b/docs/alpha_asi_world_model/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Alpha Asi World Model'>
 
 <p><a href='../demos/alpha_asi_world_model.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='👁️ Alpha-Factory v1 — Cross-Industry AGENTIC α-AGI Demo'>
 
 <p><a href='../demos/cross_industry_alpha_factory.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Era Of Experience'>
 
 <p><a href='../demos/era_of_experience.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Alpha‑Factory Demos 📊'>
 
 <p><a href='../demos/finance_alpha.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨'>
 
 <p><a href='../demos/macro_sentinel.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Meta‑Agentic α‑AGI 👁️✨ Demo – Production‑Grade v0.1.0'>
 
 <p><a href='../demos/meta_agentic_agi.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Meta‑Agentic α‑AGI 👁️✨ Demo v2 – Production‑Grade v0.1.0'>
 
 <p><a href='../demos/meta_agentic_agi_v2.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)'>
 
 <p><a href='../demos/meta_agentic_agi_v3.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Meta‑Agentic Tree Search (MATS) Demo — v0'>
 
 <p><a href='../demos/meta_agentic_tree_search_v0.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='🌟 Mastery Without a Rule‑Book — watch MuZero think in real time'>
 
 <p><a href='../demos/muzero_planning.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='MuZero MCTS LLM Agent Demo'>
 
 <p><a href='../demos/muzeromctsllmagent_v0.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)'>
 
 <p><a href='../demos/omni_factory_demo.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/self_healing_repo/index.html
+++ b/docs/self_healing_repo/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='🔧 Self‑Healing Repo — when CI fails, agents patch'>
 
 <p><a href='../demos/self_healing_repo.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/solving_agi_governance/index.html
+++ b/docs/solving_agi_governance/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Solving α-AGI Governance [![Open In Colab]][colab-notebook]'>
 
 <p><a href='../demos/solving_agi_governance.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Sovereign Agentic AGI Alpha Agent Demo'>
 
 <p><a href='../demos/sovereign_agentic_agialpha_agent_v0.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -17,6 +17,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <img class='preview' src='assets/preview.svg' alt='Demo Utilities'>
 
 <p><a href='../demos/utils.md'>Detailed instructions</a></p>
-<p class='snippet'><a href='../DISCLAIMER_SNIPPET.html'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix disclaimers to point to directory instead of html file

## Testing
- `bash scripts/deploy_gallery_pages.sh` *(fails: preflight dependencies missing)*
- `pre-commit run --files docs/aiga_meta_evolution/index.html` *(fails: proto-verify and verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_686169deda08833399ffd44a8dad2762