### PR TITLE
[alpha_factory] treat wasm placeholders

### DIFF
--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -189,16 +189,22 @@ def main() -> None:
         return
 
     dl_failures: list[str] = []
+    PLACEHOLDER_ASSETS = {
+        "lib/bundle.esm.min.js",
+        "lib/workbox-sw.js",
+        "wasm/pyodide.js",
+        "wasm/pyodide.asm.wasm",
+        "wasm/pyodide_py.tar",
+        "wasm/packages.json",
+    }
     for rel, cid in ASSETS.items():
         dest = base / rel
-        check_placeholder = rel in {
-            "lib/bundle.esm.min.js",
-            "lib/workbox-sw.js",
-        }
+        check_placeholder = rel in PLACEHOLDER_ASSETS
         placeholder = False
         if dest.exists() and check_placeholder:
             text = dest.read_text(errors="ignore")
-            placeholder = "placeholder" in text.lower()
+            content = text.strip()
+            placeholder = not content or content == "{}" or "placeholder" in content.lower()
         if not dest.exists() or placeholder:
             if placeholder:
                 print(f"Replacing placeholder {rel}...")


### PR DESCRIPTION
## Summary
- trigger download when pyodide placeholder files detected

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files scripts/fetch_assets.py` *(with many hooks skipped)*
- `npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets` *(fails: 504 Gateway Timeout)*
- `bash scripts/edge_of_knowledge_sprint.sh` *(fails: missing docker)*

------
https://chatgpt.com/codex/tasks/task_e_6867df5fb10083338802d6dd6e45a8a0