### PR TITLE
[alpha_factory] pin mkdocs versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run pre-commit checks
         run: pre-commit run --all-files
       - name: Install docs dependencies
-        run: pip install mkdocs mkdocs-material
+        run: pip install -r requirements-docs.txt
       - name: Make scripts executable
         run: chmod +x ./scripts/*.sh
       - name: Compute asset cache key

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs==1.6.1
+mkdocs-material==9.6.15


### PR DESCRIPTION
## Summary
- add requirements-docs.txt with pinned mkdocs versions
- update docs workflow to install from requirements file

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files requirements-docs.txt .github/workflows/docs.yml` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6868846dd5c88333953bda408fef98ab