### PR TITLE
[alpha_factory] fix gallery subdir paths

### DIFF
--- a/docs/alpha_factory_v1/demos/index.html
+++ b/docs/alpha_factory_v1/demos/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Alpha‑Factory Demo Gallery</title>
-  <link rel="stylesheet" href="stylesheets/cards.css">
+  <link rel="stylesheet" href="../../stylesheets/cards.css">
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background: #f7f7f7; }
     h1 { text-align: center; margin-bottom: 1rem; }
@@ -55,10 +55,10 @@
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
     </a>
-    <a class="demo-card" href="../../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨ last updated 2025-04-25   maintainer → montreal.ai core agi team">
+    <a class="demo-card" href="../../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="use the **offline/openai api** toggle below the chart to run locally or with your own api key. keys never leave your browser. readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨">
       <img src="../../alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
-      <p class='demo-desc'>README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team</p>
+      <p class='demo-desc'>Use the **Offline/OpenAI API** toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨</p>
     </a>
     <a class="demo-card" href="../../cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="current demo version: `1.0.0`. *out-learn • out-think • out-design • out-strategise • out-execute*">
       <img src="../../cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
@@ -115,15 +115,15 @@
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb). To verify local prerequisites before launching the demo, run:</p>
     </a>
-    <a class="demo-card" href="../../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="self‑healing repo demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
+    <a class="demo-card" href="../../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="use the mode toggle in the demo to switch between the offline pyodide simulation and openai api mode. any key entered is kept in memory only. self‑healing repo demo">
       <img src="../../self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
-      <p class='demo-desc'>Self‑Healing Repo Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
+      <p class='demo-desc'>Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo</p>
     </a>
-    <a class="demo-card" href="../../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="*minimal conditions for stable, antifragile multi-agent order* **author :** vincent boucher — president, montreal.ai · quebec.ai">
+    <a class="demo-card" href="../../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="choose **offline** or **openai api** using the toggle under the chart. the demo stores your api key only for the current session. *minimal conditions for stable, antifragile multi-agent order*">
       <img src="../../solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
-      <p class='demo-desc'>*Minimal Conditions for Stable, Antifragile Multi-Agent Order* **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI</p>
+      <p class='demo-desc'>Choose **Offline** or **OpenAI API** using the toggle under the chart. The demo stores your API key only for the current session. *Minimal Conditions for Stable, Antifragile Multi-Agent Order*</p>
     </a>
     <a class="demo-card" href="../../sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="a minimal showcase of a self-directed agent with token-gated access. run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.">
       <img src="../../sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Alpha‑Factory Demo Gallery</title>
-  <link rel="stylesheet" href="stylesheets/cards.css">
+  <link rel="stylesheet" href="../stylesheets/cards.css">
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background: #f7f7f7; }
     h1 { text-align: center; margin-bottom: 1rem; }
@@ -55,10 +55,10 @@
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
     </a>
-    <a class="demo-card" href="../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨ last updated 2025-04-25   maintainer → montreal.ai core agi team">
+    <a class="demo-card" href="../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="use the **offline/openai api** toggle below the chart to run locally or with your own api key. keys never leave your browser. readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨">
       <img src="../alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
-      <p class='demo-desc'>README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team</p>
+      <p class='demo-desc'>Use the **Offline/OpenAI API** toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨</p>
     </a>
     <a class="demo-card" href="../cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="current demo version: `1.0.0`. *out-learn • out-think • out-design • out-strategise • out-execute*">
       <img src="../cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
@@ -115,15 +115,15 @@
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb). To verify local prerequisites before launching the demo, run:</p>
     </a>
-    <a class="demo-card" href="../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="self‑healing repo demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
+    <a class="demo-card" href="../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="use the mode toggle in the demo to switch between the offline pyodide simulation and openai api mode. any key entered is kept in memory only. self‑healing repo demo">
       <img src="../self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
-      <p class='demo-desc'>Self‑Healing Repo Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
+      <p class='demo-desc'>Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo</p>
     </a>
-    <a class="demo-card" href="../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="*minimal conditions for stable, antifragile multi-agent order* **author :** vincent boucher — president, montreal.ai · quebec.ai">
+    <a class="demo-card" href="../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="choose **offline** or **openai api** using the toggle under the chart. the demo stores your api key only for the current session. *minimal conditions for stable, antifragile multi-agent order*">
       <img src="../solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
-      <p class='demo-desc'>*Minimal Conditions for Stable, Antifragile Multi-Agent Order* **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI</p>
+      <p class='demo-desc'>Choose **Offline** or **OpenAI API** using the toggle under the chart. The demo stores your API key only for the current session. *Minimal Conditions for Stable, Antifragile Multi-Agent Order*</p>
     </a>
     <a class="demo-card" href="../sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="a minimal showcase of a self-directed agent with token-gated access. run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.">
       <img src="../sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">
@@ -149,12 +149,5 @@
       });
     });
   </script>
-<script>
-  if ("serviceWorker" in navigator) {
-    navigator.serviceWorker.register("service-worker.js").catch(() => {
-      console.warn("Service worker registration failed");
-    });
-  }
-</script>
 </body>
 </html>

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -55,10 +55,10 @@
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
     </a>
-    <a class="demo-card" href="alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨ last updated 2025-04-25   maintainer → montreal.ai core agi team">
+    <a class="demo-card" href="alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="use the **offline/openai api** toggle below the chart to run locally or with your own api key. keys never leave your browser. readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨">
       <img src="alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy">
       <h3>Alpha Asi World Model</h3>
-      <p class='demo-desc'>README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team</p>
+      <p class='demo-desc'>Use the **Offline/OpenAI API** toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨</p>
     </a>
     <a class="demo-card" href="cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="current demo version: `1.0.0`. *out-learn • out-think • out-design • out-strategise • out-execute*">
       <img src="cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo" loading="lazy">
@@ -115,15 +115,15 @@
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb). To verify local prerequisites before launching the demo, run:</p>
     </a>
-    <a class="demo-card" href="self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="self‑healing repo demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**">
+    <a class="demo-card" href="self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="use the mode toggle in the demo to switch between the offline pyodide simulation and openai api mode. any key entered is kept in memory only. self‑healing repo demo">
       <img src="self_healing_repo/assets/preview.svg" alt="🔧 **Self‑Healing Repo** — when CI fails, agents patch" loading="lazy">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
-      <p class='demo-desc'>Self‑Healing Repo Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**</p>
+      <p class='demo-desc'>Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo</p>
     </a>
-    <a class="demo-card" href="solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="*minimal conditions for stable, antifragile multi-agent order* **author :** vincent boucher — president, montreal.ai · quebec.ai">
+    <a class="demo-card" href="solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="choose **offline** or **openai api** using the toggle under the chart. the demo stores your api key only for the current session. *minimal conditions for stable, antifragile multi-agent order*">
       <img src="solving_agi_governance/assets/preview.svg" alt="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]" loading="lazy">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
-      <p class='demo-desc'>*Minimal Conditions for Stable, Antifragile Multi-Agent Order* **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI</p>
+      <p class='demo-desc'>Choose **Offline** or **OpenAI API** using the toggle under the chart. The demo stores your API key only for the current session. *Minimal Conditions for Stable, Antifragile Multi-Agent Order*</p>
     </a>
     <a class="demo-card" href="sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="a minimal showcase of a self-directed agent with token-gated access. run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.">
       <img src="sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy">

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -108,7 +108,7 @@ def collect_entries() -> list[tuple[str, str, str, str]]:
     return entries
 
 
-def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: str = "") -> str:
+def build_html(entries: list[tuple[str, str, str, str]], *, prefix: str = "") -> str:
     head = """<!-- SPDX-License-Identifier: Apache-2.0 -->
 <!DOCTYPE html>
 <html lang=\"en\">
@@ -116,14 +116,14 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
   <meta charset=\"UTF-8\">
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
   <title>Alpha‑Factory Demo Gallery</title>
-  <link rel=\"stylesheet\" href=\"stylesheets/cards.css\">
+  <link rel=\"stylesheet\" href=\"{prefix}stylesheets/cards.css\">
   <style>
-    body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background: #f7f7f7; }
-    h1 { text-align: center; margin-bottom: 1rem; }
-    p.subtitle { text-align: center; margin-bottom: 2rem; }
-    a.demo-card { text-decoration: none; color: inherit; }
-    .demo-card h3 { margin-top: 0.5rem; text-align: center; }
-    .search-input { display: block; margin: 0 auto 1.5rem; padding: 0.5rem; width: min(300px, 80%); font-size: 1rem; }
+    body {{ font-family: Arial, sans-serif; margin: 0; padding: 2rem; background: #f7f7f7; }}
+    h1 {{ text-align: center; margin-bottom: 1rem; }}
+    p.subtitle {{ text-align: center; margin-bottom: 2rem; }}
+    a.demo-card {{ text-decoration: none; color: inherit; }}
+    .demo-card h3 {{ margin-top: 0.5rem; text-align: center; }}
+    .search-input {{ display: block; margin: 0 auto 1.5rem; padding: 0.5rem; width: min(300px, 80%); font-size: 1rem; }}
   </style>
 </head>
 <body>
@@ -131,9 +131,10 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
   <p class=\"subtitle\">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id=\"search-input\" class=\"search-input\" type=\"text\" placeholder=\"Search demos...\">
   <div class=\"demo-grid\">"""
+    head = head.format(prefix=prefix)
     lines = [head]
     for title, preview, link, summary in entries:
-        full_link = f"{disclaimer_prefix}{link}"
+        full_link = f"{prefix}{link}"
         summary_attr = html.escape(summary.lower()) if summary else ""
         lines.append(
             '    <a class="demo-card" '
@@ -141,7 +142,7 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
             'rel="noopener noreferrer" '
             f'data-summary="{summary_attr}">'
         )
-        preview_path = f"{disclaimer_prefix}{preview}"
+        preview_path = f"{prefix}{preview}"
         ext = Path(preview).suffix.lower()
         if ext in {".mp4", ".webm"}:
             lines.append(
@@ -155,11 +156,9 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
             lines.append(f"      <p class='demo-desc'>{html.escape(summary)}</p>")
         lines.append("    </a>")
     lines.append("  </div>")
-    home_link = f"{disclaimer_prefix}index.html"
+    home_link = f"{prefix}index.html"
     lines.append(f'  <p><a href="{home_link}">\u2b05\ufe0f Back to Home</a></p>')
-    lines.append(
-        f'  <p class="snippet"><a href="{disclaimer_prefix}DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>'
-    )
+    lines.append(f'  <p class="snippet"><a href="{prefix}DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>')
     lines.append("  <script>")
     lines.append("    const input = document.getElementById('search-input');")
     lines.append("    const cards = document.querySelectorAll('.demo-card');")
@@ -179,11 +178,11 @@ def build_html(entries: list[tuple[str, str, str, str]], *, disclaimer_prefix: s
 
 def main() -> None:
     entries = collect_entries()
-    gallery_html = build_html(entries, disclaimer_prefix="")
+    gallery_html = build_html(entries, prefix="")
     GALLERY_FILE.write_text(gallery_html, encoding="utf-8")
-    demos_html = build_html(entries, disclaimer_prefix="../")
+    demos_html = build_html(entries, prefix="../")
     DEMOS_INDEX_FILE.write_text(demos_html, encoding="utf-8")
-    subdir_html = build_html(entries, disclaimer_prefix="../../")
+    subdir_html = build_html(entries, prefix="../../")
     SUBDIR_GALLERY_FILE.parent.mkdir(parents=True, exist_ok=True)
     SUBDIR_GALLERY_FILE.write_text(subdir_html, encoding="utf-8")
     print(


### PR DESCRIPTION
## Summary
- fix `generate_gallery_html.py` to prefix asset links correctly
- regenerate gallery pages with valid relative paths

## Testing
- `ruff check scripts/generate_gallery_html.py`
- `flake8 scripts/generate_gallery_html.py`
- `mypy --config-file mypy.ini scripts/generate_gallery_html.py`
- `pre-commit run --files scripts/generate_gallery_html.py` *(skipped heavy hooks)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6861bf04dea08333845f3d401948df1c