### PR TITLE
[alpha_factory] add eslint ignore file

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.eslintignore
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.eslintignore
@@ -1,0 +1,5 @@
+lib/
+dist/
+build/
+docs/
+*.min.js

--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -6,4 +6,11 @@ BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v
 # Install npm dependencies deterministically
 npm --prefix "$BROWSER_DIR" ci >/dev/null
 # Run eslint on provided file paths using the flat config
-ESLINT_USE_FLAT_CONFIG=true npx --prefix "$BROWSER_DIR" eslint --config "$BROWSER_DIR/eslint.config.js" "$@"
+ESLINT_USE_FLAT_CONFIG=true npx --prefix "$BROWSER_DIR" eslint \
+    --config "$BROWSER_DIR/eslint.config.js" \
+    --ignore-path "$BROWSER_DIR/.eslintignore" "$@" || {
+    patterns=$(grep -v '^\s*$' "$BROWSER_DIR/.eslintignore" \
+        | sed 's/^/--ignore-pattern /' | tr '\n' ' ')
+    ESLINT_USE_FLAT_CONFIG=true npx --prefix "$BROWSER_DIR" eslint \
+        --config "$BROWSER_DIR/eslint.config.js" $patterns "$@"
+}


### PR DESCRIPTION
## Summary
- add `.eslintignore` to Insight Browser
- update ESLint runner to honour ignore patterns with fallback

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js`


------
https://chatgpt.com/codex/tasks/task_e_6869840a2dc08333b940110ac7056694