### PR TITLE
[alpha_factory] Update docs workflow for Python 3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
       - name: Install project dependencies
         run: python check_env.py --auto-install


### PR DESCRIPTION
## Summary
- use Python 3.12 for the docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/docs.yml`
- `pytest -q` *(fails: 84 errors, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686a6ccc47608333b670838419ff3598