### PR TITLE
[alpha_factory] automate service-worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,11 @@ Follow these steps when installing without internet access:
   ```
   The `verify-alpha-colab-requirements-lock` hook relies on this lock file.
 
- - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
+- See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
 - Run `python scripts/check_python_deps.py` **before running `pytest`** to quickly verify that `numpy`, `yaml` and `pandas` are installed. If it reports missing packages, execute `python check_env.py --auto-install` before running the tests. This step fetches packages from PyPI, so in air‑gapped setups you **must** pass `--wheelhouse <path>` or set `WHEELHOUSE` so `pip` installs from the local cache.
+- When adding new demos or assets, regenerate `docs/assets/service-worker.js` with
+  `python scripts/build_service_worker.py`. The gallery deployment helper invokes
+  this script automatically.
  - After setup, validate with `python check_env.py --auto-install`. This command reaches out to PyPI unless `--wheelhouse <path>` or the `WHEELHOUSE` environment variable is supplied. When working offline run `python check_env.py --auto-install --wheelhouse <path>` so optional packages install correctly. The test suite passes this variable to `check_env.py` automatically when set.
 - The unit tests rely on `fastapi`, `opentelemetry-api`, `openai-agents`, `google-adk`, `pytest` and `prometheus_client`. `./codex/setup.sh` installs these packages automatically. When skipping the setup script, run
   `pip install -r requirements-dev.txt` or ensure `check_env.py` reports no

--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -27,8 +27,9 @@ Execute the helper from the repository root:
 ```
 This command fetches browser assets, compiles the α‑AGI Insight interface, runs
 integrity checks and builds the MkDocs site under `site/`. It also runs
-`scripts/generate_gallery_html.py` to refresh `docs/gallery.html`. If Playwright
-is installed the script also verifies offline functionality.
+`scripts/generate_gallery_html.py` to refresh `docs/gallery.html` and
+`scripts/build_service_worker.py` to update the precache list. If Playwright is
+installed the script also verifies offline functionality.
 Run the Playwright smoke tests to ensure every built demo loads when offline:
 ```bash
 python scripts/verify_demo_pages.py
@@ -55,6 +56,8 @@ Verify the service worker caches assets for offline use and that the page includ
 
 ## 5. Maintenance Tips
 - Re‑run the helper whenever demo docs or assets change.
+- If adding new demos manually, run `python scripts/build_service_worker.py` to
+  refresh `docs/assets/service-worker.js`.
 - Test with `mkdocs build --strict` before deploying.
 - Keep `pre-commit` hooks green so the gallery builds reproducibly.
 

--- a/scripts/build_service_worker.py
+++ b/scripts/build_service_worker.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generate docs/assets/service-worker.js with updated precache list."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+HEADER = """/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v3';
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE)
+      .then(async (cache) => {
+        const assets = ["""
+
+FOOTER = """        ];
+        await cache.addAll(assets);
+      })
+      .catch(() => undefined),
+  );
+  self.skipWaiting();
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) {
+    event.respondWith(
+      caches.open(CACHE).then(async (cache) => {
+        try {
+          const resp = await fetch(event.request);
+          if (resp.ok) {
+            cache.put(event.request, resp.clone());
+          }
+          return resp;
+        } catch (err) {
+          const cached =
+            (await cache.match(event.request)) ||
+            (await cache.match(`pyodide/${url.pathname.split('/').pop()}`));
+          return cached || Promise.reject(err);
+        }
+      }),
+    );
+    return;
+  }
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});
+"""
+
+
+def gather_assets(docs_dir: Path) -> list[str]:
+    base_assets = docs_dir / "assets"
+    assets: list[str] = []
+    allowed = {".js", ".css", ".svg", ".json", ".wasm", ".tar", ".cast"}
+    pyodide_dir = base_assets / "pyodide"
+    if pyodide_dir.is_dir():
+        order = ["pyodide.js", "pyodide.asm.wasm", "pyodide_py.tar"]
+        for name in order:
+            file = pyodide_dir / name
+            if file.is_file() and file.suffix in allowed:
+                rel = Path("assets") / "pyodide" / file.name
+                assets.append(rel.as_posix())
+    for item in sorted(docs_dir.iterdir()):
+        if not item.is_dir() or item.name == "assets":
+            continue
+        a_dir = item / "assets"
+        if a_dir.is_dir():
+            for file in sorted(a_dir.rglob("*")):
+                if file.is_file() and file.suffix in allowed:
+                    rel = Path("..") / item.name / "assets" / file.relative_to(a_dir)
+                    assets.append(rel.as_posix())
+    return assets
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--docs", default="docs", help="Documentation directory")
+    args = parser.parse_args()
+    docs_dir = Path(args.docs)
+    assets = gather_assets(docs_dir)
+    sw_path = docs_dir / "assets" / "service-worker.js"
+    lines = [HEADER]
+    for asset in assets:
+        lines.append(f"          '{asset}',")
+    lines.append(FOOTER)
+    sw_path.write_text("\n".join(lines))
+    print(f"Wrote {sw_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -24,6 +24,7 @@ python -m alpha_factory_v1.demos.validate_demos
 npm --prefix "$BROWSER_DIR" run fetch-assets
 npm --prefix "$BROWSER_DIR" ci
 "$SCRIPT_DIR/build_insight_docs.sh"
+python scripts/build_service_worker.py
 
 # Compile and verify the MkDocs site. Use --strict so warnings fail the build
 mkdocs build --strict


### PR DESCRIPTION
## Summary
- add build_service_worker.py to detect demo assets
- call new script from deploy_gallery_pages.sh
- document auto-generation process in AGENTS.md and GITHUB_PAGES_DEMO_TASKS.md

## Testing
- `pre-commit run --files scripts/build_service_worker.py scripts/deploy_gallery_pages.sh AGENTS.md docs/GITHUB_PAGES_DEMO_TASKS.md` *(fails: verify-alpha-colab-requirements-lock)*
- `pytest -q` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6862d689e6448333a70790bbe488fcc8