### PR TITLE
[alpha_factory] add OpenAI GPT-2 download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
 ```
 
-See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`.
+See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 
@@ -96,7 +96,7 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
-Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror with IPFS as a fallback. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` to fetch the model directly.
+Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror with IPFS as a fallback. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py` to fetch the model directly.
 
 Requires **Python 3.11 or 3.12** and **Docker Compose ≥2.5**.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -77,8 +77,9 @@ from the official mirror and falls back to the configured gateway. Set
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
 ```
 
-Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` to
-fetch the GPT‑2 model directly.
+Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` or
+`python ../../../../scripts/download_openai_gpt2.py` to fetch the GPT‑2 model
+directly.
 
 See [`.env.sample`](.env.sample) for the full list of supported variables.
 The compiled `dist/` directory is not version controlled. Run the build script
@@ -86,8 +87,9 @@ to create it before launching the demo.
 
 ## Build & Run
 Run `npm run fetch-assets` **before installing dependencies** to download the
-Pyodide runtime and `wasm-gpt2` model, then install the Node modules and
-`python ../../../../scripts/download_wasm_gpt2.py` can also fetch the model
+Pyodide runtime and `wasm-gpt2` model, then install the Node modules.
+`python ../../../../scripts/download_wasm_gpt2.py` or
+`python ../../../../scripts/download_openai_gpt2.py` can also fetch the model
 directly if you prefer,
 compile the bundle:
 ```bash
@@ -126,7 +128,8 @@ This downloads the Pyodide runtime and `wasm-gpt2` model from the official
 mirror with a fallback to the configured IPFS gateway. Assets land in `wasm/`
 and `wasm_llm/`.
 It also retrieves `lib/bundle.esm.min.js` from the mirror. You may instead run
-`python ../../../../scripts/download_wasm_gpt2.py` to pull the model
+`python ../../../../scripts/download_wasm_gpt2.py` or
+`python ../../../../scripts/download_openai_gpt2.py` to pull the model
 directly. The build and
 `manual_build.py` scripts scan every downloaded asset for the word
 `"placeholder"` and abort when any file still contains that marker.
@@ -162,7 +165,8 @@ Use `manual_build.py` for air‑gapped environments:
 
 1. `cp .env.sample .env` and edit the values if you haven't already, then `chmod 600 .env`.
 2. `npm run fetch-assets` to fetch Pyodide and the GPT‑2 model.
-   Alternatively run `python ../../../../scripts/download_wasm_gpt2.py` to grab
+   Alternatively run `python ../../../../scripts/download_wasm_gpt2.py` or
+   `python ../../../../scripts/download_openai_gpt2.py` to grab
    the model directly from the official IPFS mirror.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.
@@ -181,7 +185,7 @@ If `.env` is absent the script continues with empty defaults rather than abortin
 
 Follow these steps when building without internet access:
 
-1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_wasm_gpt2.py`).
+1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_wasm_gpt2.py` or `python ../../../../scripts/download_openai_gpt2.py`).
 2. Verify checksums match `build_assets.json` and ensure no files under
    `wasm/` or `lib/` contain the word "placeholder".
 3. `npm ci` to install the locked dependencies.
@@ -193,7 +197,7 @@ Failing to replace placeholders will break offline mode.
 ### Offline build checklist
 
 1. Run `npm run fetch-assets`.
-   (`python ../../../../scripts/download_wasm_gpt2.py` also works.)
+   (`python ../../../../scripts/download_wasm_gpt2.py` or `python ../../../../scripts/download_openai_gpt2.py` also works.)
 2. `npm ci` to install dependencies from `package-lock.json`.
 3. Confirm no placeholder text remains in `lib/` or `wasm*/`.
 4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`. Use

--- a/scripts/download_openai_gpt2.py
+++ b/scripts/download_openai_gpt2.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# See docs/DISCLAIMER_SNIPPET.md
+"""Download GPT-2 checkpoint files from OpenAI's public storage."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import requests  # type: ignore
+from tqdm import tqdm
+
+
+_FILE_LIST = [
+    "checkpoint",
+    "encoder.json",
+    "hparams.json",
+    "model.ckpt.data-00000-of-00001",
+    "model.ckpt.index",
+    "model.ckpt.meta",
+    "vocab.bpe",
+]
+
+
+def model_urls(model: str) -> list[str]:
+    base = f"https://openaipublic.blob.core.windows.net/gpt-2/models/{model}/"
+    return [base + name for name in _FILE_LIST]
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with requests.get(url, stream=True, timeout=60) as resp:
+        resp.raise_for_status()
+        total = int(resp.headers.get("Content-Length", 0))
+        with open(dest, "wb") as fh, tqdm(total=total, unit="B", unit_scale=True, desc=dest.name) as bar:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if chunk:
+                    fh.write(chunk)
+                    bar.update(len(chunk))
+
+
+def download_openai_gpt2(model: str = "117M", dest: Path | str = "models", attempts: int = 3) -> None:
+    dest_dir = Path(dest) / model
+    urls = model_urls(model)
+    last_exc: Exception | None = None
+    for url in urls:
+        target = dest_dir / Path(url).name
+        if target.exists():
+            print(f"{target} already exists, skipping")
+            continue
+        for i in range(1, attempts + 1):
+            try:
+                print(f"Downloading {url} to {target} (attempt {i})")
+                _download(url, target)
+                break
+            except Exception as exc:  # noqa: PERF203
+                last_exc = exc
+                if i < attempts:
+                    print(f"Attempt {i} failed: {exc}, retrying...")
+                else:
+                    print(f"ERROR: could not download {url}: {exc}")
+                    if target.exists():
+                        try:
+                            target.unlink()
+                        except Exception:
+                            pass
+    if last_exc:
+        raise last_exc
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", nargs="?", default="117M", help="GPT-2 model size")
+    parser.add_argument("--dest", type=Path, default=Path("models"), help="Target directory")
+    args = parser.parse_args()
+    try:
+        download_openai_gpt2(args.model, args.dest)
+    except Exception as exc:
+        sys.exit(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_download_openai_gpt2.py
+++ b/tests/test_download_openai_gpt2.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+from pathlib import Path
+
+import pytest
+
+import scripts.download_openai_gpt2 as dg
+
+
+def test_model_urls() -> None:
+    urls = dg.model_urls("124M")
+    prefix = "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/"
+    assert urls[0].startswith(prefix)
+    assert urls[-1].endswith("vocab.bpe")
+
+
+@pytest.mark.skipif(os.getenv("PYTEST_NET_OFF") == "1", reason="network disabled")  # type: ignore[misc]
+def test_download_invocation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, Path]] = []
+
+    def fake_download(url: str, dest: Path) -> None:
+        calls.append((url, dest))
+        dest.write_text("stub")
+
+    monkeypatch.setattr(dg, "_download", fake_download)
+    dg.download_openai_gpt2("117M", dest=tmp_path)
+    assert len(calls) == len(dg._FILE_LIST)
+    assert calls[0][0] == dg.model_urls("117M")[0]


### PR DESCRIPTION
## Summary
- add helper script to fetch GPT-2 checkpoints from OpenAI
- document usage of `download_openai_gpt2.py`
- mention new script in the browser demo README
- test URL generation and patched download logic

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError during test collection)*
- `SKIP=verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-backend-requirements-lock,verify-era-experience-requirements-lock,verify-mats-demo-lock,verify-mats-requirements-lock,verify-aiga-requirements-lock,verify-disclaimer-helper,verify-gallery-assets pre-commit run --files scripts/download_openai_gpt2.py tests/test_download_openai_gpt2.py README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68669c17acfc8333914e340fe7d85dd1