### PR TITLE
feat: add offline toggle for insight browser

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -63,6 +63,10 @@ is missing the build scripts continue with default empty values:
 - `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
 - Browsers with WebGPU can accelerate the local model using the ONNX runtime.
   Use the GPU toggle in the power panel to switch between WebGPU and WASM.
+- The power panel also includes an **Offline/API** selector. Choose
+  **Run Offline** to execute the bundled GPT‑2 model via Pyodide or
+  **Run with OpenAI API** when an `OPENAI_API_KEY` is available. The key is
+  stored in `localStorage` and the app falls back to offline mode when absent.
 - Set `window.DEBUG = true` before loading the page to expose debugging helpers
   like `window.pop` and `window.coldZone`.
 
@@ -131,6 +135,7 @@ exported JSON results can be pinned.
 If `OPENAI_API_KEY` is stored in `localStorage`, the demo uses the OpenAI API for
 chat prompts. When no key is present a lightweight GPT‑2 model under
 `wasm_llm/` runs locally.
+Use the Offline/API selector in the power panel to switch modes at any time.
 
 Open `index.html` directly or pin the built `dist/` directory to IPFS
 (`ipfs add -r dist`) and share the CID.
@@ -260,6 +265,9 @@ browser console and the demo falls back to the built‑in English strings.
 - **GPU** – enable or disable WebGPU acceleration. The app sends a
   `{type:'gpu', available:<flag>}` message to the evolver worker which
   forwards the flag to mutation functions.
+- **Offline/API** – toggle between the local Pyodide model and the
+  OpenAI API. When the key is missing the demo automatically reverts to
+  offline mode.
 
   Set `localStorage.setItem('USE_GPU','1')` to force the GPU backend when
   WebGPU is available.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-import { setUseGpu, gpuAvailable } from '../utils/llm.ts';
+import { setUseGpu, gpuAvailable, setOffline, isOffline } from '../utils/llm.ts';
 import type { EvaluatorGenome } from '../evaluator_genome.ts';
 import type { GpuToggleEvent } from './types.ts';
 
 export function initPowerPanel(): {
   update: (e: EvaluatorGenome | GpuToggleEvent) => void;
   gpuToggle: HTMLInputElement;
+  modeSelect: HTMLSelectElement;
 } {
   const panel = document.createElement('div');
   panel.id = 'power-panel';
@@ -35,6 +36,19 @@ export function initPowerPanel(): {
   gpuStatus.textContent = gpuAvailable ? '(available)' : '(unavailable)';
   gpuLabel.appendChild(gpuStatus);
   panel.appendChild(gpuLabel);
+
+  const modeLabel = document.createElement('label');
+  const modeSelect = document.createElement('select');
+  modeSelect.id = 'api-mode';
+  const optOffline = document.createElement('option');
+  optOffline.value = 'offline';
+  optOffline.textContent = 'Run Offline';
+  const optApi = document.createElement('option');
+  optApi.value = 'api';
+  optApi.textContent = 'Run with OpenAI API';
+  modeSelect.append(optOffline, optApi);
+  modeLabel.appendChild(modeSelect);
+  panel.appendChild(modeLabel);
   panel.appendChild(pre);
   try {
     const saved = localStorage.getItem('USE_GPU');
@@ -48,9 +62,27 @@ export function initPowerPanel(): {
     window.USE_GPU = gpuToggle.checked && !!(navigator as any).gpu;
     setUseGpu(window.USE_GPU);
   });
+  try {
+    modeSelect.value = isOffline() ? 'offline' : 'api';
+  } catch {
+    modeSelect.value = 'offline';
+  }
+  setOffline(modeSelect.value === 'offline');
+  modeSelect.addEventListener('change', () => {
+    const offline = modeSelect.value === 'offline';
+    if (!offline && !localStorage.getItem('OPENAI_API_KEY')) {
+      const key = prompt('Enter OpenAI API key');
+      if (key) {
+        try { localStorage.setItem('OPENAI_API_KEY', key); } catch {}
+      } else {
+        modeSelect.value = 'offline';
+      }
+    }
+    setOffline(modeSelect.value === 'offline');
+  });
   document.body.appendChild(panel);
   function update(e: EvaluatorGenome | GpuToggleEvent): void {
     pre.textContent = JSON.stringify(e, null, 2);
   }
-  return { update, gpuToggle };
+  return { update, gpuToggle, modeSelect };
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.ts
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.ts
@@ -7,6 +7,12 @@ export const LLM_LOAD_START = 'llm-load-start';
 export const LLM_LOAD_END = 'llm-load-end';
 export const gpuAvailable =
   typeof navigator !== 'undefined' && !!(navigator as any).gpu;
+let runOffline = false;
+
+try {
+  const offline = localStorage.getItem('RUN_OFFLINE');
+  runOffline = offline === '1';
+} catch {}
 
 try {
   const saved = localStorage.getItem('USE_GPU');
@@ -21,6 +27,17 @@ export function setUseGpu(flag: boolean) {
     localStorage.setItem('USE_GPU', useGpu ? '1' : '0');
   } catch {}
   localModel = null;
+}
+
+export function setOffline(flag: boolean) {
+  runOffline = !!flag;
+  try {
+    localStorage.setItem('RUN_OFFLINE', runOffline ? '1' : '0');
+  } catch {}
+}
+
+export function isOffline(): boolean {
+  return runOffline;
 }
 
 async function ensureOrt(): Promise<boolean> {
@@ -74,7 +91,8 @@ async function loadLocal(): Promise<any> {
 }
 
 export async function chat(prompt: string): Promise<string> {
-  const key = localStorage.getItem('OPENAI_API_KEY');
+  const offline = runOffline;
+  const key = offline ? null : localStorage.getItem('OPENAI_API_KEY');
   if (key) {
     const resp = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -135,9 +135,11 @@ The demo ships with both a **command-line interface** *and* an
 optional **web dashboard** (Streamlit *or* FastAPI + React) so that analysts,
 executives, and researchers can explore “what-if” scenarios in minutes.
 
-> **Runs anywhere – with or without an `OPENAI_API_KEY`.**  
+> **Runs anywhere – with or without an `OPENAI_API_KEY`.**
 > When the key is absent, the system automatically switches to a local
-> open-weights model and offline toolset.
+> open-weights model and offline toolset. The browser demo includes an
+> **Offline/API** selector that stores the key in `localStorage` and
+> falls back gracefully when missing.
 
 ### Repository Layout
 


### PR DESCRIPTION
## Summary
- add RUN_OFFLINE selector to Insight browser power panel
- update LLM utility to respect RUN_OFFLINE setting
- mention the new selector in documentation

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ModuleNotFoundError in tests)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/utils/llm.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/ui/PowerPanel.ts alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md docs/demos/alpha_agi_insight_v1.md` *(fails: proto-verify hook)*

------
https://chatgpt.com/codex/tasks/task_e_686173fbbc3c8333aa79e3230b32b706