### PR TITLE
[alpha_factory] verify hf gpt2 weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ curl -O https://huggingface.co/openai-community/gpt2/resolve/main/model.ckpt.ind
 curl -O https://huggingface.co/openai-community/gpt2/resolve/main/model.ckpt.data-00000-of-00001
 curl -O https://huggingface.co/openai-community/gpt2/resolve/main/model.ckpt.meta
 ```
+The consolidated PyTorch weights are also available at:
+`https://huggingface.co/openai-community/gpt2/resolve/main/pytorch_model.bin`
+(SHA-256 `7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421`).
 See [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md) for details. You can also retrieve the model directly with `python scripts/download_hf_gpt2.py` or `python scripts/download_gpt2_small.py`.
 
 [![Launch \u03b1\u2011AGI Insight](https://img.shields.io/badge/Launch-%CE%B1%E2%80%91AGI%20Insight-blue?style=for-the-badge)](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/)

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -55,6 +55,7 @@ CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",  # noqa: E501
     "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",  # noqa: E501
     "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
+    "pytorch_model.bin": "sha256-fF0/S4t2WDtCL8uRia1sidXZeglFQc6JMtzj7KveFCE=",
 }
 
 
@@ -84,8 +85,9 @@ def download(cid: str, path: Path, fallback: str | None = None, label: str | Non
     key = label or path.name
     expected = CHECKSUMS.get(key) or CHECKSUMS.get(path.name)
     if expected:
-        digest = base64.b64encode(hashlib.sha384(data).digest()).decode()
-        if not expected.endswith(digest):
+        algo, b64_hash = expected.split("-", 1)
+        digest = base64.b64encode(getattr(hashlib, algo)(data).digest()).decode()
+        if digest != b64_hash:
             raise RuntimeError(f"Checksum mismatch for {key}")
 
 
@@ -162,8 +164,9 @@ def verify_assets(base: Path) -> list[str]:
             continue
         expected = CHECKSUMS.get(rel) or CHECKSUMS.get(dest.name)
         if expected:
-            digest = base64.b64encode(hashlib.sha384(dest.read_bytes()).digest()).decode()
-            if not expected.endswith(digest):
+            algo, b64_hash = expected.split("-", 1)
+            digest = base64.b64encode(getattr(hashlib, algo)(dest.read_bytes()).digest()).decode()
+            if digest != b64_hash:
                 print(f"Checksum mismatch for {rel}")
                 failures.append(rel)
     return failures


### PR DESCRIPTION
## Summary
- verify HuggingFace GPT‑2 weights during asset download
- mention official GPT‑2 PyTorch link and hash in README

## Testing
- `pre-commit run --files scripts/fetch_assets.py README.md`
- `pytest tests/test_fetch_assets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6867cea6cc188333a8a95d1da313825b