### PR TITLE
fix: use HF mirror for CLI model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ docker compose up --build
 ./run_quickstart.sh
 ```
 
-Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper retrieves the GPT‑2 model from the official mirror, then tries the OpenAI fallback and finally IPFS. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can alternatively run `python scripts/download_gpt2_small.py` or `python scripts/download_openai_gpt2.py 124M` to fetch the model directly.
+Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to download the Insight demo assets. The helper fetches the GPT‑2 checkpoint from the official Hugging Face mirror and falls back to OpenAI if necessary. See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for a detailed guide. You can also run `python scripts/download_gpt2_small.py` to retrieve the model directly, or `python scripts/download_openai_gpt2.py 124M` as a last resort.
 
 `fetch_assets.py` honors the `IPFS_GATEWAY` environment variable when downloading assets from IPFS. If the default gateway is unreachable, set it before running the helper:
 

--- a/alpha_factory_v1/demos/gpt2_small_cli/README.md
+++ b/alpha_factory_v1/demos/gpt2_small_cli/README.md
@@ -3,10 +3,10 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 # GPT‑2 Small CLI Demo
 
-This minimal example downloads the official GPT‑2 124M checkpoint from
-Hugging Face with `scripts/download_hf_gpt2.py`. The helper stores the files
-under `models/gpt2`. `scripts/download_openai_gpt2.py` or
-`scripts/download_gpt2_small.py` remain available as fallbacks. The weights are
+This minimal example downloads the official GPT‑2 124M checkpoint using
+`scripts/download_gpt2_small.py`, which first tries the Hugging Face mirror and
+falls back to the OpenAI archive if necessary. Files land under `models/gpt2`.
+`scripts/download_openai_gpt2.py` remains available as a direct fallback. The weights are
 converted to the Hugging Face format via `scripts/convert_openai_gpt2.py` on
 first run. If PyTorch is unavailable, the demo falls back to the hosted `gpt2`
 model from the `transformers` hub.

--- a/alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py
+++ b/alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py
@@ -25,8 +25,8 @@ def ensure_model() -> Path:
     """Ensure the checkpoint files are available and converted."""
     dest = MODEL_DIR / MODEL_NAME
     if not dest.exists():
-        script = Path(__file__).resolve().parents[2] / "scripts" / "download_openai_gpt2.py"
-        subprocess.run([sys.executable, str(script), MODEL_NAME, "--dest", str(MODEL_DIR)], check=True)
+        script = Path(__file__).resolve().parents[2] / "scripts" / "download_gpt2_small.py"
+        subprocess.run([sys.executable, str(script), str(MODEL_DIR), "--model", MODEL_NAME], check=True)
 
     pt_file = dest / "pytorch_model.bin"
     if not pt_file.exists():


### PR DESCRIPTION
## Summary
- download GPT-2 weights via `download_gpt2_small.py`
- mention Hugging Face mirror in CLI README
- clarify asset helper docs

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/gpt2_small_cli/README.md alpha_factory_v1/demos/gpt2_small_cli/gpt2_cli.py` *(fails: verify-requirements-lock)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867cb069bbc8333b46a47531d41ea2b