### PR TITLE
[alpha_factory] Update service worker docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,8 +122,8 @@ Follow these steps when installing without internet access:
 - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
 - Run `python scripts/check_python_deps.py` **before running `pytest`** to quickly verify that `numpy`, `yaml` and `pandas` are installed. If it reports missing packages, execute `python check_env.py --auto-install` before running the tests. This step fetches packages from PyPI, so in air‑gapped setups you **must** pass `--wheelhouse <path>` or set `WHEELHOUSE` so `pip` installs from the local cache.
 - When adding new demos or assets, regenerate `docs/assets/service-worker.js` with
-  `python scripts/build_service_worker.py`. The gallery deployment helper invokes
-  this script automatically.
+  `python scripts/build_service_worker.py` to prevent stale caches on GitHub Pages.
+  The gallery deployment helper invokes this script automatically.
 - Every `docs/demos/*.md` page must start with a preview image using
   `![preview](...)`. Run `pre-commit run --files docs/demos/<page>.md` to catch
   missing previews.

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -76,6 +76,10 @@ The helper script `scripts/build_insight_docs.sh` automates the steps above.
 Run it from the repository root to build the bundle, refresh
 `docs/alpha_agi_insight_v1` and generate the site.
 
+Whenever demo assets change, rerun `python scripts/build_service_worker.py` to
+update `docs/assets/service-worker.js`. Otherwise visitors may see outdated
+files due to the service worker cache on GitHub Pages.
+
 
 ## Building the Site
 


### PR DESCRIPTION
## Summary
- note to rebuild service worker when assets change
- highlight this in contributor guide

## Testing
- `pre-commit run --files AGENTS.md docs/HOSTING_INSTRUCTIONS.md` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6863e53d61c0833393be0d28fef93aa4