### PR TITLE
[alpha_factory] fix gallery links

### DIFF
--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_asi_world_model/index.html
+++ b/docs/alpha_asi_world_model/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script type="module" src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/aiga_meta_evolution/index.html
+++ b/docs/alpha_factory_v1/demos/aiga_meta_evolution/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/alpha_asi_world_model/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_asi_world_model/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script type="module" src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/index.html
+++ b/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/era_of_experience/index.html
+++ b/docs/alpha_factory_v1/demos/era_of_experience/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/finance_alpha/index.html
+++ b/docs/alpha_factory_v1/demos/finance_alpha/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/index.html
+++ b/docs/alpha_factory_v1/demos/index.html
@@ -20,9 +20,10 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="../../demos/README/" target="_blank" rel="noopener noreferrer" data-summary="" title="Alpha-Factory Demos">
-      <img src="../../alpha_agi_insight_v1/favicon.svg" alt="Alpha-Factory Demos" loading="lazy" title="Alpha-Factory Demos">
-      <h3>Alpha-Factory Demos</h3>
+    <a class="demo-card" href="../../demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
+      <img src="../../demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
+      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
+      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
     </a>
     <a class="demo-card" href="../../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="../../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">

--- a/docs/alpha_factory_v1/demos/macro_sentinel/index.html
+++ b/docs/alpha_factory_v1/demos/macro_sentinel/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/muzero_planning/index.html
+++ b/docs/alpha_factory_v1/demos/muzero_planning/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/index.html
+++ b/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/alpha_factory_v1/demos/omni_factory_demo/index.html
+++ b/docs/alpha_factory_v1/demos/omni_factory_demo/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/alpha_factory_v1/demos/self_healing_repo/index.html
+++ b/docs/alpha_factory_v1/demos/self_healing_repo/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script type="module" src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/solving_agi_governance/index.html
+++ b/docs/alpha_factory_v1/demos/solving_agi_governance/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script type="module" src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/alpha_factory_v1/index.html
+++ b/docs/alpha_factory_v1/index.html
@@ -13,6 +13,6 @@
 <body>
   <p>Redirecting to the <a href="demos/index.html">Alpha‑Factory demo gallery</a>...</p>
   <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -20,9 +20,10 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="../demos/README/" target="_blank" rel="noopener noreferrer" data-summary="" title="Alpha-Factory Demos">
-      <img src="../alpha_agi_insight_v1/favicon.svg" alt="Alpha-Factory Demos" loading="lazy" title="Alpha-Factory Demos">
-      <h3>Alpha-Factory Demos</h3>
+    <a class="demo-card" href="../demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
+      <img src="../demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
+      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
+      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
     </a>
     <a class="demo-card" href="../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -20,9 +20,10 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="demos/README/" target="_blank" rel="noopener noreferrer" data-summary="" title="Alpha-Factory Demos">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha-Factory Demos" loading="lazy" title="Alpha-Factory Demos">
-      <h3>Alpha-Factory Demos</h3>
+    <a class="demo-card" href="demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
+      <img src="demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
+      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
+      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
     </a>
     <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,9 +20,10 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="demos/README/" target="_blank" rel="noopener noreferrer" data-summary="" title="Alpha-Factory Demos">
-      <img src="alpha_agi_insight_v1/favicon.svg" alt="Alpha-Factory Demos" loading="lazy" title="Alpha-Factory Demos">
-      <h3>Alpha-Factory Demos</h3>
+    <a class="demo-card" href="demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
+      <img src="demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
+      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
+      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
     </a>
     <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/self_healing_repo/index.html
+++ b/docs/self_healing_repo/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script type="module" src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/solving_agi_governance/index.html
+++ b/docs/solving_agi_governance/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script type="module" src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
 <script src="assets/script.js"></script>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -18,7 +18,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 
 <p><a href='../demos/utils.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
-<p><a href="../gallery.html">⬅️ Back to Gallery</a></p>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("../assets/service-worker.js").catch(() => {

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -117,10 +117,17 @@ def insert_back_link(pages: Iterable[Path]) -> None:
         if not page.is_file():
             continue
         text = page.read_text(encoding="utf-8")
-        if "Back to Gallery" in text:
-            continue
-        rel = Path(os.path.relpath(GALLERY_FILE, page.parent)).as_posix()
+        rel = Path(os.path.relpath(INDEX_FILE, page.parent)).as_posix()
         link = f'<p><a href="{rel}">\u2b05\ufe0f Back to Gallery</a></p>'
+        if "Back to Gallery" in text:
+            new_text = re.sub(
+                r"<p><a href=\"[^\"]+\">\u2b05\ufe0f Back to Gallery</a></p>",
+                link,
+                text,
+            )
+            if new_text != text:
+                page.write_text(new_text, encoding="utf-8")
+            continue
         lines = text.splitlines()
         inserted = False
         for i, line in enumerate(lines):


### PR DESCRIPTION
## Summary
- update `insert_back_link` so generated demo pages link back to `index.html`
- regenerate gallery pages

## Testing
- `pre-commit run --files scripts/generate_gallery_html.py` *(fails: verify-requirements-lock)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68634388c2a88333ad2e867fc90bc887