### PR TITLE
[alpha_factory] add demo footer links

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -101,6 +101,9 @@
       <p>
         <a href="../README/">⬅ Back to Documentation</a>
       </p>
+      <p>
+        <a href="../gallery.html">⬅️ Back to Gallery</a>
+      </p>
     </footer>
 
   <script>

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi_v2.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi_v3.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/muzeromctsllmagent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/omni_factory_demo.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/solving_agi_governance/index.html
+++ b/docs/solving_agi_governance/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/solving_agi_governance.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/sovereign_agentic_agialpha_agent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -18,5 +18,6 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/utils.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add gallery link footer to multiple demo docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686172b9be388333b77b7ca9be2cb3e9