### PR TITLE
[alpha_factory] update pyodide checksums

### DIFF
--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -69,6 +69,9 @@ CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",  # noqa: E501
     "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",  # noqa: E501
     "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
+    "pyodide.js": "sha384-okMTEZ8ZyBqYdx16cV0ouuwwg/XsRvqpTMEVld4H1PCCCZ0WfHuAfpGY61KFM8Uc",
+    "pyodide_py.tar": "sha384-rPiQj50jWaYANJhJndPDROq8z252DlRmXhzjVa9sDOeMJlrKZ5DIWRLd6UrnhZau",
+    "packages.json": "sha384-aa2pOjyGkOWdUDx78GrRC8Bk/k2+/qhHRXOGWfm1YaqwUgpoOJCIr2yCuLRVoEm7",
     "pytorch_model.bin": "sha256-fF0/S4t2WDtCL8uRia1sidXZeglFQc6JMtzj7KveFCE=",
 }
 


### PR DESCRIPTION
## Summary
- add SHA-384 digests for pyodide.js, pyodide_py.tar and packages.json

## Testing
- `pytest tests/test_fetch_assets.py::test_fetch_assets_failure tests/test_fetch_assets.py::test_download_with_retry_fallback tests/test_fetch_assets.py::test_download_with_retry_auth_message tests/test_fetch_assets.py::test_verify_assets -q`


------
https://chatgpt.com/codex/tasks/task_e_686817b6b4d88333aee0d747fb398f5a