### PR TITLE
[alpha_factory] update GPT-2 mirror URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide
 
 ```bash
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
-export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar"
+export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar"
 ```
 
 If `npm run fetch-assets` fails with '401 Unauthorized', set `WASM_GPT2_URL` to the official OpenAI link shown above.
 Example:
 ```bash
-WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar" npm run fetch-assets
+WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
 ```
 
 See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py`.
@@ -1176,7 +1176,7 @@ for instructions and example volume mounts.
 | `MAX_RESULTS` | `100` | Maximum stored simulation results. |
 | `MAX_SIM_TASKS` | `4` | Maximum concurrent simulation tasks. |
 | `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for IPFS downloads used by `npm run fetch-assets`. Override with `IPFS_GATEWAY=<url> npm run fetch-assets`. |
-| `OPENAI_GPT2_URL` | `https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar` | Fallback URL for the `wasm-gpt2` model tried when Hugging Face mirrors fail. |
+| `OPENAI_GPT2_URL` | `https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar` | Fallback URL for the `wasm-gpt2` model tried when Hugging Face mirrors fail. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |
 | `ALPHA_FACTORY_ADK_PORT` | `9000` | Port for the ADK gateway when enabled. |
@@ -1206,10 +1206,10 @@ If `scripts/fetch_assets.py` or `npm run fetch-assets` returns `401` or `404`,
 explicitly set `OPENAI_GPT2_URL` to the public OpenAI mirror and try again:
 
 ```bash
-OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar" \
+OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" \
     python scripts/fetch_assets.py
 # or
-OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar" npm run fetch-assets
+OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
 ```
 
 For a production-ready ADK setup see

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -76,13 +76,13 @@ finally the configured gateway. Set `WASM_GPT2_URL` to override the list or
 
 ```bash
 export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
-export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar"
+export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar"
 ```
 
 If `npm run fetch-assets` fails with '401 Unauthorized', set `WASM_GPT2_URL` to the official OpenAI link shown above.
 Example:
 ```bash
-WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar" npm run fetch-assets
+WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
 ```
 
 Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` or

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -13,7 +13,7 @@ import requests  # type: ignore[import-untyped]
 from tqdm import tqdm
 
 _DEFAULT_URLS = [
-    "https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar",
+    "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar",
     "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
     "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",
 ]

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -29,7 +29,7 @@ WASM_GPT2_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
 # they are tried in order separated by commas.
 OPENAI_GPT2_URL = os.environ.get(
     "OPENAI_GPT2_URL",
-    "https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar",
+    "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar",
 )
 _DEFAULT_WASM_GPT2_URLS = [
     OPENAI_GPT2_URL,
@@ -147,7 +147,7 @@ def download_with_retry(
                     print(
                         "Download returned HTTP"
                         f" {status}. Set OPENAI_GPT2_URL to"
-                        " https://openaipublic.blob.core.windows.net/gpt-2/models/117M/wasm-gpt2.tar"
+                        " https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar"
                         " or another mirror"
                     )
             for alt in alt_urls:


### PR DESCRIPTION
## Summary
- update docs and fetch scripts to reference the 124M GPT‑2 mirror
- adjust Insight browser readme accordingly

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pyyaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(errors: ImportError: cannot import name 'research_agent')*
- `pre-commit run --hook-stage manual --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md scripts/download_wasm_gpt2.py scripts/fetch_assets.py` *(failed: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68670aa317948333bbf30779301e9d38