### PR TITLE
[alpha_factory] fix docs asset fetch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
-      # - name: Install pre-commit
-      #   run: pip install pre-commit && pre-commit install
-      # - name: Run pre-commit checks
-      #   run: pre-commit run --all-files
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
       - name: Install docs dependencies
         run: pip install mkdocs mkdocs-material
       - name: Make scripts executable

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -111,8 +111,6 @@ jsDelivr and GitHub mirrors when needed. You can also retrieve the runtime with
 ```bash
 curl -L https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js -o wasm/pyodide.js
 curl -L https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.asm.wasm -o wasm/pyodide.asm.wasm
-curl -L https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide_py.tar -o wasm/pyodide_py.tar
-curl -L https://cdn.jsdelivr.net/pyodide/v0.24.1/full/packages.json -o wasm/packages.json
 ```
 Verify the downloads with:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -233,7 +233,7 @@ async function bundle() {
     const wasmSri =
         "sha384-" + createHash("sha384").update(wasmBuf).digest("base64");
 
-    for (const name of ["pyodide.js", "pyodide_py.tar", "packages.json"]) {
+    for (const name of ["pyodide.js"]) {
         const p = path.join("wasm", name);
         if (fsSync.existsSync(p)) {
             verify(fsSync.readFileSync(p), name);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -30,8 +30,6 @@
   "assets": [
     "wasm/pyodide.js",
     "wasm/pyodide.asm.wasm",
-    "wasm/pyodide_py.tar",
-    "wasm/packages.json",
     "wasm_llm/pytorch_model.bin",
     "wasm_llm/vocab.json",
     "wasm_llm/merges.txt",
@@ -44,8 +42,6 @@
     "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",
     "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
     "pyodide.js": "sha384-okMTEZ8ZyBqYdx16cV0ouuwwg/XsRvqpTMEVld4H1PCCCZ0WfHuAfpGY61KFM8Uc",
-    "pyodide_py.tar": "sha384-rPiQj50jWaYANJhJndPDROq8z252DlRmXhzjVa9sDOeMJlrKZ5DIWRLd6UrnhZau",
-    "packages.json": "sha384-aa2pOjyGkOWdUDx78GrRC8Bk/k2+/qhHRXOGWfm1YaqwUgpoOJCIr2yCuLRVoEm7",
     "service-worker.js": "sha384-o4otzwjbNKzpYYcqiTHOYyd9asjheSu1P8UVzmVl3HU8cvmE86GWhOgWUjkJ6gXT"
   },
   "quickstart_pdf": "docs/insight_browser_quickstart.pdf"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -316,7 +316,7 @@ wasm_b64 = ""
 wasm_file = ROOT / "wasm" / "pyodide.asm.wasm"
 if wasm_file.exists():
     wasm_b64 = base64.b64encode(_verify(wasm_file, "pyodide.asm.wasm")).decode()
-for name in ("pyodide.js", "pyodide_py.tar", "packages.json"):
+for name in ("pyodide.js",):
     f = ROOT / "wasm" / name
     if f.exists():
         _verify(f, name)
@@ -417,7 +417,7 @@ if wasm_dir.exists():
     expected = checksums.get("pyodide.asm.wasm")
     if expected and expected != wasm_sri:
         sys.exit("Checksum mismatch for pyodide.asm.wasm")
-    for name in ("pyodide.js", "pyodide_py.tar", "packages.json"):
+    for name in ("pyodide.js",):
         f = dist_dir / manifest["dirs"]["wasm"] / name
         if f.exists():
             actual = sha384(f)

--- a/scripts/build_service_worker.py
+++ b/scripts/build_service_worker.py
@@ -81,7 +81,7 @@ def gather_assets(docs_dir: Path) -> list[str]:
     allowed = {".js", ".css", ".svg", ".json", ".wasm", ".tar", ".cast"}
     pyodide_dir = base_assets / "pyodide"
     if pyodide_dir.is_dir():
-        order = ["pyodide.js", "pyodide.asm.wasm", "pyodide_py.tar"]
+        order = ["pyodide.js", "pyodide.asm.wasm"]
         for name in order:
             file = pyodide_dir / name
             if file.is_file() and file.suffix in allowed:

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -51,16 +51,12 @@ FALLBACK_GATEWAYS = [
 PYODIDE_ASSETS = {
     "wasm/pyodide.js",
     "wasm/pyodide.asm.wasm",
-    "wasm/pyodide_py.tar",
-    "wasm/packages.json",
 }
 
 ASSETS = {
     # Pyodide 0.24.1 runtime files
     "wasm/pyodide.js": f"{PYODIDE_BASE_URL}/pyodide.js",
     "wasm/pyodide.asm.wasm": f"{PYODIDE_BASE_URL}/pyodide.asm.wasm",
-    "wasm/pyodide_py.tar": f"{PYODIDE_BASE_URL}/pyodide_py.tar",
-    "wasm/packages.json": f"{PYODIDE_BASE_URL}/packages.json",
     # GPT-2 small weights
     "wasm_llm/pytorch_model.bin": f"{HF_GPT2_BASE_URL}/pytorch_model.bin",
     "wasm_llm/vocab.json": f"{HF_GPT2_BASE_URL}/vocab.json",
@@ -77,8 +73,6 @@ CHECKSUMS = {
     "lib/workbox-sw.js": "sha384-LWo7skrGueg8Fa4y2Vpe1KB4g0SifqKfDr2gWFRmzZF9n9F1bQVo1F0dUurlkBJo",  # noqa: E501
     "pyodide.asm.wasm": "sha384-XmiypR2FYQ6+bKPYiwek6XzKP+9Y0X800XuxdKfS6X+49Z+wskdeoYiUB/rED0Vn",
     "pyodide.js": "sha384-+R8PTzDXzivdjpxOqwVwRhPS9dlske7tKAjwj0O0Kr361gKY5d2Xe6Osl+faRLT7",
-    "pyodide_py.tar": "sha384-4avshemUWv205Gc966cs13LM0YYaiSqs/z6RyedKSA6lcVQ48wfD4pjdTk/TIpGs",
-    "packages.json": "sha384-zjvSUou3MtjJoDmJNakFljF3tMwxBpcFusWO5zGDU2I1VBljIRUB7KPQDEYGVG/C",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",
 }
 
@@ -245,8 +239,6 @@ def main() -> None:
         "lib/workbox-sw.js",
         "wasm/pyodide.js",
         "wasm/pyodide.asm.wasm",
-        "wasm/pyodide_py.tar",
-        "wasm/packages.json",
     }
     for rel, cid in ASSETS.items():
         dest = base / rel


### PR DESCRIPTION
## Summary
- drop deprecated Pyodide assets from fetch script
- update service worker and browser build to match
- enable pre-commit checks in docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run black ruff ruff-format flake8 --files scripts/fetch_assets.py scripts/build_service_worker.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686875a3a934833391b31c331446030e