### PR TITLE
Improve asset fetch fallback

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
       IPFS_GATEWAY: https://cloudflare-ipfs.com/ipfs
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.25.1/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
+      FETCH_ASSETS_ATTEMPTS: '5'
       # Keep the asset mirrors pinned to official hosts.
       # PYODIDE_BASE_URL and HF_GPT2_BASE_URL must remain exported
       # so edge_human_knowledge_pages_sprint.sh downloads from

--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,7 @@ for instructions and example volume mounts.
 | `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for IPFS downloads used by `npm run fetch-assets`. Override with `IPFS_GATEWAY=<url> npm run fetch-assets`. |
 | `HF_GPT2_BASE_URL` | `https://huggingface.co/openai-community/gpt2/resolve/main` | Base URL for the GPT‑2 checkpoints. |
 | `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.25.1/full` | Base URL for the Pyodide runtime files. |
+| `FETCH_ASSETS_ATTEMPTS` | `3` | Download retry count for `fetch_assets.py`. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |
 | `ALPHA_FACTORY_ADK_PORT` | `9000` | Port for the ADK gateway when enabled. |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -76,6 +76,7 @@ retrieves the official Pyodide runtime from the jsDelivr CDN and the GPT‑2
 small checkpoint from Hugging Face. If a custom `PYODIDE_BASE_URL` is unreachable the helper
 automatically retries using the official CDN. The deprecated `wasm-gpt2.tar`
 archive is no longer used.
+Set `FETCH_ASSETS_ATTEMPTS` to control the retry count when downloading assets.
 Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change the mirrors, for example:
 
 ```bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@ Downstream users should consult this section when upgrading.
   picked up by browsers.
 - `scripts/fetch_assets.py` now downloads the Pyodide runtime from the official
   CDN and retrieves GPT-2 weights directly from Hugging Face.
+- Added `FETCH_ASSETS_ATTEMPTS` environment variable to control download retries.
 - The browser bundle now defaults to the official Web3 Storage CDN. IPFS is
   used only as a secondary mirror.
 ## [0.1.0-alpha] - 2024-05-01

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -33,6 +33,8 @@ HF_GPT2_BASE_URL = os.environ.get("HF_GPT2_BASE_URL", DEFAULT_HF_GPT2_BASE_URL).
 DEFAULT_PYODIDE_BASE_URL = "https://cdn.jsdelivr.net/pyodide/v0.25.1/full"
 ALT_PYODIDE_BASE_URL = "https://pyodide-cdn2.iodide.io/v0.25.1/full"
 PYODIDE_BASE_URL = os.environ.get("PYODIDE_BASE_URL", DEFAULT_PYODIDE_BASE_URL).rstrip("/")
+# Number of download attempts before giving up
+MAX_ATTEMPTS = int(os.environ.get("FETCH_ASSETS_ATTEMPTS", "3"))
 # Alternate gateways to try when the main download fails
 FALLBACK_GATEWAYS = [
     "https://ipfs.io/ipfs",
@@ -115,7 +117,7 @@ def download_with_retry(
     cid: str,
     path: Path,
     fallback: str | None = None,
-    attempts: int = 3,
+    attempts: int = MAX_ATTEMPTS,
     label: str | None = None,
     disable_ipfs_fallback: bool = False,
 ) -> None:


### PR DESCRIPTION
## Summary
- allow overriding fetch retries for browser assets
- document FETCH_ASSETS_ATTEMPTS env var
- show retry control in insight browser README
- document new variable in changelog
- update docs workflow to set retry count

## Testing
- `pre-commit` *(failed: could not download hook environment)*
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q` *(failed: network issues running check_env)*

------
https://chatgpt.com/codex/tasks/task_e_686847a713c88333b58f819172acbcf4