### PR TITLE
[alpha_factory] update wasm-gpt2 fetch link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ dist/
 # Browser demo assets
 alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm/
 alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/
+!alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/
+!alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
 
 # Logs
 *.log

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -5,8 +5,10 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 This folder is intentionally empty. During development the lightweight `wasm-gpt2` model (~124 MB) should be placed here and pinned to IPFS. The build script copies the contents of this directory to `dist/wasm_llm/` so the demo can load the model offline.
 
-To fetch the model automatically, run `npm run fetch-assets` or `python ../../../../scripts/fetch_assets.py`. The script downloads `wasm-gpt2.tar` from IPFS using CID `bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku` which is accessible via the gateway:
+To fetch the model automatically, run `npm run fetch-assets` or `python ../../../../scripts/fetch_assets.py`.
+The script retrieves `wasm-gpt2.tar` from the official mirror at:
 
 ```
-https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku
+https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1
 ```
+This URL points to the canonical IPFS CID and is used as the fallback source when other gateways fail.

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -13,7 +13,12 @@ import sys
 import requests  # type: ignore
 from requests.adapters import HTTPAdapter, Retry  # type: ignore
 
+# IPFS gateway used for model downloads
 GATEWAY = os.environ.get("IPFS_GATEWAY", "https://ipfs.io/ipfs").rstrip("/")
+# Official fallback link for the wasm-gpt2 model
+OFFICIAL_WASM_GPT2_URL = (
+    "https://cloudflare-ipfs.com/ipfs/" "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+)
 # Alternate gateways to try when the main download fails
 FALLBACK_GATEWAYS = [
     "https://w3s.link/ipfs",
@@ -163,7 +168,7 @@ def main() -> None:
             if rel == "lib/bundle.esm.min.js":
                 fallback = "https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js"  # noqa: E501
             elif rel == "wasm_llm/wasm-gpt2.tar":
-                fallback = f"https://cloudflare-ipfs.com/ipfs/{cid}"
+                fallback = OFFICIAL_WASM_GPT2_URL
             try:
                 download_with_retry(cid, dest, fallback, label=rel)
             except Exception as exc:


### PR DESCRIPTION
## Summary
- expose official link for wasm-gpt2 tarball
- document the new link in the browser demo README
- allow tracking the README in ignored directory

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files scripts/fetch_assets.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md` *(failed: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6865e3d3f9288333adea47876d33f2a9