### PR TITLE
feat: add offline caching for demo pages

### DIFF
--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/aiga_meta_evolution/service-worker.js
+++ b/docs/aiga_meta_evolution/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/alpha_agi_business_2_v1/service-worker.js
+++ b/docs/alpha_agi_business_2_v1/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/alpha_agi_business_3_v1/service-worker.js
+++ b/docs/alpha_agi_business_3_v1/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/alpha_agi_business_v1/service-worker.js
+++ b/docs/alpha_agi_business_v1/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/alpha_agi_insight_v0/service-worker.js
+++ b/docs/alpha_agi_insight_v0/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/alpha_agi_marketplace_v1/service-worker.js
+++ b/docs/alpha_agi_marketplace_v1/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/alpha_asi_world_model/index.html
+++ b/docs/alpha_asi_world_model/index.html
@@ -28,5 +28,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script type="module" src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/alpha_asi_world_model/service-worker.js
+++ b/docs/alpha_asi_world_model/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/cross_industry_alpha_factory/service-worker.js
+++ b/docs/cross_industry_alpha_factory/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -149,5 +149,12 @@
       });
     });
   </script>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/demos/service-worker.js
+++ b/docs/demos/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/era_of_experience/service-worker.js
+++ b/docs/era_of_experience/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/finance_alpha/service-worker.js
+++ b/docs/finance_alpha/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/macro_sentinel/service-worker.js
+++ b/docs/macro_sentinel/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -23,5 +23,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/meta_agentic_agi/service-worker.js
+++ b/docs/meta_agentic_agi/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -23,5 +23,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v2/service-worker.js
+++ b/docs/meta_agentic_agi_v2/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -23,5 +23,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/meta_agentic_agi_v3/service-worker.js
+++ b/docs/meta_agentic_agi_v3/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/meta_agentic_tree_search_v0/service-worker.js
+++ b/docs/meta_agentic_tree_search_v0/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -24,5 +24,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/muzero_planning/service-worker.js
+++ b/docs/muzero_planning/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -23,5 +23,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/muzeromctsllmagent_v0/service-worker.js
+++ b/docs/muzeromctsllmagent_v0/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -23,5 +23,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/omni_factory_demo/service-worker.js
+++ b/docs/omni_factory_demo/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/self_healing_repo/index.html
+++ b/docs/self_healing_repo/index.html
@@ -28,5 +28,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script type="module" src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/self_healing_repo/service-worker.js
+++ b/docs/self_healing_repo/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/solving_agi_governance/index.html
+++ b/docs/solving_agi_governance/index.html
@@ -27,5 +27,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/solving_agi_governance/service-worker.js
+++ b/docs/solving_agi_governance/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -23,5 +23,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/sovereign_agentic_agialpha_agent_v0/service-worker.js
+++ b/docs/sovereign_agentic_agialpha_agent_v0/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -19,5 +19,12 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/utils.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<script>
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("service-worker.js").catch(() => {
+      console.warn("Service worker registration failed");
+    });
+  }
+</script>
 </body>
 </html>

--- a/docs/utils/service-worker.js
+++ b/docs/utils/service-worker.js
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v1';
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});


### PR DESCRIPTION
## Summary
- add a simple service worker for caching to every docs demo folder
- register the worker in each demo index file
- generalize `verify_workbox_hash.py` to scan all demo directories

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}' | tr '\n' ' ')` *(fails: proto-verify, verify-requirements-lock)*
- `pytest -q` *(fails: import errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861b6fb89e48333aa6b9c8352ad0e14