### PR TITLE
docs: clarify official asset sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ All browser demos include a **mode toggle**. Choose **Offline** to run a Pyodide
 `./setup.sh` to download the browser demo assets. Run this command in a fresh
 checkout—or delete existing `wasm*/` files first—so placeholder files are
 replaced. After the download, verify checksums with
-`python scripts/fetch_assets.py --verify-only`. The helper retrieves the official
-Pyodide runtime and GPT‑2 small checkpoint directly from the Hugging Face CDN.
+`python scripts/fetch_assets.py --verify-only`. The helper retrieves the
+official Pyodide runtime from the jsDelivr CDN and the GPT‑2 small checkpoint
+directly from the Hugging Face CDN.
 If a custom `PYODIDE_BASE_URL` is set and fails, the script falls back to the
 official CDN automatically. The legacy `wasm-gpt2.tar` bundle is no longer used.
 Override `HF_GPT2_BASE_URL`
@@ -129,7 +130,8 @@ Run `npm run fetch-assets` before `npm install` or executing `./setup.sh` to
 download the Insight demo assets. Delete any old `wasm*/` directories or start
 from a clean checkout so placeholders are replaced. After fetching, verify the
 files with `python scripts/fetch_assets.py --verify-only`. The helper retrieves
-the official Pyodide runtime and GPT‑2 small checkpoint from Hugging Face.
+the official Pyodide runtime from the jsDelivr CDN and the GPT‑2 small
+checkpoint from Hugging Face.
 Override `HF_GPT2_BASE_URL` or `PYODIDE_BASE_URL` to use alternate mirrors. See
 [insight_browser_v1/README.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md)
 for a detailed guide. You can also run `python scripts/download_gpt2_small.py`

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -72,8 +72,8 @@ before installing dependencies. Execute this command in a fresh checkout—or
 remove the existing `wasm*/` directories—so placeholder files are replaced.
 After the download completes, verify each file with
 `python ../../../../scripts/fetch_assets.py --verify-only`. The script
-retrieves the official Pyodide runtime and GPT‑2 small checkpoint from
-Hugging Face. If a custom `PYODIDE_BASE_URL` is unreachable the helper
+retrieves the official Pyodide runtime from the jsDelivr CDN and the GPT‑2
+small checkpoint from Hugging Face. If a custom `PYODIDE_BASE_URL` is unreachable the helper
 automatically retries using the official CDN. The deprecated `wasm-gpt2.tar`
 archive is no longer used.
 Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change the mirrors, for example:


### PR DESCRIPTION
## Summary
- clarify that Pyodide comes from the official jsDelivr CDN
- note GPT-2 small weights are hosted on Hugging Face

## Testing
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md` *(failed: requirements.lock is outdated)*
- `python check_env.py --auto-install`
- `pytest -q` *(failed: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868332406808333a06014e3baa5f29c