### PR TITLE
Add Node install steps to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,10 @@ jobs:
           cache-dependency-path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
             alpha_factory_v1/core/interface/web_client/package-lock.json
+      - name: Install Insight Browser dependencies
+        run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+      - name: Install Web client dependencies
+        run: npm ci --prefix alpha_factory_v1/core/interface/web_client
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Fetch browser assets


### PR DESCRIPTION
## Summary
- install Node modules for Insight demo and web client in docs workflow

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `pytest -m smoke -q` *(fails: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686a7c9343588333aba5f3f6ab4cf28a