### PR TITLE
Add service worker step to gallery build

### DIFF
--- a/scripts/build_gallery_site.sh
+++ b/scripts/build_gallery_site.sh
@@ -25,6 +25,7 @@ npm --prefix "$BROWSER_DIR" ci
 "$SCRIPT_DIR/build_insight_docs.sh"
 python scripts/generate_demo_docs.py
 python scripts/generate_gallery_html.py
+python scripts/build_service_worker.py
 
 # Build the static site and verify integrity
 mkdocs build --strict


### PR DESCRIPTION
## Summary
- call build_service_worker.py from build_gallery_site.sh

## Testing
- `pre-commit run --files scripts/build_gallery_site.sh docs/assets/service-worker.js .github/workflows/docs.yml` *(skipped heavy hooks)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6862dc24e898833396390ebb6f280aa6