### PR TITLE
[alpha_factory] add --ignore-scripts to eslint install

### DIFF
--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -6,7 +6,7 @@ BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v
 # Install npm dependencies deterministically
 # Install npm dependencies deterministically if missing
 if [ ! -d "$BROWSER_DIR/node_modules" ]; then
-    npm --prefix "$BROWSER_DIR" ci >/dev/null
+    npm --prefix "$BROWSER_DIR" ci --ignore-scripts >/dev/null
 fi
 cd "$BROWSER_DIR"
 args=()


### PR DESCRIPTION
## Summary
- skip npm postinstall in `scripts/run_eslint.sh`
- verify the ESLint hook

## Testing
- `pre-commit run eslint-insight-browser --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js`

------
https://chatgpt.com/codex/tasks/task_e_686a0b37b7f48333b1bd650e240a3e75