### PR TITLE
[alpha_factory] docs: add custom 404 page

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Not Found</title>
+  <link rel="stylesheet" href="stylesheets/cards.css">
+</head>
+<body>
+  <h1>404 – Page Not Found</h1>
+  <p>The requested page doesn’t exist. Return to the <a href="index.html">demo gallery</a>.</p>
+  <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an Apache-2.0 licensed 404 page with a link back to the gallery and the standard disclaimer

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files docs/404.html` *(with nonessential hooks skipped)*
- `./scripts/build_gallery_site.sh` *(fails: `Preflight checks failed. Please install required dependencies.`)*
- `python -m http.server --directory docs 8001 &` + `curl -s http://localhost:8001/bad-path`


------
https://chatgpt.com/codex/tasks/task_e_6864ae6f6b18833391a9e3b23061d36f