### PR TITLE
refactor: use official GPT-2 mirror

### DIFF
--- a/scripts/download_gpt2_small.py
+++ b/scripts/download_gpt2_small.py
@@ -5,25 +5,15 @@
 from __future__ import annotations
 
 import argparse
-import shutil
-import subprocess
-import sys
-import tempfile
 from pathlib import Path
+import sys
 
-OPENAI_REPO = "https://github.com/openai/gpt-2.git"
+from scripts import download_openai_gpt2
 
 
 def download_model(dest: Path, model: str = "124M") -> None:
-    """Download GPT-2 weights using the official helper script."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
-        subprocess.run(["git", "clone", "--depth", "1", OPENAI_REPO, str(tmp_path)], check=True)
-        script = tmp_path / "download_model.py"
-        subprocess.run([sys.executable, str(script), model], cwd=tmp_path, check=True)
-        target = dest / model
-        target.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(tmp_path / "models" / model, target, dirs_exist_ok=True)
+    """Download GPT-2 weights using the official OpenAI mirror."""
+    download_openai_gpt2.download_openai_gpt2(model, dest)
 
 
 def main() -> None:
@@ -40,4 +30,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- call official `download_openai_gpt2` mirror in `download_gpt2_small.py`

## Checks
- `pre-commit` *(fails: verify-requirements-lock)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 28 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68672a6f62808333ba35f50e98ab9136