### PR TITLE
[alpha_factory] fix eslint hook paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,12 +71,16 @@ repos:
         name: Lint Insight Browser with ESLint
         entry: scripts/run_eslint.sh
         language: system
+        files: ^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/
         types: [javascript]
         exclude: |
           (^docs/)|
           (^dist/)|
           (^alpha_factory_v1/core/interface/web_client/dist/)|
-          (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/(dist|lib|build|tests)/)|
+          (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/(dist|lib)/)|
+          (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/)|
+          (build\.js$)|
+          (^tests/)|
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/)|
           (^alpha_factory_v1/ui/static/)|
           (bundle\.esm\.min\.js$)|(insight\.bundle\.js$)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/app.js
@@ -95,7 +95,7 @@ function updateLegend(strats){
   }
 }
 
-function updateDepthLegend(max){
+function updateDepthLegend(){
   const dl=document.getElementById('depth-legend');
   dl.innerHTML='depth';
   const bar=document.createElement('div');
@@ -250,7 +250,7 @@ window.addEventListener('DOMContentLoaded',async()=>{
   telemetry = initTelemetry();
   archive = new Archive();
   if (typeof document.hasStorageAccess === 'function') {
-    try { await document.hasStorageAccess(); } catch {}
+    try { await document.hasStorageAccess(); } catch { /* noop */ }
   }
   await archive.open();
   evolutionPanel = initEvolutionPanel(archive);
@@ -312,7 +312,7 @@ window.addEventListener('DOMContentLoaded',async()=>{
     if(!deferredPrompt)return;
     installBtn.hidden=true;
     deferredPrompt.prompt();
-    try{await deferredPrompt.userChoice;}catch{}
+    try{await deferredPrompt.userChoice;}catch{ /* noop */ }
     deferredPrompt=null;
   });
   window.addEventListener("appinstalled",()=>{
@@ -332,12 +332,12 @@ window.addEventListener('DOMContentLoaded',async()=>{
     }
     if (pinned && pinned.url) {
       if (navigator.clipboard) {
-        try { await navigator.clipboard.writeText(pinned.url); } catch {}
+        try { await navigator.clipboard.writeText(pinned.url); } catch { /* noop */ }
       }
       toast(`pinned ${pinned.cid}`);
     } else {
       if (navigator.clipboard) {
-        try { await navigator.clipboard.writeText(url); } catch {}
+        try { await navigator.clipboard.writeText(url); } catch { /* noop */ }
       }
       toast(t('link_copied'));
     }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/eslint.config.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/eslint.config.js
@@ -14,6 +14,22 @@ const browserGlobals = {
     Event: "readonly",
     DOMException: "readonly",
     indexedDB: "readonly",
+    btoa: "readonly",
+    crypto: "readonly",
+    Blob: "readonly",
+    URL: "readonly",
+    importScripts: "readonly",
+    caches: "readonly",
+    console: "readonly",
+    workbox: "readonly",
+    d3: "readonly",
+    performance: "readonly",
+    requestAnimationFrame: "readonly",
+    clearTimeout: "readonly",
+    setTimeout: "readonly",
+    File: "readonly",
+    HashChangeEvent: "readonly",
+    MessageEvent: "readonly",
 };
 
 export default [

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/error_boundary_limit.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/error_boundary_limit.test.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { initErrorBoundary, getErrorLog, clearErrorLog, record } from '../src/utils/errorBoundary.ts';
+import { initErrorBoundary, getErrorLog, clearErrorLog } from '../src/utils/errorBoundary.ts';
 import { t } from '../src/ui/i18n.ts';
 
 function makeMocks() {


### PR DESCRIPTION
## Summary
- adjust pre-commit ESLint hook ignore patterns
- declare browser globals in eslint config
- silence unused imports and empty catches in browser demo

## Testing
- `pre-commit run --all-files` *(fails: npm install errors)*
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6869d608d6b48333b8f2dfc5020b0e09