### PR TITLE
[alpha_factory] update proto paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ pre-commit run --files <paths>   # before each commit
   - Re-run `pre-commit run --all-files` whenever `requirements.txt`, `requirements-dev.txt`,
     `.pre-commit-config.yaml`, `pyproject.toml`, `mypy.ini`, or other lint configs change.
     **CI enforces these checks.**
-  - After editing `src/utils/a2a.proto`, run `pre-commit run --files src/utils/a2a.proto`
+  - After editing `alpha_factory_v1/core/utils/a2a.proto`, run `pre-commit run --files alpha_factory_v1/core/utils/a2a.proto`
     to regenerate and verify protobuf sources.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using
     `mypy.ini`.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ proto:
 	./scripts/gen_proto.py
 
 proto-verify:
-	git --no-pager diff --exit-code src/utils/a2a_pb2.py tools/go_a2a_client/a2a.pb.go
+	git --no-pager diff --exit-code alpha_factory_v1/core/utils/a2a_pb2.py tools/go_a2a_client/a2a.pb.go
 
 benchmark:
 	python benchmarks/docker_runner.py > bench_results.json

--- a/README.md
+++ b/README.md
@@ -1341,7 +1341,7 @@ make build_web
 ./tools/gen_proto_stubs.sh  # updates alpha_factory_v1/core/utils/a2a_pb2.py and tools/go_a2a_client/a2a.pb.go
 make compose-up  # builds and waits for healthy services
 ```
-Run `./tools/gen_proto_stubs.sh` whenever `src/utils/a2a.proto` changes to keep the
+Run `./tools/gen_proto_stubs.sh` whenever `alpha_factory_v1/core/utils/a2a.proto` changes to keep the
 Python and Go stubs up to date.
 Open <http://localhost:8080> in your browser. When `RUN_MODE=web`, the container
 serves the static files from `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist` using `python -m

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -5,13 +5,13 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 Documentation for the α‑AGI Insight demo.
 
 
-Whenever `src/utils/a2a.proto` changes, regenerate the protocol stubs:
+Whenever `alpha_factory_v1/core/utils/a2a.proto` changes, regenerate the protocol stubs:
 
 ```bash
 ./tools/gen_proto_stubs.sh
 ```
 
-This updates `src/utils/a2a_pb2.py` and `tools/go_a2a_client/a2a.pb.go`.
+This updates `alpha_factory_v1/core/utils/a2a_pb2.py` and `tools/go_a2a_client/a2a.pb.go`.
 
 ## Quickstart
 

--- a/tools/gen_proto_stubs.sh
+++ b/tools/gen_proto_stubs.sh
@@ -3,8 +3,8 @@
 # Generate protobuf stubs for Python and Go.
 set -euo pipefail
 
-PROTO="src/utils/a2a.proto"
-PY_OUT="src/utils"
+PROTO="alpha_factory_v1/core/utils/a2a.proto"
+PY_OUT="alpha_factory_v1/core/utils"
 GO_OUT="tools/go_a2a_client"
 PY_INCLUDE=$(python -c 'import pkg_resources,os;print(os.path.dirname(pkg_resources.resource_filename("google.protobuf","struct.proto")))')
 


### PR DESCRIPTION
## Summary
- fix path in proto stub generation script
- update Makefile proto verification rule
- update documentation references to a2a.proto

## Testing
- `pre-commit run --files alpha_factory_v1/core/utils/a2a.proto` *(fails: requirements.lock is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_6862b6e9538083338230f43f1e7cab09