### PR TITLE
[alpha_factory] Update sandbox image reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     env:
-      SANDBOX_IMAGE: selfheal-sandbox:latest
+      SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
## Summary
- adjust docs workflow to use registry image

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `docker build -t sandbox-image -f sandbox.Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865562e346c83338892d7ac70db05a3