### PR TITLE
[alpha_factory] fix relative import for demos

### DIFF
--- a/docs/alpha_asi_world_model/assets/script.js
+++ b/docs/alpha_asi_world_model/assets/script.js
@@ -2,7 +2,7 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../assets/pyodide_demo.js';
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
 
 fetch('assets/logs.json')
   .then(res => res.json())

--- a/docs/self_healing_repo/assets/script.js
+++ b/docs/self_healing_repo/assets/script.js
@@ -2,7 +2,7 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../assets/pyodide_demo.js';
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
 
 fetch('assets/logs.json')
   .then(res => res.json())

--- a/docs/solving_agi_governance/assets/script.js
+++ b/docs/solving_agi_governance/assets/script.js
@@ -2,7 +2,7 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../assets/pyodide_demo.js';
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
 
 fetch('assets/logs.json')
   .then(res => res.json())


### PR DESCRIPTION
## Summary
- correct path to `pyodide_demo.js` in several demo pages

## Testing
- `pre-commit run --files docs/alpha_asi_world_model/assets/script.js docs/self_healing_repo/assets/script.js docs/solving_agi_governance/assets/script.js` *(failed: proto-verify)*
- `pytest -q` *(failed: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861c9d960dc8333a89a3e56e4237fd6