### PR TITLE
[alpha_factory] Add disclaimers to gallery launchers

### DIFF
--- a/scripts/open_gallery.py
+++ b/scripts/open_gallery.py
@@ -12,6 +12,8 @@ functionality such as service workers and relative assets.
 """
 from __future__ import annotations
 
+from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+
 import subprocess
 import sys
 from pathlib import Path
@@ -53,6 +55,7 @@ def _remote_available(url: str) -> bool:
 
 
 def main() -> None:
+    print(DISCLAIMER, file=sys.stderr)
     url = _gallery_url()
     if _remote_available(url):
         print(f"Opening {url}")

--- a/scripts/open_subdir_gallery.py
+++ b/scripts/open_subdir_gallery.py
@@ -9,6 +9,8 @@ local build when offline by invoking ``scripts/build_gallery_site.sh``.
 """
 from __future__ import annotations
 
+from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+
 import subprocess
 import sys
 from pathlib import Path
@@ -49,6 +51,7 @@ def _remote_available(url: str) -> bool:
 
 
 def main() -> None:
+    print(DISCLAIMER, file=sys.stderr)
     url = _subdir_url()
     index = url + "index.html"
     if _remote_available(index):


### PR DESCRIPTION
## Summary
- print the project disclaimer when launching the gallery via `open_gallery.py`
- print the same disclaimer in `open_subdir_gallery.py`

## Testing
- `pre-commit run --files scripts/open_gallery.py scripts/open_subdir_gallery.py` *(failed to install hook environment)*
- `pytest -q` *(failed to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8a9a0a483338c9ee68e4d0409f8