### PR TITLE
[alpha_factory] add offline mode buttons

### DIFF
--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/aiga_meta_evolution.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/alpha_agi_business_2_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/alpha_agi_business_3_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/alpha_agi_business_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/alpha_agi_insight_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/alpha_agi_marketplace_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/cross_industry_alpha_factory.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/era_of_experience.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/finance_alpha.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/macro_sentinel.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <script>

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi_v2.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <script>

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_agi_v3.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <script>

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/meta_agentic_tree_search_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/muzero_planning.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/muzeromctsllmagent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <script>

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/omni_factory_demo.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <script>

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -18,9 +18,14 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/sovereign_agentic_agialpha_agent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+<div id="mode-control">
+  <button id="offline-mode">Offline</button>
+  <button id="online-mode">OpenAI API</button>
+</div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
+<script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
 <p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 <script>


### PR DESCRIPTION
## Summary
- add offline/online mode buttons and pyodide script to demo pages

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*
- `pre-commit run --files docs/aiga_meta_evolution/index.html docs/alpha_agi_business_2_v1/index.html docs/alpha_agi_business_3_v1/index.html docs/alpha_agi_business_v1/index.html docs/alpha_agi_insight_v0/index.html docs/alpha_agi_marketplace_v1/index.html docs/cross_industry_alpha_factory/index.html docs/era_of_experience/index.html docs/finance_alpha/index.html docs/macro_sentinel/index.html docs/meta_agentic_agi/index.html docs/meta_agentic_agi_v2/index.html docs/meta_agentic_agi_v3/index.html docs/meta_agentic_tree_search_v0/index.html docs/muzero_planning/index.html docs/muzeromctsllmagent_v0/index.html docs/omni_factory_demo/index.html docs/sovereign_agentic_agialpha_agent_v0/index.html` *(fails: proto-verify, verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_686203b4609883338ee77391c262b7ae