### PR TITLE
[alpha_factory] Fix docs assets download

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build-test:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy-kind:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   sbom-scan-sign:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   smoke:
-    if: github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -66,10 +66,10 @@ ASSETS = {
 CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",  # noqa: E501
     "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",  # noqa: E501
-    "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
-    "pyodide.js": "sha384-okMTEZ8ZyBqYdx16cV0ouuwwg/XsRvqpTMEVld4H1PCCCZ0WfHuAfpGY61KFM8Uc",
-    "pyodide_py.tar": "sha384-rPiQj50jWaYANJhJndPDROq8z252DlRmXhzjVa9sDOeMJlrKZ5DIWRLd6UrnhZau",
-    "packages.json": "sha384-aa2pOjyGkOWdUDx78GrRC8Bk/k2+/qhHRXOGWfm1YaqwUgpoOJCIr2yCuLRVoEm7",
+    "pyodide.asm.wasm": "sha384-jazqcjXUeIYMNgPrqcZmv0cjFnPj/e0eC+x9e0NleEYkCOxveIMMtXU3uD7uRlMM",
+    "pyodide.js": "sha384-seajjUQIcvEwMC5MMXEiumXqlQqO0Bx2snuTKoW5x3LQ5o2nPJDK7cQsB4M0a7fw",
+    "pyodide_py.tar": "sha384-Oe3ZdqqHmtobZikk5G/AWIdYyUypw30uWF4Lo9fpFxgUNZkc05jkZSloDk2uj5kU",
+    "packages.json": "sha384-keC5mSZ0xcS+ymiCjzPcpOuGvAwQRBkm1a0MQofaH0KZyr36otPgshJ/Odvg1V4g",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",
 }
 


### PR DESCRIPTION
## Summary
- update Pyodide checksum values in `fetch_assets.py`
- restrict manual workflows to repository owner

## Testing
- `pre-commit run --files scripts/fetch_assets.py .github/workflows/docs.yml .github/workflows/build-and-test.yml .github/workflows/deploy-kind.yml .github/workflows/security.yml .github/workflows/smoke.yml` *(fails: `Verify era_of_experience requirements.lock is up to date`)*
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent' from 'alpha_factory_v1.core.agents')*

------
https://chatgpt.com/codex/tasks/task_e_68683b4435a88333a349f82729221c92