### PR TITLE
[alpha_factory] docs: update demo gallery link

### DIFF
--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -5,4 +5,5 @@
 
 ![preview](../demos/assets/readme_preview.svg){.demo-preview}
 
-This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse them at [https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/).
+This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`.
+Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).


### PR DESCRIPTION
## Summary
- adjust docs to point to the root demo gallery

## Testing
- `python scripts/verify_disclaimer_snippet.py`
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*
- `pre-commit run --files docs/demos/README.md` *(fails: requirements.lock is outdated)*


------
https://chatgpt.com/codex/tasks/task_e_686336f22ba88333aaa678636a674916