### PR TITLE
[alpha_factory] expose orchestrator and planning

### DIFF
--- a/alpha_factory_v1/core/agents/__init__.py
+++ b/alpha_factory_v1/core/agents/__init__.py
@@ -4,5 +4,6 @@
 from .meta_refinement_agent import MetaRefinementAgent
 from .self_improver_agent import SelfImproverAgent
 from .base_agent import BaseAgent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import planning_agent
 
-__all__ = ["MetaRefinementAgent", "SelfImproverAgent", "BaseAgent"]
+__all__ = ["MetaRefinementAgent", "SelfImproverAgent", "BaseAgent", "planning_agent"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/__init__.py
@@ -5,3 +5,12 @@ This package exposes lightweight agents, the orchestrator and helper
 utilities used by the α‑AGI Insight example. Interface layers under
 ``interface`` provide a CLI, optional Streamlit dashboards and a REST API.
 """
+
+# Re-export frequently used modules so test imports remain stable
+from __future__ import annotations
+
+from .agents import planning_agent
+from alpha_factory_v1.core import orchestrator
+from alpha_factory_v1.core.self_evolution import self_improver
+
+__all__ = ["planning_agent", "orchestrator", "self_improver"]


### PR DESCRIPTION
## Summary
- re-export orchestrator module from Insight demo package
- re-export planning agent from core agent package
- simplify imports in demo package

## Testing
- `pytest --collect-only` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861e5ffcd248333ac8d78fe7ebbda2a