### PR TITLE
Fix docs workflow ESLint scope

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,3 +74,8 @@ repos:
         entry: scripts/run_eslint.sh
         language: system
         types: [javascript]
+        exclude: |
+          (^docs/)|
+          (^alpha_factory_v1/core/interface/web_client/dist/)|
+          (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/(dist|lib|build|tests)/)|
+          (^alpha_factory_v1/ui/static/)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.eslintignore
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.eslintignore
@@ -2,4 +2,5 @@ lib/
 dist/
 build/
 docs/
+../../../../docs/
 *.min.js


### PR DESCRIPTION
## Summary
- exclude docs and built JS from ESLint to prevent failures in docs workflow

## Testing
- `pre-commit run --files .pre-commit-config.yaml alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.eslintignore`

------
https://chatgpt.com/codex/tasks/task_e_6869881ecc788333ba48bd26451332b2