### PR TITLE
[alpha_factory] fix docs references to IPFS fallback

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,7 +33,8 @@ API_TOKEN=REPLACE_ME_TOKEN
 # Web3.Storage token for pinning Insight demo exports
 PINNER_TOKEN=
 
-# IPFS gateway base URL. Override to use a different primary gateway.
+# IPFS gateway base URL used to fetch pinned Insight demo runs.
+# Override to use a different primary gateway.
 IPFS_GATEWAY=https://ipfs.io/ipfs
 
 # Working memory directory used by demos and tests

--- a/README.md
+++ b/README.md
@@ -1207,7 +1207,7 @@ for instructions and example volume mounts.
 | `SANDBOX_MEM_MB` | `256` | Memory cap for sandboxed code in MB. |
 | `MAX_RESULTS` | `100` | Maximum stored simulation results. |
 | `MAX_SIM_TASKS` | `4` | Maximum concurrent simulation tasks. |
-| `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for fetching pinned Insight demo runs. |
+| `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for fetching pinned Insight demo runs. Not used for asset downloads. |
 | `HF_GPT2_BASE_URL` | `https://huggingface.co/openai-community/gpt2/resolve/main` | Base URL for the GPT‑2 checkpoints. |
 | `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.26.0/full` | Base URL for the Pyodide runtime files. |
 | `FETCH_ASSETS_ATTEMPTS` | `3` | Download retry count for `fetch_assets.py`. |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -56,11 +56,7 @@ is missing the build scripts continue with default empty values:
   embed the key in the built HTML.** Store it in `localStorage` or enter it at
   runtime instead.
 - `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs. Set
-  `IPFS_GATEWAY=<url>` to override the primary gateway. When assets fail to load
-  the build scripts automatically try `https://ipfs.io/ipfs`,
-  `https://cloudflare-ipfs.com/ipfs`, `https://w3s.link/ipfs`,
-  `https://cf-ipfs.com/ipfs` and `https://gateway.pinata.cloud/ipfs` as
-  fallbacks.
+  `IPFS_GATEWAY=<url>` to override the primary gateway.
 - `OTEL_ENDPOINT` – OTLP/HTTP endpoint for anonymous telemetry (leave blank to disable).
 - `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
 - Browsers with WebGPU can accelerate the local model using the ONNX runtime.


### PR DESCRIPTION
## Summary
- clarify that `IPFS_GATEWAY` is only used for pinned runs
- drop stale fallback info from Insight Browser README
- update `.env.sample` comment

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: ImportError: cannot import name 'research_agent')*
- `pre-commit run --files README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md .env.sample`

------
https://chatgpt.com/codex/tasks/task_e_6869e143b9808333a743165796fc5413