### PR TITLE
[alpha_factory] remove era experience lock requirement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,12 +46,6 @@ repos:
         language: python
         additional_dependencies: [pip-tools, "pip<25"]
         pass_filenames: false
-      - id: verify-era-experience-requirements-lock
-        name: Verify era_of_experience requirements.lock is up to date
-        entry: python scripts/verify_era_experience_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
       - id: verify-mats-demo-lock
         name: Verify meta_agentic_tree_search_v0 requirements.lock is up to date
         entry: python scripts/verify_mats_requirements_lock.py


### PR DESCRIPTION
## Summary
- stop verifying `era_of_experience` requirements lock during pre-commit

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files .pre-commit-config.yaml` *(fails: alpha_factory_v1/requirements.lock is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_68696f9d3a94833392bc8f0a00046572