### PR TITLE
[alpha_factory] add restore-keys to docs asset cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,6 +82,7 @@ jobs:
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
           key: assets-${{ steps.asset-key.outputs.key }}
+          restore-keys: assets-
       - name: Build and deploy gallery
         env:
           IPFS_GATEWAY: ${{ env.IPFS_GATEWAY }}


### PR DESCRIPTION
## Summary
- allow cache fallback in docs workflow by adding `restore-keys`

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*

------
https://chatgpt.com/codex/tasks/task_e_6869b2ac296c8333b3a30c40b02b045d