### PR TITLE
Ensure docs workflow exports asset mirrors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,10 @@ jobs:
       IPFS_GATEWAY: https://w3s.link/ipfs
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.25.1/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
+      # Keep the asset mirrors pinned to official hosts.
+      # PYODIDE_BASE_URL and HF_GPT2_BASE_URL must remain exported
+      # so edge_human_knowledge_pages_sprint.sh downloads from
+      # these mirrors rather than IPFS.
       # Optional environment variables for asset downloads. See
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
@@ -43,4 +47,6 @@ jobs:
       - name: Build and deploy gallery
         env:
           IPFS_GATEWAY: ${{ env.IPFS_GATEWAY }}
+          PYODIDE_BASE_URL: ${{ env.PYODIDE_BASE_URL }}
+          HF_GPT2_BASE_URL: ${{ env.HF_GPT2_BASE_URL }}
         run: ./scripts/edge_human_knowledge_pages_sprint.sh


### PR DESCRIPTION
## Summary
- keep Pyodide and GPT‑2 URLs passed through to docs deploy step
- clarify these URLs must remain pinned to official mirrors

## Testing
- `pre-commit run --files .github/workflows/docs.yml` *(fails: verify-requirements-lock)*
- `pytest -m 'not e2e'` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68680c2cf278833388ee1f5c4a0f427a