### PR TITLE
Improve gallery scripts

### DIFF
--- a/scripts/check_python_deps.py
+++ b/scripts/check_python_deps.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import subprocess
 import sys
 
-REQUIRED = ["numpy", "pytest", "yaml", "pandas"]
+REQUIRED = ["numpy", "pytest", "pyyaml", "pandas"]
 
 
 def _pkg_installed(pkg: str) -> bool:

--- a/scripts/open_gallery.py
+++ b/scripts/open_gallery.py
@@ -12,11 +12,16 @@ functionality such as service workers and relative assets.
 """
 from __future__ import annotations
 
-from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+from pathlib import Path
+
+try:
+    from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+except Exception:  # pragma: no cover - fallback when package not installed
+    _DOCS_PATH = Path(__file__).resolve().parents[1] / "docs" / "DISCLAIMER_SNIPPET.md"
+    DISCLAIMER = _DOCS_PATH.read_text(encoding="utf-8").strip()
 
 import subprocess
 import sys
-from pathlib import Path
 from urllib.request import Request, urlopen
 import webbrowser
 from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler

--- a/scripts/open_subdir_gallery.py
+++ b/scripts/open_subdir_gallery.py
@@ -9,7 +9,14 @@ local build when offline by invoking ``scripts/build_gallery_site.sh``.
 """
 from __future__ import annotations
 
-from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+from pathlib import Path
+
+try:
+    from alpha_factory_v1.utils.disclaimer import DISCLAIMER
+except Exception:  # pragma: no cover - fallback when package not installed
+    _DOCS_PATH = Path(__file__).resolve().parents[1] / "docs" / "DISCLAIMER_SNIPPET.md"
+    DISCLAIMER = _DOCS_PATH.read_text(encoding="utf-8").strip()
+
 import argparse
 
 import subprocess


### PR DESCRIPTION
## Summary
- improve resilience of open_gallery.py and open_subdir_gallery.py
- fix dependency check script

## Testing
- `pre-commit run --files scripts/open_gallery.py scripts/open_subdir_gallery.py scripts/check_python_deps.py`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*

------
https://chatgpt.com/codex/tasks/task_e_686403246d388333a705b4842a7c0aab