### PR TITLE
fix: update Pyodide source

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
       IPFS_GATEWAY: https://cloudflare-ipfs.com/ipfs
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.25.1/full
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.24.1/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
       # Keep the asset mirrors pinned to official hosts.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If the default mirrors are blocked, set `PYODIDE_BASE_URL` or
 `HF_GPT2_BASE_URL` before running `npm run fetch-assets`:
 
 ```bash
-export PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/v0.25.1/full"
+export PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/v0.24.1/full"
 export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"
 npm run fetch-assets
 ```
@@ -1221,7 +1221,7 @@ for instructions and example volume mounts.
 | `MAX_SIM_TASKS` | `4` | Maximum concurrent simulation tasks. |
 | `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for IPFS downloads used by `npm run fetch-assets`. Override with `IPFS_GATEWAY=<url> npm run fetch-assets`. |
 | `HF_GPT2_BASE_URL` | `https://huggingface.co/openai-community/gpt2/resolve/main` | Base URL for the GPT‑2 checkpoints. |
-| `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.25.1/full` | Base URL for the Pyodide runtime files. |
+| `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.24.1/full` | Base URL for the Pyodide runtime files. |
 | `FETCH_ASSETS_ATTEMPTS` | `3` | Download retry count for `fetch_assets.py`. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |

--- a/docs/assets/pyodide_demo.js
+++ b/docs/assets/pyodide_demo.js
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* eslint-env browser */
 /* eslint-disable no-undef */
-const CDN_BASE = 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/';
+const CDN_BASE = 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/';
 
 export async function loadRuntime() {
   const localBase = '../assets/pyodide/';

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -31,10 +31,10 @@ DEFAULT_HF_GPT2_BASE_URL = "https://huggingface.co/openai-community/gpt2/resolve
 HF_GPT2_BASE_URL = os.environ.get("HF_GPT2_BASE_URL", DEFAULT_HF_GPT2_BASE_URL).rstrip("/")
 
 # Base URL for the Pyodide runtime
-DEFAULT_PYODIDE_BASE_URL = "https://cdn.jsdelivr.net/pyodide/v0.25.1/full"
-ALT_PYODIDE_BASE_URL = "https://pyodide-cdn2.iodide.io/v0.25.1/full"
+DEFAULT_PYODIDE_BASE_URL = "https://cdn.jsdelivr.net/pyodide/v0.24.1/full"
+ALT_PYODIDE_BASE_URL = "https://pyodide-cdn2.iodide.io/v0.24.1/full"
 # GitHub publishes the same assets under the releases page.
-GITHUB_PYODIDE_BASE_URL = "https://github.com/pyodide/pyodide/releases/download/0.25.1"
+GITHUB_PYODIDE_BASE_URL = "https://github.com/pyodide/pyodide/releases/download/0.24.1"
 PYODIDE_BASE_URL = os.environ.get("PYODIDE_BASE_URL", DEFAULT_PYODIDE_BASE_URL).rstrip("/")
 # Number of download attempts before giving up
 MAX_ATTEMPTS = int(os.environ.get("FETCH_ASSETS_ATTEMPTS", "3"))
@@ -56,7 +56,7 @@ PYODIDE_ASSETS = {
 }
 
 ASSETS = {
-    # Pyodide 0.25.1 runtime files
+    # Pyodide 0.24.1 runtime files
     "wasm/pyodide.js": f"{PYODIDE_BASE_URL}/pyodide.js",
     "wasm/pyodide.asm.wasm": f"{PYODIDE_BASE_URL}/pyodide.asm.wasm",
     "wasm/pyodide_py.tar": f"{PYODIDE_BASE_URL}/pyodide_py.tar",
@@ -75,10 +75,10 @@ ASSETS = {
 CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",  # noqa: E501
     "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",  # noqa: E501
-    "pyodide.asm.wasm": "sha384-jazqcjXUeIYMNgPrqcZmv0cjFnPj/e0eC+x9e0NleEYkCOxveIMMtXU3uD7uRlMM",
-    "pyodide.js": "sha384-seajjUQIcvEwMC5MMXEiumXqlQqO0Bx2snuTKoW5x3LQ5o2nPJDK7cQsB4M0a7fw",
-    "pyodide_py.tar": "sha384-Oe3ZdqqHmtobZikk5G/AWIdYyUypw30uWF4Lo9fpFxgUNZkc05jkZSloDk2uj5kU",
-    "packages.json": "sha384-keC5mSZ0xcS+ymiCjzPcpOuGvAwQRBkm1a0MQofaH0KZyr36otPgshJ/Odvg1V4g",
+    "pyodide.asm.wasm": "sha384-XmiypR2FYQ6+bKPYiwek6XzKP+9Y0X800XuxdKfS6X+49Z+wskdeoYiUB/rED0Vn",
+    "pyodide.js": "sha384-+R8PTzDXzivdjpxOqwVwRhPS9dlske7tKAjwj0O0Kr361gKY5d2Xe6Osl+faRLT7",
+    "pyodide_py.tar": "sha384-4avshemUWv205Gc966cs13LM0YYaiSqs/z6RyedKSA6lcVQ48wfD4pjdTk/TIpGs",
+    "packages.json": "sha384-zjvSUou3MtjJoDmJNakFljF3tMwxBpcFusWO5zGDU2I1VBljIRUB7KPQDEYGVG/C",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",
 }
 


### PR DESCRIPTION
## Summary
- use official Pyodide 0.24.1 CDN
- keep docs in sync with new Pyodide base URL

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686864d795b08333a1abbd852b02eb85