### PR TITLE
[alpha_factory] Add HTML disclaimer check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,6 +107,11 @@ repos:
         entry: python scripts/verify_gallery_assets.py
         language: python
         pass_filenames: false
+      - id: verify-html-disclaimer
+        name: Verify HTML pages reference the disclaimer snippet
+        entry: python scripts/verify_html_disclaimer.py
+        language: python
+        pass_filenames: false
       - id: py-compile
         name: Validate Python syntax with py_compile
         entry: python -m py_compile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,6 +300,8 @@ pre-commit run --files <paths>   # before each commit
     invoking `eslint`.
   - Hook `env-check` verifies Python packages are installed by running
     `scripts/check_python_deps.py` and `check_env.py --auto-install`.
+  - Hook `verify-html-disclaimer` fails if any `docs/index.html` page is missing
+    the link to `docs/DISCLAIMER_SNIPPET.md`.
 
 #### Pre-commit in Air-Gapped Setups
 

--- a/scripts/verify_html_disclaimer.py
+++ b/scripts/verify_html_disclaimer.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# This script is a conceptual research prototype.
+"""Fail if docs index pages omit the disclaimer snippet."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SNIPPET = "docs/DISCLAIMER_SNIPPET.md"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    docs_dir = repo_root / "docs"
+    missing: list[Path] = []
+
+    for html in sorted(docs_dir.rglob("index.html")):
+        if html.parent.name == "DISCLAIMER_SNIPPET":
+            continue
+        text = html.read_text(encoding="utf-8", errors="ignore")
+        if SNIPPET not in text:
+            missing.append(html.relative_to(repo_root))
+
+    if missing:
+        print("Missing HTML disclaimer link:", file=sys.stderr)
+        for path in missing:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add script to verify disclaimer link on each docs `index.html`
- wire script into pre-commit hooks
- document new `verify-html-disclaimer` hook

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `python scripts/verify_html_disclaimer.py`
- `pre-commit run verify-html-disclaimer --files scripts/verify_html_disclaimer.py` *(failed to run: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6867f7e596948333a38e0a070b680ad8