### PR TITLE
[alpha_factory] Clarify offline demo requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,21 +389,27 @@ for a concise summary of the wheelhouse setup.
    ```
    Skipping this step or running without Node.js prevents the service worker
    from being generated, so offline functionality is limited.
-5. **Skip browser downloads** when running the web demo tests offline:
+5. **Bundle Pyodide for offline demos**
+   ```bash
+   make gallery-build
+   ```
+   This command generates the `site/` directory with the Pyodide runtime and demo assets so the browser examples work without a network connection. The service worker caches these files. Use a hard refresh (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>) or clear site data to pick up new releases.
+
+6. **Skip browser downloads** when running the web demo tests offline:
    ```bash
    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test
    ```
 
-6. **Enable offline inference** by setting ``AGI_INSIGHT_OFFLINE=1`` in
+7. **Enable offline inference** by setting ``AGI_INSIGHT_OFFLINE=1`` in
    ``.env`` or the environment (ensure `llama-cpp-python` or `ctransformers`
    is installed).
 
-7. **Disable broadcasting** to avoid network calls:
+8. **Disable broadcasting** to avoid network calls:
    ```bash
    export AGI_INSIGHT_BROADCAST=0
    ```
 
-8. **Seed the lineage database** from existing DGM logs using ``--import-dgm``.
+9. **Seed the lineage database** from existing DGM logs using ``--import-dgm``.
    ```bash
    python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli \
      simulate --import-dgm path/to/dgm/logs


### PR DESCRIPTION
## Summary
- explain that offline demos need Pyodide assets from a gallery build
- add instructions to run `make gallery-build` before disconnecting
- mention service worker caching behaviour

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files README.md` *(fails: proto-verify and verify-requirements-lock hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68628738da648333b2ec19b023a72807