### PR TITLE
Bundle pyodide locally for Insight gallery

### DIFF
--- a/docs/assets/pyodide_demo.js
+++ b/docs/assets/pyodide_demo.js
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* eslint-env browser */
 /* eslint-disable no-undef */
-import {loadPyodide} from 'https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.mjs';
+import {loadPyodide} from '../assets/pyodide/pyodide.js';
 
 export function setupPyodideDemo(chart, logEl, defaultData) {
   function showMessage(msg) {

--- a/docs/assets/service-worker.js
+++ b/docs/assets/service-worker.js
@@ -7,8 +7,8 @@ self.addEventListener('install', (event) => {
       .open(CACHE)
       .then(async (cache) => {
         const assets = [
-          'pyodide/pyodide.js',
-          'pyodide/pyodide.asm.wasm',
+          'assets/pyodide/pyodide.js',
+          'assets/pyodide/pyodide.asm.wasm',
         ];
         await cache.addAll(assets);
       })

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -110,6 +110,12 @@ copy_assets() {
         mkdir -p "$dest"
         cp -a "$src"/* "$dest/"
     done
+
+    # Copy Pyodide runtime files for the gallery
+    wasm_src="$BROWSER_DIR/wasm"
+    pyodide_dest="docs/assets/pyodide"
+    mkdir -p "$pyodide_dest"
+    cp -a "$wasm_src"/pyodide.* "$pyodide_dest/"
 }
 copy_assets
 


### PR DESCRIPTION
## Summary
- copy pyodide runtime files into `docs/assets/pyodide`
- adjust service worker and demo script to load pyodide from local assets

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files docs/assets/pyodide_demo.js docs/assets/service-worker.js scripts/build_insight_docs.sh` *(fails: proto-verify hook missing)*
- `bash scripts/build_insight_docs.sh` *(fails: IPFS gateway unavailable)*
- `bash scripts/deploy_gallery_pages.sh` *(fails: preflight missing docker)*


------
https://chatgpt.com/codex/tasks/task_e_68628bce7c288333a7d7b46b97700dd8