### PR TITLE
[alpha_factory] Update IPFS fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,9 @@ for instructions and example volume mounts.
 files from IPFS. The default is `https://ipfs.io/ipfs`, but any reachable mirror will work.
 Set `IPFS_GATEWAY` before running the helper to switch gateways.
 
+If no `IPFS_GATEWAY` is provided, the helper falls back to `https://ipfs.io/ipfs`,
+then `https://cloudflare-ipfs.com/ipfs`, and finally `https://w3s.link/ipfs`.
+
 The values above mirror `.env.sample`. When running the stack with Docker
 Compose, adjust the environment section of
 `infrastructure/docker-compose.yml` to override any variable—such as the gRPC

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -36,9 +36,9 @@ PYODIDE_BASE_URL = os.environ.get(
 ).rstrip("/")
 # Alternate gateways to try when the main download fails
 FALLBACK_GATEWAYS = [
-    "https://w3s.link/ipfs",
     "https://ipfs.io/ipfs",
     "https://cloudflare-ipfs.com/ipfs",
+    "https://w3s.link/ipfs",
 ]
 
 PYODIDE_ASSETS = {


### PR DESCRIPTION
## Summary
- reorder IPFS fallback gateways
- document fallback order in README

## Testing
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files scripts/fetch_assets.py README.md` *(with various hooks skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68681b3cd10c8333a00f4565946a5c47