### PR TITLE
[alpha_factory] fix service worker template generation

### DIFF
--- a/docs/assets/service-worker.js
+++ b/docs/assets/service-worker.js
@@ -169,7 +169,7 @@ self.addEventListener('install', (event) => {
   );
   self.skipWaiting();
 });
-self.addEventListener('activate', (event) => {{
+self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((names) =>
       Promise.all(
@@ -179,19 +179,19 @@ self.addEventListener('activate', (event) => {{
   );
   self.clients.claim();
 });
-self.addEventListener('fetch', (event) => {{
+self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
   const url = new URL(event.request.url);
-  if (url.origin !== self.location.origin) {{
+  if (url.origin !== self.location.origin) {
     event.respondWith(
-      caches.open(CACHE).then(async (cache) => {{
-        try {{
+      caches.open(CACHE).then(async (cache) => {
+        try {
           const resp = await fetch(event.request);
-          if (resp.ok) {{
+          if (resp.ok) {
             cache.put(event.request, resp.clone());
           }
           return resp;
-        }} catch (err) {{
+        } catch (err) {
           const cached =
             (await cache.match(event.request)) ||
             (await cache.match(`pyodide/${url.pathname.split('/').pop()}`));
@@ -207,12 +207,12 @@ self.addEventListener('fetch', (event) => {{
         (cached) =>
           cached ||
           fetch(event.request)
-            .then((resp) => {{
-              if (resp.ok) {{
+            .then((resp) => {
+              if (resp.ok) {
                 cache.put(event.request, resp.clone());
-              }}
+              }
               return resp;
-            }})
+            })
             .catch(() => cached),
       ),
     ),

--- a/scripts/build_service_worker.py
+++ b/scripts/build_service_worker.py
@@ -117,7 +117,7 @@ def main() -> None:
     lines = [header]
     for asset in assets:
         lines.append(f"          '{asset}',")
-    lines.append(FOOTER)
+    lines.append(FOOTER.replace("{{", "{").replace("}}", "}"))
     sw_path.write_text("\n".join(lines))
     print(f"Wrote {sw_path} with cache {version}")
 


### PR DESCRIPTION
## Summary
- ensure braces are rendered once when generating the service worker
- rebuild service-worker.js

## Testing
- `python scripts/build_service_worker.py`
- `node -c docs/assets/service-worker.js`
- `python scripts/check_python_deps.py` *(fails: Missing packages: numpy, pyyaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: import errors)*
- `pre-commit run --files scripts/build_service_worker.py docs/assets/service-worker.js` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68644d97c49083338f9ef718050411d6