### PR TITLE
[alpha_factory] fix wasm asset mirror note

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide
 
 ```bash
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
-export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/misc/wasm-gpt2.tar"
+export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/"
+```
+
+If `npm run fetch-assets` fails with '401 Unauthorized', set `WASM_GPT2_URL` to the official OpenAI link shown above.
+Example:
+```bash
+WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/" npm run fetch-assets
 ```
 
 See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py`.
@@ -1170,7 +1176,7 @@ for instructions and example volume mounts.
 | `MAX_RESULTS` | `100` | Maximum stored simulation results. |
 | `MAX_SIM_TASKS` | `4` | Maximum concurrent simulation tasks. |
 | `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for IPFS downloads used by `npm run fetch-assets`. Override with `IPFS_GATEWAY=<url> npm run fetch-assets`. |
-| `OPENAI_GPT2_URL` | `https://openaipublic.blob.core.windows.net/misc/wasm-gpt2.tar` | Fallback URL for the `wasm-gpt2` model tried when Hugging Face mirrors fail. |
+| `OPENAI_GPT2_URL` | `https://openaipublic.blob.core.windows.net/gpt-2/models/117M/` | Fallback URL for the `wasm-gpt2` model tried when Hugging Face mirrors fail. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |
 | `ALPHA_FACTORY_ADK_PORT` | `9000` | Port for the ADK gateway when enabled. |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -76,7 +76,13 @@ finally the configured gateway. Set `WASM_GPT2_URL` to override the list or
 
 ```bash
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
-export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/misc/wasm-gpt2.tar"
+export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/"
+```
+
+If `npm run fetch-assets` fails with '401 Unauthorized', set `WASM_GPT2_URL` to the official OpenAI link shown above.
+Example:
+```bash
+WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/" npm run fetch-assets
 ```
 
 Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` or


### PR DESCRIPTION
## Summary
- point `OPENAI_GPT2_URL` at the official GPT‑2 117M location
- add troubleshooting note for `npm run fetch-assets`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6866d8cbf760833396a4626f4b101be9