### PR TITLE
[alpha_factory] Add disclaimer HTML page

### DIFF
--- a/docs/DISCLAIMER_SNIPPET/index.html
+++ b/docs/DISCLAIMER_SNIPPET/index.html
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Project Disclaimer</title>
+  <link rel="stylesheet" href="../stylesheets/cards.css">
+  <style>
+    body { font-family: Arial, sans-serif; margin:2rem; }
+  </style>
+</head>
+<body>
+  <p>This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+  <p><a href="../index.html">\u2b05\ufe0f Back to Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/DISCLAIMER_SNIPPET/index.html` so gallery links resolve

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError in multiple tests)*
- `pre-commit run --files docs/DISCLAIMER_SNIPPET/index.html` *(failed: proto-verify hook)*

------
https://chatgpt.com/codex/tasks/task_e_6861c647de188333b51b79c9954978d9