### PR TITLE
feat: add wasm gpt2 fetch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 **Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` (or set `AF_GALLERY_URL` to your own mirror) for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
-**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details.
+**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 
@@ -90,7 +90,7 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
-Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide.
+Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` to fetch the GPT‑2 model directly.
 
 Requires **Python 3.11 or 3.12** and **Docker Compose ≥2.5**.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -69,7 +69,9 @@ is missing the build scripts continue with default empty values:
 
 Run `npm run fetch-assets` to download the Pyodide runtime and local model
 before installing dependencies. The script invokes
-`scripts/fetch_assets.py` under the hood.
+`scripts/fetch_assets.py` under the hood. Alternatively, execute
+`python ../../../../scripts/download_wasm_gpt2.py` to fetch the GPT‑2 model
+directly from the official mirror.
 
 See [`.env.sample`](.env.sample) for the full list of supported variables.
 The compiled `dist/` directory is not version controlled. Run the build script
@@ -78,6 +80,8 @@ to create it before launching the demo.
 ## Build & Run
 Run `npm run fetch-assets` **before installing dependencies** to download the
 Pyodide runtime and `wasm-gpt2` model, then install the Node modules and
+`python ../../../../scripts/download_wasm_gpt2.py` can also fetch the model
+directly if you prefer,
 compile the bundle:
 ```bash
 npm run fetch-assets
@@ -113,7 +117,9 @@ npm run fetch-assets
 
 This downloads the Pyodide runtime and `wasm-gpt2` model from IPFS into
 `wasm/` and `wasm_llm/`.
-It also retrieves `lib/bundle.esm.min.js` from the mirror. The build and
+It also retrieves `lib/bundle.esm.min.js` from the mirror. You may instead run
+`python ../../../../scripts/download_wasm_gpt2.py` to pull the model from the
+official mirror without IPFS. The build and
 `manual_build.py` scripts scan every downloaded asset for the word
 `"placeholder"` and abort when any file still contains that marker.
 `npm run fetch-assets` also downloads `lib/workbox-sw.js` from
@@ -148,6 +154,8 @@ Use `manual_build.py` for air‑gapped environments:
 
 1. `cp .env.sample .env` and edit the values if you haven't already, then `chmod 600 .env`.
 2. `npm run fetch-assets` to fetch Pyodide and the GPT‑2 model.
+   Alternatively run `python ../../../../scripts/download_wasm_gpt2.py` to grab
+   the model directly from the official mirror.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.
 3. Run `node build/version_check.js` to ensure Node.js **v20** or newer is
@@ -165,7 +173,7 @@ If `.env` is absent the script continues with empty defaults rather than abortin
 
 Follow these steps when building without internet access:
 
-1. Run `npm run fetch-assets`.
+1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_wasm_gpt2.py`).
 2. Verify checksums match `build_assets.json` and ensure no files under
    `wasm/` or `lib/` contain the word "placeholder".
 3. `npm ci` to install the locked dependencies.
@@ -177,6 +185,7 @@ Failing to replace placeholders will break offline mode.
 ### Offline build checklist
 
 1. Run `npm run fetch-assets`.
+   (`python ../../../../scripts/download_wasm_gpt2.py` also works.)
 2. `npm ci` to install dependencies from `package-lock.json`.
 3. Confirm no placeholder text remains in `lib/` or `wasm*/`.
 4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`. Use

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Download the wasm-gpt2 model archive from the official mirror."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import requests
+from tqdm import tqdm
+
+OFFICIAL_URL = (
+    "https://cloudflare-ipfs.com/ipfs/"
+    "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+)
+
+
+def fetch(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with requests.get(url, stream=True, timeout=60) as resp:
+        resp.raise_for_status()
+        total = int(resp.headers.get("Content-Length", 0))
+        with open(dest, "wb") as f, tqdm(
+            total=total, unit="B", unit_scale=True, desc=dest.name
+        ) as bar:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+                    bar.update(len(chunk))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dest",
+        nargs="?",
+        default="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/wasm-gpt2.tar",
+        type=Path,
+        help="Destination file path",
+    )
+    args = parser.parse_args()
+    if args.dest.exists():
+        print(f"{args.dest} already exists, skipping")
+        return
+    print(f"Downloading wasm-gpt2 model to {args.dest}...")
+    fetch(OFFICIAL_URL, args.dest)
+    print("Download complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `download_wasm_gpt2.py` helper script to pull the GPT-2 wasm model from the official mirror
- mention the script in project README and Insight browser README

## Testing
- ❌ `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md scripts/download_wasm_gpt2.py` *(failed: pre-commit installation timeout)*
- ❌ `pytest tests/test_assets_replaced.py::test_assets_replaced -q` *(failed: environment check timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6865ed8b0e5c833398681ee631526c76