### PR TITLE
[alpha_factory] fix wasm-gpt2 link

### DIFF
--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -13,8 +13,7 @@ import requests
 from tqdm import tqdm
 
 _DEFAULT_URLS = [
-    "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
-    "https://raw.githubusercontent.com/huggingface/transformers.js/main/weights/wasm/wasm-gpt2.tar",
+    "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",
 ]
 
 

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -23,8 +23,7 @@ WASM_GPT2_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
 # different location. When multiple URLs are provided via ``WASM_GPT2_URL``
 # they are tried in order separated by commas.
 _DEFAULT_WASM_GPT2_URLS = [
-    "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
-    "https://raw.githubusercontent.com/huggingface/transformers.js/main/weights/wasm/wasm-gpt2.tar",
+    "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",
 ]
 
 
@@ -196,7 +195,7 @@ def main() -> None:
             if rel == "lib/bundle.esm.min.js":
                 fallback = "https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js"  # noqa: E501
             elif rel == "wasm_llm/wasm-gpt2.tar":
-                fallback = f"{GATEWAY}/{WASM_GPT2_CID}"
+                fallback = f"{GATEWAY}/{WASM_GPT2_CID}?download=1"
                 last_exc = None
                 for url in OFFICIAL_WASM_GPT2_URLS:
                     try:
@@ -222,7 +221,7 @@ def main() -> None:
         print(
             f"\nERROR: Unable to retrieve {joined}.\n"
             "Check your internet connection or set IPFS_GATEWAY to a reachable "
-            "gateway."
+            "gateway, or specify a mirror via WASM_GPT2_URL."
         )
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- update official wasm-gpt2 download URL to cloudflare IPFS mirror
- use ?download=1 when falling back to IPFS
- clarify failure message to mention WASM_GPT2_URL override

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686678656cc08333a028dc8126776295