### PR TITLE
[alpha_factory] add docstrings to demo packages

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/__init__.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/__init__.py
@@ -3,6 +3,7 @@
 This module is part of a conceptual research prototype. References to
 'AGI' or 'superintelligence' describe aspirational goals and do not
 indicate the presence of real general intelligence. Use at your own risk.
+
+Entry point for the AIGA Meta Evolution demo package.
 """
 
-# Demo package

--- a/alpha_factory_v1/demos/alpha_agi_business_2_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_2_v1/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Alpha‑AGI Business 2 demo package."""

--- a/alpha_factory_v1/demos/era_of_experience/__init__.py
+++ b/alpha_factory_v1/demos/era_of_experience/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Era of Experience demo package."""
 from .alpha_detection import (
     detect_yield_curve_alpha,
     detect_supply_chain_alpha,

--- a/alpha_factory_v1/demos/finance_alpha/__init__.py
+++ b/alpha_factory_v1/demos/finance_alpha/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Finance Alpha demo package."""

--- a/alpha_factory_v1/demos/macro_sentinel/__init__.py
+++ b/alpha_factory_v1/demos/macro_sentinel/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Macro Sentinel demo package."""

--- a/alpha_factory_v1/demos/meta_agentic_agi/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Meta-Agentic AGI demo package."""

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Meta-Agentic AGI v2 demo package."""

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/__init__.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Meta-Agentic AGI v3 demo package."""

--- a/alpha_factory_v1/demos/muzeromctsllmagent_v0/__init__.py
+++ b/alpha_factory_v1/demos/muzeromctsllmagent_v0/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the MuZero MCTS LLM Agent v0 demo package."""

--- a/alpha_factory_v1/demos/omni_factory_demo/__init__.py
+++ b/alpha_factory_v1/demos/omni_factory_demo/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Omni Factory demo package."""

--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/__init__.py
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Demo package
+"""Entry point for the Sovereign Agentic AGI Alpha Agent v0 demo package."""


### PR DESCRIPTION
## Summary
- add a short Google-style docstring to each demo `__init__.py`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea1cc9f48333a76aaaaf90a3779b