### PR TITLE
[alpha_factory] add disclaimer checks for HTML

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,11 +98,11 @@ repos:
         language: system
         pass_filenames: false
       - id: verify-disclaimer-snippet
-        name: Verify Markdown and notebook files include disclaimer snippet
+        name: Verify Markdown, HTML and notebook files include disclaimer snippet
         entry: python scripts/verify_disclaimer_snippet.py
         language: python
         pass_filenames: false
-        files: \.(md|ipynb)$
+        files: \.(md|ipynb|html)$
       - id: verify-disclaimer-helper
         name: Ensure scripts import disclaimer helper
         entry: python scripts/verify_disclaimer_helper.py

--- a/tests/test_verify_disclaimer_snippet.py
+++ b/tests/test_verify_disclaimer_snippet.py
@@ -19,6 +19,14 @@ def _create_repo(tmpdir: Path, content: str) -> Path:
     return tmpdir
 
 
+def _create_html_repo(tmpdir: Path, content: str) -> Path:
+    docs = tmpdir / "docs"
+    docs.mkdir()
+    (docs / "DISCLAIMER_SNIPPET.md").write_text(SNIPPET_TEXT)
+    (tmpdir / "index.html").write_text(content)
+    return tmpdir
+
+
 def test_single_disclaimer_passes(tmp_path: Path) -> None:
     repo = _create_repo(tmp_path, SNIPPET_TEXT)
     missing, duplicates = verify_disclaimer_snippet.check_repo(repo)
@@ -30,3 +38,21 @@ def test_duplicate_disclaimer_fails(tmp_path: Path) -> None:
     repo = _create_repo(tmp_path, SNIPPET_TEXT + "\n" + SNIPPET_TEXT)
     missing, duplicates = verify_disclaimer_snippet.check_repo(repo)
     assert duplicates == [repo / "README.md"]
+
+
+def test_html_single_disclaimer_passes(tmp_path: Path) -> None:
+    html = "<p><a href='docs/DISCLAIMER_SNIPPET.md'>See docs/DISCLAIMER_SNIPPET.md</a></p>"
+    repo = _create_html_repo(tmp_path, html)
+    missing, duplicates = verify_disclaimer_snippet.check_repo(repo)
+    assert missing == []
+    assert duplicates == []
+
+
+def test_html_duplicate_disclaimer_fails(tmp_path: Path) -> None:
+    html = (
+        "<p><a href='docs/DISCLAIMER_SNIPPET.md'>See docs/DISCLAIMER_SNIPPET.md</a></p>"
+        * 2
+    )
+    repo = _create_html_repo(tmp_path, html)
+    missing, duplicates = verify_disclaimer_snippet.check_repo(repo)
+    assert duplicates == [repo / "index.html"]


### PR DESCRIPTION
## Summary
- update `verify_disclaimer_snippet.py` to scan HTML pages
- test HTML logic in `test_verify_disclaimer_snippet`
- run disclaimer hook on `.html` files

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_verify_disclaimer_snippet.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68635aa69fb88333a89adf7a5fd21f3e