### PR TITLE
[alpha_factory] dynamic service worker cache version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,8 @@ Downstream users should consult this section when upgrading.
 - Clarified that `transfer_test.evaluate_agent` is a placeholder returning the archived
   score. Added a simple heuristic in `MetaRefinementAgent` that proposes a longer
   cycle period when logs show slow agent cycles.
+- Service worker cache version is now generated dynamically to ensure updates are
+  picked up by browsers.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.

--- a/docs/assets/service-worker.js
+++ b/docs/assets/service-worker.js
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* eslint-env serviceworker */
-const CACHE = 'v4';
+const CACHE = 'v4a7e24e7';
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches
@@ -169,7 +169,7 @@ self.addEventListener('install', (event) => {
   );
   self.skipWaiting();
 });
-self.addEventListener('activate', (event) => {
+self.addEventListener('activate', (event) => {{
   event.waitUntil(
     caches.keys().then((names) =>
       Promise.all(
@@ -179,19 +179,19 @@ self.addEventListener('activate', (event) => {
   );
   self.clients.claim();
 });
-self.addEventListener('fetch', (event) => {
+self.addEventListener('fetch', (event) => {{
   if (event.request.method !== 'GET') return;
   const url = new URL(event.request.url);
-  if (url.origin !== self.location.origin) {
+  if (url.origin !== self.location.origin) {{
     event.respondWith(
-      caches.open(CACHE).then(async (cache) => {
-        try {
+      caches.open(CACHE).then(async (cache) => {{
+        try {{
           const resp = await fetch(event.request);
-          if (resp.ok) {
+          if (resp.ok) {{
             cache.put(event.request, resp.clone());
           }
           return resp;
-        } catch (err) {
+        }} catch (err) {{
           const cached =
             (await cache.match(event.request)) ||
             (await cache.match(`pyodide/${url.pathname.split('/').pop()}`));
@@ -207,12 +207,12 @@ self.addEventListener('fetch', (event) => {
         (cached) =>
           cached ||
           fetch(event.request)
-            .then((resp) => {
-              if (resp.ok) {
+            .then((resp) => {{
+              if (resp.ok) {{
                 cache.put(event.request, resp.clone());
-              }
+              }}
               return resp;
-            })
+            }})
             .catch(() => cached),
       ),
     ),


### PR DESCRIPTION
## Summary
- generate a hash-based cache version when building the service worker
- regenerate docs assets with the dynamic version
- note dynamic cache versioning in the changelog

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files scripts/build_service_worker.py docs/assets/service-worker.js docs/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6863eff50cf88333bab29bb880a6ed57