### PR TITLE
[alpha_factory] docs: register service worker

### DIFF
--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -150,5 +150,10 @@
       });
     });
   </script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('../assets/service-worker.js').catch(() => console.warn('Service worker registration failed'));
+    }
+  </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,5 +149,10 @@
       });
     });
   </script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('assets/service-worker.js').catch(() => console.warn('Service worker registration failed'));
+    }
+  </script>
 </body>
 </html>

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -203,7 +203,8 @@ def build_html(
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class=\"subtitle\">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   {subdir}
-  <input id=\"search-input\" class=\"search-input\" type=\"text\" placeholder=\"Search demos...\" aria-label=\"Search demos\">
+    <input id=\"search-input\" class=\"search-input\" type=\"text\"
+           placeholder=\"Search demos...\" aria-label=\"Search demos\">
   <div class=\"demo-grid\">"""
     subdir_html = (
         f'<p class="subtitle"><a href="{prefix}alpha_factory_v1/demos/index.html">Open Subdirectory Gallery</a></p>'
@@ -277,6 +278,14 @@ def build_html(
     lines.append("        c.style.display = text.includes(term) ? 'block' : 'none';")
     lines.append("      });")
     lines.append("    });")
+    lines.append("  </script>")
+    lines.append("  <script>")
+    lines.append("    if ('serviceWorker' in navigator) {")
+    lines.append(
+        f"      navigator.serviceWorker.register('{prefix}assets/service-worker.js')"
+        ".catch(() => console.warn('Service worker registration failed'));"
+    )
+    lines.append("    }")
     lines.append("  </script>")
     lines.append("</body>\n</html>\n")
     html_out = "\n".join(lines)


### PR DESCRIPTION
## Summary
- inject service worker registration into generated gallery pages
- regenerate `docs/index.html` and `docs/demos/index.html`

## Testing
- `python check_env.py --auto-install`
- `python scripts/check_python_deps.py`
- `pytest -q` *(fails: ImportError for research_agent)*
- `pre-commit run --files docs/index.html docs/demos/index.html scripts/generate_gallery_html.py` *(fails: verify-requirements-lock)*
- `bash scripts/build_insight_docs.sh` *(fails: could not fetch wasm-gpt2.tar)*

------
https://chatgpt.com/codex/tasks/task_e_6864ab76fd28833390e0291a778626fd