### PR TITLE
[alpha_factory] fix asset docs and checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide
 checkout—or delete existing `wasm*/` files first—so placeholder files are
 replaced. After the download, verify checksums with
 `python scripts/fetch_assets.py --verify-only`. The helper retrieves the official
-GPT‑2 small checkpoint from Hugging Face. Override `HF_GPT2_BASE_URL` to change
-the mirror, for example:
+Pyodide runtime and GPT‑2 small checkpoint directly from the Hugging Face CDN.
+The legacy `wasm-gpt2.tar` bundle is no longer used. Override `HF_GPT2_BASE_URL`
+to change the mirror, for example:
 
 ```bash
 export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -73,8 +73,8 @@ remove the existing `wasm*/` directories—so placeholder files are replaced.
 After the download completes, verify each file with
 `python ../../../../scripts/fetch_assets.py --verify-only`. The script
 retrieves the official Pyodide runtime and GPT‑2 small checkpoint from
-Hugging Face. Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change the
-mirrors, for example:
+Hugging Face. The deprecated `wasm-gpt2.tar` archive is no longer used.
+Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change the mirrors, for example:
 
 ```bash
 export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"


### PR DESCRIPTION
## Summary
- mention HF PyTorch download in README
- note wasm-gpt2.tar removal in Insight README
- verify checksums against hex or base64

## Testing
- `pre-commit run --files scripts/fetch_assets.py` *(passes; interrupted after verifying requirements)*
- `python scripts/check_python_deps.py`
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868282b9d28833392ac93be52343de5