### PR TITLE
[alpha_factory] update wasm download defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 **Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` (or set `AF_GALLERY_URL` to your own mirror) for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
-**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official mirror and falls back to OpenAI's storage then the configured gateway. Set `WASM_GPT2_URL` to override the source or `OPENAI_GPT2_URL` to customize the fallback, for example:
+**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official mirror and falls back to the OpenAI link shown below when other mirrors fail. Set `WASM_GPT2_URL` to override the list of mirrors or `OPENAI_GPT2_URL` to change the fallback URL, for example:
 
 ```bash
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -72,7 +72,7 @@ before installing dependencies. The script invokes
 `scripts/fetch_assets.py` under the hood, which retrieves `wasm-gpt2.tar`
 from the OpenAI mirror first, then falls back to the Hugging Face link and
 finally the configured gateway. Set `WASM_GPT2_URL` to override the list or
-`OPENAI_GPT2_URL` to change the primary mirror, for example:
+`OPENAI_GPT2_URL` to change the fallback URL, for example:
 
 ```bash
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -13,6 +13,7 @@ import requests  # type: ignore[import-untyped]
 from tqdm import tqdm
 
 _DEFAULT_URLS = [
+    "https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar",
     "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
     "https://raw.githubusercontent.com/huggingface/transformers.js/main/weights/wasm/wasm-gpt2.tar",
     "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -222,12 +222,11 @@ def main() -> None:
             if rel == "lib/bundle.esm.min.js":
                 fallback = "https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js"  # noqa: E501
             elif rel == "wasm_llm/wasm-gpt2.tar":
-                ipfs_fallback = f"{GATEWAY}/{WASM_GPT2_CID}?download=1"
+                fallback_url = OPENAI_GPT2_URL
                 last_exc = None
                 for url in OFFICIAL_WASM_GPT2_URLS:
                     try:
-                        fb = OPENAI_GPT2_URL if "huggingface" in url else ipfs_fallback
-                        download_with_retry(url, dest, fb, label=rel)
+                        download_with_retry(url, dest, fallback_url, label=rel)
                         break
                     except Exception as exc:
                         last_exc = exc


### PR DESCRIPTION
## Summary
- set openaipublic mirror as default and fallback in scripts
- document OPENAI_GPT2_URL and WASM_GPT2_URL usage
- test `_resolve_url` fallback in wasm download helper

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md scripts/download_wasm_gpt2.py scripts/fetch_assets.py tests/test_download_openai_gpt2.py` *(fails: requirements.lock is outdated)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6866f53d9184833393ea96ca3c6aac2f