### PR TITLE
Update docs landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,22 +1,20 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>α‑AGI Insight</title>
-  <meta http-equiv="refresh" content="0; url=alpha_agi_insight_v1/" />
-  <script>
-    window.location.href = "alpha_agi_insight_v1/";
-  </script>
+  <title>Alpha‑Factory</title>
   <style>
-    body { font-family: sans-serif; text-align: center; margin-top: 4rem; }
-    .btn { display: inline-block; padding: 1em 2em; margin: 1em; font-size: 1.2em; text-decoration: none; border-radius: 4px; }
-    .demo { background: #4caf50; color: #fff; }
-    .docs { background: #2196f3; color: #fff; }
+    body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; text-align: center; }
+    .btn { display: inline-block; padding: 0.5rem 1rem; margin: 1rem; text-decoration: none; border-radius: 4px; color: #fff; }
+    .demo { background: #4caf50; }
+    .docs { background: #2196f3; }
   </style>
 </head>
 <body>
-  <p>The Alpha-Factory project showcases experimental AGI research tools and demos.</p>
+  <h1>Alpha‑Factory v1</h1>
+  <p>Explore experimental AGI research tools and demos.</p>
   <p>
     <a class="btn demo" href="alpha_agi_insight_v1/index.html">Launch Demo</a>
     <a class="btn docs" href="gallery.html">Visual Demo Gallery</a>


### PR DESCRIPTION
## Summary
- remove auto-redirect from `docs/index.html`
- add landing page links to the Insight demo and gallery

## Testing
- `pre-commit run --hook-stage manual --files docs/index.html mkdocs.yml` *(failed: proto-verify, verify-requirements-lock)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68616ea0127c83338524709c486c5870