### PR TITLE
chore: move dispatch token check to step

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,9 +12,11 @@ permissions:
 
 jobs:
   replay-bench:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,12 +17,14 @@ env:
 
 jobs:
   build-test:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,15 @@ jobs:
   tests:
     name: "✅ Pytest"
     needs: lint-type
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -179,10 +181,12 @@ jobs:
   docker:
     name: "🐳 Docker build"
     needs: tests
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -220,10 +224,13 @@ jobs:
 
   deploy:
     name: "📦 Deploy"
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) && startsWith(github.ref, 'refs/tags/') }}
+    if: startsWith(github.ref, 'refs/tags/')
     needs: docker
     runs-on: ubuntu-latest
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -12,9 +12,11 @@ permissions:
 
 jobs:
   deploy-kind:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   build-deploy:
     # Allow maintainers to trigger with DISPATCH_TOKEN
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
@@ -26,6 +25,9 @@ jobs:
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -12,9 +12,11 @@ permissions:
 
 jobs:
   load-test:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -12,9 +12,11 @@ permissions:
 
 jobs:
   transfer-matrix:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,9 +18,11 @@ permissions:
 
 jobs:
   sbom-scan-sign:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -12,9 +12,11 @@ permissions:
 
 jobs:
   build-and-check:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,13 +15,15 @@ env:
 
 jobs:
   smoke:
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.actor == github.repository_owner || github.event.inputs.run_token == secrets.DISPATCH_TOKEN) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
+      - name: Check dispatch token
+        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
+        run: echo "Unauthorized" && exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- avoid referencing `secrets.DISPATCH_TOKEN` at the job level
- add early step to verify dispatch authorization

## Testing
- `pre-commit run --files .github/workflows/bench.yml .github/workflows/build-and-test.yml .github/workflows/ci.yml .github/workflows/deploy-kind.yml .github/workflows/docs.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/security.yml .github/workflows/size-check.yml .github/workflows/smoke.yml`

------
https://chatgpt.com/codex/tasks/task_e_686aa4a2bf748333bcdab91a18df47e8