### PR TITLE
[alpha_factory] add pre-commit to workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,6 +22,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
       - name: Run replay harness
         run: python scripts/run_replay_bench.py
       - name: Run micro benchmarks

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
+
       - name: Build Docker image
         run: |
           docker build -t ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ruff mypy
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
       - name: Ruff lint
         run: ruff check alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Mypy type-check

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
+
       - name: Set up Kind cluster
         uses: helm/kind-action@v1.7.0
 

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -22,6 +22,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
       - name: Start API server
         run: |
           API_TOKEN=test-token python -m src.interface.api_server &

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -22,6 +22,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
       - name: Run transfer test
         run: |
           python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli transfer-test --models "o3-mini,llama-3" --top-n 5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip cyclonedx-bom
           npm install -g @cyclonedx/bom
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
       - name: Install dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Build distribution zip

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,6 +29,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
       - name: Run 2-year simulation
         run: |
           python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,7 @@ install dependencies without internet access.
 - Pull requests should follow [`pull_request_template.md`](.github/pull_request_template.md). Fill out
   all sections to confirm linting, type checks and tests pass.
 - Ensure `pre-commit` passes locally; the CI pipeline runs the same hooks and will fail if they do not.
+- CI jobs execute `pre-commit run --all-files`. Any failing hook stops the build.
 
 ### Starting the CI Pipeline
 You can manually trigger the CI run from the GitHub UI:


### PR DESCRIPTION
## Summary
- run pre-commit in all CI workflows
- note in the contributor guide that CI runs `pre-commit`

## Testing
- `pre-commit run --files AGENTS.md .github/workflows/bench.yml .github/workflows/build-and-test.yml .github/workflows/ci.yml .github/workflows/deploy-kind.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/security.yml .github/workflows/size-check.yml .github/workflows/smoke.yml` *(fails: Verify requirements.lock is up to date)*

------
https://chatgpt.com/codex/tasks/task_e_68688fdbc75083338426abd6a1b61f5b