### PR TITLE
[alpha_factory] add job token permissions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,9 @@ on:
         description: 'Authorization token for maintainers'
         required: false
 
+permissions:
+  contents: write
+
 jobs:
   replay-bench:
     if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,10 @@ on:
         description: 'Authorization token for maintainers'
         required: false
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   PYTHON_VERSION_MATRIX: "3.11,3.12"
   DOCKER_IMAGE: alpha-factory

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -7,6 +7,9 @@ on:
         description: 'Authorization token for maintainers'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy-kind:
     if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -7,6 +7,9 @@ on:
         description: 'Authorization token for maintainers'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   load-test:
     if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -7,6 +7,9 @@ on:
         description: 'Authorization token for maintainers'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   transfer-matrix:
     if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -7,6 +7,9 @@ on:
         description: 'Authorization token for maintainers'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build-and-check:
     if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,6 +7,9 @@ on:
         description: 'Authorization token for maintainers'
         required: false
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION_MATRIX: "3.11,3.12"
 


### PR DESCRIPTION
## Summary
- require least privilege tokens across CI workflows

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files .github/workflows/bench.yml .github/workflows/build-and-test.yml .github/workflows/deploy-kind.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/size-check.yml .github/workflows/smoke.yml` *(fails: verify-requirements-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68691bb4e7648333a1e0008189c181a7