### PR TITLE
[alpha_factory] clarify subdir gallery launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 
 **Browse the visual demo gallery:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/>
 
-**Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` for a local or online launch.
+**Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
 **Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details.


### PR DESCRIPTION
## Summary
- note `make subdir-gallery-open` in the main README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent' ...)*
- `pre-commit run --files README.md` *(fails: requirements.lock is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_68633cdb7e048333b3035a39656055e9