### PR TITLE
Fix wasm-gpt2 mirror path

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -76,13 +76,13 @@ finally the configured gateway. Set `WASM_GPT2_URL` to override the list or
 
 ```bash
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
-export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/"
+export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar"
 ```
 
 If `npm run fetch-assets` fails with '401 Unauthorized', set `WASM_GPT2_URL` to the official OpenAI link shown above.
 Example:
 ```bash
-WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/" npm run fetch-assets
+WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar" npm run fetch-assets
 ```
 
 Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` or


### PR DESCRIPTION
## Summary
- correct OpenAI mirror example for `wasm-gpt2.tar`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md`
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6866e40ae77883338db835cd772a0c70