### PR TITLE
[alpha_factory] allow wasm-gpt2 url override

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 **Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` (or set `AF_GALLERY_URL` to your own mirror) for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
-**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official mirror and falls back to the configured IPFS gateway. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
+**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official mirror, falling back to the configured IPFS gateway. Set `WASM_GPT2_URL` to override the source. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -5,10 +5,15 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 This folder is intentionally empty. During development the lightweight `wasm-gpt2` model (~124 MB) should be placed here and pinned to IPFS. The build script copies the contents of this directory to `dist/wasm_llm/` so the demo can load the model offline.
 
-To fetch the model automatically, run `npm run fetch-assets` or `python ../../../../scripts/fetch_assets.py`.
-The script retrieves `wasm-gpt2.tar` from the official mirror at:
+To fetch the model automatically, run `npm run fetch-assets` or
+`python ../../../../scripts/fetch_assets.py`.
+The helper retrieves `wasm-gpt2.tar` from the official mirror. Set
+`WASM_GPT2_URL` to override the default URL:
 
+```bash
+export WASM_GPT2_URL="https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+npm run fetch-assets
 ```
-https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1
-```
-This URL points to the canonical IPFS CID and is now used as the primary source when fetching the model. The script falls back to the configured IPFS gateway if the mirror is unavailable.
+
+The default URL points to the canonical IPFS CID. The script automatically falls
+back to the configured IPFS gateway if the mirror is unavailable.

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -19,7 +19,11 @@ GATEWAY = os.environ.get("IPFS_GATEWAY", "https://ipfs.io/ipfs").rstrip("/")
 # Canonical CID for the wasm-gpt2 model
 WASM_GPT2_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
 # Public mirror used as the primary source for the wasm-gpt2 model
-OFFICIAL_WASM_GPT2_URL = f"https://cloudflare-ipfs.com/ipfs/{WASM_GPT2_CID}?download=1"
+# Allow overriding via ``WASM_GPT2_URL`` so CI can point to a known mirror.
+OFFICIAL_WASM_GPT2_URL = os.environ.get(
+    "WASM_GPT2_URL",
+    f"https://cloudflare-ipfs.com/ipfs/{WASM_GPT2_CID}?download=1",
+)
 # Alternate gateways to try when the main download fails
 FALLBACK_GATEWAYS = [
     "https://w3s.link/ipfs",


### PR DESCRIPTION
## Summary
- make wasm-gpt2 mirror configurable with `WASM_GPT2_URL`
- document the new variable in README files

## Testing
- `python scripts/check_python_deps.py` *(shows missing deps then hints to check_env)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError during test collection)*
- `pre-commit run --files scripts/fetch_assets.py README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68666631c3dc8333b6584c4858fb5202