### PR TITLE
feat: expand fallback gateways

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,7 +33,7 @@ API_TOKEN=REPLACE_ME_TOKEN
 # Web3.Storage token for pinning Insight demo exports
 PINNER_TOKEN=
 
-# IPFS gateway base URL
+# IPFS gateway base URL. Override to use a different primary gateway.
 IPFS_GATEWAY=https://ipfs.io/ipfs
 
 # Working memory directory used by demos and tests

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ python scripts/download_gpt2_small.py models/
 
 As a last resort use `python scripts/download_openai_gpt2.py 124M`.
 
-`fetch_assets.py` honors the `IPFS_GATEWAY` environment variable for assets still hosted on IPFS. If the default gateway is unreachable, set it before running the helper:
+`fetch_assets.py` honors the `IPFS_GATEWAY` environment variable for assets still hosted on IPFS. Set `IPFS_GATEWAY=<url>` to override the primary gateway when running the helper:
 
 ```bash
 IPFS_GATEWAY=https://ipfs.io/ipfs npm run fetch-assets
@@ -1230,12 +1230,13 @@ for instructions and example volume mounts.
 
 #### IPFS Gateway
 
-`scripts/fetch_assets.py` uses the `IPFS_GATEWAY` variable to construct URLs when downloading
-files from IPFS. The default is `https://ipfs.io/ipfs`, but any reachable mirror will work.
-Set `IPFS_GATEWAY` before running the helper to switch gateways.
+`scripts/fetch_assets.py` uses the `IPFS_GATEWAY` environment variable to construct the
+primary download URL. The default is `https://ipfs.io/ipfs`, but any reachable mirror will work.
+Set `IPFS_GATEWAY=<url>` before running the helper to override the primary gateway.
 
 If no `IPFS_GATEWAY` is provided, the helper falls back to `https://ipfs.io/ipfs`,
-then `https://cloudflare-ipfs.com/ipfs`, and finally `https://w3s.link/ipfs`.
+`https://cloudflare-ipfs.com/ipfs`, `https://w3s.link/ipfs`, `https://cf-ipfs.com/ipfs` and
+`https://gateway.pinata.cloud/ipfs`.
 
 The values above mirror `.env.sample`. When running the stack with Docker
 Compose, adjust the environment section of

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -55,7 +55,12 @@ is missing the build scripts continue with default empty values:
 - `OPENAI_API_KEY` – optional OpenAI key for chat prompts. **For security, do not
   embed the key in the built HTML.** Store it in `localStorage` or enter it at
   runtime instead.
-- `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs. When assets fail to load the build scripts automatically try `https://w3s.link/ipfs`, `https://ipfs.io/ipfs` and `https://cloudflare-ipfs.com/ipfs` as fallbacks.
+- `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs. Set
+  `IPFS_GATEWAY=<url>` to override the primary gateway. When assets fail to load
+  the build scripts automatically try `https://ipfs.io/ipfs`,
+  `https://cloudflare-ipfs.com/ipfs`, `https://w3s.link/ipfs`,
+  `https://cf-ipfs.com/ipfs` and `https://gateway.pinata.cloud/ipfs` as
+  fallbacks.
 - `OTEL_ENDPOINT` – OTLP/HTTP endpoint for anonymous telemetry (leave blank to disable).
 - `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
 - Browsers with WebGPU can accelerate the local model using the ONNX runtime.

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -25,8 +25,10 @@ offline functionality and then publishes the docs in one step.
 The `fetch-assets` command downloads the Pyodide runtime and GPT‑2 weights from
 official mirrors. Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change
 the sources. Remaining assets are fetched via IPFS and the command respects the
-`IPFS_GATEWAY` environment variable. If downloads fail, set
-`IPFS_GATEWAY=https://w3s.link/ipfs` and rerun the step.
+`IPFS_GATEWAY` environment variable. Set `IPFS_GATEWAY=<url>` to override the
+primary gateway when running the command. If downloads fail the script
+automatically retries using `https://ipfs.io/ipfs`, `https://cloudflare-ipfs.com/ipfs`,
+`https://w3s.link/ipfs`, `https://cf-ipfs.com/ipfs` and `https://gateway.pinata.cloud/ipfs`.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- add additional IPFS gateway mirrors
- log which gateway succeeded in fetch_assets
- document how to override the primary gateway and show new fallbacks

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files .env.sample README.md docs/HOSTING_INSTRUCTIONS.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md scripts/fetch_assets.py` *(with several hooks skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686850a11f988333bd72a71ef23a6635