### PR TITLE
[alpha_factory] Improve gallery accessibility

### DIFF
--- a/docs/aiga_meta_evolution/index.html
+++ b/docs/aiga_meta_evolution/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/aiga_meta_evolution.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/alpha_agi_business_2_v1/index.html
+++ b/docs/alpha_agi_business_2_v1/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_business_2_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/alpha_agi_business_3_v1/index.html
+++ b/docs/alpha_agi_business_3_v1/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_business_3_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/alpha_agi_business_v1/index.html
+++ b/docs/alpha_agi_business_v1/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_business_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/alpha_agi_insight_v0/index.html
+++ b/docs/alpha_agi_insight_v0/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_insight_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -28,8 +28,8 @@
     </p>
   </header>
   <div id="mode-control">
-    <button id="offline-mode">Offline</button>
-    <button id="online-mode">OpenAI API</button>
+    <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+    <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
   </div>
 
   <main>

--- a/docs/alpha_agi_marketplace_v1/index.html
+++ b/docs/alpha_agi_marketplace_v1/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_agi_marketplace_v1.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/alpha_asi_world_model/index.html
+++ b/docs/alpha_asi_world_model/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/alpha_asi_world_model.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/alpha_factory_v1/demos/index.html
+++ b/docs/alpha_factory_v1/demos/index.html
@@ -18,7 +18,7 @@
 <body>
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
-  <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
+  <input id="search-input" class="search-input" type="text" placeholder="Search demos..." aria-label="Search demos">
   <div class="demo-grid">
     <a class="demo-card" href="../../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="🌌 algorithms that invent algorithms — ai‑ga meta‑evolution demo ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">

--- a/docs/cross_industry_alpha_factory/index.html
+++ b/docs/cross_industry_alpha_factory/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/cross_industry_alpha_factory.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -18,7 +18,7 @@
 <body>
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
-  <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
+  <input id="search-input" class="search-input" type="text" placeholder="Search demos..." aria-label="Search demos">
   <div class="demo-grid">
     <a class="demo-card" href="../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="🌌 algorithms that invent algorithms — ai‑ga meta‑evolution demo ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">

--- a/docs/era_of_experience/index.html
+++ b/docs/era_of_experience/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/era_of_experience.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/finance_alpha/index.html
+++ b/docs/finance_alpha/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/finance_alpha.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
 <body>
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
-  <input id="search-input" class="search-input" type="text" placeholder="Search demos...">
+  <input id="search-input" class="search-input" type="text" placeholder="Search demos..." aria-label="Search demos">
   <div class="demo-grid">
     <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="🌌 algorithms that invent algorithms — ai‑ga meta‑evolution demo ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">

--- a/docs/macro_sentinel/index.html
+++ b/docs/macro_sentinel/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/macro_sentinel.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/meta_agentic_agi/index.html
+++ b/docs/meta_agentic_agi/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/meta_agentic_agi.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/meta_agentic_agi_v2/index.html
+++ b/docs/meta_agentic_agi_v2/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/meta_agentic_agi_v2.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/meta_agentic_agi_v3/index.html
+++ b/docs/meta_agentic_agi_v3/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/meta_agentic_agi_v3.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/meta_agentic_tree_search_v0/index.html
+++ b/docs/meta_agentic_tree_search_v0/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/meta_agentic_tree_search_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/muzero_planning/index.html
+++ b/docs/muzero_planning/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/muzero_planning.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/muzeromctsllmagent_v0/index.html
+++ b/docs/muzeromctsllmagent_v0/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/muzeromctsllmagent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/omni_factory_demo/index.html
+++ b/docs/omni_factory_demo/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/omni_factory_demo.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/self_healing_repo/index.html
+++ b/docs/self_healing_repo/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/self_healing_repo.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/solving_agi_governance/index.html
+++ b/docs/solving_agi_governance/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/solving_agi_governance.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/sovereign_agentic_agialpha_agent_v0/index.html
+++ b/docs/sovereign_agentic_agialpha_agent_v0/index.html
@@ -19,8 +19,8 @@ body { font-family: Arial, sans-serif; margin:0; padding:2rem; text-align:center
 <p><a href='../demos/sovereign_agentic_agialpha_agent_v0.md'>Detailed instructions</a></p>
 <p class='snippet'><a href='../DISCLAIMER_SNIPPET/'>See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
 <div id="mode-control">
-  <button id="offline-mode">Offline</button>
-  <button id="online-mode">OpenAI API</button>
+  <button id="offline-mode" aria-label="Run demo offline">Offline</button>
+  <button id="online-mode" aria-label="Use OpenAI API">OpenAI API</button>
 </div>
 <canvas id="chart"></canvas>
 <pre id="logs-panel"></pre>

--- a/docs/stylesheets/cards.css
+++ b/docs/stylesheets/cards.css
@@ -56,4 +56,6 @@ video.demo-preview {
   border-radius: 4px;
   font-weight: bold;
   text-align: center;
+  border: none;
+  cursor: pointer;
 }

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -196,7 +196,7 @@ def build_html(entries: list[tuple[str, str, str, str]], *, prefix: str = "", ho
 <body>
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class=\"subtitle\">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
-  <input id=\"search-input\" class=\"search-input\" type=\"text\" placeholder=\"Search demos...\">
+  <input id=\"search-input\" class=\"search-input\" type=\"text\" placeholder=\"Search demos...\" aria-label=\"Search demos\">
   <div class=\"demo-grid\">"""
     head = head.format(prefix=prefix)
     lines = [head]
@@ -267,7 +267,12 @@ def build_html(entries: list[tuple[str, str, str, str]], *, prefix: str = "", ho
     lines.append("    });")
     lines.append("  </script>")
     lines.append("</body>\n</html>\n")
-    return "\n".join(lines)
+    html_out = "\n".join(lines)
+    html_out = html_out.replace(
+        "<p class='launch'>Launch Demo</p>",
+        "<button class='launch' type='button'>Launch Demo</button>",
+    )
+    return html_out
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- make gallery search input accessible
- add fallback for old launch paragraphs in gallery builder
- style launch button and add aria labels on offline/online controls
- regenerate docs gallery pages

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent' from 'alpha_factory_v1.core.agents')*

------
https://chatgpt.com/codex/tasks/task_e_686465742b9c833383631a1a257af135