### PR TITLE
[alpha_factory] restrict docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-deploy:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner }}
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest


### PR DESCRIPTION
## Summary
- fix docs workflow gating expression

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files .github/workflows/docs.yml` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68691f2244688333ad337ee058398f37