### PR TITLE
feat: update asset fallback logic

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -55,7 +55,7 @@ is missing the build scripts continue with default empty values:
 - `OPENAI_API_KEY` – optional OpenAI key for chat prompts. **For security, do not
   embed the key in the built HTML.** Store it in `localStorage` or enter it at
   runtime instead.
-- `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs.
+- `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs. When assets fail to load the build scripts automatically try `https://w3s.link/ipfs`, `https://ipfs.io/ipfs` and `https://cloudflare-ipfs.com/ipfs` as fallbacks.
 - `OTEL_ENDPOINT` – OTLP/HTTP endpoint for anonymous telemetry (leave blank to disable).
 - `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
 - Browsers with WebGPU can accelerate the local model using the ONNX runtime.


### PR DESCRIPTION
## Summary
- support multiple fallback IPFS gateways in `fetch_assets.py`
- document fallback gateways for the insight browser demo

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files scripts/fetch_assets.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: verify requirements.lock is out of date)*
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6865bea434c88333a68031317168e484