### PR TITLE
[alpha_factory] Update docs cache key

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,8 +50,15 @@ jobs:
         run: |
           key=$(python - <<'EOF'
           import hashlib
+          import os
           import scripts.fetch_assets as fa
-          data = fa.CHECKSUMS["pyodide.asm.wasm"] + fa.CHECKSUMS["pytorch_model.bin"]
+
+          env_data = os.getenv("PYODIDE_BASE_URL", "") + os.getenv("HF_GPT2_BASE_URL", "")
+          data = (
+              fa.CHECKSUMS["pyodide.asm.wasm"]
+              + fa.CHECKSUMS["pytorch_model.bin"]
+              + env_data
+          )
           print(hashlib.sha256(data.encode()).hexdigest())
           EOF
           )


### PR DESCRIPTION
## Summary
- refresh docs workflow cache when asset mirrors change

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files .github/workflows/docs.yml` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68686bdba90083339d6d372ad576d10a