### PR TITLE
[alpha_factory] Update gallery docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ and docs with a single command:
 ```bash
 make gallery-deploy
 ```
+`make gallery-deploy` wraps [`scripts/deploy_gallery_pages.sh`](scripts/deploy_gallery_pages.sh),
+which calls [`scripts/generate_gallery_html.py`](scripts/generate_gallery_html.py)
+to refresh `docs/index.html` and `docs/gallery.html`.
 
 See [docs/GITHUB_PAGES_DEMO_TASKS.md](docs/GITHUB_PAGES_DEMO_TASKS.md) for a
 detailed walkthrough. Once the build finishes, open the gallery locally with:

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -117,7 +117,9 @@ To trigger a one-off deployment outside of CI run:
 ```
 
 This wrapper script rebuilds the browser bundle, regenerates the MkDocs site and
-uses `mkdocs gh-deploy` to push the contents of `site/` to the `gh-pages` branch.
+runs [`scripts/generate_gallery_html.py`](../scripts/generate_gallery_html.py)
+so `docs/index.html` and `docs/gallery.html` include the latest demos.
+It then uses `mkdocs gh-deploy` to push the contents of `site/` to the `gh-pages` branch.
 Use it when testing changes locally or publishing from a personal fork.
 
 ## Publishing to GitHub Pages


### PR DESCRIPTION
## Summary
- clarify how `make gallery-deploy` rebuilds HTML
- mention `generate_gallery_html.py` in HOSTING instructions

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files README.md docs/HOSTING_INSTRUCTIONS.md` *(failed to complete due to environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_6861fa70bd6083338ee4bb2ed0d3ec02