### PR TITLE
[alpha_factory] Update eslint-insight-browser hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,8 +74,12 @@ repos:
         entry: scripts/run_eslint.sh
         language: system
         types: [javascript]
+        args: ["--env", "jest"]
         exclude: |
           (^docs/)|
+          (^dist/)|
           (^alpha_factory_v1/core/interface/web_client/dist/)|
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/(dist|lib|build|tests)/)|
-          (^alpha_factory_v1/ui/static/)
+          (^alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/)|
+          (^alpha_factory_v1/ui/static/)|
+          (bundle\.esm\.min\.js$)|(insight\.bundle\.js$)


### PR DESCRIPTION
## Summary
- tweak eslint-insight-browser hook in `.pre-commit-config.yaml`
  - add `--env jest` to args
  - ignore dist output and bundle files

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 29 errors during collection)*
- `pre-commit run --files .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6869bf47fc0083339a8e592ca2718c2d