### PR TITLE
[alpha_factory] Add GPT-2 small CLI demo

### DIFF
--- a/alpha_factory_v1/demos/gpt2_small_cli/README.md
+++ b/alpha_factory_v1/demos/gpt2_small_cli/README.md
@@ -1,0 +1,12 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# GPT‑2 Small CLI Demo
+
+This minimal example downloads the official OpenAI GPT‑2 117M checkpoint using
+`scripts/download_openai_gpt2.py` if it is not already present and then runs a
+short text generation using the Hugging Face `transformers` library.
+
+```bash
+python -m alpha_factory_v1.demos.gpt2_small_cli --prompt "The future of AI" --max-length 50
+```

--- a/alpha_factory_v1/demos/gpt2_small_cli/__init__.py
+++ b/alpha_factory_v1/demos/gpt2_small_cli/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Simple GPT-2 small command-line demo."""
+
+__version__ = "0.1.0"

--- a/alpha_factory_v1/demos/gpt2_small_cli/__main__.py
+++ b/alpha_factory_v1/demos/gpt2_small_cli/__main__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Entry point for the GPT-2 small CLI demo."""
+from __future__ import annotations
+
+from ..utils.disclaimer import print_disclaimer
+from .gpt2_cli import main
+
+
+if __name__ == "__main__":
+    print_disclaimer()
+    main()

--- a/alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py
+++ b/alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+#!/usr/bin/env python3
+"""Interactive GPT-2 small demo.
+
+This module downloads the official GPT-2 117M model using
+``scripts/download_openai_gpt2.py`` if necessary and generates text
+with the Hugging Face ``transformers`` library.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+MODEL_NAME = "117M"
+MODEL_DIR = Path(__file__).resolve().parent / "models"
+
+
+def ensure_model() -> None:
+    """Ensure the checkpoint files are available."""
+    dest = MODEL_DIR / MODEL_NAME
+    if dest.exists():
+        return
+    script = Path(__file__).resolve().parents[2] / "scripts" / "download_openai_gpt2.py"
+    subprocess.run([sys.executable, str(script), MODEL_NAME, "--dest", str(MODEL_DIR)], check=True)
+
+
+def generate(prompt: str, max_length: int) -> str:
+    """Generate text from the prompt using GPT-2."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
+
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    model = AutoModelForCausalLM.from_pretrained("gpt2")
+    inputs = tokenizer(prompt, return_tensors="pt")
+    tokens = model.generate(
+        **inputs,
+        max_length=max_length,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+    return tokenizer.decode(tokens[0], skip_special_tokens=True)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run a small GPT-2 generation demo")
+    parser.add_argument("--prompt", default="Hello, world!", help="Input prompt")
+    parser.add_argument("--max-length", type=int, default=50, help="Maximum output length")
+    args = parser.parse_args(argv)
+    ensure_model()
+    output = generate(args.prompt, args.max_length)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gpt2_cli_demo.py
+++ b/tests/test_gpt2_cli_demo.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the GPT-2 small CLI demo."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("transformers")
+
+SCRIPT = Path("alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py")
+
+
+def test_gpt2_cli_help() -> None:
+    result = subprocess.run([sys.executable, str(SCRIPT), "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()
+
+
+def test_generate_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+    import alpha_factory_v1.demos.gpt2_small_cli.gpt2_cli as mod
+
+    class FakeTokenizer:
+        eos_token_id = 0
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def __call__(self, text: str, return_tensors: str = "pt") -> dict[str, list[int]]:
+            return {"input_ids": [0]}
+
+        def decode(self, ids: list[int], skip_special_tokens: bool = True) -> str:
+            return "output"
+
+    class FakeModel:
+        @classmethod
+        def from_pretrained(cls, name: str) -> "FakeModel":
+            return cls()
+
+        def generate(self, **kwargs: object) -> list[list[int]]:
+            return [[0]]
+
+    monkeypatch.setattr("transformers.AutoTokenizer", FakeTokenizer, raising=False)
+    monkeypatch.setattr("transformers.AutoModelForCausalLM", FakeModel, raising=False)
+
+    result = mod.generate("hi", 5)
+    assert result == "output"


### PR DESCRIPTION
## Summary
- add a minimal GPT-2 small command line demo
- include README instructions and entry point
- add unit tests with transformer mocks

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_gpt2_cli_demo.py -q`
- `pre-commit run --files alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py alpha_factory_v1/demos/gpt2_small_cli/__init__.py alpha_factory_v1/demos/gpt2_small_cli/README.md alpha_factory_v1/demos/gpt2_small_cli/__main__.py tests/test_gpt2_cli_demo.py` *(fails: mypy unused-ignore; requirements.lock outdated)*

------
https://chatgpt.com/codex/tasks/task_e_6866e7a5dfc0833388f01fd755f2169b