### PR TITLE
[alpha_factory] docs: drop IPFS fallback references

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,8 +49,8 @@ Downstream users should consult this section when upgrading.
 - `scripts/fetch_assets.py` now downloads the Pyodide runtime from the official
   CDN and retrieves GPT-2 weights directly from Hugging Face.
 - Added `FETCH_ASSETS_ATTEMPTS` environment variable to control download retries.
-- The browser bundle now defaults to the official Web3 Storage CDN. IPFS is
-  used only as a secondary mirror.
+- The browser bundle now defaults to the official Web3 Storage CDN. IPFS
+  fallback has been removed.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.

--- a/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
+++ b/docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
@@ -13,8 +13,9 @@ This sprint explains how Codex can publish the **Alpha-Factory** demo gallery to
    python scripts/edge_human_knowledge_pages_sprint.py
    ```
   This triggers `edge_of_knowledge_sprint.sh` which performs environment validation, dependency checks, asset builds, integrity tests and finally deploys the site via `mkdocs gh-deploy`.
-  Export `IPFS_GATEWAY`, `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` beforehand to
-  customize asset downloads if the defaults fail.
+  Export `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` beforehand to
+  customize asset downloads if the defaults fail. `IPFS_GATEWAY` only
+  applies when retrieving pinned Insight demo runs.
 3. Visit the printed URL in an incognito window and ensure `index.html` links to every demo with preview media.
 4. The repository owner must start the [`Docs` workflow](../.github/workflows/docs.yml)
    manually from the **Actions** tab to publish the site to GitHub Pages.

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -24,11 +24,9 @@ offline functionality and then publishes the docs in one step.
 
 The `fetch-assets` command downloads the Pyodide runtime and GPT‑2 weights from
 official mirrors. Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change
-the sources. Remaining assets are fetched via IPFS and the command respects the
-`IPFS_GATEWAY` environment variable. Set `IPFS_GATEWAY=<url>` to override the
-primary gateway when running the command. If downloads fail the script
-automatically retries using `https://ipfs.io/ipfs`, `https://cloudflare-ipfs.com/ipfs`,
-`https://w3s.link/ipfs`, `https://cf-ipfs.com/ipfs` and `https://gateway.pinata.cloud/ipfs`.
+the sources. IPFS is no longer used for these assets, so failures should be
+diagnosed by checking your network connection or mirror URLs. `IPFS_GATEWAY`
+only affects loading pinned Insight demo runs.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- update hosting docs to clarify IPFS gateway use
- note removal of IPFS fallback in changelog

## Testing
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ccf253cc83339b01cdd0eadffb07