### PR TITLE
Update docs for edge knowledge workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide
 ### Automatic Deployment
 
 Pushes to `main` trigger the [Docs workflow](.github/workflows/docs.yml), which
-runs [`scripts/build_insight_docs.sh`](scripts/build_insight_docs.sh) to rebuild
+runs [`scripts/edge_human_knowledge_pages_sprint.sh`](scripts/edge_human_knowledge_pages_sprint.sh) to rebuild
 the Insight demo and MkDocs site. The workflow publishes the result to GitHub
 Pages, so once it completes the live demo is available at
 <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/> with no
@@ -76,7 +76,7 @@ checks and offline validation. Use the shell or Python version:
 python scripts/edge_human_knowledge_pages_sprint.py
 ```
 
-Ensure **Python 3.11+**, **Node 20+**, `mkdocs` and Playwright are installed. The
+Ensure **Python 3.11+**, **Node 20+** and `mkdocs` are installed. The
 script mirrors the [Docs workflow](.github/workflows/docs.yml) used for automatic
 deployment.
 

--- a/docs/ADVANCED_GITHUB_PAGES_DEMO_SPRINT.md
+++ b/docs/ADVANCED_GITHUB_PAGES_DEMO_SPRINT.md
@@ -33,7 +33,7 @@ Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for a compl
 ## 2. Build the Insight Demo
 Regenerate the progressive web app and check the service worker hash:
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 This step exports `tree.json` when lineage logs are present,
 regenerates `docs/index.html` via `scripts/generate_gallery_html.py` and ensures

--- a/docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -44,7 +44,7 @@ The steps below triple-verify environment integrity, rebuild all assets and depl
 ## 2. Build the Insight Demo
 Compile the progressive web app and verify the service worker hash:
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 If lineage logs are available this exports `tree.json`, updates
 `docs/index.html` via `scripts/generate_gallery_html.py` and ensures the

--- a/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -32,7 +32,7 @@ Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for a one-c
 ## 2. Build the Insight Demo
 Execute the helper to compile the progressive web app and confirm the service worker hash:
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 When lineage logs are present this exports `tree.json`, refreshes
 `docs/index.html` via `scripts/generate_gallery_html.py` and ensures the

--- a/docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
+++ b/docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
@@ -23,7 +23,7 @@ This sprint outlines a robust sequence to publish the **Alpha‑Factory** demo g
 ## 2. Build the Insight Demo
 Execute the bundled helper:
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 This compiles the Insight PWA, exports `tree.json` when logs are present,
 regenerates `docs/index.html` via `scripts/generate_gallery_html.py` and

--- a/docs/CODEX_INSIGHT_PAGES_SPRINT.md
+++ b/docs/CODEX_INSIGHT_PAGES_SPRINT.md
@@ -26,7 +26,7 @@ This short guide provides a step-by-step sprint for Codex to ensure the **α‑A
 Run the bundled helper from the repository root:
 
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 
 This script fetches the browser assets, compiles the PWA, exports `tree.json` when lineage logs are present, verifies the service worker and generates the MkDocs site under `site/`. After the build completes run the integrity check to ensure the cached Workbox file matches the service worker hash:

--- a/docs/CODEX_SUPER_DEMO_PAGES_SPRINT.md
+++ b/docs/CODEX_SUPER_DEMO_PAGES_SPRINT.md
@@ -28,7 +28,7 @@ launch each showcase directly from a browser and watch it unfold in real time.
 
 The Insight browser bundle powers the animated tree search. Refresh it with:
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 This step exports `tree.json` when lineage logs exist, regenerates
 `docs/index.html` via `scripts/generate_gallery_html.py` and verifies the

--- a/docs/DEMO_ACCESS_SPRINT.md
+++ b/docs/DEMO_ACCESS_SPRINT.md
@@ -25,7 +25,7 @@ This short sprint distills how Codex can publish the **Alpha‑Factory v1** demo
 
 The Insight browser bundle powers many visualisations. Refresh it with:
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 This regenerates `docs/alpha_agi_insight_v1/`, refreshes `docs/index.html` via
 `scripts/generate_gallery_html.py` and verifies the service worker hash. The

--- a/docs/EDGE_DEMO_PAGES_SPRINT.md
+++ b/docs/EDGE_DEMO_PAGES_SPRINT.md
@@ -29,7 +29,7 @@ Execute the new helper from the repository root:
 ./scripts/deploy_gallery_pages.sh
 ```
 
-The script fetches browser assets, compiles the Insight demo, regenerates documentation and runs integrity checks. If Playwright is available, it opens a local server and verifies the PWA works offline.
+The script fetches browser assets, compiles the Insight demo, regenerates documentation and runs integrity checks.
 `scripts/generate_gallery_html.py` runs as part of the helper so `docs/index.html`
 always lists the current demos and updates the `docs/gallery.html` redirect.
 

--- a/docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
+++ b/docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
@@ -25,7 +25,7 @@ Execute the helper from the repository root:
 ```bash
 ./scripts/deploy_gallery_pages.sh
 ```
-This command fetches browser assets, compiles the Insight demo, refreshes all documentation, runs integrity checks and, when Playwright is available, validates offline functionality.
+This command fetches browser assets, compiles the Insight demo, refreshes all documentation, runs integrity checks and validates offline functionality.
 The helper also invokes `scripts/generate_gallery_html.py` so `docs/index.html`
 tracks new demos automatically.
 

--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -29,12 +29,8 @@ This command fetches browser assets, compiles the α‑AGI Insight interface, ru
 integrity checks and builds the MkDocs site under `site/`. It also runs
 `scripts/generate_gallery_html.py` to refresh `docs/index.html` and
 update the `docs/gallery.html` redirect, and
-`scripts/build_service_worker.py` to update the precache list. If Playwright is
-installed the script also verifies offline functionality.
-Run the Playwright smoke tests to ensure every built demo loads when offline:
-```bash
-python scripts/verify_demo_pages.py
-```
+`scripts/build_service_worker.py` to update the precache list.
+
 
 
 ## 3. Preview Locally
@@ -70,6 +66,6 @@ Run the wrapper to rebuild and publish the entire site in one step:
 python scripts/edge_human_knowledge_pages_sprint.py
 ```
 
-Prerequisites: **Python 3.11+**, **Node.js 20+**, `mkdocs` and Playwright. This
+Prerequisites: **Python 3.11+**, **Node.js 20+** and `mkdocs`. This
 script mirrors the [Docs workflow](../.github/workflows/docs.yml) used for
 continuous deployment.

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -9,7 +9,7 @@ The generated site is hosted at <https://montrealai.github.io/AGI-Alpha-Agent-v0
 
 `deploy_insight_demo.sh` downloads the Insight browser assets, installs the
 Node dependencies and then invokes `publish_insight_pages.sh`. The latter runs
-`build_insight_docs.sh` to refresh the MkDocs site and pushes the result to the
+`edge_human_knowledge_pages_sprint.sh` to refresh the MkDocs site and pushes the result to the
 `gh-pages` branch. When the script completes it prints the GitHub Pages URL.
 
 For an end‑to‑end build **with verification** use `deploy_insight_full.sh`. This
@@ -63,7 +63,7 @@ unzip -o insight_browser.zip -d ../../../docs/alpha_agi_insight_v1
 ```
 
 Generate `tree.json` from the latest run so the visualization reflects the
-current meta-agent state. `scripts/build_insight_docs.sh` automatically
+current meta-agent state. `scripts/edge_human_knowledge_pages_sprint.sh` automatically
 refreshes this file when `lineage/run.jsonl` is present, so the command below is
 only needed when running it manually:
 
@@ -72,7 +72,7 @@ python alpha_factory_v1/demos/alpha_agi_insight_v1/tools/export_tree.py \
   lineage/run.jsonl -o docs/alpha_agi_insight_v1/tree.json
 ```
 
-The helper script `scripts/build_insight_docs.sh` automates the steps above.
+The helper script `scripts/edge_human_knowledge_pages_sprint.sh` automates the steps above.
 Run it from the repository root to build the bundle, refresh
 `docs/alpha_agi_insight_v1` and generate the site.
 
@@ -109,7 +109,7 @@ GitHub Pages.
 
 The "📚 Docs" workflow
 [`docs.yml`](../.github/workflows/docs.yml) automatically runs
-`scripts/build_insight_docs.sh`, builds the site and pushes the result to the
+`scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
 `gh-pages` branch.
 
 ### Manual Publish

--- a/docs/INSIGHT_ACCESS_SPRINT.md
+++ b/docs/INSIGHT_ACCESS_SPRINT.md
@@ -26,7 +26,7 @@ This short guide distills the essential steps required to build and publish the 
 Run the helper script from the repository root:
 
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 
 This command:

--- a/docs/INSIGHT_SPRINT_PLAN.md
+++ b/docs/INSIGHT_SPRINT_PLAN.md
@@ -9,7 +9,7 @@ This document outlines the minimal tasks required to publish the **α‑AGI Insi
 - Execute `python scripts/check_python_deps.py` and `python check_env.py --auto-install` to install optional dependencies.
 
 ## 2. Build the Static Demo
-- From the repository root, run `./scripts/build_insight_docs.sh`.
+- From the repository root, run `./scripts/edge_human_knowledge_pages_sprint.sh`.
   - This fetches assets, builds the browser bundle, and refreshes `docs/alpha_agi_insight_v1/`.
 - Verify that `docs/alpha_agi_insight_v1/index.html` loads locally using:
   ```bash
@@ -24,7 +24,7 @@ This document outlines the minimal tasks required to publish the **α‑AGI Insi
 - Opening <https://montrealai.github.io/AGI-Alpha-Agent-v0/> shows a landing page with quick links. Use **Launch Demo** to reach this path or open the **Visual Demo Gallery** for other pages.
 
 ## 4. Maintain the Demo
-- Update `forecast.json` or `population.json` to change the scenario, then re-run `build_insight_docs.sh`.
+- Update `forecast.json` or `population.json` to change the scenario, then re-run `edge_human_knowledge_pages_sprint.sh`.
 - Run `scripts/verify_insight_offline.py` to ensure offline caching works before publishing.
 
 These steps keep the demo production-ready and easily reproducible for non‑technical users.
@@ -34,7 +34,7 @@ These steps keep the demo production-ready and easily reproducible for non‑tec
   ```bash
   python alpha_factory_v1/demos/alpha_agi_insight_v1/tools/export_tree.py lineage/run.jsonl -o docs/alpha_agi_insight_v1/tree.json
   ```
-- Rebuild the site with `./scripts/build_insight_docs.sh` and confirm the nodes animate progressively on page load.
+- Rebuild the site with `./scripts/edge_human_knowledge_pages_sprint.sh` and confirm the nodes animate progressively on page load.
 
 ## 6. Final Verification Checklist
 - Check that `docs/index.html` links to `alpha_agi_insight_v1/index.html`.

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -55,8 +55,4 @@ The command prints `Environment OK` when all required packages are available.
 
 ## Browser Demo Tests
 
-The Insight browser demo includes Playwright-based tests that can run without
-internet access. See the [README](../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md#running-browser-tests)
-for detailed steps. Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and optionally
-`PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` before executing `npm test`.
 

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -110,11 +110,6 @@ recommended.
    python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
    ```
 
-### Playwright tests
-
-Browser tests that rely on Playwright work best on Linux. They can fail on
-macOS or WSL2 when the required browsers are missing. Skip them by deselecting
-the files, for example:
 
 ```bash
 pytest -k 'not pwa_offline and not browser_ui'

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ To update the charts, edit `forecast.json` and `population.json` and rebuild
 the site:
 
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 
 This helper fetches all assets, compiles the browser bundle and runs `mkdocs build`.

--- a/docs/USER_FRIENDLY_DEMO_PAGES_SPRINT.md
+++ b/docs/USER_FRIENDLY_DEMO_PAGES_SPRINT.md
@@ -23,7 +23,7 @@ This sprint ensures that every advanced demo in `alpha_factory_v1/demos/` unfold
 ## 2. Build the Insight Demo
 Execute the bundled helper to compile the progressive web app and verify its service worker:
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 This step exports `tree.json` when lineage logs exist, rebuilds
 `docs/index.html` via `scripts/generate_gallery_html.py` and ensures offline

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -31,7 +31,7 @@ Below the interactive charts, the demo includes a dedicated **Meta‑Agentic Tre
 Run the helper script to build the Insight progressive web app (PWA) and generate the `site/` directory:
 
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 
 The script installs Node dependencies, builds the browser bundle and runs `mkdocs build`. When executed in CI, it also publishes the resulting `site/` directory to GitHub Pages.
@@ -52,11 +52,11 @@ The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same scrip
 To verify that the PWA works without an internet connection:
 
 1. Run `./scripts/preview_insight_docs.sh`. The script builds the docs, starts a
-   local server and automatically launches a headless browser with Playwright.
+   local server and automatically launches a headless browser.
    It waits for the service worker to register, disables network access and
    reloads the page. The command exits with an error if the page fails to load
    offline.
-2. Alternatively, build the documentation with `./scripts/build_insight_docs.sh`
+2. Alternatively, build the documentation with `./scripts/edge_human_knowledge_pages_sprint.sh`
    and serve the `site/` directory locally:
    `python -m http.server --directory site 8000`.
 3. Open <http://localhost:8000/> in a browser.
@@ -75,10 +75,3 @@ python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 
 This prevents caching issues caused by missing or corrupted assets.
 
-### Browser compatibility
-
-Automated Playwright tests run the meta-agentic tree visualization in
-Chromium, Firefox and WebKit. Firefox and Safari (WebKit) may render the
-animated transitions more slowly, so the tests allow extra time for nodes to
-appear. The CI workflow installs these browsers and sets `SKIP_WEBKIT_TESTS=1`
-if WebKit fails to install so the suite can still pass.

--- a/docs/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -31,7 +31,7 @@ Below the interactive charts, the demo includes a dedicated **Meta‑Agentic Tre
 Run the helper script to build the Insight progressive web app (PWA) and generate the `site/` directory:
 
 ```bash
-./scripts/build_insight_docs.sh
+./scripts/edge_human_knowledge_pages_sprint.sh
 ```
 
 The script installs Node dependencies, builds the browser bundle and runs `mkdocs build`. When executed in CI, it also publishes the resulting `site/` directory to GitHub Pages.
@@ -52,11 +52,11 @@ The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same scrip
 To verify that the PWA works without an internet connection:
 
 1. Run `./scripts/preview_insight_docs.sh`. The script builds the docs, starts a
-   local server and automatically launches a headless browser with Playwright.
+   local server and automatically launches a headless browser.
    It waits for the service worker to register, disables network access and
    reloads the page. The command exits with an error if the page fails to load
    offline.
-2. Alternatively, build the documentation with `./scripts/build_insight_docs.sh`
+2. Alternatively, build the documentation with `./scripts/edge_human_knowledge_pages_sprint.sh`
    and serve the `site/` directory locally:
    `python -m http.server --directory site 8000`.
 3. Open <http://localhost:8000/> in a browser.
@@ -75,10 +75,4 @@ python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 
 This prevents caching issues caused by missing or corrupted assets.
 
-### Browser compatibility
-
-Automated Playwright tests run the meta-agentic tree visualization in
-Chromium, Firefox and WebKit. Firefox and Safari (WebKit) may render the
-animated transitions more slowly, so the tests allow extra time for nodes to
-appear. The CI workflow installs these browsers and sets `SKIP_WEBKIT_TESTS=1`
 if WebKit fails to install so the suite can still pass.


### PR DESCRIPTION
## Summary
- switch docs from `build_insight_docs.sh` to `edge_human_knowledge_pages_sprint.sh`
- remove Playwright from instructions

## Testing
- `pre-commit run --files README.md` *(fails: Verify requirements.lock is up to date)*

------
https://chatgpt.com/codex/tasks/task_e_6865445635088333b182707a113f88ad