### PR TITLE
Fix docs workflow asset mirror

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
       IPFS_GATEWAY: https://cloudflare-ipfs.com/ipfs
-      PYODIDE_BASE_URL: https://github.com/pyodide/pyodide/releases/download/0.25.1
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.25.1/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
       # Keep the asset mirrors pinned to official hosts.


### PR DESCRIPTION
## Summary
- use official jsDelivr URL for Pyodide runtime in docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files .github/workflows/docs.yml` *(fails: requirements.lock outdated)*

------
https://chatgpt.com/codex/tasks/task_e_686858762e608333b3327c14aa3d7d19