### PR TITLE
ci: fetch assets before docs pre-commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,8 @@ jobs:
             alpha_factory_v1/core/interface/web_client/package-lock.json
       - name: Install pre-commit
         run: pip install pre-commit
+      - name: Fetch browser assets
+        run: python scripts/fetch_assets.py
       - name: Run pre-commit checks
         run: pre-commit run --all-files
       - name: Install docs dependencies


### PR DESCRIPTION
## Summary
- download browser assets earlier in the docs workflow

## Checks
- `pre-commit run --files .github/workflows/docs.yml`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6869bc481ce883338d3780c1acf8ffbd