### PR TITLE
[alpha_factory] enforce manual dispatch token check

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,8 +23,12 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,12 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -185,8 +189,12 @@ jobs:
     environment: ci-on-demand
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -229,8 +237,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,12 @@ jobs:
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,8 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,8 +22,12 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Check dispatch token
-        if: github.event.inputs.run_token != secrets.DISPATCH_TOKEN && github.actor != github.repository_owner
-        run: echo "Unauthorized" && exit 1
+        if: github.actor != github.repository_owner
+        run: |
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- update all workflow dispatch checks to only gate on actor
- verify dispatch token inside each run script

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError cannot access submodule 'messaging')*
- `pre-commit run --files .github/workflows/bench.yml .github/workflows/build-and-test.yml .github/workflows/ci.yml .github/workflows/deploy-kind.yml .github/workflows/docs.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/security.yml .github/workflows/size-check.yml .github/workflows/smoke.yml`

------
https://chatgpt.com/codex/tasks/task_e_686aac7c76788333844677a2716fd2a5