### PR TITLE
[alpha_factory] update docs for manual docs workflow

### DIFF
--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -66,6 +66,4 @@ Run the wrapper to rebuild and publish the entire site in one step:
 python scripts/edge_human_knowledge_pages_sprint.py
 ```
 
-Prerequisites: **Python 3.11+**, **Node.js 20+** and `mkdocs`. This
-script mirrors the [Docs workflow](../.github/workflows/docs.yml) used for
-continuous deployment.
+Prerequisites: **Python 3.11+**, **Node.js 20+** and `mkdocs`. This script mirrors the [Docs workflow](../.github/workflows/docs.yml) which the repository owner triggers manually to deploy the site.

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -111,7 +111,7 @@ access is unsupported due to the service worker; use a minimal HTTP server or
 GitHub Pages.
 
 The "📚 Docs" workflow
-[`docs.yml`](../.github/workflows/docs.yml) automatically runs
+The repository owner manually triggers [`docs.yml`](../.github/workflows/docs.yml), which runs
 `scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
 `gh-pages` branch.
 
@@ -132,7 +132,7 @@ Use it when testing changes locally or publishing from a personal fork.
 
 ## Publishing to GitHub Pages
 
-When changes land on `main` or a release is published, `docs.yml` pushes the
+When triggered, `docs.yml` pushes the
 `site/` directory to the `gh-pages` branch. GitHub Pages serves the result at
 `https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
 Opening `https://montrealai.github.io/AGI-Alpha-Agent-v0/` shows a landing page
@@ -144,8 +144,7 @@ The standard [project disclaimer](DISCLAIMER_SNIPPET.md) applies.
 
 Confirm the workflow is enabled under **Actions** and that
 [`docs.yml`](../.github/workflows/docs.yml) specifies
-`permissions: contents: write`. Run the "📚 Docs" workflow from the GitHub UI or
-push to `main` to trigger it. The initial run creates the `gh-pages` branch.
+`permissions: contents: write`. Run the "📚 Docs" workflow from the GitHub UI to trigger it. The initial run creates the `gh-pages` branch.
 After it finishes, browse to
 <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/> and
 check that the insight demo loads.

--- a/docs/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_agi_insight_v1/README.md
@@ -45,7 +45,7 @@ python -m http.server --directory site 8000
 
 For convenience, run `./scripts/preview_insight_docs.sh` to build the demo and immediately serve it on `http://localhost:8000/`.
 
-The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same script and publishes the contents of `site/` to GitHub Pages on every push to `main`.
+The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same script but is triggered manually from the GitHub UI by the repository owner to publish the contents of `site/` to GitHub Pages.
 
 ### Testing offline mode
 

--- a/docs/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/docs/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -45,7 +45,7 @@ python -m http.server --directory site 8000
 
 For convenience, run `./scripts/preview_insight_docs.sh` to build the demo and immediately serve it on `http://localhost:8000/`.
 
-The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same script and publishes the contents of `site/` to GitHub Pages on every push to `main`.
+The [`📚 Docs` workflow](../../.github/workflows/docs.yml) runs the same script but is triggered manually from the GitHub UI by the repository owner to publish the contents of `site/` to GitHub Pages.
 
 ### Testing offline mode
 


### PR DESCRIPTION
## Summary
- clarify that docs workflow only runs when triggered manually by repo owner

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files docs/alpha_agi_insight_v1/README.md docs/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md docs/GITHUB_PAGES_DEMO_TASKS.md docs/HOSTING_INSTRUCTIONS.md` *(fails: requirements.lock is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_6865d721889c8333bef47c094549865a