### PR TITLE
[alpha_factory] update asset fetch URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,15 @@ docker compose up --build
 Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to
 download the Insight demo assets. Delete any old `wasm*/` directories or start
 from a clean checkout so placeholders are replaced. After fetching, verify the
-files with `python scripts/fetch_assets.py --verify-only`. The helper falls back
-to OpenAI when Hugging Face is unreachable. See
+files with `python scripts/fetch_assets.py --verify-only`. The helper retrieves
+the official Pyodide runtime and GPT‑2 small checkpoint from Hugging Face.
+Override `HF_GPT2_BASE_URL` or `PYODIDE_BASE_URL` to use alternate mirrors. See
 [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md)
 for a detailed guide. You can also run `python scripts/download_gpt2_small.py`
 to retrieve the model directly, or `python scripts/download_openai_gpt2.py
 124M` as a last resort.
 
-`fetch_assets.py` honors the `IPFS_GATEWAY` environment variable when downloading assets from IPFS. If the default gateway is unreachable, set it before running the helper:
+`fetch_assets.py` honors the `IPFS_GATEWAY` environment variable for assets still hosted on IPFS. If the default gateway is unreachable, set it before running the helper:
 
 ```bash
 IPFS_GATEWAY=https://ipfs.io/ipfs npm run fetch-assets
@@ -1199,6 +1200,7 @@ for instructions and example volume mounts.
 | `MAX_SIM_TASKS` | `4` | Maximum concurrent simulation tasks. |
 | `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for IPFS downloads used by `npm run fetch-assets`. Override with `IPFS_GATEWAY=<url> npm run fetch-assets`. |
 | `HF_GPT2_BASE_URL` | `https://huggingface.co/openai-community/gpt2/resolve/main` | Base URL for the GPT‑2 checkpoints. |
+| `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.25.1/full` | Base URL for the Pyodide runtime files. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |
 | `ALPHA_FACTORY_ADK_PORT` | `9000` | Port for the ADK gateway when enabled. |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -72,8 +72,9 @@ before installing dependencies. Execute this command in a fresh checkout—or
 remove the existing `wasm*/` directories—so placeholder files are replaced.
 After the download completes, verify each file with
 `python ../../../../scripts/fetch_assets.py --verify-only`. The script
-retrieves the official GPT‑2 small checkpoint from Hugging Face. Override
-`HF_GPT2_BASE_URL` to change the mirror, for example:
+retrieves the official Pyodide runtime and GPT‑2 small checkpoint from
+Hugging Face. Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change the
+mirrors, for example:
 
 ```bash
 export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"
@@ -133,7 +134,7 @@ npm run fetch-assets
 ```
 
 This downloads the Pyodide runtime and GPT‑2 model from the configured
-mirror. Assets land in `wasm/` and `wasm_llm/`.
+mirrors. Assets land in `wasm/` and `wasm_llm/`.
 It also retrieves `lib/bundle.esm.min.js` from the mirror. You may instead run
 `python ../../../../scripts/download_hf_gpt2.py` or
 `python ../../../../scripts/download_gpt2_small.py` to pull the model

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,8 @@ Downstream users should consult this section when upgrading.
   cycle period when logs show slow agent cycles.
 - Service worker cache version is now generated dynamically to ensure updates are
   picked up by browsers.
+- `scripts/fetch_assets.py` now downloads the Pyodide runtime from the official
+  CDN and retrieves GPT-2 weights directly from Hugging Face.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.

--- a/docs/DEPLOYMENT_QUICKSTART.md
+++ b/docs/DEPLOYMENT_QUICKSTART.md
@@ -21,6 +21,7 @@ node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/versio
    ```bash
    npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
    ```
+   Set `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to mirror locations if the default CDN is blocked.
 2. Build the PWA and deploy to GitHub Pages:
    ```bash
    ./scripts/publish_insight_pages.sh

--- a/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
+++ b/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
@@ -13,7 +13,8 @@ This sprint explains how Codex can publish the **Alpha-Factory** demo gallery to
    python scripts/edge_human_knowledge_pages_sprint.py
    ```
   This triggers `edge_of_knowledge_sprint.sh` which performs environment validation, dependency checks, asset builds, integrity tests and finally deploys the site via `mkdocs gh-deploy`.
-  Export `IPFS_GATEWAY` or `HF_GPT2_BASE_URL` beforehand to customize asset downloads if the defaults fail.
+  Export `IPFS_GATEWAY`, `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` beforehand to
+  customize asset downloads if the defaults fail.
 3. Visit the printed URL in an incognito window and ensure `index.html` links to every demo with preview media.
 
 ## Maintenance

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -22,8 +22,11 @@ offline functionality and then publishes the docs in one step.
    `deploy_insight_demo.sh` to perform both steps automatically).
 3. Verify the page at `https://<org>.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/`.
 
-The `fetch-assets` command respects the `IPFS_GATEWAY` environment variable.
-If downloads fail, set `IPFS_GATEWAY=https://w3s.link/ipfs` and rerun the step.
+The `fetch-assets` command downloads the Pyodide runtime and GPT‑2 weights from
+official mirrors. Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change
+the sources. Remaining assets are fetched via IPFS and the command respects the
+`IPFS_GATEWAY` environment variable. If downloads fail, set
+`IPFS_GATEWAY=https://w3s.link/ipfs` and rerun the step.
 
 ## Prerequisites
 

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: Apache-2.0
 # See docs/DISCLAIMER_SNIPPET.md
-"""Download browser demo assets from IPFS or a mirror.
+"""Download browser demo assets from IPFS or public mirrors.
 
 Environment variables:
     HF_GPT2_BASE_URL -- Override the Hugging Face base URL for the GPT‑2 model.
+    PYODIDE_BASE_URL -- Override the base URL for Pyodide runtime files.
 """
 from __future__ import annotations
 
@@ -25,6 +26,11 @@ HF_GPT2_BASE_URL = os.environ.get(
     "HF_GPT2_BASE_URL",
     "https://huggingface.co/openai-community/gpt2/resolve/main",
 ).rstrip("/")
+# Base URL for the Pyodide runtime
+PYODIDE_BASE_URL = os.environ.get(
+    "PYODIDE_BASE_URL",
+    "https://cdn.jsdelivr.net/pyodide/v0.25.1/full",
+).rstrip("/")
 # Alternate gateways to try when the main download fails
 FALLBACK_GATEWAYS = [
     "https://w3s.link/ipfs",
@@ -33,11 +39,11 @@ FALLBACK_GATEWAYS = [
 ]
 
 ASSETS = {
-    # Pyodide 0.25 runtime files
-    "wasm/pyodide.js": "bafybeiaxk3fzpjn4oi2z7rn6p5wqp5b62ukptmzqk7qhmyeeri3zx4t2pa",  # noqa: E501
-    "wasm/pyodide.asm.wasm": "bafybeifub317gmrhdss4u5aefygb4oql6dyks3v6llqj77pnibsglj6nde",  # noqa: E501
-    "wasm/pyodide_py.tar": "bafybeidazzkz4a3qle6wvyjfwcb36br4idlm43oe5cb26wqzsa4ho7t52e",  # noqa: E501
-    "wasm/packages.json": "bafybeib44a4x7jgqhkgzo5wmgyslyqi1aocsswcdpsnmqkhmvqchwdcql4",  # noqa: E501
+    # Pyodide 0.25.1 runtime files
+    "wasm/pyodide.js": f"{PYODIDE_BASE_URL}/pyodide.js",
+    "wasm/pyodide.asm.wasm": f"{PYODIDE_BASE_URL}/pyodide.asm.wasm",
+    "wasm/pyodide_py.tar": f"{PYODIDE_BASE_URL}/pyodide_py.tar",
+    "wasm/packages.json": f"{PYODIDE_BASE_URL}/packages.json",
     # GPT-2 small weights
     "wasm_llm/pytorch_model.bin": f"{HF_GPT2_BASE_URL}/pytorch_model.bin",
     "wasm_llm/vocab.json": f"{HF_GPT2_BASE_URL}/vocab.json",


### PR DESCRIPTION
## Summary
- fetch Pyodide runtime and GPT-2 weights from official mirrors
- document `PYODIDE_BASE_URL` variable and update instructions
- mention new mirror options in deployment docs
- note asset download change in changelog

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages numpy, pyyaml, pandas)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867faa8f39c833391280c5ffbcb8f93