### PR TITLE
[alpha_factory] enable caching in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install project dependencies
         run: python check_env.py --auto-install
       - name: Build sandbox image
@@ -41,6 +42,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+          cache: 'npm'
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit checks


### PR DESCRIPTION
## Summary
- reuse pip and npm caches in docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files .github/workflows/docs.yml`

------
https://chatgpt.com/codex/tasks/task_e_68698693ac188333b971a3b68821ddc9