### PR TITLE
ci: simplify docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   release:
     types: [published]
+  workflow_dispatch:
+    # enables manual runs from the Actions tab
 
 permissions:
   contents: write
@@ -21,8 +23,8 @@ jobs:
         with:
           node-version: '20'
       - name: Install docs dependencies
-        run: pip install mkdocs mkdocs-material playwright
-      - name: Install Playwright browsers
-        run: playwright install chromium firefox webkit
+        run: pip install mkdocs mkdocs-material
+      - name: Make scripts executable
+        run: chmod +x ./scripts/*.sh
       - name: Build and deploy gallery
         run: ./scripts/edge_human_knowledge_pages_sprint.sh


### PR DESCRIPTION
## Summary
- enable manual workflow dispatch for Docs
- drop Playwright steps and add permission fix

## Testing
- `pre-commit run --files .github/workflows/docs.yml` *(fails: Verify requirements.lock is up to date)*

------
https://chatgpt.com/codex/tasks/task_e_68653c8619708333bde91609f6611c4d