### PR TITLE
[alpha_factory] add pre-commit helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,9 @@ Run `./codex/setup.sh` to install project dependencies. The script also
 installs `pre-commit` and all lint tools before configuring the git hook.
 If you skip the setup script, manually install these tools with
 `pip install pre-commit -r requirements-dev.txt` and then run
-`pre-commit install` once.
+`pre-commit install` once. Alternatively, execute
+`tools/setup_precommit.sh` to install `pre-commit` and configure the hook
+without the full environment setup.
 
 Install the git hooks once and run them before each commit:
 

--- a/tools/setup_precommit.sh
+++ b/tools/setup_precommit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Install pre-commit and configure the git hook.
+set -euo pipefail
+
+PYTHON=${PYTHON:-python3}
+
+wheel_opts=()
+if [[ -n "${WHEELHOUSE:-}" ]]; then
+  wheel_opts+=(--no-index --find-links "$WHEELHOUSE")
+fi
+
+if ! command -v pre-commit >/dev/null; then
+  "$PYTHON" -m pip install --quiet "${wheel_opts[@]}" pre-commit
+fi
+
+pre-commit install


### PR DESCRIPTION
## Summary
- add `tools/setup_precommit.sh` to install `pre-commit` and configure the hook
- reference the helper in CONTRIBUTING.md

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files tools/setup_precommit.sh CONTRIBUTING.md` *(fails: environment setup interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686869c88bcc833392fd436460af2b9b