### PR TITLE
[alpha_factory] cache browser assets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,25 @@ jobs:
         run: pip install mkdocs mkdocs-material
       - name: Make scripts executable
         run: chmod +x ./scripts/*.sh
+      - name: Compute asset cache key
+        id: asset-key
+        run: |
+          key=$(python - <<'EOF'
+import hashlib
+import scripts.fetch_assets as fa
+data = fa.CHECKSUMS["pyodide.asm.wasm"] + fa.CHECKSUMS["pytorch_model.bin"]
+print(hashlib.sha256(data.encode()).hexdigest())
+EOF
+          )
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+      - name: Cache Pyodide and GPT-2 assets
+        id: asset-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
+          key: assets-${{ steps.asset-key.outputs.key }}
       - name: Build and deploy gallery
         env:
           IPFS_GATEWAY: ${{ env.IPFS_GATEWAY }}

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -117,6 +117,9 @@ The "📚 Docs" workflow
 The repository owner manually triggers [`docs.yml`](../.github/workflows/docs.yml), which runs
 `scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
 `gh-pages` branch.
+The workflow restores a cache keyed by the Pyodide and GPT‑2 file checksums before
+running `npm run fetch-assets`. Once the assets pass verification the cache is
+saved so subsequent runs skip the downloads.
 
 ### Manual Publish
 


### PR DESCRIPTION
## Summary
- add asset cache steps to docs workflow
- document cache usage in hosting instructions

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files .github/workflows/docs.yml docs/HOSTING_INSTRUCTIONS.md` *(failed: environment setup blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68680fb5b5348333885ea99b4ec2cdda