### PR TITLE
[alpha_factory] log pyodide url in fetch-assets

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -10,7 +10,7 @@
     "preinstall": "node -e \"const m=parseInt(process.versions.node); if(m<20){console.error('Node.js 20+ is required. Current version: '+process.versions.node); process.exit(1);} \"",
     "lint": "eslint --config eslint.config.js src --ext .js,.ts",
     "build": "node build.js",
-    "fetch-assets": "python ../../../../scripts/fetch_assets.py",
+    "fetch-assets": "node -e \"console.log('Using PYODIDE_BASE_URL:', process.env.PYODIDE_BASE_URL)\" && python ../../../../scripts/fetch_assets.py",
     "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js lib/workbox-sw.js manifest.json style.css assets insight_browser_quickstart.pdf && rm service-worker.js",
     "size": "gzip-size-cli dist/insight.bundle.js --bytes",
     "start": "npx serve dist",

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -232,6 +232,8 @@ def main() -> None:
                 print(f"Replacing placeholder {rel}...")
             else:
                 print(f"Fetching {rel} from {cid}...")
+            if rel in PYODIDE_ASSETS:
+                print(f"Resolved Pyodide URL: {cid}")
             fallback = None
             if rel == "lib/bundle.esm.min.js":
                 fallback = "https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js"  # noqa: E501


### PR DESCRIPTION
## Summary
- print the URL used for Pyodide downloads in `fetch_assets.py`
- show `PYODIDE_BASE_URL` when running `npm run fetch-assets`

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `SKIP=verify-requirements-lock,verify-alpha-requirements-lock,verify-alpha-colab-requirements-lock,verify-era-experience-requirements-lock,verify-mats-requirements-lock,verify-mats-demo-lock,verify-aiga-requirements-lock,verify-backend-requirements-lock,env-check,verify-disclaimer-helper,verify-gallery-assets pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json scripts/fetch_assets.py`
- `PYODIDE_BASE_URL=https://cdn.example.com npx --yes --quiet npm-run-all --serial fetch-assets` *(fails: 503 Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68681ee05de083339fa1210e4e3cd3ab