### PR TITLE
Add Playwright smoke tests for demo pages

### DIFF
--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -29,6 +29,11 @@ This command fetches browser assets, compiles the α‑AGI Insight interface, ru
 integrity checks and builds the MkDocs site under `site/`. It also runs
 `scripts/generate_gallery_html.py` to refresh `docs/gallery.html`. If Playwright
 is installed the script also verifies offline functionality.
+Run the Playwright smoke tests to ensure every built demo loads when offline:
+```bash
+python scripts/verify_demo_pages.py
+```
+
 
 ## 3. Preview Locally
 Start a quick HTTP server to examine the result:

--- a/scripts/edge_of_knowledge_sprint.sh
+++ b/scripts/edge_of_knowledge_sprint.sh
@@ -28,7 +28,12 @@ python -m alpha_factory_v1.demos.validate_demos
 python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 
 # Optional second offline validation if Playwright is available
-if python - "import importlib,sys;sys.exit(0 if importlib.util.find_spec('playwright') else 1)"; then
+if python - <<'EOF'
+import importlib, sys
+sys.exit(0 if importlib.util.find_spec('playwright') else 1)
+EOF
+then
+  python scripts/verify_demo_pages.py
   python -m http.server --directory site 8000 &
   SERVER_PID=$!
   trap 'kill $SERVER_PID' EXIT

--- a/scripts/verify_demo_pages.py
+++ b/scripts/verify_demo_pages.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Smoke test that built demo pages load offline."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from playwright.sync_api import sync_playwright, Error as PlaywrightError
+
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+
+
+def iter_demos() -> list[Path]:
+    return sorted(p for p in DOCS_DIR.iterdir() if p.is_dir() and (p / "index.html").exists())
+
+
+def main() -> int:
+    demos = iter_demos()
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            for demo in demos:
+                page = browser.new_page()
+                page.goto((demo / "index.html").resolve().as_uri())
+                page.wait_for_selector("body")
+                page.wait_for_selector("h1")
+                page.close()
+            browser.close()
+        return 0
+    except PlaywrightError as exc:
+        print(f"Playwright error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"Demo check failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docs_demos.py
+++ b/tests/test_docs_demos.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+import pytest
+
+pw = pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import Error as PlaywrightError  # noqa: E402
+
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+DEMOS = sorted(p for p in DOCS_DIR.iterdir() if p.is_dir() and (p / "index.html").exists())
+
+
+@pytest.mark.parametrize("demo_dir", DEMOS, ids=[d.name for d in DEMOS])
+def test_demo_index_loads(demo_dir: Path) -> None:
+    url = (demo_dir / "index.html").resolve().as_uri()
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(url)
+            page.wait_for_selector("body")
+            assert page.query_selector("h1"), "h1 element missing"
+            browser.close()
+    except PlaywrightError as exc:
+        pytest.skip(f"Playwright browser not installed: {exc}")


### PR DESCRIPTION
## Summary
- check demo directories in docs using Playwright
- expose verification script for edge sprint
- run smoke tests when deploying
- mention offline smoke test in the GitHub Pages guide

## Testing
- `pre-commit run --files docs/GITHUB_PAGES_DEMO_TASKS.md scripts/edge_of_knowledge_sprint.sh scripts/verify_demo_pages.py tests/test_docs_demos.py` *(fails: proto-verify, verify-requirements-lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q tests/test_docs_demos.py`

------
https://chatgpt.com/codex/tasks/task_e_6861b484e2848333bd31c3b064b573c1