### PR TITLE
[alpha_factory] remove README from gallery

### DIFF
--- a/docs/alpha_factory_v1/demos/index.html
+++ b/docs/alpha_factory_v1/demos/index.html
@@ -20,11 +20,6 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="../../demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
-      <img src="../../demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
-      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
-      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
-    </a>
     <a class="demo-card" href="../../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="../../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -20,11 +20,6 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="../demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
-      <img src="../demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
-      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
-      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
-    </a>
     <a class="demo-card" href="../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -20,11 +20,6 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
-      <img src="demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
-      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
-      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
-    </a>
     <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,11 +20,6 @@
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
   <div class="demo-grid">
-    <a class="demo-card" href="demos/README/" target="_blank" rel="noopener noreferrer" data-summary="this directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. browse the full gallery at [https://montrealai.github.io/agi-alpha-agent-v0/](https://montrealai.github.io/agi-alpha-agent-v0/)." title="This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).">
-      <img src="demos/assets/readme_preview.svg" alt="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)" loading="lazy" title="[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)">
-      <h3>[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)</h3>
-      <p class='demo-desc'>This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`. Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).</p>
-    </a>
     <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent **agentic α‑agi**" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent **AGENTIC α‑AGI**">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>


### PR DESCRIPTION
## Summary
- skip docs/demos/README.md when collecting gallery entries
- ignore disclaimer headings when parsing demo pages
- rebuild the gallery

## Testing
- `pre-commit run --files scripts/generate_gallery_html.py` *(fails: verify-requirements-lock)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*
- `python scripts/generate_gallery_html.py`

------
https://chatgpt.com/codex/tasks/task_e_68634f0c2cf4833394c17e82628d3cab