### PR TITLE
[alpha_factory] docs: add IPFS fetch instructions

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -3,4 +3,10 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 # wasm-gpt2
 
-This folder is intentionally empty. During development the lightweight `wasm-gpt2` model (~124 MB) should be placed here and pinned to IPFS. The build script copies the contents of this directory to `dist/wasm_llm/` so the demo can load the model offline.
+This folder is intentionally empty. During development the lightweight `wasm-gpt2` model (~124 MB) should be placed here and pinned to IPFS. The build script copies the contents of this directory to `dist/wasm_llm/` so the demo can load the model offline.
+
+To fetch the model automatically, run `npm run fetch-assets` or `python ../../../../scripts/fetch_assets.py`. The script downloads `wasm-gpt2.tar` from IPFS using CID `bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku` which is accessible via the gateway:
+
+```
+https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku
+```


### PR DESCRIPTION
## Summary
- mention that `fetch_assets.py` can fetch `wasm-gpt2.tar`
- document IPFS CID and gateway link

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6865e14cd9d08333899afd7a37789381