### PR TITLE
ci: use .nvmrc in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,10 +39,13 @@ jobs:
         run: python check_env.py --auto-install
       - name: Build sandbox image
         run: docker build -t $SANDBOX_IMAGE -f sandbox.Dockerfile .
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'npm'
+          cache-dependency-path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+            alpha_factory_v1/core/interface/web_client/package-lock.json
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit checks


### PR DESCRIPTION
## Summary
- read Node.js version from `.nvmrc`
- update docs workflow to use `actions/setup-node@v4`

## Testing
- `pre-commit run --files .github/workflows/docs.yml --hook-stage manual -v`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68699e9ece5c83338c568a950f4e94d5