### PR TITLE
[alpha_factory] add GitHub fallback for Pyodide assets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
       IPFS_GATEWAY: https://cloudflare-ipfs.com/ipfs
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.25.1/full
+      PYODIDE_BASE_URL: https://github.com/pyodide/pyodide/releases/download/0.25.1
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
       # Keep the asset mirrors pinned to official hosts.


### PR DESCRIPTION
## Summary
- add a GitHub mirror constant for Pyodide
- allow multiple fallback URLs in `download_with_retry`
- include GitHub mirror when fetching Pyodide runtime
- point the docs workflow to the new mirror

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError during collection)*
- `pre-commit run --files .github/workflows/docs.yml scripts/fetch_assets.py` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68684c5c9b648333b40cb3f59cc39404