### PR TITLE
fix: update docs asset fetch and caching

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,6 +60,8 @@ jobs:
           env_data = os.getenv("PYODIDE_BASE_URL", "") + os.getenv("HF_GPT2_BASE_URL", "")
           data = (
               fa.CHECKSUMS["pyodide.asm.wasm"]
+              + fa.CHECKSUMS["pyodide.js"]
+              + fa.CHECKSUMS["repodata.json"]
               + fa.CHECKSUMS["pytorch_model.bin"]
               + env_data
           )

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -265,6 +265,12 @@ def main() -> None:
                 else:
                     fb.append(f"{ALT_PYODIDE_BASE_URL}/{dest.name}")
                 fb.append(f"{GITHUB_PYODIDE_BASE_URL}/{dest.name}")
+                if dest.name == "repodata.json":
+                    custom_root = PYODIDE_BASE_URL.rsplit("/", 1)[0]
+                    default_root = DEFAULT_PYODIDE_BASE_URL.rsplit("/", 1)[0]
+                    fb.append(f"{custom_root}/{dest.name}")
+                    fb.append(f"{default_root}/{dest.name}")
+                    fb.append(f"{GITHUB_PYODIDE_BASE_URL.rsplit('/', 1)[0]}/{dest.name}")
                 fallback = fb
             if rel == "lib/bundle.esm.min.js":
                 fallback = "bafkreihgldx46iuks4lybdsc5qc6xom2y5fqdy5w3vvrxntlr42wc43u74"


### PR DESCRIPTION
## Summary
- improve fallback URL handling for `repodata.json` in `fetch_assets.py`
- factor Pyodide checksums into docs asset cache key

## Testing
- `pre-commit run --files scripts/fetch_assets.py .github/workflows/docs.yml` *(skipped some hooks due to environment restrictions)*
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68690856160883338a5a08bfd3694cdc