### PR TITLE
[alpha_factory] update pyodide placeholders

### DIFF
--- a/docs/assets/pyodide/pyodide.asm.wasm
+++ b/docs/assets/pyodide/pyodide.asm.wasm
@@ -1,1 +1,1 @@
-placeholder wasm binary
+placeholder wasm binary (Pyodide 0.24.1) - fetch via scripts/fetch_assets.py

--- a/docs/assets/pyodide/pyodide.js
+++ b/docs/assets/pyodide/pyodide.js
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: Apache-2.0
-// Pyodide 0.25 placeholder
+// Pyodide 0.24.1 placeholder - use scripts/fetch_assets.py to download real assets
 export async function loadPyodide() { throw new Error('Pyodide runtime unavailable'); }

--- a/docs/assets/pyodide/repodata.json
+++ b/docs/assets/pyodide/repodata.json
@@ -1,1 +1,1 @@
-{"placeholder":true}
+{"placeholder": true, "pyodide": "0.24.1"}


### PR DESCRIPTION
## Summary
- keep pyodide placeholders tiny and mention `fetch_assets.py`
- note correct version 0.24.1 instead of 0.25

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent' ...)*
- `pre-commit run --files docs/assets/pyodide/pyodide.js docs/assets/pyodide/pyodide.asm.wasm docs/assets/pyodide/repodata.json` *(with SKIP for heavy hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68688c25567c8333a4df75d1e67623a5