### PR TITLE
[alpha_factory] docs: allow mirror overrides

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
       IPFS_GATEWAY: https://w3s.link/ipfs
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.25.1/full
+      HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       # Optional environment variables for asset downloads. See
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.

--- a/README.md
+++ b/README.md
@@ -262,6 +262,15 @@ Offline example using a local wheelhouse:
 WHEELHOUSE=$(pwd)/wheels AUTO_INSTALL_MISSING=1 ./quickstart.sh
 ```
 
+If the default mirrors are blocked, set `PYODIDE_BASE_URL` or
+`HF_GPT2_BASE_URL` before running `npm run fetch-assets`:
+
+```bash
+export PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/v0.25.1/full"
+export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"
+npm run fetch-assets
+```
+
 Or launch the full stack with Docker:
 
 ```bash


### PR DESCRIPTION
## Summary
- add Pyodide/HF mirror envs to docs workflow
- disable IPFS fallback when `PYODIDE_BASE_URL` set
- document asset mirror variables in Quick Start

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files .github/workflows/docs.yml scripts/fetch_assets.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_6867fea998188333b499488e1aeeae16