### PR TITLE
[alpha_factory] default GPT-2 124M

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example:
 WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
 ```
 
-See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py`.
+See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py 124M`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 
@@ -103,7 +103,7 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
-Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror, then tries the OpenAI fallback and finally IPFS. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py` to fetch the model directly.
+Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror, then tries the OpenAI fallback and finally IPFS. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py 124M` to fetch the model directly.
 
 `fetch_assets.py` honors the `IPFS_GATEWAY` environment variable when downloading assets from IPFS. If the default gateway is unreachable, set it before running the helper:
 

--- a/alpha_factory_v1/demos/gpt2_small_cli/README.md
+++ b/alpha_factory_v1/demos/gpt2_small_cli/README.md
@@ -3,7 +3,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 # GPT‑2 Small CLI Demo
 
-This minimal example downloads the official OpenAI GPT‑2 117M checkpoint using
+This minimal example downloads the official OpenAI GPT‑2 124M checkpoint using
 `scripts/download_openai_gpt2.py`. The weights are converted to the Hugging Face
 format via `scripts/convert_openai_gpt2.py` on first run. If PyTorch is
 unavailable, the demo falls back to the hosted `gpt2` model from the

--- a/alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py
+++ b/alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Interactive GPT‑2 small demo.
 
-This module downloads the official GPT‑2 117M checkpoint from
+This module downloads the official GPT‑2 124M checkpoint from
 OpenAI if it is not already present and then generates text.
 
 The demo prefers the locally converted PyTorch weights when
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path
 
 
-MODEL_NAME = "117M"
+MODEL_NAME = "124M"
 MODEL_DIR = Path(__file__).resolve().parent / "models"
 
 

--- a/scripts/download_openai_gpt2.py
+++ b/scripts/download_openai_gpt2.py
@@ -9,7 +9,7 @@ import argparse
 import sys
 from pathlib import Path
 
-import requests  # type: ignore
+import requests
 from tqdm import tqdm
 
 
@@ -41,7 +41,7 @@ def _download(url: str, dest: Path) -> None:
                     bar.update(len(chunk))
 
 
-def download_openai_gpt2(model: str = "117M", dest: Path | str = "models", attempts: int = 3) -> None:
+def download_openai_gpt2(model: str = "124M", dest: Path | str = "models", attempts: int = 3) -> None:
     dest_dir = Path(dest) / model
     urls = model_urls(model)
     last_exc: Exception | None = None
@@ -72,7 +72,7 @@ def download_openai_gpt2(model: str = "117M", dest: Path | str = "models", attem
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("model", nargs="?", default="117M", help="GPT-2 model size")
+    parser.add_argument("model", nargs="?", default="124M", help="GPT-2 model size")
     parser.add_argument("--dest", type=Path, default=Path("models"), help="Target directory")
     args = parser.parse_args()
     try:

--- a/tests/test_download_openai_gpt2.py
+++ b/tests/test_download_openai_gpt2.py
@@ -27,34 +27,34 @@ def test_download_invocation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
         dest.write_text("stub")
 
     monkeypatch.setattr(dg, "_download", fake_download)
-    dg.download_openai_gpt2("117M", dest=tmp_path)
+    dg.download_openai_gpt2("124M", dest=tmp_path)
     assert len(calls) == len(dg._FILE_LIST)
-    assert calls[0][0] == dg.model_urls("117M")[0]
+    assert calls[0][0] == dg.model_urls("124M")[0]
 
 
 def test_download_file_success(tmp_path: Path, requests_mock: "requests_mock.Mocker") -> None:
     monkeypatch_file_list = ["dummy.txt"]
-    url = dg.model_urls("117M")[0].replace("checkpoint", "dummy.txt")
+    url = dg.model_urls("124M")[0].replace("checkpoint", "dummy.txt")
     requests_mock.get(url, text="ok")
 
     dest_dir = tmp_path / "models"
     with pytest.MonkeyPatch.context() as m:
         m.setattr(dg, "_FILE_LIST", monkeypatch_file_list)
-        dg.download_openai_gpt2("117M", dest=dest_dir)
+        dg.download_openai_gpt2("124M", dest=dest_dir)
 
-    assert (dest_dir / "117M" / "dummy.txt").read_text() == "ok"
+    assert (dest_dir / "124M" / "dummy.txt").read_text() == "ok"
 
 
 def test_download_error(tmp_path: Path, requests_mock: "requests_mock.Mocker") -> None:
     monkeypatch_file_list = ["dummy.txt"]
-    url = dg.model_urls("117M")[0].replace("checkpoint", "dummy.txt")
+    url = dg.model_urls("124M")[0].replace("checkpoint", "dummy.txt")
     requests_mock.get(url, status_code=404)
 
     dest_dir = tmp_path / "models"
     with pytest.MonkeyPatch.context() as m:
         m.setattr(dg, "_FILE_LIST", monkeypatch_file_list)
         with pytest.raises(Exception):
-            dg.download_openai_gpt2("117M", dest=dest_dir, attempts=1)
+            dg.download_openai_gpt2("124M", dest=dest_dir, attempts=1)
 
 
 def test_resolve_url_fallback(monkeypatch: pytest.MonkeyPatch, requests_mock: "requests_mock.Mocker") -> None:


### PR DESCRIPTION
## Summary
- switch GPT-2 utilities and demo to use the 124M model
- update test expectations
- reference the new model in README files

## Testing
- `pytest -q tests/test_download_openai_gpt2.py`
- `pre-commit run --files scripts/download_openai_gpt2.py alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py tests/test_download_openai_gpt2.py README.md` *(skipping verify requirements and gallery hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68671522366c8333badf9d9b9248c821