### PR TITLE
Add demo README preview image

### DIFF
--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -3,4 +3,6 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Alpha-Factory Demos
 
+![preview](../demos/assets/readme_preview.svg){.demo-preview}
+
 This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse them at [https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/).

--- a/docs/demos/assets/readme_preview.svg
+++ b/docs/demos/assets/readme_preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/scripts/verify_gallery_assets.py
+++ b/scripts/verify_gallery_assets.py
@@ -24,7 +24,10 @@ def main() -> int:
             continue
         rel = Path(m.group(1).split("#", 1)[0])
         target = (md_file.parent / rel).resolve()
-        expected_dir = repo_root / "docs" / md_file.stem / "assets"
+        if md_file.name == "README.md":
+            expected_dir = repo_root / "docs" / "demos" / "assets"
+        else:
+            expected_dir = repo_root / "docs" / md_file.stem / "assets"
         if not target.is_file() or not target.is_relative_to(expected_dir):
             missing.append(f"{md_file.relative_to(repo_root)}: {target.relative_to(repo_root)}")
 


### PR DESCRIPTION
## Summary
- add placeholder preview image for demo gallery
- show preview at the top of the demo README
- verify script supports README preview directory

## Testing
- `CUSTOM_COMPILE_COMMAND='pip-compile requirements.txt -o requirements.lock' pre-commit run --files docs/demos/README.md` *(fails: Verify alpha_factory_v1 requirements.lock is up to date)*

------
https://chatgpt.com/codex/tasks/task_e_68631bf9ae748333aa9256037c793076