### PR TITLE
[alpha_factory] update wasm gpt2 defaults

### DIFF
--- a/scripts/download_gpt2_small.py
+++ b/scripts/download_gpt2_small.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: Apache-2.0
 # See docs/DISCLAIMER_SNIPPET.md
-"""Retrieve the 124M GPT-2 checkpoint from OpenAI's public storage.
+"""Retrieve the 124M GPT-2 checkpoint.
 
-Files are fetched from ``https://openaipublic.blob.core.windows.net/gpt-2/models/124M/``.
+The script first attempts the official Hugging Face mirror at
+``https://huggingface.co/openai-community/gpt2`` and falls back to the
+OpenAI mirror ``https://openaipublic.blob.core.windows.net/gpt-2`` when
+the Hugging Face download fails.
 """
 from __future__ import annotations
 
@@ -11,11 +14,16 @@ import argparse
 from pathlib import Path
 import sys
 
-from scripts import download_openai_gpt2
+from scripts import download_hf_gpt2, download_openai_gpt2
 
 
 def download_model(dest: Path, model: str = "124M") -> None:
-    """Download GPT-2 weights using the official OpenAI mirror."""
+    """Download GPT-2 weights from Hugging Face with an OpenAI fallback."""
+    try:
+        download_hf_gpt2.download_hf_gpt2(dest / "gpt2")
+        return
+    except Exception as exc:
+        print(f"Hugging Face download failed: {exc}; falling back to OpenAI")
     download_openai_gpt2.download_openai_gpt2(model, dest)
 
 

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -14,10 +14,11 @@ from tqdm import tqdm
 
 WASM_GPT2_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
 
+# Primary Hugging Face URL with OpenAI and IPFS fallbacks.
 _DEFAULT_URLS = [
-    f"https://w3s.link/ipfs/{WASM_GPT2_CID}?download=1",
-    "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar",
     "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
+    "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar",
+    f"https://w3s.link/ipfs/{WASM_GPT2_CID}?download=1",
 ]
 
 

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -34,10 +34,11 @@ if not OPENAI_GPT2_URL:
         "https://openaipublic.blob.core.windows.net/gpt-2/models",
     ).rstrip("/")
     OPENAI_GPT2_URL = f"{base_url}/124M/wasm-gpt2.tar"
+# Official Hugging Face mirror. OpenAI and IPFS remain as fallbacks.
 _DEFAULT_WASM_GPT2_URLS = [
-    f"https://w3s.link/ipfs/{WASM_GPT2_CID}?download=1",
-    OPENAI_GPT2_URL,
     "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
+    OPENAI_GPT2_URL,
+    f"https://w3s.link/ipfs/{WASM_GPT2_CID}?download=1",
 ]
 
 
@@ -89,9 +90,7 @@ def _session() -> requests.Session:
     return s
 
 
-def download(
-    cid: str, path: Path, fallback: str | None = None, label: str | None = None
-) -> None:
+def download(cid: str, path: Path, fallback: str | None = None, label: str | None = None) -> None:
     url = cid if cid.startswith("http") else f"{GATEWAY}/{cid}"
     path.parent.mkdir(parents=True, exist_ok=True)
     try:


### PR DESCRIPTION
## Summary
- fetch wasm-gpt2 from the official Hugging Face mirror first
- do the same in `download_wasm_gpt2.py`
- prefer Hugging Face when downloading GPT‑2 small weights

## Testing
- `pre-commit run --files scripts/fetch_assets.py scripts/download_wasm_gpt2.py scripts/download_gpt2_small.py` *(fails: verify-disclaimer-helper, verify-gallery-assets)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: import errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686757b84bbc8333adc9f4533345ab74