### PR TITLE
[alpha_factory] update wasm-gpt2 mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The GitHub Pages site hosts the interactive demo under the `alpha_agi_insight_v1
 **Explore all demos:** <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_factory_v1/demos/> – run `./scripts/open_subdir_gallery.py` (or set `AF_GALLERY_URL` to your own mirror) for a local or online launch. Alternatively execute `make subdir-gallery-open` to build the gallery if needed and open it automatically.
 All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide simulation directly in your browser or switch to **OpenAI API** when you provide a key. The key is stored only in memory.
 
-**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the official mirror and falls back to the OpenAI link shown below when other mirrors fail. Set `WASM_GPT2_URL` to override the list of mirrors or `OPENAI_GPT2_URL` to change the fallback URL, for example:
+**Important:** Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the browser demo assets. The helper fetches `wasm-gpt2.tar` from the canonical IPFS mirror and falls back to the OpenAI URL shown below when other mirrors fail. Set `WASM_GPT2_URL` to override the list of mirrors or `OPENAI_GPT2_URL` to change the fallback URL, for example:
 
 ```bash
-export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
+export WASM_GPT2_URL="https://w3s.link/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
 export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar"
 ```
 
-If `npm run fetch-assets` fails with '401 Unauthorized', set `WASM_GPT2_URL` to the official OpenAI link shown above.
+If `npm run fetch-assets` fails with a 401 or 404 error, explicitly set `WASM_GPT2_URL` to the official OpenAI link shown above.
 Example:
 ```bash
 WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
@@ -1176,7 +1176,7 @@ for instructions and example volume mounts.
 | `MAX_RESULTS` | `100` | Maximum stored simulation results. |
 | `MAX_SIM_TASKS` | `4` | Maximum concurrent simulation tasks. |
 | `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for IPFS downloads used by `npm run fetch-assets`. Override with `IPFS_GATEWAY=<url> npm run fetch-assets`. |
-| `OPENAI_GPT2_URL` | `https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar` | Fallback URL for the `wasm-gpt2` model tried when Hugging Face mirrors fail. |
+| `OPENAI_GPT2_URL` | `https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar` | Fallback URL for the `wasm-gpt2` model when IPFS mirrors fail. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |
 | `ALPHA_FACTORY_ADK_PORT` | `9000` | Port for the ADK gateway when enabled. |
@@ -1203,7 +1203,7 @@ Use whichever mirror is fastest in your region.
 #### Troubleshooting Asset Downloads
 
 If `scripts/fetch_assets.py` or `npm run fetch-assets` returns `401` or `404`,
-explicitly set `OPENAI_GPT2_URL` to the public OpenAI mirror and try again:
+explicitly set `OPENAI_GPT2_URL` to the OpenAI fallback URL and try again:
 
 ```bash
 OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" \

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -70,16 +70,16 @@ is missing the build scripts continue with default empty values:
 Run `npm run fetch-assets` to download the Pyodide runtime and local model
 before installing dependencies. The script invokes
 `scripts/fetch_assets.py` under the hood, which retrieves `wasm-gpt2.tar`
-from the OpenAI mirror first, then falls back to the Hugging Face link and
+from the canonical IPFS mirror first, then falls back to the OpenAI URL and
 finally the configured gateway. Set `WASM_GPT2_URL` to override the list or
 `OPENAI_GPT2_URL` to change the fallback URL, for example:
 
 ```bash
-export WASM_GPT2_URL="https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1"
+export WASM_GPT2_URL="https://w3s.link/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
 export OPENAI_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar"
 ```
 
-If `npm run fetch-assets` fails with '401 Unauthorized', set `WASM_GPT2_URL` to the official OpenAI link shown above.
+If `npm run fetch-assets` fails with a 401 or 404 error, set `WASM_GPT2_URL` to the official OpenAI link shown above.
 Example:
 ```bash
 WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
@@ -132,8 +132,8 @@ offline run:
 npm run fetch-assets
 ```
 
-This downloads the Pyodide runtime and `wasm-gpt2` model from the OpenAI
-mirror first, then the Hugging Face mirror and finally the configured IPFS
+This downloads the Pyodide runtime and `wasm-gpt2` model from the IPFS
+mirror first, then the OpenAI fallback and finally the configured
 gateway. Assets land in `wasm/` and `wasm_llm/`.
 It also retrieves `lib/bundle.esm.min.js` from the mirror. You may instead run
 `python ../../../../scripts/download_wasm_gpt2.py` or
@@ -249,7 +249,7 @@ WEB3_STORAGE_TOKEN=<token> npm run fetch-assets
 
 
 The script retrieves the WebAssembly runtime and supporting files from the
-OpenAI mirror first and falls back to the Hugging Face or configured IPFS
+IPFS mirror first and falls back to the OpenAI URL or configured
 gateway, verifying checksums to ensure each asset is intact.
 
 ### Offline Build Steps

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -12,10 +12,12 @@ import os
 import requests  # type: ignore[import-untyped]
 from tqdm import tqdm
 
+WASM_GPT2_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
+
 _DEFAULT_URLS = [
+    f"https://w3s.link/ipfs/{WASM_GPT2_CID}?download=1",
     "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar",
     "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
-    "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",
 ]
 
 

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -32,9 +32,9 @@ OPENAI_GPT2_URL = os.environ.get(
     "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar",
 )
 _DEFAULT_WASM_GPT2_URLS = [
+    f"https://w3s.link/ipfs/{WASM_GPT2_CID}?download=1",
     OPENAI_GPT2_URL,
     "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
-    "https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1",
 ]
 
 


### PR DESCRIPTION
## Summary
- use IPFS as the primary download source for `wasm-gpt2`
- update fetch_assets and helper script with new mirror order
- refresh documentation to mention the IPFS mirror

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*

------
https://chatgpt.com/codex/tasks/task_e_68671b652b388333849a1d446aea3b5a