### PR TITLE
[alpha_factory] update GPT-2 download workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
-Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror, then tries the OpenAI fallback and finally IPFS. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_wasm_gpt2.py` or `python scripts/download_openai_gpt2.py 124M` to fetch the model directly.
+Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror, then tries the OpenAI fallback and finally IPFS. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_gpt2_small.py` or `python scripts/download_openai_gpt2.py 124M` to fetch the model directly.
 
 `fetch_assets.py` honors the `IPFS_GATEWAY` environment variable when downloading assets from IPFS. If the default gateway is unreachable, set it before running the helper:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -83,9 +83,8 @@ python ../../../../scripts/download_hf_gpt2.py models/gpt2
 ```
 
 Alternatively, execute `python ../../../../scripts/download_hf_gpt2.py`,
-`python ../../../../scripts/download_wasm_gpt2.py`,
-`python ../../../../scripts/download_openai_gpt2.py`, or
-`python ../../../../scripts/download_gpt2_small.py` to fetch the GPT‑2 model
+`python ../../../../scripts/download_gpt2_small.py`, or
+`python ../../../../scripts/download_openai_gpt2.py` to fetch the GPT‑2 model
 directly.
 
 See [`.env.sample`](.env.sample) for the full list of supported variables.
@@ -171,10 +170,10 @@ Use `manual_build.py` for air‑gapped environments:
 
 1. `cp .env.sample .env` and edit the values if you haven't already, then `chmod 600 .env`.
 2. `npm run fetch-assets` to fetch Pyodide and the GPT‑2 model.
-   Alternatively run `python ../../../../scripts/download_wasm_gpt2.py`,
-   `python ../../../../scripts/download_openai_gpt2.py`, or
-   `python ../../../../scripts/download_gpt2_small.py` to grab
-   the model directly from the official IPFS mirror.
+   Alternatively run `python ../../../../scripts/download_gpt2_small.py`,
+   `python ../../../../scripts/download_openai_gpt2.py` or
+   `python ../../../../scripts/download_hf_gpt2.py` to grab
+   the model directly from the official mirror.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.
 3. Run `node build/version_check.js` to ensure Node.js **v20** or newer is
@@ -192,7 +191,7 @@ If `.env` is absent the script continues with empty defaults rather than abortin
 
 Follow these steps when building without internet access:
 
-1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_wasm_gpt2.py`, `python ../../../../scripts/download_openai_gpt2.py`, or `python ../../../../scripts/download_gpt2_small.py`).
+1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_gpt2_small.py`, `python ../../../../scripts/download_openai_gpt2.py`).
 2. Verify checksums match `build_assets.json` and ensure no files under
    `wasm/` or `lib/` contain the word "placeholder".
 3. `npm ci` to install the locked dependencies.
@@ -204,7 +203,7 @@ Failing to replace placeholders will break offline mode.
 ### Offline build checklist
 
 1. Run `npm run fetch-assets`.
-   (`python ../../../../scripts/download_wasm_gpt2.py`, `python ../../../../scripts/download_openai_gpt2.py`, or `python ../../../../scripts/download_gpt2_small.py` also works.)
+   (`python ../../../../scripts/download_gpt2_small.py` or `python ../../../../scripts/download_openai_gpt2.py` also works.)
 2. `npm ci` to install dependencies from `package-lock.json`.
 3. Confirm no placeholder text remains in `lib/` or `wasm*/`.
 4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`. Use

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py
@@ -72,8 +72,8 @@ def test_llm_offline() -> None:
 
 
 @pytest.mark.skipif(
-    not (Path(__file__).resolve().parents[1] / "wasm_llm" / "wasm-gpt2.tar").exists(),
-    reason="wasm model missing",
+    not (Path(__file__).resolve().parents[1] / "wasm_llm" / "pytorch_model.bin").exists(),
+    reason="model file missing",
 )  # type: ignore[misc]
 def test_llm_offline_pipeline() -> None:
     dist = Path(__file__).resolve().parents[1] / "dist" / "index.html"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -1,19 +1,17 @@
 [See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
-# wasm-gpt2
+# GPT‑2 Small Weights
 
-This folder is intentionally empty. During development the lightweight `wasm-gpt2` model (~124 MB) should be placed here and pinned to IPFS. The build script copies the contents of this directory to `dist/wasm_llm/` so the demo can load the model offline.
-
-To fetch the model automatically, run `npm run fetch-assets` or
-`python ../../../../scripts/fetch_assets.py`.
-The helper retrieves `wasm-gpt2.tar` from the official mirror. Set
-`WASM_GPT2_URL` to override the default URL:
+This directory stores the GPT‑2 124M checkpoint used for offline inference. Run
+`npm run fetch-assets` or `python ../../../../scripts/fetch_assets.py` to
+download the files from the official Hugging Face repository. Set
+`HF_GPT2_BASE_URL` to override the default mirror:
 
 ```bash
-export WASM_GPT2_URL="https://cloudflare-ipfs.com/ipfs/bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku?download=1"
+export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"
 npm run fetch-assets
 ```
 
-The default URL points to the canonical IPFS CID. The script automatically falls
-back to the configured IPFS gateway if the mirror is unavailable.
+After downloading, the build script copies this directory to `dist/wasm_llm/` so
+the browser demo can operate without an internet connection.

--- a/scripts/download_wasm_gpt2.py
+++ b/scripts/download_wasm_gpt2.py
@@ -1,56 +1,19 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: Apache-2.0
-"""Download the wasm-gpt2 model archive from the official mirror.
+"""Download the GPT‑2 small weights used by the browser demo.
 
-Set the ``WASM_GPT2_URL`` environment variable to override the default source.
+This helper mirrors :mod:`scripts.download_hf_gpt2` but defaults to the
+``wasm_llm`` directory so the Insight browser can run offline. The files are
+retrieved from the official Hugging Face repository unless
+``HF_GPT2_BASE_URL`` points to a different mirror.
 """
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
-import os
-import requests  # type: ignore[import-untyped]
-from tqdm import tqdm
+import sys
 
-WASM_GPT2_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
-
-# Primary Hugging Face URL with OpenAI and IPFS fallbacks.
-_DEFAULT_URLS = [
-    "https://huggingface.co/datasets/xenova/wasm-gpt2/resolve/main/wasm-gpt2.tar?download=1",
-    "https://openaipublic.blob.core.windows.net/gpt-2/models/124M/wasm-gpt2.tar",
-    f"https://w3s.link/ipfs/{WASM_GPT2_CID}?download=1",
-]
-
-
-def _resolve_urls() -> list[str]:
-    env = os.environ.get("WASM_GPT2_URL")
-    if env:
-        return [u.strip() for u in env.split(",") if u.strip()]
-    return _DEFAULT_URLS
-
-
-def _resolve_url() -> str:
-    """Return the first reachable download URL for the model."""
-    for url in _resolve_urls():
-        try:
-            r = requests.head(url, timeout=10)
-            r.raise_for_status()
-            return url
-        except Exception:
-            continue
-    raise RuntimeError("No valid download URL found")
-
-
-def fetch(url: str, dest: Path) -> None:
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    with requests.get(url, stream=True, timeout=60) as resp:
-        resp.raise_for_status()
-        total = int(resp.headers.get("Content-Length", 0))
-        with open(dest, "wb") as f, tqdm(total=total, unit="B", unit_scale=True, desc=dest.name) as bar:
-            for chunk in resp.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-                    bar.update(len(chunk))
+from scripts import download_hf_gpt2
 
 
 def main() -> None:
@@ -58,9 +21,9 @@ def main() -> None:
     parser.add_argument(
         "dest",
         nargs="?",
-        default="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/wasm-gpt2.tar",
+        default="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm",
         type=Path,
-        help="Destination file path",
+        help="Destination directory",
     )
     parser.add_argument(
         "--attempts",
@@ -69,30 +32,11 @@ def main() -> None:
         help="Number of download attempts",
     )
     args = parser.parse_args()
-    if args.dest.exists():
-        print(f"{args.dest} already exists, skipping")
-        return
 
-    last_exc: Exception | None = None
-    for i in range(1, args.attempts + 1):
-        try:
-            url = _resolve_url()
-            print(f"Downloading wasm-gpt2 model from {url} to {args.dest}...")
-            fetch(url, args.dest)
-            print("Download complete")
-            return
-        except Exception as exc:  # noqa: PERF203
-            last_exc = exc
-            if i < args.attempts:
-                print(f"Attempt {i} failed: {exc}, retrying...")
-            else:
-                print(f"ERROR: could not download wasm-gpt2 after {args.attempts} attempts: {exc}")
-                print(
-                    "Set WASM_GPT2_URL to a reachable mirror. See README.md "
-                    "for instructions under the 'npm run fetch-assets' section."
-                )
-    if last_exc:
-        raise SystemExit(1) from last_exc
+    try:
+        download_hf_gpt2.download_hf_gpt2(args.dest, attempts=args.attempts)
+    except Exception as exc:
+        sys.exit(str(exc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop wasm-gpt2 archive and fetch small GPT-2 files directly
- update Insight browser docs for new model fetch instructions
- adjust browser offline test for new checkpoint
- clean up download tests

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_browser_ui.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md scripts/download_wasm_gpt2.py tests/test_download_openai_gpt2.py` *(skipped env checks)*
- `python scripts/check_python_deps.py && python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError in alpha_factory_v1.core.agents)*

------
https://chatgpt.com/codex/tasks/task_e_6867c549c288833397a4a67477246e93