### PR TITLE
[alpha_factory] Add Super Planner demo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,16 +3,13 @@ name: "📚 Docs"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ "main" ]
-  release:
-    types: [ published ]
 
 permissions:
   contents: write
 
 jobs:
   build-deploy:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest

--- a/alpha_factory_v1/demos/alpha_super_planner_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_super_planner_v1/README.md
@@ -1,0 +1,13 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Alpha Super Planner V1 👁️✨
+A lightweight demo showcasing a console-based planning loop. The program displays
+progress in real time using the Rich library. It is self-contained and suitable
+for non-technical users.
+
+To launch the demonstration:
+
+```bash
+python -m alpha_factory_v1.demos.alpha_super_planner_v1
+```

--- a/alpha_factory_v1/demos/alpha_super_planner_v1/__init__.py
+++ b/alpha_factory_v1/demos/alpha_super_planner_v1/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Alpha Super Planner V1 demo package."""
+
+from typing import Final
+
+__all__ = ["__version__"]
+
+__version__: Final[str] = "0.1.0"

--- a/alpha_factory_v1/demos/alpha_super_planner_v1/__main__.py
+++ b/alpha_factory_v1/demos/alpha_super_planner_v1/__main__.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Console demo for the Alpha Super Planner."""
+
+from __future__ import annotations
+
+import time
+from typing import Final
+
+from rich.console import Console
+from rich.progress import Progress
+
+from ...utils.disclaimer import print_disclaimer
+
+
+def main() -> None:
+    """Run the Super Planner demo."""
+    print_disclaimer()
+
+    console: Final = Console()
+    tasks = [
+        "Initializing reasoning engine",
+        "Aggregating knowledge",
+        "Synthesizing strategies",
+        "Evaluating outcomes",
+        "Finalizing plan",
+    ]
+    with Progress(transient=True) as progress:
+        job = progress.add_task("Super Planner", total=len(tasks))
+        for step in tasks:
+            console.log(step)
+            time.sleep(1)
+            progress.advance(job)
+    console.rule("[bold green]Plan Complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `alpha_super_planner_v1` demo with console progress animation
- restrict `docs.yml` to manual runs by the repo owner

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*
- `black alpha_factory_v1/demos/alpha_super_planner_v1/__init__.py alpha_factory_v1/demos/alpha_super_planner_v1/__main__.py --check`
- `ruff check alpha_factory_v1/demos/alpha_super_planner_v1/__init__.py alpha_factory_v1/demos/alpha_super_planner_v1/__main__.py`
- `ruff format alpha_factory_v1/demos/alpha_super_planner_v1/__init__.py alpha_factory_v1/demos/alpha_super_planner_v1/__main__.py --check`

------
https://chatgpt.com/codex/tasks/task_e_6865cbf2a848833397ff122f8cf1aea5