### PR TITLE
[alpha_factory] queue cross-industry jobs demo

### DIFF
--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/queue_cross_alpha.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/queue_cross_alpha.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+"""Queue cross‑industry opportunities on the α‑AGI Marketplace.
+
+This helper script discovers potential opportunities using
+:func:`cross_alpha_discovery_stub.discover_alpha` and submits them as
+jobs to the orchestrator via :class:`MarketplaceClient`. It can operate
+fully offline when no OpenAI key is configured.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, List, Mapping
+
+from alpha_factory_v1.demos.alpha_agi_marketplace_v1 import MarketplaceClient
+from .cross_alpha_discovery_stub import discover_alpha
+
+DEFAULT_AGENT = "finance"
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 8000
+
+
+def make_job(opportunity: Mapping[str, str], agent: str = DEFAULT_AGENT) -> Mapping[str, Any]:
+    """Return a job dict for the marketplace."""
+    note = f"Evaluate opportunity: {opportunity['opportunity']} ({opportunity['sector']})"
+    return {"agent": agent, "note": note}
+
+
+def queue_opportunities(
+    num: int,
+    *,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    agent: str = DEFAULT_AGENT,
+    model: str | None = None,
+    dry_run: bool = False,
+) -> List[Mapping[str, Any]]:
+    """Discover opportunities and queue them on the orchestrator."""
+    opps = discover_alpha(num=num, ledger=None, model=model)
+    client = MarketplaceClient(host, port)
+    jobs = [make_job(o, agent=agent) for o in opps]
+    for job in jobs:
+        if dry_run:
+            print(json.dumps(job, indent=2))
+        else:
+            resp = client.queue_job(job)
+            print(f"Queued: {resp.status_code} -> {job['note']}")
+    return jobs
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-n", "--num", type=int, default=1, help="number of opportunities")
+    ap.add_argument("--model", help="OpenAI model when API key is available")
+    ap.add_argument("--agent", default=DEFAULT_AGENT, help="target agent name")
+    ap.add_argument("--host", default=DEFAULT_HOST, help="orchestrator host")
+    ap.add_argument("--port", type=int, default=DEFAULT_PORT, help="orchestrator port")
+    ap.add_argument("--dry-run", action="store_true", help="print jobs without queueing")
+    return ap.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = parse_args(argv)
+    queue_opportunities(
+        args.num,
+        host=args.host,
+        port=args.port,
+        agent=args.agent,
+        model=args.model,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/alpha_factory_v1/tests/test_queue_cross_alpha.py
+++ b/alpha_factory_v1/tests/test_queue_cross_alpha.py
@@ -1,0 +1,48 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import unittest
+
+from alpha_factory_v1.demos.cross_industry_alpha_factory import queue_cross_alpha
+
+
+class _Handler(BaseHTTPRequestHandler):
+    received_path = None
+    received_body = None
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        type(self).received_body = self.rfile.read(length)
+        type(self).received_path = self.path
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+
+def _start_server() -> tuple[HTTPServer, threading.Thread]:
+    server = HTTPServer(("localhost", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+class QueueCrossAlphaTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        if hasattr(self, "server"):
+            self.server.shutdown()
+            self.thread.join()
+            self.server.server_close()
+
+    def test_queue_opportunities(self) -> None:
+        self.server, self.thread = _start_server()
+        host, port = self.server.server_address
+        jobs = queue_cross_alpha.queue_opportunities(1, host=str(host), port=port, dry_run=False)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(_Handler.received_path, "/agent/finance/trigger")
+        assert _Handler.received_body is not None
+        body = json.loads(_Handler.received_body.decode())
+        self.assertEqual(body["agent"], "finance")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add queue_cross_alpha helper to submit discovery results to the marketplace
- test queuing logic

## Testing
- `pre-commit run --files alpha_factory_v1/demos/cross_industry_alpha_factory/queue_cross_alpha.py alpha_factory_v1/tests/test_queue_cross_alpha.py` *(fails: Verify requirements.lock is out of date)*
- `pytest alpha_factory_v1/tests/test_queue_cross_alpha.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d30ef0e083338643ff0a15436259