### PR TITLE
[alpha_factory] integrate pyodide demo into docs

### DIFF
--- a/docs/aiga_meta_evolution/assets/script.js
+++ b/docs/aiga_meta_evolution/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_agi_business_2_v1/assets/script.js
+++ b/docs/alpha_agi_business_2_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_agi_business_3_v1/assets/script.js
+++ b/docs/alpha_agi_business_3_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_agi_business_v1/assets/script.js
+++ b/docs/alpha_agi_business_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_agi_insight_v0/assets/script.js
+++ b/docs/alpha_agi_insight_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_agi_insight_v1/assets/script.js
+++ b/docs/alpha_agi_insight_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_agi_marketplace_v1/assets/script.js
+++ b/docs/alpha_agi_marketplace_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/aiga_meta_evolution/assets/script.js
+++ b/docs/alpha_factory_v1/demos/aiga_meta_evolution/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/aiga_meta_evolution/index.html
+++ b/docs/alpha_factory_v1/demos/aiga_meta_evolution/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/script.js
+++ b/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/index.html
+++ b/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/era_of_experience/assets/script.js
+++ b/docs/alpha_factory_v1/demos/era_of_experience/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/era_of_experience/index.html
+++ b/docs/alpha_factory_v1/demos/era_of_experience/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/finance_alpha/assets/script.js
+++ b/docs/alpha_factory_v1/demos/finance_alpha/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/finance_alpha/index.html
+++ b/docs/alpha_factory_v1/demos/finance_alpha/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/macro_sentinel/assets/script.js
+++ b/docs/alpha_factory_v1/demos/macro_sentinel/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/macro_sentinel/index.html
+++ b/docs/alpha_factory_v1/demos/macro_sentinel/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/index.html
+++ b/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/muzero_planning/assets/script.js
+++ b/docs/alpha_factory_v1/demos/muzero_planning/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/muzero_planning/index.html
+++ b/docs/alpha_factory_v1/demos/muzero_planning/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/index.html
+++ b/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/omni_factory_demo/assets/script.js
+++ b/docs/alpha_factory_v1/demos/omni_factory_demo/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/omni_factory_demo/index.html
+++ b/docs/alpha_factory_v1/demos/omni_factory_demo/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../../../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/cross_industry_alpha_factory/assets/script.js
+++ b/docs/cross_industry_alpha_factory/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/era_of_experience/assets/script.js
+++ b/docs/era_of_experience/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/finance_alpha/assets/script.js
+++ b/docs/finance_alpha/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/macro_sentinel/assets/script.js
+++ b/docs/macro_sentinel/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/meta_agentic_agi/assets/script.js
+++ b/docs/meta_agentic_agi/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/meta_agentic_agi_v2/assets/script.js
+++ b/docs/meta_agentic_agi_v2/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/meta_agentic_agi_v3/assets/script.js
+++ b/docs/meta_agentic_agi_v3/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/meta_agentic_tree_search_v0/assets/script.js
+++ b/docs/meta_agentic_tree_search_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/muzero_planning/assets/script.js
+++ b/docs/muzero_planning/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <link rel="stylesheet" href="assets/style.css">
 <script>

--- a/docs/muzeromctsllmagent_v0/assets/script.js
+++ b/docs/muzeromctsllmagent_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/omni_factory_demo/assets/script.js
+++ b/docs/omni_factory_demo/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {

--- a/docs/sovereign_agentic_agialpha_agent_v0/assets/script.js
+++ b/docs/sovereign_agentic_agialpha_agent_v0/assets/script.js
@@ -1,29 +1,20 @@
-(() => {
-  fetch('assets/logs.json')
-    .then(res => res.json())
-    .then(data => {
-      const steps = data.steps || [];
-      const values = data.values || [];
-      const logs = data.logs || steps.map(s => `Step ${s}`);
-      const ctx = document.getElementById('chart');
-      if (!ctx) return;
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-        options: { animation: false, responsive: true, maintainAspectRatio: false }
-      });
-      let i = 0;
-      const logEl = document.getElementById('logs-panel');
-      function step() {
-        if (i >= steps.length) return;
-        chart.data.labels.push(steps[i]);
-        chart.data.datasets[0].data.push(values[i]);
-        chart.update();
-        if (logEl) logEl.textContent += logs[i] + '\n';
-        i += 1;
-        setTimeout(step, 800);
-      }
-      step();
-    })
-    .catch(err => console.error('replay failed', err));
-})();
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
+
+fetch('assets/logs.json')
+  .then(res => res.json())
+  .then(data => {
+    const ctx = document.getElementById('chart');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById('logs-panel');
+    setupPyodideDemo(chart, logEl, data);
+  })
+  .catch(err => console.error('replay failed', err));

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -26,7 +26,7 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <pre id="logs-panel"></pre>
 <script src="../assets/chart.min.js"></script>
 <script type="module" src="../assets/pyodide_demo.js"></script>
-<script src="assets/script.js"></script>
+<script type="module" src="assets/script.js"></script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <script>
   if ("serviceWorker" in navigator) {


### PR DESCRIPTION
## Summary
- expose offline/online controls in various demos
- load `setupPyodideDemo` in each demo script
- mark scripts as ES modules

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, yaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*
- `pre-commit run --files $(cat /tmp/changed_files.txt)` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6863df8702208333b6f4145f14575bee