### PR TITLE
[alpha_factory] ensure ESLint installs properly

### DIFF
--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -6,7 +6,7 @@ BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v
 # Install npm dependencies deterministically
 # Install npm dependencies deterministically if missing
 if [ ! -d "$BROWSER_DIR/node_modules" ]; then
-    npm --prefix "$BROWSER_DIR" ci --ignore-scripts >/dev/null
+    npm --prefix "$BROWSER_DIR" ci >/dev/null
 fi
 cd "$BROWSER_DIR"
 args=()


### PR DESCRIPTION
## Summary
- ensure ESLint install scripts run by dropping `--ignore-scripts`

## Testing
- `pre-commit run --all-files`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule ... 84 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a62fd5bbc83339f865b4719ceb83f