### PR TITLE
[alpha_factory] Remove old pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
         entry: make proto-verify
         language: system
         pass_filenames: false
-      - id: verify-requirements-lock
-        name: Verify requirements.lock is up to date
-        entry: python scripts/verify_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
       - id: verify-alpha-requirements-lock
         name: Verify alpha_factory_v1 requirements.lock is up to date
         entry: python scripts/verify_alpha_requirements_lock.py


### PR DESCRIPTION
## Summary
- drop the obsolete `verify-requirements-lock` hook from pre-commit
- refresh pre-commit hooks

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68696806eaac8333abc4e684129c0d7d