### PR TITLE
[alpha_factory] simplify eslint runner

### DIFF
--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -6,11 +6,10 @@ BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v
 LOCK_FILE="$BROWSER_DIR/package-lock.json"
 CHECK_FILE="$BROWSER_DIR/node_modules/.package_lock_checksum"
 
-# Install npm dependencies deterministically when needed
-lock_hash="$(sha256sum "$LOCK_FILE" | awk '{print $1}')"
-if [ ! -d "$BROWSER_DIR/node_modules" ] || [ ! -f "$CHECK_FILE" ] || [ "$(cat "$CHECK_FILE" 2>/dev/null)" != "$lock_hash" ]; then
+# Only (re)install dependencies when node_modules or the checksum file is missing
+if [ ! -d "$BROWSER_DIR/node_modules" ] || [ ! -f "$CHECK_FILE" ]; then
     npm --prefix "$BROWSER_DIR" ci >/dev/null
-    echo "$lock_hash" > "$CHECK_FILE"
+    sha256sum "$LOCK_FILE" | awk '{print $1}' > "$CHECK_FILE"
 fi
 cd "$BROWSER_DIR"
 args=()


### PR DESCRIPTION
## Summary
- ensure docs workflow still installs npm packages
- rework `scripts/run_eslint.sh` to only run `npm ci` when the cache file or `node_modules` is missing

## Testing
- `pre-commit run --files scripts/run_eslint.sh .github/workflows/docs.yml`
- `pytest tests/test_ping_agent.py -q`
- `curl -L -o run_logs.zip https://api.github.com/repos/MontrealAI/AGI-Alpha-Agent-v0/actions/runs/16080231962/logs` *(fails: Must have admin rights)*

------
https://chatgpt.com/codex/tasks/task_e_686a8fcff1b88333acd43a2ae36d7cad