### PR TITLE
[alpha_factory] fix agent imports

### DIFF
--- a/alpha_factory_v1/core/agents/base_agent.py
+++ b/alpha_factory_v1/core/agents/base_agent.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Base class shared by all Insight demo agents.
 
-The class wires each agent into the :class:`~..utils.messaging.A2ABus` and
+The class wires each agent into the :class:`~alpha_factory_v1.common.utils.messaging.A2ABus` and
 provides helper methods for sending and receiving envelopes. Subclasses
 implement :meth:`handle` to process messages and :meth:`run_cycle` for
 periodic behaviour.
@@ -17,12 +17,12 @@ try:
 except Exception:  # pragma: no cover - optional
     LLMProvider = None
 
-from ..utils import messaging
-from .adk_adapter import ADKAdapter
-from .mcp_adapter import MCPAdapter
+from ...common.utils import messaging
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.adk_adapter import ADKAdapter
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.mcp_adapter import MCPAdapter
 
 if TYPE_CHECKING:  # pragma: no cover - type hint only
-    from ..utils.logging import Ledger
+    from ...common.utils.logging import Ledger
 
 try:
     from openai.agents import AgentContext as _AgentContext

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -2,13 +2,14 @@
 """Collection of minimal agents used in the Insight scenario.
 
 The package exposes small, single‑responsibility agents. Each agent
-subclasses :class:`~.base_agent.BaseAgent` and cooperates via the
+subclasses :class:`~alpha_factory_v1.core.agents.base_agent.BaseAgent` and cooperates via the
 :class:`~alpha_factory_v1.common.utils.messaging.A2ABus`.
 """
 
 from .adk_adapter import ADKAdapter
 from .mcp_adapter import MCPAdapter
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents import base_agent as base_agent
+BaseAgent = base_agent.BaseAgent
 from .research_agent import ResearchAgent
 from .adk_summariser_agent import ADKSummariserAgent
 from .chaos_agent import ChaosAgent
@@ -16,7 +17,6 @@ from .chaos_agent import ChaosAgent
 __all__ = [
     "ADKAdapter",
     "MCPAdapter",
-    "BaseAgent",
     "ResearchAgent",
     "ADKSummariserAgent",
     "ChaosAgent",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/adk_summariser_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/adk_summariser_agent.py
@@ -2,7 +2,7 @@
 """Agent summarising research data via the Google ADK."""
 from __future__ import annotations
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.core.utils.tracing import span

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/chaos_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/chaos_agent.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.core.utils.tracing import span

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/codegen_agent.py
@@ -37,7 +37,7 @@ from alpha_factory_v1.core.utils.opa_policy import violates_finance_policy
 from alpha_factory_v1.core.utils.secure_run import secure_run
 
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging, logging as insight_logging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.common.utils.retry import with_retry

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/market_agent.py
@@ -8,7 +8,7 @@ passed to the :class:`CodeGenAgent`.
 
 from __future__ import annotations
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging, logging as insight_logging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.common.utils.retry import with_retry

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/memory_agent.py
@@ -8,7 +8,7 @@ of stored items back to the orchestrator.
 
 from __future__ import annotations
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging, logging as insight_logging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.core.utils.tracing import span

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/planning_agent.py
@@ -8,7 +8,7 @@ inside :meth:`run_cycle`.
 
 from __future__ import annotations
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.common.utils.retry import with_retry

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/research_agent.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import random
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from ..simulation import forecast, sector
 from alpha_factory_v1.common.utils import messaging, logging as insight_logging
 from alpha_factory_v1.common.utils.logging import Ledger

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/safety_agent.py
@@ -8,7 +8,7 @@ implemented for demonstration purposes.
 
 from __future__ import annotations
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.core.utils.tracing import span

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/strategy_agent.py
@@ -8,7 +8,7 @@ for the market agent. It can optionally leverage a local or remote LLM during
 
 from __future__ import annotations
 
-from .base_agent import BaseAgent
+from alpha_factory_v1.core.agents.base_agent import BaseAgent
 from alpha_factory_v1.common.utils import messaging, logging as insight_logging
 from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.common.utils.retry import with_retry


### PR DESCRIPTION
## Summary
- reference BaseAgent from core.agents
- keep base_agent module alias for tests
- hook up adapters using absolute imports

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'forecast')*
- `mypy --config-file mypy.ini` *(fails: Module "alpha_factory_v1.demos.alpha_agi_insight_v1.src.simulation" has no attribute "forecast" [attr-defined])*

------
https://chatgpt.com/codex/tasks/task_e_68619a34e82883339031548553d25a09