### PR TITLE
Improve asset retrieval

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,3 +69,5 @@ EOF
           PYODIDE_BASE_URL: ${{ env.PYODIDE_BASE_URL }}
           HF_GPT2_BASE_URL: ${{ env.HF_GPT2_BASE_URL }}
         run: ./scripts/edge_human_knowledge_pages_sprint.sh
+      - name: Verify downloaded assets
+        run: python scripts/fetch_assets.py --verify-only

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,8 @@ Downstream users should consult this section when upgrading.
   picked up by browsers.
 - `scripts/fetch_assets.py` now downloads the Pyodide runtime from the official
   CDN and retrieves GPT-2 weights directly from Hugging Face.
+- The browser bundle now defaults to the official Web3 Storage CDN. IPFS is
+  used only as a secondary mirror.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -60,7 +60,7 @@ ASSETS = {
     "wasm_llm/merges.txt": f"{HF_GPT2_BASE_URL}/merges.txt",
     "wasm_llm/config.json": f"{HF_GPT2_BASE_URL}/config.json",
     # Web3.Storage bundle
-    "lib/bundle.esm.min.js": "bafkreihgldx46iuks4lybdsc5qc6xom2y5fqdy5w3vvrxntlr42wc43u74",  # noqa: E501
+    "lib/bundle.esm.min.js": "https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js",  # noqa: E501
     # Workbox runtime
     "lib/workbox-sw.js": "https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js",
 }
@@ -236,7 +236,7 @@ def main() -> None:
                 print(f"Resolved Pyodide URL: {cid}")
             fallback = None
             if rel == "lib/bundle.esm.min.js":
-                fallback = "https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js"  # noqa: E501
+                fallback = "bafkreihgldx46iuks4lybdsc5qc6xom2y5fqdy5w3vvrxntlr42wc43u74"
             disable_fallback = rel in PYODIDE_ASSETS
             try:
                 download_with_retry(cid, dest, fallback, label=rel, disable_ipfs_fallback=disable_fallback)


### PR DESCRIPTION
## Summary
- fetch `bundle.esm.min.js` from the official CDN with IPFS as fallback
- verify downloaded assets in the docs workflow
- document new mirror in the changelog

## Checks
- `pre-commit run --files scripts/fetch_assets.py .github/workflows/docs.yml docs/CHANGELOG.md` *(with requirement checks skipped)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868224478b88333a42193dd7f5b8862