### PR TITLE
[alpha_factory] clarify wasm-gpt2 fetch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 **Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` (or set `AF_GALLERY_URL` to your own mirror) for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
-**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
+**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official mirror and falls back to the configured IPFS gateway. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 
@@ -90,7 +90,7 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
-Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` to fetch the GPT‑2 model directly.
+Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror with IPFS as a fallback. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` to fetch the model directly.
 
 Requires **Python 3.11 or 3.12** and **Docker Compose ≥2.5**.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -69,9 +69,10 @@ is missing the build scripts continue with default empty values:
 
 Run `npm run fetch-assets` to download the Pyodide runtime and local model
 before installing dependencies. The script invokes
-`scripts/fetch_assets.py` under the hood. Alternatively, execute
-`python ../../../../scripts/download_wasm_gpt2.py` to fetch the GPT‑2 model
-directly from the official mirror.
+`scripts/fetch_assets.py` under the hood, which retrieves `wasm-gpt2.tar`
+from the official mirror and falls back to the configured IPFS gateway.
+Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` to
+fetch the GPT‑2 model directly.
 
 See [`.env.sample`](.env.sample) for the full list of supported variables.
 The compiled `dist/` directory is not version controlled. Run the build script
@@ -115,11 +116,12 @@ offline run:
 npm run fetch-assets
 ```
 
-This downloads the Pyodide runtime and `wasm-gpt2` model from IPFS into
-`wasm/` and `wasm_llm/`.
+This downloads the Pyodide runtime and `wasm-gpt2` model from the official
+mirror with a fallback to the configured IPFS gateway. Assets land in `wasm/`
+and `wasm_llm/`.
 It also retrieves `lib/bundle.esm.min.js` from the mirror. You may instead run
-`python ../../../../scripts/download_wasm_gpt2.py` to pull the model from the
-official mirror without IPFS. The build and
+`python ../../../../scripts/download_wasm_gpt2.py` to pull the model
+directly. The build and
 `manual_build.py` scripts scan every downloaded asset for the word
 `"placeholder"` and abort when any file still contains that marker.
 `npm run fetch-assets` also downloads `lib/workbox-sw.js` from
@@ -228,8 +230,9 @@ WEB3_STORAGE_TOKEN=<token> npm run fetch-assets
 ```
 
 
-The script retrieves the WebAssembly runtime and supporting files from IPFS,
-verifying checksums to ensure each asset is intact.
+The script retrieves the WebAssembly runtime and supporting files from the
+official mirror or the configured IPFS gateway, verifying checksums to ensure
+each asset is intact.
 
 ### Offline Build Steps
 

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: Apache-2.0
-"""Download the wasm-gpt2 model archive from the official mirror."""
+"""Download the wasm-gpt2 model archive from the official mirror.
+
+Set the ``WASM_GPT2_URL`` environment variable to override the default source.
+"""
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import os
 import requests
 from tqdm import tqdm
 
@@ -12,6 +16,10 @@ OFFICIAL_URL = (
     "https://cloudflare-ipfs.com/ipfs/"
     "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
 )
+
+def _resolve_url() -> str:
+    """Return the download URL for the model."""
+    return os.environ.get("WASM_GPT2_URL", OFFICIAL_URL)
 
 
 def fetch(url: str, dest: Path) -> None:
@@ -41,8 +49,9 @@ def main() -> None:
     if args.dest.exists():
         print(f"{args.dest} already exists, skipping")
         return
-    print(f"Downloading wasm-gpt2 model to {args.dest}...")
-    fetch(OFFICIAL_URL, args.dest)
+    url = _resolve_url()
+    print(f"Downloading wasm-gpt2 model from {url} to {args.dest}...")
+    fetch(url, args.dest)
     print("Download complete")
 
 


### PR DESCRIPTION
## Summary
- document official wasm-gpt2 mirror in README
- show fallback logic in Insight browser README
- add environment override support in `download_wasm_gpt2.py`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pyyaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files scripts/download_wasm_gpt2.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md README.md` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6865fadae8b08333b7f99a47f6a203bc