### PR TITLE
docs: show full disclaimer on gallery index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -136,7 +136,7 @@
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.</p>
     </a>
   </div>
-  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
+  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
   <script>
     const input = document.getElementById('search-input');
     const cards = document.querySelectorAll('.demo-card');


### PR DESCRIPTION
## Summary
- include standard disclaimer text on the docs index page

## Testing
- `pre-commit run --files docs/index.html` *(fails: Verify protobuf files are up to date)*

------
https://chatgpt.com/codex/tasks/task_e_6862a3da0cc883339f701f957e22218e