### PR TITLE
[alpha_factory] allow maintainer token dispatch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,10 +2,14 @@ name: "📈 Replay Bench"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 jobs:
   replay-bench:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,10 @@ name: "🐳 Build & Test"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 env:
   PYTHON_VERSION_MATRIX: "3.11,3.12"
@@ -9,7 +13,7 @@ env:
 
 jobs:
   build-test:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ name: "🚀 CI"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 permissions:
   contents: read
@@ -47,7 +51,7 @@ jobs:
   tests:
     name: "✅ Pytest"
     needs: lint-type
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
@@ -171,7 +175,7 @@ jobs:
   docker:
     name: "🐳 Docker build"
     needs: tests
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
@@ -212,7 +216,7 @@ jobs:
 
   deploy:
     name: "📦 Deploy"
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) && startsWith(github.ref, 'refs/tags/')
     needs: docker
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -2,10 +2,14 @@ name: "🚀 Deploy — Kind"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 jobs:
   deploy-kind:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,13 +3,17 @@ name: "📚 Docs"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 permissions:
   contents: write
 
 jobs:
   build-deploy:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -2,10 +2,14 @@ name: "🌩 Load Test"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 jobs:
   load-test:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -2,10 +2,14 @@ name: "📊 Transfer Matrix"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 jobs:
   transfer-matrix:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,10 @@ name: "🔒 Container Security"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 env:
   DOCKER_IMAGE: alpha-factory
@@ -14,7 +18,7 @@ permissions:
 
 jobs:
   sbom-scan-sign:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -2,10 +2,14 @@ name: "📦 Browser Size"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 jobs:
   build-and-check:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,13 +2,17 @@ name: "🔥 Smoke Test"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 env:
   PYTHON_VERSION_MATRIX: "3.11,3.12"
 
 jobs:
   smoke:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
+    if: github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:


### PR DESCRIPTION
## Summary
- allow maintainers to trigger workflows using `run_token`
- default owner-only restrictions remain

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files .github/workflows/bench.yml .github/workflows/build-and-test.yml .github/workflows/ci.yml .github/workflows/deploy-kind.yml .github/workflows/docs.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/security.yml .github/workflows/size-check.yml .github/workflows/smoke.yml` *(fails: requirements.lock is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_686871508fec83339d1e15af53ed0978