### PR TITLE
Add SPDX headers across tests

### DIFF
--- a/alpha_factory_v1/backend/services/__init__.py
+++ b/alpha_factory_v1/backend/services/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Service helpers for the orchestrator."""
 
 __all__ = ["APIServer", "KafkaService", "MetricsExporter"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/dgm_import.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/dgm_import.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Compatibility wrapper for :mod:`alpha_factory_v1.core.tools.dgm_import`."""
 
 from warnings import warn

--- a/alpha_factory_v1/tests/test_queue_cross_alpha.py
+++ b/alpha_factory_v1/tests/test_queue_cross_alpha.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer

--- a/tests/resources/alpha_factory_v1/__init__.py
+++ b/tests/resources/alpha_factory_v1/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1 import *  # noqa: F403

--- a/tests/resources/alpha_factory_v1/demos/__init__.py
+++ b/tests/resources/alpha_factory_v1/demos/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.demos import *  # noqa: F403

--- a/tests/resources/alpha_factory_v1/demos/utils/__init__.py
+++ b/tests/resources/alpha_factory_v1/demos/utils/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.utils.disclaimer import *  # noqa: F403

--- a/tests/resources/openai_agents.py
+++ b/tests/resources/openai_agents.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 class OpenAIAgent:
     def __init__(self, *a: object, **_k: object) -> None:
         pass

--- a/tests/resources/rocketry/__init__.py
+++ b/tests/resources/rocketry/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 class Rocketry:
     pass
 

--- a/tests/resources/rocketry/conds.py
+++ b/tests/resources/rocketry/conds.py
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 def every(*_args, **_kwargs):
     return None

--- a/tests/resources/sentence_transformers.py
+++ b/tests/resources/sentence_transformers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 class SentenceTransformer:
     def __init__(self, *a, **k):
         pass

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib
 import os
 import sys

--- a/tests/test_agent_manager_consumer.py
+++ b/tests/test_agent_manager_consumer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import pytest
 from alpha_factory_v1.backend.agent_manager import AgentManager

--- a/tests/test_api_server_service.py
+++ b/tests/test_api_server_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ async def test_api_server_start_stop(monkeypatch):
 
         async def sleeper():
             await asyncio.sleep(0)
+
         task = asyncio.create_task(sleeper())
         server = SimpleNamespace(stop=lambda code=0: events.append("stop"))
         return task, server

--- a/tests/test_eventbus.py
+++ b/tests/test_eventbus.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
 import sys
@@ -18,6 +19,7 @@ backend_pkg = types.ModuleType("alpha_factory_v1.backend")
 backend_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "alpha_factory_v1/backend")]
 sys.modules.setdefault("alpha_factory_v1.backend", backend_pkg)
 
+
 class _M:
     def labels(self, *a, **kw):
         return self
@@ -27,6 +29,7 @@ class _M:
 
     def inc(self, *a, **kw):
         pass
+
 
 dummy_registry.get_metric = lambda *a, **kw: _M()
 sys.modules.setdefault("alpha_factory_v1.backend.metrics_registry", dummy_registry)

--- a/tests/test_failed_agent_discovery.py
+++ b/tests/test_failed_agent_discovery.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for failed agent discovery handling."""
 
 from __future__ import annotations

--- a/tests/test_kafka_service.py
+++ b/tests/test_kafka_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.backend.services.kafka_service import KafkaService
 
 

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.backend.services.metrics_service import MetricsExporter
 
 

--- a/tests/test_orchestrator_utils.py
+++ b/tests/test_orchestrator_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from alpha_factory_v1.backend import orchestrator_utils
 from alpha_factory_v1.backend import demo_orchestrator
 from alpha_factory_v1.core import orchestrator as core_orchestrator

--- a/tests/test_register_mesh_backoff.py
+++ b/tests/test_register_mesh_backoff.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import types
 import pytest

--- a/tests/test_wealth_projection.py
+++ b/tests/test_wealth_projection.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from alpha_factory_v1.core.finance.wealth_projection import projection_from_json


### PR DESCRIPTION
## Summary
- add missing Apache 2.0 SPDX headers in service helpers and insight demo
- prepend headers in numerous test modules

## Testing
- `pre-commit run --files alpha_factory_v1/backend/services/__init__.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/tools/dgm_import.py alpha_factory_v1/tests/test_queue_cross_alpha.py tests/resources/alpha_factory_v1/__init__.py tests/resources/alpha_factory_v1/demos/__init__.py tests/resources/alpha_factory_v1/demos/utils/__init__.py tests/resources/openai_agents.py tests/resources/rocketry/__init__.py tests/resources/rocketry/conds.py tests/resources/sentence_transformers.py tests/test_agent_factory.py tests/test_agent_manager_consumer.py tests/test_api_server_service.py tests/test_eventbus.py tests/test_failed_agent_discovery.py tests/test_kafka_service.py tests/test_metrics_service.py tests/test_orchestrator_utils.py tests/test_register_mesh_backoff.py tests/test_wealth_projection.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bda7c4888333b12762929eb17b37