### PR TITLE
[alpha_factory] fix subdir gallery tools

### DIFF
--- a/scripts/open_subdir_demo.py
+++ b/scripts/open_subdir_demo.py
@@ -33,13 +33,26 @@ def _build_local_site(repo_root: Path) -> bool:
 
 
 def _demo_url(demo: str) -> str:
+    """Return the public URL for *demo*.
+
+    ``AF_GALLERY_URL`` overrides the base path. When not set, the GitHub Pages
+    URL is derived from ``git remote``. If the remote cannot be resolved, fall
+    back to the official MontrealAI mirror.
+    """
+
     env = os.environ.get("AF_GALLERY_URL")
     if env:
         return f"{env.rstrip('/')}/alpha_factory_v1/demos/{demo}/index.html"
-    remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
-    repo_path = remote.split("github.com")[-1].lstrip(":/").removesuffix(".git")
-    org, repo = repo_path.split("/", 1)
-    return f"https://{org}.github.io/{repo}/alpha_factory_v1/demos/{demo}/index.html"
+    try:
+        remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
+    except Exception:
+        remote = ""
+    if remote:
+        repo_path = remote.split("github.com")[-1].lstrip(":/").removesuffix(".git")
+        if "/" in repo_path:
+            org, repo = repo_path.split("/", 1)
+            return f"https://{org}.github.io/{repo}/alpha_factory_v1/demos/{demo}/index.html"
+    return f"https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/{demo}/index.html"
 
 
 def _remote_available(url: str) -> bool:

--- a/scripts/open_subdir_gallery.py
+++ b/scripts/open_subdir_gallery.py
@@ -42,14 +42,28 @@ def _build_local_site(repo_root: Path) -> bool:
 
 
 def _subdir_url() -> str:
+    """Return the base URL for the subdirectory gallery.
+
+    When ``AF_GALLERY_URL`` is set, use that value. Otherwise attempt to infer
+    the GitHub Pages URL from ``git remote``. If no remote is configured,
+    default to the official MontrealAI mirror.
+    """
+
     env = os.environ.get("AF_GALLERY_URL")
     if env:
         return env.rstrip("/") + "/alpha_factory_v1/demos/"
-    remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
-    repo_path = remote.split("github.com")[-1].lstrip(":/")
-    repo_path = repo_path.removesuffix(".git")
-    org, repo = repo_path.split("/", 1)
-    return f"https://{org}.github.io/{repo}/alpha_factory_v1/demos/"
+    try:
+        remote = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
+    except Exception:
+        remote = ""
+    if remote:
+        repo_path = remote.split("github.com")[-1].lstrip(":/")
+        repo_path = repo_path.removesuffix(".git")
+        if "/" in repo_path:
+            org, repo = repo_path.split("/", 1)
+            return f"https://{org}.github.io/{repo}/alpha_factory_v1/demos/"
+    # Fall back to the upstream project URL when the remote is missing.
+    return "https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/"
 
 
 def _remote_available(url: str) -> bool:


### PR DESCRIPTION
## Summary
- handle missing git remote in gallery helper scripts
- fall back to official demo URL when remote unavailable

## Testing
- `pre-commit run --files scripts/open_subdir_gallery.py scripts/open_subdir_demo.py` *(fails: verify-requirements-lock)*
- `python check_env.py --auto-install` *(failed: subprocess-exited-with-error)*
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686476c624188333bf0878dd6c4aad84