### PR TITLE
[alpha_factory] Add license header to insight demo

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX comment to `docs/alpha_agi_insight_v1/index.html`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files docs/alpha_agi_insight_v1/index.html` *(with hooks skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68631469b1708333917b6fb4e5351db4