### PR TITLE
[alpha_factory] refine docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
-      IPFS_GATEWAY: https://w3s.link/ipfs
+      IPFS_GATEWAY: https://cloudflare-ipfs.com/ipfs
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.25.1/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       # Keep the asset mirrors pinned to official hosts.


### PR DESCRIPTION
## Summary
- use Cloudflare's IPFS gateway in the docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68682be3d9948333b60ba6e6383ed438