### PR TITLE
Update docs dispatch workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-deploy:
-    if: ${{ github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner }}
+    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -116,7 +116,10 @@ GitHub Pages.
 The "📚 Docs" workflow
 The repository owner manually triggers [`docs.yml`](../.github/workflows/docs.yml), which runs
 `scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
-`gh-pages` branch.
+`gh-pages` branch. Maintainers can supply a `run_token` input matching the
+`DISPATCH_TOKEN` repository secret to authorize the workflow when launching it
+from **Actions → 📚 Docs**. Without this token only the repository owner can
+dispatch the job.
 The workflow restores a cache keyed by the Pyodide and GPT‑2 file checksums before
 running `npm run fetch-assets`. Once the assets pass verification the cache is
 saved so subsequent runs skip the downloads.


### PR DESCRIPTION
## Summary
- allow maintainers to pass a dispatch token to run the docs workflow
- document the run_token input in hosting instructions

## Testing
- `pre-commit run --files .github/workflows/docs.yml docs/HOSTING_INSTRUCTIONS.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8587fbe48333813e6f25875a5908