### PR TITLE
Add env hints for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,10 @@ jobs:
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
       IPFS_GATEWAY: https://w3s.link/ipfs
+      # Optional environment variables for asset downloads. See
+      # scripts/fetch_assets.py for details.
+      # WASM_GPT2_URL can mirror the wasm-gpt2 model archive and
+      # OPENAI_GPT2_URL overrides the fallback OpenAI location.
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
+++ b/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
@@ -13,6 +13,8 @@ This sprint explains how Codex can publish the **Alpha-Factory** demo gallery to
    python scripts/edge_human_knowledge_pages_sprint.py
    ```
    This triggers `edge_of_knowledge_sprint.sh` which performs environment validation, dependency checks, README disclaimer verification, asset builds, integrity tests and finally deploys the site via `mkdocs gh-deploy`.
+   Export `IPFS_GATEWAY`, `WASM_GPT2_URL` or `OPENAI_GPT2_URL` beforehand to
+   customize asset downloads if the defaults fail.
 3. Visit the printed URL in an incognito window and ensure `index.html` links to every demo with preview media.
 
 ## Maintenance


### PR DESCRIPTION
## Summary
- document asset mirror variables in docs workflow
- note optional IPFS_GATEWAY/WASM_GPT2_URL/OPENAI_GPT2_URL for docs script

## Testing
- `pre-commit run --files .github/workflows/docs.yml docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686702656dfc8333b0c517c4f34a51c8