### PR TITLE
feat: add IPFS gateway to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
+      IPFS_GATEWAY: https://w3s.link/ipfs
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -38,4 +39,6 @@ jobs:
       - name: Make scripts executable
         run: chmod +x ./scripts/*.sh
       - name: Build and deploy gallery
+        env:
+          IPFS_GATEWAY: ${{ env.IPFS_GATEWAY }}
         run: ./scripts/edge_human_knowledge_pages_sprint.sh

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -22,6 +22,9 @@ offline functionality and then publishes the docs in one step.
    `deploy_insight_demo.sh` to perform both steps automatically).
 3. Verify the page at `https://<org>.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
 
+The `fetch-assets` command respects the `IPFS_GATEWAY` environment variable.
+If downloads fail, set `IPFS_GATEWAY=https://w3s.link/ipfs` and rerun the step.
+
 ## Prerequisites
 
 - **Python 3.11 or 3.12**


### PR DESCRIPTION
## Summary
- export IPFS_GATEWAY variable during docs workflow
- mention the recommended gateway in the hosting guide

## Testing
- `pre-commit run --files .github/workflows/docs.yml docs/HOSTING_INSTRUCTIONS.md` *(fails: verify-requirements-lock)*
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c4a4a7488333980ebd3867cadf77