### PR TITLE
[alpha_factory] refactor demo replay logic

### DIFF
--- a/docs/aiga_meta_evolution/assets/script.js
+++ b/docs/aiga_meta_evolution/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_agi_business_2_v1/assets/script.js
+++ b/docs/alpha_agi_business_2_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_agi_business_3_v1/assets/script.js
+++ b/docs/alpha_agi_business_3_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_agi_business_v1/assets/script.js
+++ b/docs/alpha_agi_business_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_agi_insight_v0/assets/script.js
+++ b/docs/alpha_agi_insight_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_agi_insight_v1/assets/script.js
+++ b/docs/alpha_agi_insight_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_agi_marketplace_v1/assets/script.js
+++ b/docs/alpha_agi_marketplace_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_asi_world_model/assets/script.js
+++ b/docs/alpha_asi_world_model/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/aiga_meta_evolution/assets/script.js
+++ b/docs/alpha_factory_v1/demos/aiga_meta_evolution/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_2_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_3_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/alpha_agi_business_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_business_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_insight_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_agi_marketplace_v1/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/alpha_asi_world_model/assets/script.js
+++ b/docs/alpha_factory_v1/demos/alpha_asi_world_model/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/script.js
+++ b/docs/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/era_of_experience/assets/script.js
+++ b/docs/alpha_factory_v1/demos/era_of_experience/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/finance_alpha/assets/script.js
+++ b/docs/alpha_factory_v1/demos/finance_alpha/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/macro_sentinel/assets/script.js
+++ b/docs/alpha_factory_v1/demos/macro_sentinel/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v2/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_agi_v3/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/meta_agentic_tree_search_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/muzero_planning/assets/script.js
+++ b/docs/alpha_factory_v1/demos/muzero_planning/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/muzeromctsllmagent_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/omni_factory_demo/assets/script.js
+++ b/docs/alpha_factory_v1/demos/omni_factory_demo/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/self_healing_repo/assets/script.js
+++ b/docs/alpha_factory_v1/demos/self_healing_repo/assets/script.js
@@ -2,23 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    // allow both {steps, values} and {timestamps, metrics}
-    if (data.timestamps && !data.steps) data.steps = data.timestamps;
-    if (data.metrics && !data.values) data.values = data.metrics;
-
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/solving_agi_governance/assets/script.js
+++ b/docs/alpha_factory_v1/demos/solving_agi_governance/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/assets/script.js
+++ b/docs/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/assets/replay_chart.js
+++ b/docs/assets/replay_chart.js
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env browser */
+/* global Chart */
+/* eslint-disable no-undef */
+import {setupPyodideDemo} from './pyodide_demo.js';
+
+export async function replayChart({logsUrl, chartId = 'chart', logElId = 'logs-panel', label = 'Demo Metric', color = 'blue'}) {
+  try {
+    const res = await fetch(logsUrl);
+    const data = await res.json();
+    const ctx = document.getElementById(chartId);
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label, data: [], fill: false, borderColor: color }] },
+      options: { animation: false, responsive: true, maintainAspectRatio: false }
+    });
+    const logEl = document.getElementById(logElId);
+    setupPyodideDemo(chart, logEl, data);
+  } catch (err) {
+    console.error('replay failed', err);
+  }
+}

--- a/docs/cross_industry_alpha_factory/assets/script.js
+++ b/docs/cross_industry_alpha_factory/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/era_of_experience/assets/script.js
+++ b/docs/era_of_experience/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/finance_alpha/assets/script.js
+++ b/docs/finance_alpha/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/macro_sentinel/assets/script.js
+++ b/docs/macro_sentinel/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/meta_agentic_agi/assets/script.js
+++ b/docs/meta_agentic_agi/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/meta_agentic_agi_v2/assets/script.js
+++ b/docs/meta_agentic_agi_v2/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/meta_agentic_agi_v3/assets/script.js
+++ b/docs/meta_agentic_agi_v3/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/meta_agentic_tree_search_v0/assets/script.js
+++ b/docs/meta_agentic_tree_search_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/muzero_planning/assets/script.js
+++ b/docs/muzero_planning/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/muzeromctsllmagent_v0/assets/script.js
+++ b/docs/muzeromctsllmagent_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/omni_factory_demo/assets/script.js
+++ b/docs/omni_factory_demo/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/self_healing_repo/assets/script.js
+++ b/docs/self_healing_repo/assets/script.js
@@ -2,23 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    // allow both {steps, values} and {timestamps, metrics}
-    if (data.timestamps && !data.steps) data.steps = data.timestamps;
-    if (data.metrics && !data.values) data.values = data.metrics;
-
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/solving_agi_governance/assets/script.js
+++ b/docs/solving_agi_governance/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});

--- a/docs/sovereign_agentic_agialpha_agent_v0/assets/script.js
+++ b/docs/sovereign_agentic_agialpha_agent_v0/assets/script.js
@@ -2,19 +2,5 @@
 /* eslint-env browser */
 /* global Chart */
 /* eslint-disable no-undef */
-import {setupPyodideDemo} from '../../assets/pyodide_demo.js';
-
-fetch('assets/logs.json')
-  .then(res => res.json())
-  .then(data => {
-    const ctx = document.getElementById('chart');
-    if (!ctx) return;
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels: [], datasets: [{ label: 'Demo Metric', data: [], fill: false, borderColor: 'blue' }] },
-      options: { animation: false, responsive: true, maintainAspectRatio: false }
-    });
-    const logEl = document.getElementById('logs-panel');
-    setupPyodideDemo(chart, logEl, data);
-  })
-  .catch(err => console.error('replay failed', err));
+import {replayChart} from '../../assets/replay_chart.js';
+replayChart({logsUrl: 'assets/logs.json', label: 'Demo Metric', color: 'blue'});


### PR DESCRIPTION
## Summary
- add `docs/assets/replay_chart.js` helper
- use the new helper in all demo scripts

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent' ...)*
- `pre-commit run --files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e2e48e0c8333a66690245134c514