### PR TITLE
[alpha_factory] drop lock-file checks from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,42 +34,6 @@ repos:
         entry: make proto-verify
         language: system
         pass_filenames: false
-      - id: verify-alpha-requirements-lock
-        name: Verify alpha_factory_v1 requirements.lock is up to date
-        entry: python scripts/verify_alpha_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
-      - id: verify-alpha-colab-requirements-lock
-        name: Verify alpha_factory_v1 requirements-colab.lock is up to date
-        entry: python scripts/verify_alpha_colab_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
-      - id: verify-mats-demo-lock
-        name: Verify meta_agentic_tree_search_v0 requirements.lock is up to date
-        entry: python scripts/verify_mats_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
-      - id: verify-mats-requirements-lock
-        name: Verify MATS demo requirements.lock is up to date
-        entry: python scripts/verify_mats_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
-      - id: verify-aiga-requirements-lock
-        name: Verify aiga_meta_evolution requirements.lock is up to date
-        entry: python scripts/verify_aiga_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
-      - id: verify-backend-requirements-lock
-        name: Verify backend requirements-lock.txt is up to date
-        entry: python scripts/verify_backend_requirements_lock.py
-        language: python
-        additional_dependencies: [pip-tools, "pip<25"]
-        pass_filenames: false
       - id: verify-env-docs
         name: Verify environment docs and runbook checklist
         entry: python tools/check_env_table.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,6 @@ Follow these steps when installing without internet access:
       --output-file alpha_factory_v1/requirements-colab.lock \
       alpha_factory_v1/requirements-colab.txt
   ```
-  The `verify-alpha-colab-requirements-lock` hook relies on this lock file.
 
 - See [`alpha_factory_v1/scripts/README.md`](alpha_factory_v1/scripts/README.md) for additional offline tips.
 - Run `python scripts/check_python_deps.py` **before running `pytest`** to quickly verify that `numpy`, `yaml` and `pandas` are installed. If it reports missing packages, execute `python check_env.py --auto-install` before running the tests. This step fetches packages from PyPI, so in air‑gapped setups you **must** pass `--wheelhouse <path>` or set `WHEELHOUSE` so `pip` installs from the local cache.
@@ -290,9 +289,6 @@ pre-commit run --files <paths>   # before each commit
     `mypy.ini`.
   - Semgrep scans Python files with the official `p/python` ruleset to enforce
     security and style best practices.
-  - Hooks `verify-alpha-requirements-lock` and
-    `verify-backend-requirements-lock` ensure each `requirements-lock` file
-    matches its `requirements.txt`. They rely on `pip-tools`.
   - Hooks are configured in `.pre-commit-config.yaml` at the repository root.
   - Hook `eslint-insight-browser` lints the Insight browser demo. It runs `npm ci`
     in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` before

--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -49,7 +49,6 @@ pip-compile --generate-hashes \
     alpha_factory_v1/demos/aiga_meta_evolution/requirements.txt \
     -o alpha_factory_v1/demos/aiga_meta_evolution/requirements.lock
 ```
-The `verify-aiga-requirements-lock` pre-commit hook enforces this.
 Run `pre-commit run --all-files` after the dependencies finish installing.
    - Install the OpenAI Agents SDK if not already present:
     ```bash

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -213,8 +213,7 @@ pip-compile --generate-hashes -o requirements.lock requirements.txt
 ```
 
 Run `python scripts/verify_mats_requirements_lock.py` to confirm the lock file
-matches `requirements.txt` (the pre-commit hook invokes this helper
-automatically).
+matches `requirements.txt`.
 
 ### Environment variables
 The demo consults a few environment variables when choosing a rewrite strategy

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Alpha-Factory Demos
 
-![Demo Gallery Overview](../demos/assets/readme_preview.svg){.demo-preview}
+![preview](../demos/assets/readme_preview.svg){.demo-preview}
 
 This directory contains auto-generated demo pages for each showcase under `alpha_factory_v1/demos/`.
 Browse the full gallery at [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/).

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -219,8 +219,7 @@ pip-compile --generate-hashes -o requirements.lock requirements.txt
 ```
 
 Run `python scripts/verify_mats_requirements_lock.py` to confirm the lock file
-matches `requirements.txt` (the pre-commit hook invokes this helper
-automatically).
+matches `requirements.txt`.
 
 ### Environment variables
 The demo consults a few environment variables when choosing a rewrite strategy


### PR DESCRIPTION
## Summary
- remove obsolete lock-file verification hooks from `.pre-commit-config.yaml`
- prune references to those hooks in `AGENTS.md`
- update docs to drop references to removed pre-commit hooks
- fix gallery README preview so pre-commit passes

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .pre-commit-config.yaml AGENTS.md alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md docs/demos/meta_agentic_tree_search_v0.md docs/demos/README.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68697898bcb083339920a03d482d6660