### PR TITLE
[alpha_factory] add redirect page for demo gallery

### DIFF
--- a/docs/alpha_factory_v1/index.html
+++ b/docs/alpha_factory_v1/index.html
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=demos/index.html">
+  <title>Alpha‑Factory Demos</title>
+  <link rel="stylesheet" href="../stylesheets/cards.css">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+  </style>
+</head>
+<body>
+  <p>Redirecting to the <a href="demos/index.html">Alpha‑Factory demo gallery</a>...</p>
+  <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/alpha_factory_v1/index.html` redirecting to the subdir demo gallery

## Testing
- `pre-commit run --files docs/alpha_factory_v1/index.html` *(with hooks skipped)*
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861ce8560c483339b60422abd740e3d