### PR TITLE
Update wasm-gpt2 download mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide
 **Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official IPFS mirror and falls back to the configured gateway. Set `WASM_GPT2_URL` to override the source, for example:
 
 ```bash
-export WASM_GPT2_URL="https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
 ```
 
 See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -70,11 +70,11 @@ is missing the build scripts continue with default empty values:
 Run `npm run fetch-assets` to download the Pyodide runtime and local model
 before installing dependencies. The script invokes
 `scripts/fetch_assets.py` under the hood, which retrieves `wasm-gpt2.tar`
-from the official IPFS mirror and falls back to the configured gateway. Set
+from the official mirror and falls back to the configured gateway. Set
 `WASM_GPT2_URL` to override the source, for example:
 
 ```bash
-export WASM_GPT2_URL="https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
 ```
 
 Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` to

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -13,6 +13,8 @@ import requests  # type: ignore[import-untyped]
 from tqdm import tqdm
 
 _DEFAULT_URLS = [
+    "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
+    "https://raw.githubusercontent.com/huggingface/transformers.js/main/weights/wasm/wasm-gpt2.tar",
     "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",
 ]
 

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -23,6 +23,8 @@ WASM_GPT2_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
 # different location. When multiple URLs are provided via ``WASM_GPT2_URL``
 # they are tried in order separated by commas.
 _DEFAULT_WASM_GPT2_URLS = [
+    "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
+    "https://raw.githubusercontent.com/huggingface/transformers.js/main/weights/wasm/wasm-gpt2.tar",
     "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",
 ]
 


### PR DESCRIPTION
## Summary
- update the default wasm-gpt2 mirrors in helper scripts
- document the new HuggingFace download URL

## Testing
- `pre-commit run --files scripts/fetch_assets.py scripts/download_wasm_gpt2.py README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(with several hooks skipped)*
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68668725f2d883338f7774936c4c3d6e