### PR TITLE
[alpha_factory] fix duplicate self_healing_repo module

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,7 @@ exclude = \
     alpha_factory_v1/demos/muzeromctsllmagent_v0/*,\
     alpha_factory_v1/demos/omni_factory_demo/*,\
     alpha_factory_v1/demos/self_healing_repo/*,\
-    alpha_factory_v1/demos/self_healing_repo.py,\
+    alpha_factory_v1/demos/self_healing_repo_cli.py,\
     alpha_factory_v1/demos/solving_agi_governance/*,\
     alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/*,\
     alpha_factory_v1/tests/*,\

--- a/alpha_factory_v1/demos/self_healing_repo/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-"""Entry point for the self-healing demo package."""
-# mypy: ignore-errors

--- a/alpha_factory_v1/demos/self_healing_repo_cli.py
+++ b/alpha_factory_v1/demos/self_healing_repo_cli.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""alpha_factory_v1.demos.self_healing_repo
+"""alpha_factory_v1.demos.self_healing_repo_cli
 ===========================================
 
 Self‑Healing Repository Demo
@@ -24,7 +24,7 @@ Usage
 .. code-block:: bash
 
    # from repo root
-   python -m alpha_factory_v1.demos.self_healing_repo --max-turns 6
+   python -m alpha_factory_v1.demos.self_healing_repo_cli --max-turns 6
 
 Extra CLI flags:
 
@@ -186,6 +186,6 @@ def main(argv: Optional[list[str]] = None) -> None:
 
 # ────────────────────────────────────────────────────────────────────────────────
 if __name__ == "__main__":
-    # Enables `python -m alpha_factory_v1.demos.self_healing_repo`
+    # Enables `python -m alpha_factory_v1.demos.self_healing_repo_cli`
     with contextlib.suppress(KeyboardInterrupt):
         main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ exclude = [
     "alpha_factory_v1/demos/muzeromctsllmagent_v0/*",
     "alpha_factory_v1/demos/omni_factory_demo/*",
     "alpha_factory_v1/demos/self_healing_repo/*",
-    "alpha_factory_v1/demos/self_healing_repo.py",
+    "alpha_factory_v1/demos/self_healing_repo_cli.py",
     "alpha_factory_v1/demos/solving_agi_governance/*",
     "alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/*",
     "alpha_factory_v1/tests/*",


### PR DESCRIPTION
## Summary
- remove `self_healing_repo/__init__.py`
- rename demo script to `self_healing_repo_cli.py`
- update lint config paths
- run type checks to ensure no duplicate module error

## Testing
- `pre-commit run --files .flake8 pyproject.toml alpha_factory_v1/demos/self_healing_repo_cli.py`
- `python check_env.py --auto-install`
- `mypy --config-file mypy.ini alpha_factory_v1/demos/self_healing_repo_cli.py`
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68693bf8665c833394b7477bc266ea05