### PR TITLE
[alpha_factory] add gpt2 small fetch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example:
 WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
 ```
 
-See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py 124M`.
+See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_wasm_gpt2.py`, `python scripts/download_openai_gpt2.py 124M`, or `python scripts/download_gpt2_small.py`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -85,8 +85,9 @@ Example:
 WASM_GPT2_URL="https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar" npm run fetch-assets
 ```
 
-Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py` or
-`python ../../../../scripts/download_openai_gpt2.py` to fetch the GPT‑2 model
+Alternatively, execute `python ../../../../scripts/download_wasm_gpt2.py`,
+`python ../../../../scripts/download_openai_gpt2.py`, or
+`python ../../../../scripts/download_gpt2_small.py` to fetch the GPT‑2 model
 directly.
 
 See [`.env.sample`](.env.sample) for the full list of supported variables.
@@ -96,8 +97,9 @@ to create it before launching the demo.
 ## Build & Run
 Run `npm run fetch-assets` **before installing dependencies** to download the
 Pyodide runtime and `wasm-gpt2` model, then install the Node modules.
-`python ../../../../scripts/download_wasm_gpt2.py` or
-`python ../../../../scripts/download_openai_gpt2.py` can also fetch the model
+`python ../../../../scripts/download_wasm_gpt2.py`,
+`python ../../../../scripts/download_openai_gpt2.py`, or
+`python ../../../../scripts/download_gpt2_small.py` can also fetch the model
 directly if you prefer,
 compile the bundle:
 ```bash
@@ -136,8 +138,9 @@ This downloads the Pyodide runtime and `wasm-gpt2` model from the IPFS
 mirror first, then the OpenAI fallback and finally the configured
 gateway. Assets land in `wasm/` and `wasm_llm/`.
 It also retrieves `lib/bundle.esm.min.js` from the mirror. You may instead run
-`python ../../../../scripts/download_wasm_gpt2.py` or
-`python ../../../../scripts/download_openai_gpt2.py` to pull the model
+`python ../../../../scripts/download_wasm_gpt2.py`,
+`python ../../../../scripts/download_openai_gpt2.py`, or
+`python ../../../../scripts/download_gpt2_small.py` to pull the model
 directly. The build and
 `manual_build.py` scripts scan every downloaded asset for the word
 `"placeholder"` and abort when any file still contains that marker.
@@ -173,8 +176,9 @@ Use `manual_build.py` for air‑gapped environments:
 
 1. `cp .env.sample .env` and edit the values if you haven't already, then `chmod 600 .env`.
 2. `npm run fetch-assets` to fetch Pyodide and the GPT‑2 model.
-   Alternatively run `python ../../../../scripts/download_wasm_gpt2.py` or
-   `python ../../../../scripts/download_openai_gpt2.py` to grab
+   Alternatively run `python ../../../../scripts/download_wasm_gpt2.py`,
+   `python ../../../../scripts/download_openai_gpt2.py`, or
+   `python ../../../../scripts/download_gpt2_small.py` to grab
    the model directly from the official IPFS mirror.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.
@@ -193,7 +197,7 @@ If `.env` is absent the script continues with empty defaults rather than abortin
 
 Follow these steps when building without internet access:
 
-1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_wasm_gpt2.py` or `python ../../../../scripts/download_openai_gpt2.py`).
+1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_wasm_gpt2.py`, `python ../../../../scripts/download_openai_gpt2.py`, or `python ../../../../scripts/download_gpt2_small.py`).
 2. Verify checksums match `build_assets.json` and ensure no files under
    `wasm/` or `lib/` contain the word "placeholder".
 3. `npm ci` to install the locked dependencies.
@@ -205,7 +209,7 @@ Failing to replace placeholders will break offline mode.
 ### Offline build checklist
 
 1. Run `npm run fetch-assets`.
-   (`python ../../../../scripts/download_wasm_gpt2.py` or `python ../../../../scripts/download_openai_gpt2.py` also works.)
+   (`python ../../../../scripts/download_wasm_gpt2.py`, `python ../../../../scripts/download_openai_gpt2.py`, or `python ../../../../scripts/download_gpt2_small.py` also works.)
 2. `npm ci` to install dependencies from `package-lock.json`.
 3. Confirm no placeholder text remains in `lib/` or `wasm*/`.
 4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`. Use

--- a/alpha_factory_v1/demos/gpt2_small_cli/README.md
+++ b/alpha_factory_v1/demos/gpt2_small_cli/README.md
@@ -4,7 +4,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 # GPT‑2 Small CLI Demo
 
 This minimal example downloads the official OpenAI GPT‑2 124M checkpoint using
-`scripts/download_openai_gpt2.py`. The weights are converted to the Hugging Face
+`scripts/download_openai_gpt2.py` (or `scripts/download_gpt2_small.py`). The weights are converted to the Hugging Face
 format via `scripts/convert_openai_gpt2.py` on first run. If PyTorch is
 unavailable, the demo falls back to the hosted `gpt2` model from the
 `transformers` hub.

--- a/scripts/download_gpt2_small.py
+++ b/scripts/download_gpt2_small.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# See docs/DISCLAIMER_SNIPPET.md
+"""Retrieve the 124M GPT-2 checkpoint from OpenAI's public storage."""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+OPENAI_REPO = "https://github.com/openai/gpt-2.git"
+
+
+def download_model(dest: Path, model: str = "124M") -> None:
+    """Download GPT-2 weights using the official helper script."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        subprocess.run(["git", "clone", "--depth", "1", OPENAI_REPO, str(tmp_path)], check=True)
+        script = tmp_path / "download_model.py"
+        subprocess.run([sys.executable, str(script), model], cwd=tmp_path, check=True)
+        target = dest / model
+        target.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(tmp_path / "models" / model, target, dirs_exist_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dest", type=Path, nargs="?", default=Path("models"), help="Target directory")
+    parser.add_argument("--model", default="124M", help="GPT-2 model size")
+    args = parser.parse_args()
+
+    try:
+        download_model(args.dest, args.model)
+    except Exception as exc:
+        sys.exit(str(exc))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- include helper script `download_gpt2_small.py` to fetch GPT‑2 124M directly from OpenAI
- document the new script in various READMEs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_adapters.py, tests/test_agent_runner.py, tests/test_alert_webhook.py, tests/test_cli.py, tests/test_cli_runner_ext.py, tests/test_demo_cli.py, tests/test_download_openai_gpt2.py, tests/test_evaluate_econ.py, tests/test_evolution_worker.py, tests/test_evolution_worker_safe_extract.py, tests/test_experiments.py, tests/test_fetch_assets.py, tests/test_insight_api_server.py)*

------
https://chatgpt.com/codex/tasks/task_e_68671e1616b48333a84c9833a0552c69