### PR TITLE
[alpha_factory] load Pyodide from CDN fallback

### DIFF
--- a/docs/assets/pyodide_demo.js
+++ b/docs/assets/pyodide_demo.js
@@ -1,7 +1,22 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* eslint-env browser */
 /* eslint-disable no-undef */
-import {loadPyodide} from '../assets/pyodide/pyodide.js';
+const CDN_BASE = 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/';
+
+async function loadRuntime() {
+  try {
+    const mod = await import('../assets/pyodide/pyodide.js');
+    try {
+      return await mod.loadPyodide({indexURL: '../assets/pyodide/'});
+    } catch (err) {
+      console.warn('Local Pyodide failed:', err);
+    }
+  } catch (err) {
+    console.warn('Local Pyodide not found:', err);
+  }
+  const mod = await import(`${CDN_BASE}pyodide.mjs`);
+  return await mod.loadPyodide({indexURL: CDN_BASE});
+}
 
 export function setupPyodideDemo(chart, logEl, defaultData) {
   function showMessage(msg) {
@@ -34,7 +49,7 @@ export function setupPyodideDemo(chart, logEl, defaultData) {
   offlineBtn?.addEventListener('click', async () => {
     if (!pyodide) {
       showMessage('Loading Python runtime...');
-      pyodide = await loadPyodide();
+      pyodide = await loadRuntime();
     }
     const code = `import json, random
 steps = list(range(1, 11))


### PR DESCRIPTION
## Summary
- update pyodide_demo.js to dynamically load the runtime
- fall back to jsDelivr if the local copy is missing

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files docs/assets/pyodide_demo.js -v`

------
https://chatgpt.com/codex/tasks/task_e_68629e54d654833390ed0ee2ef0b2904