### PR TITLE
Remove redundant disclaimers

### DIFF
--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -8,11 +8,6 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 ---
 
-> **Disclaimer**
-> This interactive demo is a conceptual research prototype and **not** a
-> production‑ready AGI. See the repository’s
-> [Apache 2.0 license](../../LICENSE) and
-> [security policy](../../SECURITY.md) for details.
 
 Browse the **visual demo gallery** on GitHub Pages:
 <https://montrealai.github.io/AGI-Alpha-Agent-v0/gallery.html>

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -33,11 +33,6 @@ Within **&lt; 60 s** you’ll watch neural nets **rewrite their own blueprin
 
 ---
 
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk.
-
 ---
 
 <details open>

--- a/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
@@ -9,13 +9,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 > **Global markets seep *trillions* in latent opportunity** — *alpha* in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs.  
 > **Alpha‑Factory v1** turns that raw potential into deployable breakthroughs, *autonomously*.
 
----
-## Disclaimer
-This repository is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk.
-
-
 ## ⚡ TL;DR  
 
 ```bash

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -5,7 +5,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 
 <!-- README.md — Large‑Scale α‑AGI Business Demo (v1.0‑production) -->
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 <h1 align="center">
  Large‑Scale α‑AGI Business 👁️✨ <sup><code>$AGIALPHA</code></sup>
 </h1>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -12,7 +12,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 # α‑AGI Insight v1 — Beyond Human Foresight
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb)
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
 <p align="center">
   <b>Forecast AGI-driven economic phase-transitions<br>

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -5,9 +5,6 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 A zero-backend Pareto explorer lives in
 `demos/alpha_agi_insight_v1/insight_browser_v1/`. See the **Quick-Start** section below for a short walkthrough.
 
-## Disclaimer
-This demo is a conceptual research prototype describing aspirational goals and does not contain real general intelligence. Use at your own risk.
-
 ## Quick-Start
 Open [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf)
 for a concise overview of the build and launch steps.

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -17,11 +17,6 @@ Last updated 2025-04-25   Maintainer → Montreal.AI Core AGI Team
 
 ---
 
-> **Disclaimer**
-> This demo is a conceptual research prototype and does **not** represent real
-> AGI capabilities. See the project's [Apache 2.0 license](../../../LICENSE) and
-> [security policy](../../../SECURITY.md) for details.
-
 ## 0  Table of Contents  <!-- omit in toc -->
 1. [Why this demo matters](#1-why-this-demo-matters)
 2. [Quick-start 🥑](#2-quick-start-)

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
@@ -2,9 +2,6 @@
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 
-## Disclaimer
-This demo is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
 of a real general intelligence. Use at your own risk.
 
 # Alpha‑Factory v1 👁️✨ — α‑ASI World‑Model Demo Documentation

--- a/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
@@ -4,8 +4,6 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 # α-ASI World-Model 🛰️ — Helm Chart 📦
 *Alpha-Factory v1 👁️✨ • Multi-Agent AGENTIC α-AGI*
 
-This demo is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the
 presence of a real general intelligence. Use at your own risk.
 
 | Chart version | App version | License |

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -9,8 +9,6 @@ Current demo version: `1.0.0`.
 *Out-learn • Out-think • Out-design • Out-strategise • Out-execute*
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb)
 
-This demo is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
 of a real general intelligence. Use at your own risk.
 
 See [CONCEPTUAL_FRAMEWORK.md](CONCEPTUAL_FRAMEWORK.md) for an architecture overview.

--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -10,7 +10,6 @@ Out‑learn · Out‑think · Out‑strategise · Out‑execute
 © 2025 MONTREAL.AI   Apache‑2.0 License
 -->
 
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
 <h1 align="center">🌌 Era of Experience — Your lifelong‑RL playground</h1>
 <p align="center">

--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -13,8 +13,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 
 > **TL;DR**   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.
 
-This demonstration is a conceptual research prototype. Any references to AGI or superintelligence describe aspirational goals rather than current capabilities.
-
 ---
 
 ## ✨ Key capabilities

--- a/alpha_factory_v1/demos/meta_agentic_agi/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/README.md
@@ -5,7 +5,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 
 
 # Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 
 > **Official definition – Meta-Agentic (adj.)**  
 > *Describes an agent whose **primary role** is to **create, select, evaluate, or re‑configure other agents** and the rules governing their interactions, thereby exercising **second‑order agency** over a population of first‑order agents.*

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -21,12 +21,6 @@ one‑command experience**.
 You’ll see a MuZero‑style agent improvise physics, deploy Monte‑Carlo search,
 and **stabilise CartPole** — all inside your browser. No GPU, no PhD required.
 
-> **Disclaimer**
-> This demo is a conceptual research prototype. References to "AGI" and
-> "superintelligence" describe aspirational goals and do not indicate the
-> presence of a real general intelligence. Use at your own risk.
-
----
 
 ## 🚀 Quick Start
 

--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -4,7 +4,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 
 
 # OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)
-This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
 [![Colab](https://img.shields.io/badge/Try-on-Colab-yellow?logo=googlecolab)](colab_omni_factory_demo.ipynb)
 Run the full demo interactively in [Google Colab](colab_omni_factory_demo.ipynb).
 

--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -16,11 +16,6 @@ Imagine a codebase that diagnoses its own wounds, stitches the bug, and walks
 back onto the production floor—all before coffee drips.  
 This demo turns that fantasy into a clickable reality inside **Alpha‑Factory v1**.
 
-## Disclaimer
-This demo is a conceptual research prototype. References to "AGI" and
-"superintelligence" describe aspirational goals and do not indicate the presence
-of a real general intelligence. Use at your own risk. Nothing herein constitutes
-financial advice. MontrealAI and the maintainers accept no liability for losses
 incurred from using this software.
 
 ---

--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -7,11 +7,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 *Minimal Conditions for Stable, Antifragile Multi-Agent Order*
 **Author :** Vincent Boucher — President, MONTREAL.AI · QUEBEC.AI
 
-> **Disclaimer**
-> This demo is a conceptual research prototype. References to "AGI" and
-> "superintelligence" describe aspirational goals and do not indicate the
-> presence of a real general intelligence. Use at your own risk.
-
 ---
 
 ### 1 · Executive Abstract

--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
@@ -8,9 +8,6 @@ Each demo package exposes its own `__version__` constant. The value marks the re
 A minimal showcase of a self-directed agent with token-gated access.
 Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the containerized environment.
 
-## Disclaimer
-References to AGI or superintelligence describe the aspirational design goals of this demo. The agent shown here is not a true artificial general intelligence and should not be treated as such.
-
 ## Features
 1. Docker-based deployment with one command.
 2. Flask web interface served at `http://localhost:5000`.


### PR DESCRIPTION
## Summary
- prune extra disclaimer paragraphs in demo READMEs
- keep first `See docs/DISCLAIMER_SNIPPET.md` line untouched

## Testing
- `python scripts/verify_disclaimer_snippet.py`

------
https://chatgpt.com/codex/tasks/task_e_6862934b6bf4833384d6ea033d5f26a7