### PR TITLE
[alpha_factory] Fix asset cache key generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
           import os
           import scripts.fetch_assets as fa
 
-          env_data = os.getenv("PYODIDE_BASE_URL", "") + os.getenv("HF_GPT2_BASE_URL", "")
+          env_data = f"{os.getenv('PYODIDE_BASE_URL', '')}:{os.getenv('HF_GPT2_BASE_URL', '')}"
           data = (
               fa.CHECKSUMS["pyodide.asm.wasm"]
               + fa.CHECKSUMS["pyodide.js"]


### PR DESCRIPTION
## Summary
- ensure docs workflow uses a separator when concatenating asset base URLs

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pytest -q` *(fails: 84 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a749cc92883338bd20acb03fea99a