### PR TITLE
[alpha_factory] include requests_mock in env check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ before running `pytest`. When offline, set `WHEELHOUSE` or pass
 repository ships with a `wheels/` directory that can be used as this cache.
 The full test suite relies on optional packages including `numpy`, `torch`,
 `pandas`, `prometheus_client`, `gymnasium`, `playwright`, `httpx`, `uvicorn`,
-`git` and `hypothesis`.
+`git`, `hypothesis` and `requests_mock`.
 
 #### Wheelhouse Setup
 

--- a/check_env.py
+++ b/check_env.py
@@ -88,6 +88,7 @@ REQUIRED_BASE = [
     "yaml",
     "click",
     "requests",
+    "requests_mock",
     "pandas",
     "playwright.sync_api",
     "websockets",

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,7 +84,7 @@ internet connectivity or a wheelhouse available via `--wheelhouse <dir>`
 (or the `WHEELHOUSE` environment variable).
 The full suite exercises features that depend on optional packages such as
 `numpy`, `torch`, `pandas`, `prometheus_client`, `gymnasium`, `playwright`,
-`httpx`, `uvicorn`, `git` and `hypothesis`.
+`httpx`, `uvicorn`, `git`, `hypothesis` and `requests_mock`.
 
 Tests are skipped when `numpy` or `prometheus_client` are missing. The
 `tests/conftest.py` helper checks for `torch` with `importlib.util.find_spec`


### PR DESCRIPTION
## Summary
- ensure `requests_mock` installs with check_env
- document `requests_mock` as a test dependency

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -m 'not e2e' -q` *(fails: ImportError: cannot import name 'strategy_agent')*
- `pre-commit run --files check_env.py README.md tests/README.md`

------
https://chatgpt.com/codex/tasks/task_e_686a042a45748333be779c9c5c26d077