### PR TITLE
fix: reinstall npm dependencies when package-lock changes

### DIFF
--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -3,10 +3,14 @@
 set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
-# Install npm dependencies deterministically
-# Install npm dependencies deterministically if missing
-if [ ! -d "$BROWSER_DIR/node_modules" ]; then
+LOCK_FILE="$BROWSER_DIR/package-lock.json"
+CHECK_FILE="$BROWSER_DIR/node_modules/.package_lock_checksum"
+
+# Install npm dependencies deterministically when needed
+lock_hash="$(sha256sum "$LOCK_FILE" | awk '{print $1}')"
+if [ ! -d "$BROWSER_DIR/node_modules" ] || [ ! -f "$CHECK_FILE" ] || [ "$(cat "$CHECK_FILE" 2>/dev/null)" != "$lock_hash" ]; then
     npm --prefix "$BROWSER_DIR" ci >/dev/null
+    echo "$lock_hash" > "$CHECK_FILE"
 fi
 cd "$BROWSER_DIR"
 args=()


### PR DESCRIPTION
## Summary
- detect changes to package-lock in `run_eslint.sh`
- automatically reinstall node modules when lockfile differs

## Testing
- `pre-commit run --files scripts/run_eslint.sh`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686a6fd409008333bdb2971bcd71a1b5