### PR TITLE
[alpha_factory] add dynamic log replays to demos

### DIFF
--- a/docs/aiga_meta_evolution/assets/chart.js
+++ b/docs/aiga_meta_evolution/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/aiga_meta_evolution/assets/script.js
+++ b/docs/aiga_meta_evolution/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/aiga_meta_evolution/assets/style.css
+++ b/docs/aiga_meta_evolution/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/aiga_meta_evolution.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/alpha_agi_business_2_v1/assets/chart.js
+++ b/docs/alpha_agi_business_2_v1/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/alpha_agi_business_2_v1/assets/script.js
+++ b/docs/alpha_agi_business_2_v1/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/alpha_agi_business_2_v1/assets/style.css
+++ b/docs/alpha_agi_business_2_v1/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_business_2_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/alpha_agi_business_3_v1/assets/chart.js
+++ b/docs/alpha_agi_business_3_v1/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/alpha_agi_business_3_v1/assets/script.js
+++ b/docs/alpha_agi_business_3_v1/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/alpha_agi_business_3_v1/assets/style.css
+++ b/docs/alpha_agi_business_3_v1/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_business_3_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/alpha_agi_business_v1/assets/chart.js
+++ b/docs/alpha_agi_business_v1/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/alpha_agi_business_v1/assets/script.js
+++ b/docs/alpha_agi_business_v1/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/alpha_agi_business_v1/assets/style.css
+++ b/docs/alpha_agi_business_v1/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_business_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/alpha_agi_insight_v0/assets/chart.js
+++ b/docs/alpha_agi_insight_v0/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/alpha_agi_insight_v0/assets/script.js
+++ b/docs/alpha_agi_insight_v0/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/alpha_agi_insight_v0/assets/style.css
+++ b/docs/alpha_agi_insight_v0/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_insight_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/alpha_agi_insight_v1/assets/logs.json
+++ b/docs/alpha_agi_insight_v1/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/alpha_agi_insight_v1/assets/script.js
+++ b/docs/alpha_agi_insight_v1/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/alpha_agi_insight_v1/assets/style.css
+++ b/docs/alpha_agi_insight_v1/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/alpha_agi_marketplace_v1/assets/chart.js
+++ b/docs/alpha_agi_marketplace_v1/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/alpha_agi_marketplace_v1/assets/script.js
+++ b/docs/alpha_agi_marketplace_v1/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/alpha_agi_marketplace_v1/assets/style.css
+++ b/docs/alpha_agi_marketplace_v1/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_marketplace_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/alpha_asi_world_model/assets/chart.js
+++ b/docs/alpha_asi_world_model/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/alpha_asi_world_model/assets/script.js
+++ b/docs/alpha_asi_world_model/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/alpha_asi_world_model/assets/style.css
+++ b/docs/alpha_asi_world_model/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/alpha_asi_world_model/index.html
+++ b/docs/alpha_asi_world_model/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_asi_world_model.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/cross_industry_alpha_factory/assets/chart.js
+++ b/docs/cross_industry_alpha_factory/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/cross_industry_alpha_factory/assets/script.js
+++ b/docs/cross_industry_alpha_factory/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/cross_industry_alpha_factory/assets/style.css
+++ b/docs/cross_industry_alpha_factory/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/cross_industry_alpha_factory.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/era_of_experience/assets/chart.js
+++ b/docs/era_of_experience/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/era_of_experience/assets/script.js
+++ b/docs/era_of_experience/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/era_of_experience/assets/style.css
+++ b/docs/era_of_experience/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/era_of_experience.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/finance_alpha/assets/chart.js
+++ b/docs/finance_alpha/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/finance_alpha/assets/script.js
+++ b/docs/finance_alpha/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/finance_alpha/assets/style.css
+++ b/docs/finance_alpha/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/finance_alpha.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/macro_sentinel/assets/chart.js
+++ b/docs/macro_sentinel/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/macro_sentinel/assets/script.js
+++ b/docs/macro_sentinel/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/macro_sentinel/assets/style.css
+++ b/docs/macro_sentinel/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/macro_sentinel.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/meta_agentic_agi/assets/logs.json
+++ b/docs/meta_agentic_agi/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/meta_agentic_agi/assets/script.js
+++ b/docs/meta_agentic_agi/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/meta_agentic_agi/assets/style.css
+++ b/docs/meta_agentic_agi/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -18,6 +18,10 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
+<script src="../assets/chart.min.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v2/assets/logs.json
+++ b/docs/meta_agentic_agi_v2/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/meta_agentic_agi_v2/assets/script.js
+++ b/docs/meta_agentic_agi_v2/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/meta_agentic_agi_v2/assets/style.css
+++ b/docs/meta_agentic_agi_v2/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -18,6 +18,10 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi_v2.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
+<script src="../assets/chart.min.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v3/assets/logs.json
+++ b/docs/meta_agentic_agi_v3/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/meta_agentic_agi_v3/assets/script.js
+++ b/docs/meta_agentic_agi_v3/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/meta_agentic_agi_v3/assets/style.css
+++ b/docs/meta_agentic_agi_v3/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -18,6 +18,10 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi_v3.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
+<script src="../assets/chart.min.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/meta_agentic_tree_search_v0/assets/chart.js
+++ b/docs/meta_agentic_tree_search_v0/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/meta_agentic_tree_search_v0/assets/script.js
+++ b/docs/meta_agentic_tree_search_v0/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/meta_agentic_tree_search_v0/assets/style.css
+++ b/docs/meta_agentic_tree_search_v0/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/meta_agentic_tree_search_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/muzero_planning/assets/chart.js
+++ b/docs/muzero_planning/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/muzero_planning/assets/script.js
+++ b/docs/muzero_planning/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/muzero_planning/assets/style.css
+++ b/docs/muzero_planning/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/muzero_planning.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/muzeromctsllmagent_v0/assets/logs.json
+++ b/docs/muzeromctsllmagent_v0/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/muzeromctsllmagent_v0/assets/script.js
+++ b/docs/muzeromctsllmagent_v0/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/muzeromctsllmagent_v0/assets/style.css
+++ b/docs/muzeromctsllmagent_v0/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -18,6 +18,10 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/muzeromctsllmagent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
+<script src="../assets/chart.min.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/omni_factory_demo/assets/logs.json
+++ b/docs/omni_factory_demo/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/omni_factory_demo/assets/script.js
+++ b/docs/omni_factory_demo/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/omni_factory_demo/assets/style.css
+++ b/docs/omni_factory_demo/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -18,6 +18,10 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/omni_factory_demo.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
+<script src="../assets/chart.min.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/self_healing_repo/assets/chart.js
+++ b/docs/self_healing_repo/assets/chart.js
@@ -1,6 +1,0 @@
-fetch('assets/logs.json').then(r=>r.json()).then(data=>{
- const ctx=document.getElementById('chart');
- const labels=data.steps;
- const values=data.values;
- new Chart(ctx,{type:'line',data:{labels, datasets:[{label:'Demo Metric',data:values, fill:false,borderColor:'blue'}]},options:{animation:{duration:2000}, responsive:true,maintainAspectRatio:false}});
-});

--- a/docs/self_healing_repo/assets/script.js
+++ b/docs/self_healing_repo/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/self_healing_repo/assets/style.css
+++ b/docs/self_healing_repo/assets/style.css
@@ -1,1 +1,2 @@
 #chart{width:100%;height:300px;}
+#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/self_healing_repo/index.html
+++ b/docs/self_healing_repo/index.html
@@ -19,8 +19,9 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/self_healing_repo.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
-<script src="assets/chart.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 </body>

--- a/docs/solving_agi_governance/assets/logs.json
+++ b/docs/solving_agi_governance/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/solving_agi_governance/assets/script.js
+++ b/docs/solving_agi_governance/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/solving_agi_governance/assets/style.css
+++ b/docs/solving_agi_governance/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/solving_agi_governance/index.html
+++ b/docs/solving_agi_governance/index.html
@@ -18,6 +18,10 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/solving_agi_governance.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
+<script src="../assets/chart.min.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/sovereign_agentic_agialpha_agent_v0/assets/logs.json
+++ b/docs/sovereign_agentic_agialpha_agent_v0/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/sovereign_agentic_agialpha_agent_v0/assets/script.js
+++ b/docs/sovereign_agentic_agialpha_agent_v0/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/sovereign_agentic_agialpha_agent_v0/assets/style.css
+++ b/docs/sovereign_agentic_agialpha_agent_v0/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -18,6 +18,10 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/sovereign_agentic_agialpha_agent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<canvas id="chart"></canvas>
+<pre id="logs-panel"></pre>
+<script src="../assets/chart.min.js"></script>
+<script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/utils/assets/logs.json
+++ b/docs/utils/assets/logs.json
@@ -1,0 +1,1 @@
+{"steps": [0,1,2,3,4], "values": [0,1,2,3,4], "logs": ["Init demo","Download assets","Run agents","Collect results","Done"]}

--- a/docs/utils/assets/script.js
+++ b/docs/utils/assets/script.js
@@ -1,0 +1,29 @@
+(() => {
+  fetch('assets/logs.json')
+    .then(res => res.json())
+    .then(data => {
+      const steps = data.steps || [];
+      const values = data.values || [];
+      const logs = data.logs || steps.map(s => `Step ${s}`);
+      const ctx = document.getElementById('chart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+        options: { animation: false, responsive: true, maintainAspectRatio: false }
+      });
+      let i = 0;
+      const logEl = document.getElementById('logs-panel');
+      function step() {
+        if (i >= steps.length) return;
+        chart.data.labels.push(steps[i]);
+        chart.data.datasets[0].data.push(values[i]);
+        chart.update();
+        if (logEl) logEl.textContent += logs[i] + '\n';
+        i += 1;
+        setTimeout(step, 800);
+      }
+      step();
+    })
+    .catch(err => console.error('replay failed', err));
+})();

--- a/docs/utils/assets/style.css
+++ b/docs/utils/assets/style.css
@@ -1,0 +1,1 @@
+#chart{width:100%;height:300px;}#logs-panel{white-space:pre-wrap;background:#f4f4f4;padding:1rem;height:150px;overflow:auto;margin-top:1rem;}


### PR DESCRIPTION
## Summary
- animate demo pages with step-by-step log playback
- load logs from each demo's assets
- minor layout updates for self-contained assets

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError during collection)*
- `pre-commit run --files $(cat /tmp/changed_files.txt | tr '\n' ' ')` *(fails: proto-verify and requirements lock)*

------
https://chatgpt.com/codex/tasks/task_e_68619bfab324833383f6268b025836af