### PR TITLE
[alpha_factory] auto-insert gallery links

### DIFF
--- a/docs/alpha_factory_v1/index.html
+++ b/docs/alpha_factory_v1/index.html
@@ -13,5 +13,6 @@
 <body>
   <p>Redirecting to the <a href="demos/index.html">Alpha‑Factory demo gallery</a>...</p>
   <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
+<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `generate_gallery_html.py` to insert a Back to Gallery link on demo pages
- regenerate gallery pages

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files scripts/generate_gallery_html.py docs/alpha_factory_v1/index.html` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6862823364748333a6b932a8b22da216