### PR TITLE
fix: expose messaging and demo agents

### DIFF
--- a/alpha_factory_v1/core/agents/__init__.py
+++ b/alpha_factory_v1/core/agents/__init__.py
@@ -4,7 +4,16 @@
 from .meta_refinement_agent import MetaRefinementAgent
 from .self_improver_agent import SelfImproverAgent
 from .base_agent import BaseAgent
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import planning_agent, research_agent
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (
+    planning_agent,
+    research_agent,
+    strategy_agent,
+    market_agent,
+    codegen_agent,
+    safety_agent,
+    memory_agent,
+    adk_summariser_agent,
+)
 
 __all__ = [
     "MetaRefinementAgent",
@@ -12,4 +21,10 @@ __all__ = [
     "BaseAgent",
     "planning_agent",
     "research_agent",
+    "strategy_agent",
+    "market_agent",
+    "codegen_agent",
+    "safety_agent",
+    "memory_agent",
+    "adk_summariser_agent",
 ]

--- a/alpha_factory_v1/core/utils/__init__.py
+++ b/alpha_factory_v1/core/utils/__init__.py
@@ -17,6 +17,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 from .file_ops import view, str_replace
 from . import alerts, tracing
+from alpha_factory_v1.common import utils as common_utils
+
+messaging = common_utils.messaging
 from .snark import (
     generate_proof,
     publish_proof,
@@ -38,4 +41,5 @@ __all__ = [
     "verify_aggregate_proof",
     "alerts",
     "tracing",
+    "messaging",
 ]


### PR DESCRIPTION
## Summary
- expose demo agents in `alpha_factory_v1.core.agents`
- re-export `messaging` from `alpha_factory_v1.core.utils`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 84 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a0d60d57c8333bf06f7807d27081b