### PR TITLE
feat: add Launch Demo buttons in gallery

### DIFF
--- a/docs/alpha_factory_v1/demos/index.html
+++ b/docs/alpha_factory_v1/demos/index.html
@@ -19,122 +19,146 @@
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   
-  <input id="search-input" class="search-input" type="text" placeholder="Search demos..." aria-label="Search demos">
+    <input id="search-input" class="search-input" type="text"
+           placeholder="Search demos..." aria-label="Search demos">
   <div class="demo-grid">
     <a class="demo-card" href="../../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="🌌 algorithms that invent algorithms — ai‑ga meta‑evolution demo ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
       <p class='demo-desc'>AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi business 👁️✨ ($agialpha) demo – “infinite bloom 3.0” global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. alpha‑factory v1 turns that raw potential into deployable breakthroughs, autonomously." title="Global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. Alpha‑Factory v1 turns that raw potential into deployable breakthroughs, autonomously.">
       <img src="../../alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – “Infinite Bloom 3.0”" loading="lazy" title="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
       <p class='demo-desc'>Global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. Alpha‑Factory v1 turns that raw potential into deployable breakthroughs, autonomously.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer" data-summary="🏛️ large‑scale α‑agi business 3 👁️✨ — omega‑grade edition alpha‑factory v1 → ω‑lattice v0 transmuting cosmological free‑energy gradients into compounding cash‑flows." title="Alpha‑Factory v1 → Ω‑Lattice v0 Transmuting cosmological free‑energy gradients into compounding cash‑flows.">
       <img src="../../alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — Omega‑Grade Edition" loading="lazy" title="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
       <p class='demo-desc'>Alpha‑Factory v1 → Ω‑Lattice v0 Transmuting cosmological free‑energy gradients into compounding cash‑flows.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer" data-summary="alpha agi business v1 large‑scale α‑agi business 👁️✨ $agialpha using alpha‑factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops." title="Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.">
       <img src="../../alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy" title="Alpha Agi Business V1">
       <h3>Alpha Agi Business V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer" data-summary="α‑agi insight 👁️✨ — beyond human foresight — official demo (zero data) the α‑agi insight demo predicts which industry sector is most likely to be transformed by artificial general intelligence. it runs a small" title="The α‑AGI Insight demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small">
       <img src="../../alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy" title="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
       <p class='demo-desc'>The α‑AGI Insight demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer" data-summary="α‑agi insight v1 — beyond human foresight 🎖️ α-agi insight 👁️✨ — beyond human foresight version 1.1 (2025-07-15)" title="🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)">
       <img src="../../alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy" title="α‑AGI Insight v1 — Beyond Human Foresight">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
       <p class='demo-desc'>🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer" data-summary="alpha agi marketplace v1 large‑scale α‑agi marketplace 👁️✨ $agialpha hunt exploitable alpha 🎯 and convert it into tangible value 💎." title="Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.">
       <img src="../../alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy" title="Alpha Agi Marketplace V1">
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="alpha asi world model use the offline/openai api toggle below the chart to run locally or with your own api key. keys never leave your browser. readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨" title="Use the Offline/OpenAI API toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨">
       <img src="../../alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy" title="Alpha Asi World Model">
       <h3>Alpha Asi World Model</h3>
       <p class='demo-desc'>Use the Offline/OpenAI API toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="👁️ alpha-factory v1 — cross-industry agentic α-agi demo current demo version: 1.0.0. out-learn • out-think • out-design • out-strategise • out-execute" title="Current demo version: 1.0.0. Out-learn • Out-think • Out-design • Out-strategise • Out-execute">
       <img src="../../cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry AGENTIC α-AGI Demo" loading="lazy" title="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
       <p class='demo-desc'>Current demo version: 1.0.0. Out-learn • Out-think • Out-design • Out-strategise • Out-execute</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../era_of_experience/" target="_blank" rel="noopener noreferrer" data-summary="era of experience era‑of‑experience demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../../era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy" title="Era Of Experience">
       <h3>Era Of Experience</h3>
       <p class='demo-desc'>Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../finance_alpha/" target="_blank" rel="noopener noreferrer" data-summary="alpha‑factory demos 📊 welcome! these short demos let anyone – even if you’ve never touched a terminal – spin up alpha‑factory, watch a live trade, and explore the" title="Welcome! These short demos let anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the">
       <img src="../../finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy" title="Alpha‑Factory Demos 📊">
       <h3>Alpha‑Factory Demos 📊</h3>
       <p class='demo-desc'>Welcome! These short demos let anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../macro_sentinel/" target="_blank" rel="noopener noreferrer" data-summary="🌐 macro‑sentinel · alpha‑factory v1 👁️✨ cross‑asset macro risk radar powered by multi‑agent α‑agi tl;dr   spin up a self‑healing stack that ingests macro telemetry, runs a monte‑carlo risk engine, sizes an es hedge, and explains its reasoning—all behind a gradio dashboard." title="Cross‑asset macro risk radar powered by multi‑agent α‑AGI TL;DR   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.">
       <img src="../../macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy" title="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
       <p class='demo-desc'>Cross‑asset macro risk radar powered by multi‑agent α‑AGI TL;DR   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../meta_agentic_agi/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo – production‑grade v0.1.0 official definition – meta-agentic (adj.) describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents." title="Official definition – Meta-Agentic (adj.) Describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents.">
       <img src="../../meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – Production‑Grade v0.1.0" loading="lazy" title="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Official definition – Meta-Agentic (adj.) Describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo v2 – production‑grade v0.1.0 identical to v1 plus a statistical-physics wrapper that logs and minimises gibbs / variational free-energy for each candidate agent during the evolutionary search. metric toggle: configs/default.yml → physicsmetric: freeenergy" title="Identical to v1 plus a statistical-physics wrapper that logs and minimises Gibbs / variational free-energy for each candidate agent during the evolutionary search. Metric toggle: configs/default.yml → physicsmetric: freeenergy">
       <img src="../../meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – Production‑Grade v0.1.0" loading="lazy" title="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Identical to v1 plus a statistical-physics wrapper that logs and minimises Gibbs / variational free-energy for each candidate agent during the evolutionary search. Metric toggle: configs/default.yml → physicsmetric: freeenergy</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo v3 — azr‑powered “alpha‑factory v1” (production‑grade v0.3.0) identical to v1 plus two synergistic upgrades 1. statistical‑physics wrapper — logs &amp; minimises gibbs / variational free‑energy for every candidate agent." title="Identical to v1 plus two synergistic upgrades 1. Statistical‑physics wrapper — logs &amp; minimises Gibbs / variational free‑energy for every candidate agent.">
       <img src="../../meta_agentic_agi_v3/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)" loading="lazy" title="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
       <p class='demo-desc'>Identical to v1 plus two synergistic upgrades 1. Statistical‑physics wrapper — logs &amp; minimises Gibbs / variational free‑energy for every candidate agent.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic tree search (mats) demo — v0 abstract: we pioneer meta-agentic tree search (mats), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. mats enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. in this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. this recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. status: experimental · proof‑of‑concept · alpha" title="Abstract: We pioneer Meta-Agentic Tree Search (MATS), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. In this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. Status: Experimental · Proof‑of‑Concept · Alpha">
       <img src="../../meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy" title="Meta‑Agentic Tree Search (MATS) Demo — v0">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
       <p class='demo-desc'>Abstract: We pioneer Meta-Agentic Tree Search (MATS), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. In this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. Status: Experimental · Proof‑of‑Concept · Alpha</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../muzero_planning/" target="_blank" rel="noopener noreferrer" data-summary="🌟 mastery without a rule‑book — watch muzero think in real time muzero planning demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../../muzero_planning/assets/preview.svg" alt="🌟 Mastery Without a Rule‑Book — watch MuZero think in real time" loading="lazy" title="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
       <p class='demo-desc'>MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer" data-summary="muzero mcts llm agent demo this folder contains a prototype integration of a monte carlo tree search (mcts) agent with language model guidance. run installandlaunch.sh to build the environment and start the demo in your browser. 1. ensure python 3.9+ is installed." title="This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run installandlaunch.sh to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.">
       <img src="../../muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy" title="MuZero MCTS LLM Agent Demo">
       <h3>MuZero MCTS LLM Agent Demo</h3>
       <p class='demo-desc'>This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run installandlaunch.sh to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../omni_factory_demo/" target="_blank" rel="noopener noreferrer" data-summary="omni-factory: an open-ended multi-agent simulation for smart city resilience (omni-epic + alpha-factory v1) run the full demo interactively in [google colab](colabomnifactorydemo.ipynb). to verify local prerequisites before launching the demo, run:" title="Run the full demo interactively in [Google Colab](colabomnifactorydemo.ipynb). To verify local prerequisites before launching the demo, run:">
       <img src="../../omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy" title="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colabomnifactorydemo.ipynb). To verify local prerequisites before launching the demo, run:</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="🔧 self‑healing repo — when ci fails, agents patch use the mode toggle in the demo to switch between the offline pyodide simulation and openai api mode. any key entered is kept in memory only. self‑healing repo demo" title="Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo">
       <img src="../../self_healing_repo/assets/preview.svg" alt="🔧 Self‑Healing Repo — when CI fails, agents patch" loading="lazy" title="🔧 **Self‑Healing Repo** — when CI fails, agents patch">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
       <p class='demo-desc'>Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="solving α-agi governance [![open in colab]][colab-notebook] choose offline or openai api using the toggle under the chart. the demo stores your api key only for the current session. minimal conditions for stable, antifragile multi-agent order" title="Choose Offline or OpenAI API using the toggle under the chart. The demo stores your API key only for the current session. Minimal Conditions for Stable, Antifragile Multi-Agent Order">
       <img src="../../solving_agi_governance/assets/preview.svg" alt="Solving α-AGI Governance [![Open In Colab]][colab-notebook]" loading="lazy" title="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
       <p class='demo-desc'>Choose Offline or OpenAI API using the toggle under the chart. The demo stores your API key only for the current session. Minimal Conditions for Stable, Antifragile Multi-Agent Order</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="sovereign agentic agi alpha agent demo a minimal showcase of a self-directed agent with token-gated access. run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment." title="A minimal showcase of a self-directed agent with token-gated access. Run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment.">
       <img src="../../sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy" title="Sovereign Agentic AGI Alpha Agent Demo">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
       <p class='demo-desc'>A minimal showcase of a self-directed agent with token-gated access. Run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../../utils/" target="_blank" rel="noopener noreferrer" data-summary="demo utilities this directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer." title="This directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer.">
       <img src="../../utils/assets/preview.svg" alt="Demo Utilities" loading="lazy" title="Demo Utilities">
       <h3>Demo Utilities</h3>
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
   </div>
   <p><a href="../../index.html">⬅️ Back to Home</a></p>
@@ -149,6 +173,11 @@
         c.style.display = text.includes(term) ? 'block' : 'none';
       });
     });
+  </script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('../../assets/service-worker.js').catch(() => console.warn('Service worker registration failed'));
+    }
   </script>
 </body>
 </html>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -19,122 +19,146 @@
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   
-  <input id="search-input" class="search-input" type="text" placeholder="Search demos..." aria-label="Search demos">
+    <input id="search-input" class="search-input" type="text"
+           placeholder="Search demos..." aria-label="Search demos">
   <div class="demo-grid">
     <a class="demo-card" href="../aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="🌌 algorithms that invent algorithms — ai‑ga meta‑evolution demo ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
       <p class='demo-desc'>AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi business 👁️✨ ($agialpha) demo – “infinite bloom 3.0” global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. alpha‑factory v1 turns that raw potential into deployable breakthroughs, autonomously." title="Global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. Alpha‑Factory v1 turns that raw potential into deployable breakthroughs, autonomously.">
       <img src="../alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – “Infinite Bloom 3.0”" loading="lazy" title="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
       <p class='demo-desc'>Global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. Alpha‑Factory v1 turns that raw potential into deployable breakthroughs, autonomously.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer" data-summary="🏛️ large‑scale α‑agi business 3 👁️✨ — omega‑grade edition alpha‑factory v1 → ω‑lattice v0 transmuting cosmological free‑energy gradients into compounding cash‑flows." title="Alpha‑Factory v1 → Ω‑Lattice v0 Transmuting cosmological free‑energy gradients into compounding cash‑flows.">
       <img src="../alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — Omega‑Grade Edition" loading="lazy" title="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
       <p class='demo-desc'>Alpha‑Factory v1 → Ω‑Lattice v0 Transmuting cosmological free‑energy gradients into compounding cash‑flows.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer" data-summary="alpha agi business v1 large‑scale α‑agi business 👁️✨ $agialpha using alpha‑factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops." title="Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.">
       <img src="../alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy" title="Alpha Agi Business V1">
       <h3>Alpha Agi Business V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer" data-summary="α‑agi insight 👁️✨ — beyond human foresight — official demo (zero data) the α‑agi insight demo predicts which industry sector is most likely to be transformed by artificial general intelligence. it runs a small" title="The α‑AGI Insight demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small">
       <img src="../alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy" title="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
       <p class='demo-desc'>The α‑AGI Insight demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer" data-summary="α‑agi insight v1 — beyond human foresight 🎖️ α-agi insight 👁️✨ — beyond human foresight version 1.1 (2025-07-15)" title="🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)">
       <img src="../alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy" title="α‑AGI Insight v1 — Beyond Human Foresight">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
       <p class='demo-desc'>🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer" data-summary="alpha agi marketplace v1 large‑scale α‑agi marketplace 👁️✨ $agialpha hunt exploitable alpha 🎯 and convert it into tangible value 💎." title="Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.">
       <img src="../alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy" title="Alpha Agi Marketplace V1">
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="alpha asi world model use the offline/openai api toggle below the chart to run locally or with your own api key. keys never leave your browser. readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨" title="Use the Offline/OpenAI API toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨">
       <img src="../alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy" title="Alpha Asi World Model">
       <h3>Alpha Asi World Model</h3>
       <p class='demo-desc'>Use the Offline/OpenAI API toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="👁️ alpha-factory v1 — cross-industry agentic α-agi demo current demo version: 1.0.0. out-learn • out-think • out-design • out-strategise • out-execute" title="Current demo version: 1.0.0. Out-learn • Out-think • Out-design • Out-strategise • Out-execute">
       <img src="../cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry AGENTIC α-AGI Demo" loading="lazy" title="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
       <p class='demo-desc'>Current demo version: 1.0.0. Out-learn • Out-think • Out-design • Out-strategise • Out-execute</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../era_of_experience/" target="_blank" rel="noopener noreferrer" data-summary="era of experience era‑of‑experience demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy" title="Era Of Experience">
       <h3>Era Of Experience</h3>
       <p class='demo-desc'>Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../finance_alpha/" target="_blank" rel="noopener noreferrer" data-summary="alpha‑factory demos 📊 welcome! these short demos let anyone – even if you’ve never touched a terminal – spin up alpha‑factory, watch a live trade, and explore the" title="Welcome! These short demos let anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the">
       <img src="../finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy" title="Alpha‑Factory Demos 📊">
       <h3>Alpha‑Factory Demos 📊</h3>
       <p class='demo-desc'>Welcome! These short demos let anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../macro_sentinel/" target="_blank" rel="noopener noreferrer" data-summary="🌐 macro‑sentinel · alpha‑factory v1 👁️✨ cross‑asset macro risk radar powered by multi‑agent α‑agi tl;dr   spin up a self‑healing stack that ingests macro telemetry, runs a monte‑carlo risk engine, sizes an es hedge, and explains its reasoning—all behind a gradio dashboard." title="Cross‑asset macro risk radar powered by multi‑agent α‑AGI TL;DR   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.">
       <img src="../macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy" title="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
       <p class='demo-desc'>Cross‑asset macro risk radar powered by multi‑agent α‑AGI TL;DR   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../meta_agentic_agi/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo – production‑grade v0.1.0 official definition – meta-agentic (adj.) describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents." title="Official definition – Meta-Agentic (adj.) Describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents.">
       <img src="../meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – Production‑Grade v0.1.0" loading="lazy" title="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Official definition – Meta-Agentic (adj.) Describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo v2 – production‑grade v0.1.0 identical to v1 plus a statistical-physics wrapper that logs and minimises gibbs / variational free-energy for each candidate agent during the evolutionary search. metric toggle: configs/default.yml → physicsmetric: freeenergy" title="Identical to v1 plus a statistical-physics wrapper that logs and minimises Gibbs / variational free-energy for each candidate agent during the evolutionary search. Metric toggle: configs/default.yml → physicsmetric: freeenergy">
       <img src="../meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – Production‑Grade v0.1.0" loading="lazy" title="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Identical to v1 plus a statistical-physics wrapper that logs and minimises Gibbs / variational free-energy for each candidate agent during the evolutionary search. Metric toggle: configs/default.yml → physicsmetric: freeenergy</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo v3 — azr‑powered “alpha‑factory v1” (production‑grade v0.3.0) identical to v1 plus two synergistic upgrades 1. statistical‑physics wrapper — logs &amp; minimises gibbs / variational free‑energy for every candidate agent." title="Identical to v1 plus two synergistic upgrades 1. Statistical‑physics wrapper — logs &amp; minimises Gibbs / variational free‑energy for every candidate agent.">
       <img src="../meta_agentic_agi_v3/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)" loading="lazy" title="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
       <p class='demo-desc'>Identical to v1 plus two synergistic upgrades 1. Statistical‑physics wrapper — logs &amp; minimises Gibbs / variational free‑energy for every candidate agent.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic tree search (mats) demo — v0 abstract: we pioneer meta-agentic tree search (mats), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. mats enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. in this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. this recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. status: experimental · proof‑of‑concept · alpha" title="Abstract: We pioneer Meta-Agentic Tree Search (MATS), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. In this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. Status: Experimental · Proof‑of‑Concept · Alpha">
       <img src="../meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy" title="Meta‑Agentic Tree Search (MATS) Demo — v0">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
       <p class='demo-desc'>Abstract: We pioneer Meta-Agentic Tree Search (MATS), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. In this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. Status: Experimental · Proof‑of‑Concept · Alpha</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../muzero_planning/" target="_blank" rel="noopener noreferrer" data-summary="🌟 mastery without a rule‑book — watch muzero think in real time muzero planning demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="../muzero_planning/assets/preview.svg" alt="🌟 Mastery Without a Rule‑Book — watch MuZero think in real time" loading="lazy" title="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
       <p class='demo-desc'>MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer" data-summary="muzero mcts llm agent demo this folder contains a prototype integration of a monte carlo tree search (mcts) agent with language model guidance. run installandlaunch.sh to build the environment and start the demo in your browser. 1. ensure python 3.9+ is installed." title="This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run installandlaunch.sh to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.">
       <img src="../muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy" title="MuZero MCTS LLM Agent Demo">
       <h3>MuZero MCTS LLM Agent Demo</h3>
       <p class='demo-desc'>This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run installandlaunch.sh to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../omni_factory_demo/" target="_blank" rel="noopener noreferrer" data-summary="omni-factory: an open-ended multi-agent simulation for smart city resilience (omni-epic + alpha-factory v1) run the full demo interactively in [google colab](colabomnifactorydemo.ipynb). to verify local prerequisites before launching the demo, run:" title="Run the full demo interactively in [Google Colab](colabomnifactorydemo.ipynb). To verify local prerequisites before launching the demo, run:">
       <img src="../omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy" title="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colabomnifactorydemo.ipynb). To verify local prerequisites before launching the demo, run:</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="🔧 self‑healing repo — when ci fails, agents patch use the mode toggle in the demo to switch between the offline pyodide simulation and openai api mode. any key entered is kept in memory only. self‑healing repo demo" title="Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo">
       <img src="../self_healing_repo/assets/preview.svg" alt="🔧 Self‑Healing Repo — when CI fails, agents patch" loading="lazy" title="🔧 **Self‑Healing Repo** — when CI fails, agents patch">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
       <p class='demo-desc'>Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="solving α-agi governance [![open in colab]][colab-notebook] choose offline or openai api using the toggle under the chart. the demo stores your api key only for the current session. minimal conditions for stable, antifragile multi-agent order" title="Choose Offline or OpenAI API using the toggle under the chart. The demo stores your API key only for the current session. Minimal Conditions for Stable, Antifragile Multi-Agent Order">
       <img src="../solving_agi_governance/assets/preview.svg" alt="Solving α-AGI Governance [![Open In Colab]][colab-notebook]" loading="lazy" title="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
       <p class='demo-desc'>Choose Offline or OpenAI API using the toggle under the chart. The demo stores your API key only for the current session. Minimal Conditions for Stable, Antifragile Multi-Agent Order</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="sovereign agentic agi alpha agent demo a minimal showcase of a self-directed agent with token-gated access. run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment." title="A minimal showcase of a self-directed agent with token-gated access. Run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment.">
       <img src="../sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy" title="Sovereign Agentic AGI Alpha Agent Demo">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
       <p class='demo-desc'>A minimal showcase of a self-directed agent with token-gated access. Run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="../utils/" target="_blank" rel="noopener noreferrer" data-summary="demo utilities this directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer." title="This directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer.">
       <img src="../utils/assets/preview.svg" alt="Demo Utilities" loading="lazy" title="Demo Utilities">
       <h3>Demo Utilities</h3>
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
   </div>
   <p><a href="../index.html">⬅️ Back to Home</a></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,122 +19,146 @@
   <h1>Alpha‑Factory Demo Gallery</h1>
   <p class="subtitle">Select a demo to explore detailed instructions and watch it unfold in real time.</p>
   <p class="subtitle"><a href="alpha_factory_v1/demos/index.html">Open Subdirectory Gallery</a></p>
-  <input id="search-input" class="search-input" type="text" placeholder="Search demos..." aria-label="Search demos">
+    <input id="search-input" class="search-input" type="text"
+           placeholder="Search demos..." aria-label="Search demos">
   <div class="demo-grid">
     <a class="demo-card" href="aiga_meta_evolution/" target="_blank" rel="noopener noreferrer" data-summary="🌌 algorithms that invent algorithms — ai‑ga meta‑evolution demo ai‑ga meta‑evolution demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="aiga_meta_evolution/assets/preview.svg" alt="🌌 Algorithms That Invent Algorithms — AI‑GA Meta‑Evolution Demo" loading="lazy" title="🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**">
       <h3>🌌 Algorithms That Invent Algorithms — &lt;br&gt;**AI‑GA Meta‑Evolution Demo**</h3>
       <p class='demo-desc'>AI‑GA Meta‑Evolution Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="alpha_agi_business_2_v1/" target="_blank" rel="noopener noreferrer" data-summary="large‑scale α‑agi business 👁️✨ ($agialpha) demo – “infinite bloom 3.0” global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. alpha‑factory v1 turns that raw potential into deployable breakthroughs, autonomously." title="Global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. Alpha‑Factory v1 turns that raw potential into deployable breakthroughs, autonomously.">
       <img src="alpha_agi_business_2_v1/assets/preview.svg" alt="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – “Infinite Bloom 3.0”" loading="lazy" title="Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**">
       <h3>Large‑Scale α‑AGI Business 👁️✨ ($AGIALPHA) Demo – **“Infinite Bloom 3.0”**</h3>
       <p class='demo-desc'>Global markets seep trillions in latent opportunity — alpha in the broadest sense: pricing dislocations • supply‑chain inefficiencies • novel drug targets • policy loopholes • unexplored material designs. Alpha‑Factory v1 turns that raw potential into deployable breakthroughs, autonomously.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="alpha_agi_business_3_v1/" target="_blank" rel="noopener noreferrer" data-summary="🏛️ large‑scale α‑agi business 3 👁️✨ — omega‑grade edition alpha‑factory v1 → ω‑lattice v0 transmuting cosmological free‑energy gradients into compounding cash‑flows." title="Alpha‑Factory v1 → Ω‑Lattice v0 Transmuting cosmological free‑energy gradients into compounding cash‑flows.">
       <img src="alpha_agi_business_3_v1/assets/preview.svg" alt="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — Omega‑Grade Edition" loading="lazy" title="🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**">
       <h3>🏛️ Large‑Scale α‑AGI Business 3 👁️✨ — **Omega‑Grade Edition**</h3>
       <p class='demo-desc'>Alpha‑Factory v1 → Ω‑Lattice v0 Transmuting cosmological free‑energy gradients into compounding cash‑flows.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="alpha_agi_business_v1/" target="_blank" rel="noopener noreferrer" data-summary="alpha agi business v1 large‑scale α‑agi business 👁️✨ $agialpha using alpha‑factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops." title="Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.">
       <img src="alpha_agi_business_v1/assets/preview.svg" alt="Alpha Agi Business V1" loading="lazy" title="Alpha Agi Business V1">
       <h3>Alpha Agi Business V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Business 👁️✨ $AGIALPHA using Alpha‑Factory v1 multi‑agent stack, on‑chain incentives &amp; antifragile safety‑loops.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="alpha_agi_insight_v0/" target="_blank" rel="noopener noreferrer" data-summary="α‑agi insight 👁️✨ — beyond human foresight — official demo (zero data) the α‑agi insight demo predicts which industry sector is most likely to be transformed by artificial general intelligence. it runs a small" title="The α‑AGI Insight demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small">
       <img src="alpha_agi_insight_v0/assets/preview.svg" alt="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)" loading="lazy" title="α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)">
       <h3>α‑AGI Insight 👁️✨ — Beyond Human Foresight — Official Demo (Zero Data)</h3>
       <p class='demo-desc'>The α‑AGI Insight demo predicts which industry sector is most likely to be transformed by Artificial General Intelligence. It runs a small</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="alpha_agi_insight_v1/" target="_blank" rel="noopener noreferrer" data-summary="α‑agi insight v1 — beyond human foresight 🎖️ α-agi insight 👁️✨ — beyond human foresight version 1.1 (2025-07-15)" title="🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)">
       <img src="alpha_agi_insight_v1/assets/preview.svg" alt="α‑AGI Insight v1 — Beyond Human Foresight" loading="lazy" title="α‑AGI Insight v1 — Beyond Human Foresight">
       <h3>α‑AGI Insight v1 — Beyond Human Foresight</h3>
       <p class='demo-desc'>🎖️ α-AGI Insight 👁️✨ — Beyond Human Foresight Version 1.1 (2025-07-15)</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="alpha_agi_marketplace_v1/" target="_blank" rel="noopener noreferrer" data-summary="alpha agi marketplace v1 large‑scale α‑agi marketplace 👁️✨ $agialpha hunt exploitable alpha 🎯 and convert it into tangible value 💎." title="Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.">
       <img src="alpha_agi_marketplace_v1/assets/preview.svg" alt="Alpha Agi Marketplace V1" loading="lazy" title="Alpha Agi Marketplace V1">
       <h3>Alpha Agi Marketplace V1</h3>
       <p class='demo-desc'>Large‑Scale α‑AGI Marketplace 👁️✨ $AGIALPHA hunt exploitable alpha 🎯 and convert it into tangible value 💎.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="alpha_asi_world_model/" target="_blank" rel="noopener noreferrer" data-summary="alpha asi world model use the offline/openai api toggle below the chart to run locally or with your own api key. keys never leave your browser. readme  ░α-asi world-model demo ░  alpha-factory v1 👁️✨" title="Use the Offline/OpenAI API toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨">
       <img src="alpha_asi_world_model/assets/preview.svg" alt="Alpha Asi World Model" loading="lazy" title="Alpha Asi World Model">
       <h3>Alpha Asi World Model</h3>
       <p class='demo-desc'>Use the Offline/OpenAI API toggle below the chart to run locally or with your own API key. Keys never leave your browser. README  ░α-ASI World-Model Demo ░  Alpha-Factory v1 👁️✨</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="cross_industry_alpha_factory/" target="_blank" rel="noopener noreferrer" data-summary="👁️ alpha-factory v1 — cross-industry agentic α-agi demo current demo version: 1.0.0. out-learn • out-think • out-design • out-strategise • out-execute" title="Current demo version: 1.0.0. Out-learn • Out-think • Out-design • Out-strategise • Out-execute">
       <img src="cross_industry_alpha_factory/assets/preview.svg" alt="👁️ Alpha-Factory v1 — Cross-Industry AGENTIC α-AGI Demo" loading="lazy" title="👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo">
       <h3>👁️ Alpha-Factory v1 — Cross-Industry **AGENTIC α-AGI** Demo</h3>
       <p class='demo-desc'>Current demo version: 1.0.0. Out-learn • Out-think • Out-design • Out-strategise • Out-execute</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="era_of_experience/" target="_blank" rel="noopener noreferrer" data-summary="era of experience era‑of‑experience demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="era_of_experience/assets/preview.svg" alt="Era Of Experience" loading="lazy" title="Era Of Experience">
       <h3>Era Of Experience</h3>
       <p class='demo-desc'>Era‑of‑Experience Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="finance_alpha/" target="_blank" rel="noopener noreferrer" data-summary="alpha‑factory demos 📊 welcome! these short demos let anyone – even if you’ve never touched a terminal – spin up alpha‑factory, watch a live trade, and explore the" title="Welcome! These short demos let anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the">
       <img src="finance_alpha/assets/preview.svg" alt="Alpha‑Factory Demos 📊" loading="lazy" title="Alpha‑Factory Demos 📊">
       <h3>Alpha‑Factory Demos 📊</h3>
       <p class='demo-desc'>Welcome! These short demos let anyone – even if you’ve never touched a terminal – spin up Alpha‑Factory, watch a live trade, and explore the</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="macro_sentinel/" target="_blank" rel="noopener noreferrer" data-summary="🌐 macro‑sentinel · alpha‑factory v1 👁️✨ cross‑asset macro risk radar powered by multi‑agent α‑agi tl;dr   spin up a self‑healing stack that ingests macro telemetry, runs a monte‑carlo risk engine, sizes an es hedge, and explains its reasoning—all behind a gradio dashboard." title="Cross‑asset macro risk radar powered by multi‑agent α‑AGI TL;DR   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.">
       <img src="macro_sentinel/assets/preview.svg" alt="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨" loading="lazy" title="🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨">
       <h3>🌐 Macro‑Sentinel · Alpha‑Factory v1 👁️✨</h3>
       <p class='demo-desc'>Cross‑asset macro risk radar powered by multi‑agent α‑AGI TL;DR   Spin up a self‑healing stack that ingests macro telemetry, runs a Monte‑Carlo risk engine, sizes an ES hedge, and explains its reasoning—all behind a Gradio dashboard.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="meta_agentic_agi/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo – production‑grade v0.1.0 official definition – meta-agentic (adj.) describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents." title="Official definition – Meta-Agentic (adj.) Describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents.">
       <img src="meta_agentic_agi/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo – Production‑Grade v0.1.0" loading="lazy" title="Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Official definition – Meta-Agentic (adj.) Describes an agent whose primary role is to create, select, evaluate, or re‑configure other agents and the rules governing their interactions, thereby exercising second‑order agency over a population of first‑order agents.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="meta_agentic_agi_v2/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo v2 – production‑grade v0.1.0 identical to v1 plus a statistical-physics wrapper that logs and minimises gibbs / variational free-energy for each candidate agent during the evolutionary search. metric toggle: configs/default.yml → physicsmetric: freeenergy" title="Identical to v1 plus a statistical-physics wrapper that logs and minimises Gibbs / variational free-energy for each candidate agent during the evolutionary search. Metric toggle: configs/default.yml → physicsmetric: freeenergy">
       <img src="meta_agentic_agi_v2/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – Production‑Grade v0.1.0" loading="lazy" title="Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**">
       <h3>Meta‑Agentic α‑AGI 👁️✨ Demo v2 – **Production‑Grade v0.1.0**</h3>
       <p class='demo-desc'>Identical to v1 plus a statistical-physics wrapper that logs and minimises Gibbs / variational free-energy for each candidate agent during the evolutionary search. Metric toggle: configs/default.yml → physicsmetric: freeenergy</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="meta_agentic_agi_v3/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic α‑agi 👁️✨ demo v3 — azr‑powered “alpha‑factory v1” (production‑grade v0.3.0) identical to v1 plus two synergistic upgrades 1. statistical‑physics wrapper — logs &amp; minimises gibbs / variational free‑energy for every candidate agent." title="Identical to v1 plus two synergistic upgrades 1. Statistical‑physics wrapper — logs &amp; minimises Gibbs / variational free‑energy for every candidate agent.">
       <img src="meta_agentic_agi_v3/assets/preview.svg" alt="Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)" loading="lazy" title="**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**">
       <h3>**Meta‑Agentic α‑AGI 👁️✨ Demo v3 — AZR‑Powered “Alpha‑Factory v1” (Production‑Grade v0.3.0)**</h3>
       <p class='demo-desc'>Identical to v1 plus two synergistic upgrades 1. Statistical‑physics wrapper — logs &amp; minimises Gibbs / variational free‑energy for every candidate agent.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="meta_agentic_tree_search_v0/" target="_blank" rel="noopener noreferrer" data-summary="meta‑agentic tree search (mats) demo — v0 abstract: we pioneer meta-agentic tree search (mats), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. mats enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. in this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. this recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. status: experimental · proof‑of‑concept · alpha" title="Abstract: We pioneer Meta-Agentic Tree Search (MATS), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. In this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. Status: Experimental · Proof‑of‑Concept · Alpha">
       <img src="meta_agentic_tree_search_v0/assets/preview.svg" alt="Meta‑Agentic Tree Search (MATS) Demo — v0" loading="lazy" title="Meta‑Agentic Tree Search (MATS) Demo — v0">
       <h3>Meta‑Agentic Tree Search (MATS) Demo — v0</h3>
       <p class='demo-desc'>Abstract: We pioneer Meta-Agentic Tree Search (MATS), a novel framework for autonomous multi-agent decision optimization in complex strategic domains. MATS enables intelligent agents to collaboratively navigate and optimize high-dimensional strategic search spaces through recursive agent-to-agent interactions. In this second-order agentic scheme, each agent in the system iteratively refines the intermediate strategies proposed by other agents, yielding a self-improving decision-making process. This recursive optimization mechanism systematically uncovers latent inefficiencies and unexploited opportunities that static or single-agent approaches often overlook. Status: Experimental · Proof‑of‑Concept · Alpha</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="muzero_planning/" target="_blank" rel="noopener noreferrer" data-summary="🌟 mastery without a rule‑book — watch muzero think in real time muzero planning demo alpha‑factory v1 👁️✨ — multi‑agent agentic α‑agi" title="MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI">
       <img src="muzero_planning/assets/preview.svg" alt="🌟 Mastery Without a Rule‑Book — watch MuZero think in real time" loading="lazy" title="🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time">
       <h3>🌟 **Mastery Without a Rule‑Book** — watch MuZero think in real time</h3>
       <p class='demo-desc'>MuZero Planning Demo Alpha‑Factory v1 👁️✨ — Multi‑Agent AGENTIC α‑AGI</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="muzeromctsllmagent_v0/" target="_blank" rel="noopener noreferrer" data-summary="muzero mcts llm agent demo this folder contains a prototype integration of a monte carlo tree search (mcts) agent with language model guidance. run installandlaunch.sh to build the environment and start the demo in your browser. 1. ensure python 3.9+ is installed." title="This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run installandlaunch.sh to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.">
       <img src="muzeromctsllmagent_v0/assets/preview.svg" alt="MuZero MCTS LLM Agent Demo" loading="lazy" title="MuZero MCTS LLM Agent Demo">
       <h3>MuZero MCTS LLM Agent Demo</h3>
       <p class='demo-desc'>This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS) agent with language model guidance. Run installandlaunch.sh to build the environment and start the demo in your browser. 1. Ensure Python 3.9+ is installed.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="omni_factory_demo/" target="_blank" rel="noopener noreferrer" data-summary="omni-factory: an open-ended multi-agent simulation for smart city resilience (omni-epic + alpha-factory v1) run the full demo interactively in [google colab](colabomnifactorydemo.ipynb). to verify local prerequisites before launching the demo, run:" title="Run the full demo interactively in [Google Colab](colabomnifactorydemo.ipynb). To verify local prerequisites before launching the demo, run:">
       <img src="omni_factory_demo/assets/preview.svg" alt="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)" loading="lazy" title="OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)">
       <h3>OMNI-Factory: An Open-Ended Multi-Agent Simulation for Smart City Resilience (OMNI-EPIC + Alpha-Factory v1)</h3>
       <p class='demo-desc'>Run the full demo interactively in [Google Colab](colabomnifactorydemo.ipynb). To verify local prerequisites before launching the demo, run:</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="self_healing_repo/" target="_blank" rel="noopener noreferrer" data-summary="🔧 self‑healing repo — when ci fails, agents patch use the mode toggle in the demo to switch between the offline pyodide simulation and openai api mode. any key entered is kept in memory only. self‑healing repo demo" title="Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo">
       <img src="self_healing_repo/assets/preview.svg" alt="🔧 Self‑Healing Repo — when CI fails, agents patch" loading="lazy" title="🔧 **Self‑Healing Repo** — when CI fails, agents patch">
       <h3>🔧 **Self‑Healing Repo** — when CI fails, agents patch</h3>
       <p class='demo-desc'>Use the mode toggle in the demo to switch between the offline Pyodide simulation and OpenAI API mode. Any key entered is kept in memory only. Self‑Healing Repo Demo</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="solving_agi_governance/" target="_blank" rel="noopener noreferrer" data-summary="solving α-agi governance [![open in colab]][colab-notebook] choose offline or openai api using the toggle under the chart. the demo stores your api key only for the current session. minimal conditions for stable, antifragile multi-agent order" title="Choose Offline or OpenAI API using the toggle under the chart. The demo stores your API key only for the current session. Minimal Conditions for Stable, Antifragile Multi-Agent Order">
       <img src="solving_agi_governance/assets/preview.svg" alt="Solving α-AGI Governance [![Open In Colab]][colab-notebook]" loading="lazy" title="Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]">
       <h3>Solving **α-AGI Governance** [![Open In Colab]][colab-notebook]</h3>
       <p class='demo-desc'>Choose Offline or OpenAI API using the toggle under the chart. The demo stores your API key only for the current session. Minimal Conditions for Stable, Antifragile Multi-Agent Order</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="sovereign_agentic_agialpha_agent_v0/" target="_blank" rel="noopener noreferrer" data-summary="sovereign agentic agi alpha agent demo a minimal showcase of a self-directed agent with token-gated access. run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment." title="A minimal showcase of a self-directed agent with token-gated access. Run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment.">
       <img src="sovereign_agentic_agialpha_agent_v0/assets/preview.svg" alt="Sovereign Agentic AGI Alpha Agent Demo" loading="lazy" title="Sovereign Agentic AGI Alpha Agent Demo">
       <h3>Sovereign Agentic AGI Alpha Agent Demo</h3>
       <p class='demo-desc'>A minimal showcase of a self-directed agent with token-gated access. Run ./deploysovereignagenticagialphaagentv0.sh to build and launch the containerized environment.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
     <a class="demo-card" href="utils/" target="_blank" rel="noopener noreferrer" data-summary="demo utilities this directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer." title="This directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer.">
       <img src="utils/assets/preview.svg" alt="Demo Utilities" loading="lazy" title="Demo Utilities">
       <h3>Demo Utilities</h3>
       <p class='demo-desc'>This directory holds helper utilities shared across demos, such as disclaimer.py which exposes the standard project disclaimer.</p>
+      <button class='launch' type='button'>Launch Demo</button>
     </a>
   </div>
   <p class="snippet"><a href="DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>

--- a/scripts/generate_gallery_html.py
+++ b/scripts/generate_gallery_html.py
@@ -260,6 +260,7 @@ def build_html(
         lines.append(f"      <h3>{html.escape(title)}</h3>")
         if summary:
             lines.append(f"      <p class='demo-desc'>{html.escape(summary)}</p>")
+        lines.append("      <p class='launch'>Launch Demo</p>")
         lines.append("    </a>")
     lines.append("  </div>")
     if home_link:


### PR DESCRIPTION
## Summary
- show 'Launch Demo' buttons on gallery pages

## Testing
- `python scripts/generate_gallery_html.py`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit` *(failed to fully run due to dependency setup)*

------
https://chatgpt.com/codex/tasks/task_e_6864b9e0fae88333a3c7191ec53c54ef