### PR TITLE
feat: allow custom gallery url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 
 **Browse the visual demo gallery:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/>
 
-**Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
+**Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` (or set `AF_GALLERY_URL` to your own mirror) for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
 **Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details.

--- a/scripts/open_demo.py
+++ b/scripts/open_demo.py
@@ -10,6 +10,7 @@ non-technical users can explore the demos with a single command.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import threading
@@ -32,6 +33,9 @@ def _build_local_site(repo_root: Path) -> bool:
 
 
 def _demo_url(demo: str) -> str:
+    env = os.environ.get("AF_GALLERY_URL")
+    if env:
+        return f"{env.rstrip('/')}/{demo}/"
     remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
     repo_path = remote.split("github.com")[-1].lstrip(":/")
     repo_path = repo_path.removesuffix(".git")

--- a/scripts/open_gallery.py
+++ b/scripts/open_gallery.py
@@ -20,6 +20,7 @@ except Exception:  # pragma: no cover - fallback when package not installed
     _DOCS_PATH = Path(__file__).resolve().parents[1] / "docs" / "DISCLAIMER_SNIPPET.md"
     DISCLAIMER = _DOCS_PATH.read_text(encoding="utf-8").strip()
 
+import os
 import subprocess
 import sys
 from urllib.request import Request, urlopen
@@ -42,6 +43,9 @@ def _build_local_site(repo_root: Path) -> bool:
 
 
 def _gallery_url() -> str:
+    env = os.environ.get("AF_GALLERY_URL")
+    if env:
+        return env.rstrip("/") + "/index.html"
     remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
     repo_path = remote.split("github.com")[-1].lstrip(":/")
     repo_path = repo_path.removesuffix(".git")

--- a/scripts/open_subdir_gallery.py
+++ b/scripts/open_subdir_gallery.py
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover - fallback when package not installed
     DISCLAIMER = _DOCS_PATH.read_text(encoding="utf-8").strip()
 
 import argparse
+import os
 
 import subprocess
 import sys
@@ -41,6 +42,9 @@ def _build_local_site(repo_root: Path) -> bool:
 
 
 def _subdir_url() -> str:
+    env = os.environ.get("AF_GALLERY_URL")
+    if env:
+        return env.rstrip("/") + "/alpha_factory_v1/demos/"
     remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
     repo_path = remote.split("github.com")[-1].lstrip(":/")
     repo_path = repo_path.removesuffix(".git")


### PR DESCRIPTION
## Summary
- accept `AF_GALLERY_URL` in gallery launcher scripts
- document the variable in README

## Testing
- `pre-commit` *(skipped failing requirement hooks)*
- `python check_env.py --auto-install` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68642b1618a88333b5e2abbe4d8dd433