### PR TITLE
[alpha_factory] pin agent dependencies

### DIFF
--- a/alpha_factory_v1/requirements-core.txt
+++ b/alpha_factory_v1/requirements-core.txt
@@ -40,6 +40,8 @@ playwright~=1.42
 
 # LLM / Agents stack
 openai>=1.82.0,<2.0
+openai-agents==0.0.17
+google-adk>=0.3.0
 anthropic>=0.21
 litellm>=1.31
 tiktoken>=0.5

--- a/requirements.lock
+++ b/requirements.lock
@@ -19,8 +19,12 @@ anthropic==0.56.0
 anyio==4.9.0
     # via
     #   anthropic
+    #   google-adk
+    #   google-genai
     #   httpx
+    #   mcp
     #   openai
+    #   sse-starlette
     #   starlette
     #   watchfiles
 attrs==25.3.0
@@ -28,6 +32,8 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
+authlib==1.6.0
+    # via google-adk
 backoff==2.2.1
     # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
 better-profanity==0.7.0
@@ -35,7 +41,9 @@ better-profanity==0.7.0
 blinker==1.9.0
     # via flask
 cachetools==5.5.2
-    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    # via
+    #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-auth
 certifi==2025.6.15
     # via
     #   httpcore
@@ -49,16 +57,27 @@ click==8.2.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
     #   flask
+    #   google-adk
     #   litellm
     #   uvicorn
+cloudpickle==3.1.1
+    # via google-cloud-aiplatform
+colorama==0.4.6
+    # via griffe
 cryptography==45.0.5
-    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    # via
+    #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   authlib
 distro==1.9.0
     # via
     #   anthropic
     #   openai
+docstring-parser==0.16
+    # via google-cloud-aiplatform
 fastapi==0.115.14
-    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    # via
+    #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
 filelock==3.18.0
     # via huggingface-hub
 flask==3.1.1
@@ -73,12 +92,111 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.44
     # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+google-adk==1.5.0
+    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+google-api-core[grpc]==2.25.1
+    # via
+    #   google-api-python-client
+    #   google-cloud-aiplatform
+    #   google-cloud-appengine-logging
+    #   google-cloud-bigquery
+    #   google-cloud-core
+    #   google-cloud-logging
+    #   google-cloud-resource-manager
+    #   google-cloud-secret-manager
+    #   google-cloud-speech
+    #   google-cloud-storage
+    #   google-cloud-trace
+google-api-python-client==2.175.0
+    # via google-adk
+google-auth==2.40.3
+    # via
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-aiplatform
+    #   google-cloud-appengine-logging
+    #   google-cloud-bigquery
+    #   google-cloud-core
+    #   google-cloud-logging
+    #   google-cloud-resource-manager
+    #   google-cloud-secret-manager
+    #   google-cloud-speech
+    #   google-cloud-storage
+    #   google-cloud-trace
+    #   google-genai
+google-auth-httplib2==0.2.0
+    # via google-api-python-client
+google-cloud-aiplatform[agent-engines]==1.101.0
+    # via google-adk
+google-cloud-appengine-logging==1.6.2
+    # via google-cloud-logging
+google-cloud-audit-log==0.3.2
+    # via google-cloud-logging
+google-cloud-bigquery==3.34.0
+    # via google-cloud-aiplatform
+google-cloud-core==2.4.3
+    # via
+    #   google-cloud-bigquery
+    #   google-cloud-logging
+    #   google-cloud-storage
+google-cloud-logging==3.12.1
+    # via google-cloud-aiplatform
+google-cloud-resource-manager==1.14.2
+    # via google-cloud-aiplatform
+google-cloud-secret-manager==2.24.0
+    # via google-adk
+google-cloud-speech==2.33.0
+    # via google-adk
+google-cloud-storage==2.19.0
+    # via
+    #   google-adk
+    #   google-cloud-aiplatform
+google-cloud-trace==1.16.2
+    # via
+    #   google-cloud-aiplatform
+    #   opentelemetry-exporter-gcp-trace
+google-crc32c==1.7.1
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-genai==1.24.0
+    # via
+    #   google-adk
+    #   google-cloud-aiplatform
+google-resumable-media==2.7.2
+    # via
+    #   google-cloud-bigquery
+    #   google-cloud-storage
+googleapis-common-protos[grpc]==1.70.0
+    # via
+    #   google-api-core
+    #   google-cloud-audit-log
+    #   grpc-google-iam-v1
+    #   grpcio-status
+graphviz==0.21
+    # via google-adk
 greenlet==3.2.3
-    # via playwright
+    # via
+    #   playwright
+    #   sqlalchemy
+griffe==1.7.3
+    # via openai-agents
+grpc-google-iam-v1==0.14.2
+    # via
+    #   google-cloud-logging
+    #   google-cloud-resource-manager
+    #   google-cloud-secret-manager
 grpcio==1.73.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-api-core
+    #   googleapis-common-protos
+    #   grpc-google-iam-v1
+    #   grpcio-status
     #   grpcio-tools
+grpcio-status==1.73.1
+    # via google-api-core
 grpcio-tools==1.73.1
     # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
 gunicorn==21.2.0
@@ -91,14 +209,22 @@ hf-xet==1.1.5
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
+httplib2==0.22.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
 httptools==0.6.4
     # via uvicorn
 httpx==0.28.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
     #   anthropic
+    #   google-genai
     #   litellm
+    #   mcp
     #   openai
+httpx-sse==0.4.1
+    # via mcp
 huggingface-hub==0.33.2
     # via tokenizers
 idna==3.10
@@ -124,7 +250,9 @@ jiter==0.10.0
     #   anthropic
     #   openai
 jsonschema==4.24.0
-    # via litellm
+    # via
+    #   litellm
+    #   mcp
 jsonschema-specifications==2025.4.1
     # via jsonschema
 litellm==1.73.6
@@ -136,6 +264,10 @@ markupsafe==3.0.2
     #   flask
     #   jinja2
     #   werkzeug
+mcp==1.10.1
+    # via
+    #   google-adk
+    #   openai-agents
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.6.3
@@ -146,23 +278,44 @@ numpy==2.3.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
     #   pandas
+    #   shapely
 openai==1.93.0
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
     #   litellm
+    #   openai-agents
+openai-agents==0.0.17
+    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
 opentelemetry-api==1.34.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
+    #   google-cloud-logging
+    #   opentelemetry-exporter-gcp-trace
+    #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+opentelemetry-exporter-gcp-trace==1.9.0
+    # via
+    #   google-adk
+    #   google-cloud-aiplatform
+opentelemetry-resourcedetector-gcp==1.9.0a0
+    # via opentelemetry-exporter-gcp-trace
 opentelemetry-sdk==1.34.1
-    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    # via
+    #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
+    #   google-cloud-aiplatform
+    #   opentelemetry-exporter-gcp-trace
+    #   opentelemetry-resourcedetector-gcp
 opentelemetry-semantic-conventions==0.55b1
     # via opentelemetry-sdk
 orjson==3.10.18
     # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
 packaging==25.0
     # via
+    #   google-cloud-aiplatform
+    #   google-cloud-bigquery
     #   gunicorn
     #   huggingface-hub
     #   pytest
@@ -178,10 +331,39 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+proto-plus==1.26.1
+    # via
+    #   google-api-core
+    #   google-cloud-aiplatform
+    #   google-cloud-appengine-logging
+    #   google-cloud-logging
+    #   google-cloud-resource-manager
+    #   google-cloud-secret-manager
+    #   google-cloud-speech
+    #   google-cloud-trace
 protobuf==6.31.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-api-core
+    #   google-cloud-aiplatform
+    #   google-cloud-appengine-logging
+    #   google-cloud-audit-log
+    #   google-cloud-logging
+    #   google-cloud-resource-manager
+    #   google-cloud-secret-manager
+    #   google-cloud-speech
+    #   google-cloud-trace
+    #   googleapis-common-protos
+    #   grpc-google-iam-v1
+    #   grpcio-status
     #   grpcio-tools
+    #   proto-plus
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.2
+    # via google-auth
 pycparser==2.22
     # via cffi
 pydantic==2.11.7
@@ -189,38 +371,53 @@ pydantic==2.11.7
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
     #   anthropic
     #   fastapi
+    #   google-adk
+    #   google-cloud-aiplatform
+    #   google-genai
     #   litellm
+    #   mcp
     #   openai
+    #   openai-agents
     #   pydantic-settings
     #   redbird
     #   rocketry
 pydantic-core==2.33.2
     # via pydantic
 pydantic-settings==2.10.1
-    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    # via
+    #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   mcp
 pyee==13.0.0
     # via playwright
 pygments==2.19.2
     # via
     #   pytest
     #   rich
+pyparsing==3.2.3
+    # via httplib2
 pytest==8.4.1
     # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
 python-dateutil==2.9.0.post0
     # via
+    #   google-adk
+    #   google-cloud-bigquery
     #   pandas
     #   rocketry
 python-dotenv==1.1.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
     #   litellm
     #   pydantic-settings
     #   uvicorn
+python-multipart==0.0.20
+    # via mcp
 pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
     #   huggingface-hub
     #   uvicorn
 redbird==0.7.1
@@ -234,7 +431,14 @@ regex==2024.11.6
 requests==2.32.4
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
+    #   google-api-core
+    #   google-cloud-bigquery
+    #   google-cloud-storage
+    #   google-genai
     #   huggingface-hub
+    #   openai-agents
+    #   opentelemetry-resourcedetector-gcp
     #   tiktoken
 rich==14.0.0
     # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
@@ -244,6 +448,10 @@ rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
+rsa==4.9.1
+    # via google-auth
+shapely==2.1.1
+    # via google-cloud-aiplatform
 six==1.17.0
     # via python-dateutil
 smmap==5.0.2
@@ -253,8 +461,17 @@ sniffio==1.3.1
     #   anthropic
     #   anyio
     #   openai
+sqlalchemy==2.0.41
+    # via google-adk
+sse-starlette==2.3.6
+    # via mcp
 starlette==0.46.2
-    # via fastapi
+    # via
+    #   fastapi
+    #   google-adk
+    #   mcp
+tenacity==8.5.0
+    # via google-genai
 tiktoken==0.9.0
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
@@ -266,14 +483,21 @@ tqdm==4.67.1
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
     #   huggingface-hub
     #   openai
+types-requests==2.32.4.20250611
+    # via openai-agents
 typing-extensions==4.14.0
     # via
     #   anthropic
     #   anyio
     #   fastapi
+    #   google-adk
+    #   google-cloud-aiplatform
+    #   google-genai
     #   huggingface-hub
     #   openai
+    #   openai-agents
     #   opentelemetry-api
+    #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pydantic
@@ -281,6 +505,7 @@ typing-extensions==4.14.0
     #   pyee
     #   redbird
     #   referencing
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.1
     # via
@@ -288,10 +513,19 @@ typing-inspection==0.4.1
     #   pydantic-settings
 tzdata==2025.2
     # via pandas
+tzlocal==5.3.1
+    # via google-adk
+uritemplate==4.2.0
+    # via google-api-python-client
 urllib3==2.5.0
-    # via requests
+    # via
+    #   requests
+    #   types-requests
 uvicorn[standard]==0.35.0
-    # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    # via
+    #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
+    #   mcp
 uvloop==0.21.0
     # via uvicorn
 watchfiles==1.1.0
@@ -299,6 +533,8 @@ watchfiles==1.1.0
 websockets==15.0.1
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
+    #   google-adk
+    #   google-genai
     #   uvicorn
 werkzeug==3.1.3
     # via flask


### PR DESCRIPTION
## Summary
- pin `openai-agents` and `google-adk` in core requirements
- regenerate `requirements.lock`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(installs `openai-agents` and `google-adk`)*
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files scripts/fetch_assets.py alpha_factory_v1/requirements-core.txt requirements.lock` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_6868ea3309bc833381e79a3fd3673154