### PR TITLE
Improve subdirectory gallery helper

### DIFF
--- a/scripts/open_subdir_gallery.sh
+++ b/scripts/open_subdir_gallery.sh
@@ -28,6 +28,11 @@ if check_remote; then
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$REPO_ROOT/scripts/open_subdir_gallery.py"
+fi
+
 local_page="$REPO_ROOT/site/alpha_factory_v1/demos/index.html"
 if [[ ! -f "$local_page" ]]; then
   echo "Gallery not found locally. Building a fresh copy..." >&2


### PR DESCRIPTION
## Summary
- allow `open_subdir_gallery.sh` to use the Python helper when offline

## Testing
- `pre-commit run --files scripts/open_subdir_gallery.sh` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6861c3e20a20833386bb9a3115b76d81