### PR TITLE
[alpha_factory] update gallery build scripts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,9 @@ Downstream users should consult this section when upgrading.
 - `alpha-factory` and `edge_runner.py` now print a short warning before startup.
 - Synced `openai`, `openai-agents` and `uvicorn` pins across requirements files
   and clarified why `requests` and `rich` differ between layers.
+- `build_gallery_site.sh` and `deploy_gallery_pages.sh` now run
+  `scripts/mirror_demo_pages.py` so the GitHub Pages subdirectory mirror stays
+  current.
 - Documented `API_RATE_LIMIT`, `AGI_ISLAND_BACKENDS` and `ALERT_WEBHOOK_URL`
   environment variables.
 - Added [`alpha_factory_v1/core/tools/analyse_backtrack.py`](../alpha_factory_v1/core/tools/analyse_backtrack.py) for visualising archive backtracks.

--- a/scripts/build_gallery_site.sh
+++ b/scripts/build_gallery_site.sh
@@ -25,6 +25,7 @@ npm --prefix "$BROWSER_DIR" ci
 "$SCRIPT_DIR/build_insight_docs.sh"
 python scripts/generate_demo_docs.py
 python scripts/generate_gallery_html.py
+python scripts/mirror_demo_pages.py
 python scripts/build_service_worker.py
 
 # Build the static site and verify integrity

--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -24,6 +24,7 @@ python -m alpha_factory_v1.demos.validate_demos
 npm --prefix "$BROWSER_DIR" run fetch-assets
 npm --prefix "$BROWSER_DIR" ci
 "$SCRIPT_DIR/build_insight_docs.sh"
+python scripts/mirror_demo_pages.py
 python scripts/build_service_worker.py
 
 # Compile and verify the MkDocs site. Use --strict so warnings fail the build


### PR DESCRIPTION
## Summary
- keep docs/alpha_factory_v1/demos mirror in sync
- update changelog about the mirror script

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*
- `pre-commit run --files scripts/build_gallery_site.sh scripts/deploy_gallery_pages.sh docs/CHANGELOG.md` *(fails: verify requirements hooks)*

------
https://chatgpt.com/codex/tasks/task_e_686306770ba0833386c186dab0a24918