### PR TITLE
Update default wasm-gpt2 mirror in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 **Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` (or set `AF_GALLERY_URL` to your own mirror) for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
-**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from a public Hugging Face mirror and falls back to the configured IPFS gateway. Set `WASM_GPT2_URL` to override the source. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
+**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official IPFS mirror and falls back to the configured gateway. Set `WASM_GPT2_URL` to override the source, for example:
+
+```bash
+export WASM_GPT2_URL="https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+```
+
+See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -70,7 +70,13 @@ is missing the build scripts continue with default empty values:
 Run `npm run fetch-assets` to download the Pyodide runtime and local model
 before installing dependencies. The script invokes
 `scripts/fetch_assets.py` under the hood, which retrieves `wasm-gpt2.tar`
-from a public Hugging Face mirror and falls back to the configured IPFS gateway.
+from the official IPFS mirror and falls back to the configured gateway. Set
+`WASM_GPT2_URL` to override the source, for example:
+
+```bash
+export WASM_GPT2_URL="https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+```
+
 Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` to
 fetch the GPT‑2 model directly.
 
@@ -157,7 +163,7 @@ Use `manual_build.py` for air‑gapped environments:
 1. `cp .env.sample .env` and edit the values if you haven't already, then `chmod 600 .env`.
 2. `npm run fetch-assets` to fetch Pyodide and the GPT‑2 model.
    Alternatively run `python ../../../../scripts/download_wasm_gpt2.py` to grab
-   the model directly from the public Hugging Face mirror.
+   the model directly from the official IPFS mirror.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.
 3. Run `node build/version_check.js` to ensure Node.js **v20** or newer is
@@ -231,7 +237,7 @@ WEB3_STORAGE_TOKEN=<token> npm run fetch-assets
 
 
 The script retrieves the WebAssembly runtime and supporting files from the
-public Hugging Face mirror or the configured IPFS gateway, verifying checksums to ensure
+official IPFS mirror or the configured gateway, verifying checksums to ensure
 each asset is intact.
 
 ### Offline Build Steps


### PR DESCRIPTION
## Summary
- sync README with code's default model mirror
- document `WASM_GPT2_URL` usage
- update Insight browser README with the official IPFS mirror

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: requirements.lock check)*

------
https://chatgpt.com/codex/tasks/task_e_68667abeccc08333aab894c79f628c72