### PR TITLE
Switch to npm for Node installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - name: Install pnpm
-        run: npm install -g pnpm
+          cache: 'npm'
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Audit insight browser dependencies
@@ -99,16 +97,16 @@ jobs:
       - name: Run insight browser tests
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Install web dependencies
-        run: pnpm --dir src/interface/web_client install
+        run: npm ci --prefix alpha_factory_v1/core/interface/web_client
       - name: Audit web dependencies
-        run: npm --prefix src/interface/web_client audit --production --audit-level=high
+        run: npm --prefix alpha_factory_v1/core/interface/web_client audit --production --audit-level=high
       - name: Type check insight browser
-        run: pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
+        run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
       - name: Cypress E2E tests with Percy
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_TOKEN_E2E: ${{ secrets.PERCY_TOKEN }}
-        run: pnpm --dir src/interface/web_client run percy:cypress
+        run: npm --prefix alpha_factory_v1/core/interface/web_client run percy:cypress
       - name: Install Playwright browsers
         id: install-browsers
         run: |
@@ -199,8 +197,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-      - name: Install pnpm
-        run: npm install -g pnpm
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Audit insight browser dependencies
@@ -208,14 +204,14 @@ jobs:
       - name: Run insight browser tests
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Type check insight browser
-        run: pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
+        run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
       - name: Build web client
         run: |
           make build_web
-          test -f src/interface/web_client/dist/index.html
+          test -f alpha_factory_v1/core/interface/web_client/dist/index.html
       - name: Accessibility audit
         run: |
-          npx --yes @axe-core/cli src/interface/web_client/dist/index.html --score > axe.json
+          npx --yes @axe-core/cli alpha_factory_v1/core/interface/web_client/dist/index.html --score > axe.json
           score=$(jq '.score' axe.json)
           echo "a11y score: $score"
           if [ "$score" -lt 90 ]; then
@@ -265,17 +261,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - name: Install pnpm
-        run: npm install -g pnpm
+          cache: 'npm'
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Type check insight browser
-        run: pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
+        run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
       - name: Build web client
         run: make build_web
       - name: Pack release assets
-        run: tar -czf web-client.tar.gz -C src/interface/web_client/dist .
+        run: tar -czf web-client.tar.gz -C alpha_factory_v1/core/interface/web_client/dist .
       - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ node_modules/
 build/
 dist/
 !**/package-lock.json
-!src/interface/web_client/dist/
+!alpha_factory_v1/core/interface/web_client/dist/
 !alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/
 # Browser demo assets
 alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM python:3.11-slim
 
-# install build tools and pnpm for the React UI
+# install build tools and npm for the React UI
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg build-essential postgresql-client patch && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g pnpm && \
     rm -rf /var/lib/apt/lists/*
 
 # Verify Node installation is >=20 (NodeSource script sets up latest LTS)
@@ -27,8 +26,8 @@ COPY alpha_factory_v1/demos/__init__.py alpha_factory_v1/demos/__init__.py
 COPY alpha_factory_v1/demos/alpha_agi_insight_v1 alpha_factory_v1/demos/alpha_agi_insight_v1
 
 # build the React front-end
-RUN pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client install \
-    && pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
+RUN npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client \
+    && npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
     && rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
 
 # run as non-root user for demos

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
         proto proto-verify benchmark
 
 build_web:
-	pnpm --dir src/interface/web_client install
-	pnpm --dir src/interface/web_client run build
+	npm ci --prefix alpha_factory_v1/core/interface/web_client
+	npm --prefix alpha_factory_v1/core/interface/web_client run build
 
 demo-setup:
 	bash scripts/demo_setup.sh

--- a/README.md
+++ b/README.md
@@ -1399,7 +1399,7 @@ cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
 npm ci          # use the lock file for reproducible installs
 npm run dev       # http://localhost:5173
 # build production assets
-pnpm build
+npm run build
 python -m http.server --directory dist 9000
 ```
 Alternatively run inside Docker:

--- a/alpha_factory_v1/core/interface/web_client/README.md
+++ b/alpha_factory_v1/core/interface/web_client/README.md
@@ -9,9 +9,9 @@ This directory contains a small React interface built with [Vite](https://vitejs
 
 ```bash
 cd src/interface/web_client
-pnpm install
-pnpm dev        # start the development server
-pnpm build      # build production assets in `dist/`
+npm ci
+npm run dev        # start the development server
+npm run build      # build production assets in `dist/`
 ```
 
 The build step uses Workbox to generate `service-worker.js` and precache the
@@ -22,14 +22,14 @@ embed the API bearer token at build time:
 
 ```bash
 # prepend '/api' to all requests and embed a token
-VITE_API_BASE_URL=/api VITE_API_TOKEN=test-token pnpm build
+VITE_API_BASE_URL=/api VITE_API_TOKEN=test-token npm run build
 ```
 
 The app expects the FastAPI server on `http://localhost:8000` by default. After
-running `pnpm build`, open `dist/index.html`, run `pnpm preview` or copy the
+running `npm run build`, open `dist/index.html`, run `npm run preview` or copy the
 `dist/` folder into your container image.
 
-When building the Docker image from the project root, ensure `pnpm --dir src/interface/web_client run build` completes so that `src/interface/web_client/dist/` exists. The `infrastructure/Dockerfile` copies this directory automatically.
+When building the Docker image from the project root, ensure `npm --prefix alpha_factory_v1/core/interface/web_client run build` completes so that `alpha_factory_v1/core/interface/web_client/dist/` exists. The `infrastructure/Dockerfile` copies this directory automatically.
 
 A basic smoke test simply runs `npm test`, which exits successfully if the project dependencies are installed.
 
@@ -48,24 +48,24 @@ services:
 
 Follow these steps to use the web client without internet access:
 
-- On a machine with network access, build the PNPM store and export it:
+- On a machine with network access, build the npm cache and export it:
 
 ```bash
 cd src/interface/web_client
-pnpm install
-pnpm store export > pnpm-store.tar
+npm ci
+tar -cf npm-cache.tar ~/.npm
 ```
 
-- Copy `pnpm-store.tar` to the offline host and import the cache:
+- Copy `npm-cache.tar` to the offline host and import the cache:
 
 ```bash
-pnpm store import pnpm-store.tar
+tar -xf npm-cache.tar -C ~/
 ```
 
-- Either set `PNPM_HOME` to the imported store path or run installation in offline mode:
+- Run installation in offline mode:
 
 ```bash
-PNPM_HOME=~/.local/share/pnpm pnpm install --offline
+npm ci --offline
 ```
 
 This installs packages from the local cache without contacting the registry.

--- a/alpha_factory_v1/core/interface/web_client/playwright.config.ts
+++ b/alpha_factory_v1/core/interface/web_client/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     baseURL: 'http://localhost:5173',
   },
   webServer: {
-    command: 'pnpm dev',
+    command: 'npm run dev',
     port: 5173,
     reuseExistingServer: true,
   },

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -214,7 +214,7 @@ graph TD
 
 > **Prerequisites**
 > • Python ≥ 3.11 • Git • Docker (only for container mode)
-> *(Optional)* Node ≥ 20 + pnpm if you plan to rebuild the React front-end.
+> *(Optional)* Node ≥ 20 if you plan to rebuild the React front-end.
 
 Or try the hosted notebook: [colab_alpha_agi_insight_v1.ipynb](colab_alpha_agi_insight_v1.ipynb).
 
@@ -392,10 +392,11 @@ uvicorn src/interface/api_server:app --reload --port 8000
 python -m alpha_factory_v1.demos.alpha_agi_insight_v1 api-server
 # frontend
 cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
-pnpm install
-pnpm dev            # http://localhost:5173
+npm ci
+npm run dev            # http://localhost:5173
 # build production assets
-pnpm build          # outputs to src/interface/web_client/dist/
+# outputs to src/interface/web_client/dist/
+npm run build
 # or run `make build_web` from the repo root
 # or use `npm install && npm run build`
 ```
@@ -430,19 +431,18 @@ Typical REST endpoints:
 
 ### 5.3 Rebuilding the React dashboard
 
-Install [Node.js](https://nodejs.org/) **≥ 20** and
-[pnpm](https://pnpm.io/installation) if you want to rebuild the front‑end.
+Install [Node.js](https://nodejs.org/) **≥ 20** if you want to rebuild the front‑end.
 From the repository root run:
 
 ```bash
 cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
-pnpm install && pnpm build
+npm ci && npm run build
 ```
 
 If the API runs on a different host, set `VITE_API_BASE_URL` when building:
 
 ```bash
-VITE_API_BASE_URL=http://api.example.com pnpm build
+VITE_API_BASE_URL=http://api.example.com npm run build
 ```
 
 Launch the container stack afterwards or serve `dist/` with any static server,
@@ -459,8 +459,8 @@ Run the following commands under `src/interface/web_client` to compile the
 React dashboard:
 
 ```bash
-pnpm install
-pnpm build
+npm ci
+npm run build
 ```
 
 This installs dependencies and outputs static files in `dist/`. The provided

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && \
         curl ca-certificates gnupg build-essential && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g pnpm && \
     rm -rf /var/lib/apt/lists/*
 
 # Verify Node installation is >=20 (NodeSource script sets up latest LTS)
@@ -21,8 +20,8 @@ RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements
 
 # Copy the project source
 COPY . /app
-RUN pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client install \
-    && pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
+RUN npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client \
+    && npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
     && rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
 
 # copy built assets

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
@@ -10,14 +10,14 @@ It connects to the API server at `/ws/progress` and logs messages to the console
 
 ```bash
 cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
-pnpm install
-pnpm dev       # open http://localhost:5173
+npm ci
+npm run dev       # open http://localhost:5173
 ```
 
 ## Build
 
 ```bash
-pnpm build  # outputs static files in dist/
+npm run build  # outputs static files in dist/
 ```
 
 The production bundle lives under `dist/` and is served automatically by the API

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,8 @@
 The React dashboard sources live under `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client`. Build the static assets before serving the API:
 
 ```bash
-pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client install
-pnpm --dir alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build
+npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
+npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build
 ```
 
 The compiled files appear in `alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist` and are automatically served when running `uvicorn alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server:app` with `RUN_MODE=web`.

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -222,7 +222,7 @@ graph TD
 
 > **Prerequisites**
 > • Python ≥ 3.11 • Git • Docker (only for container mode)
-> *(Optional)* Node ≥ 20 + pnpm if you plan to rebuild the React front-end.
+> *(Optional)* Node ≥ 20 if you plan to rebuild the React front-end.
 
 Or try the hosted notebook: [colab_alpha_agi_insight_v1.ipynb](colab_alpha_agi_insight_v1.ipynb).
 
@@ -400,10 +400,12 @@ uvicorn src/interface/api_server:app --reload --port 8000
 python -m alpha_factory_v1.demos.alpha_agi_insight_v1 api-server
 # frontend
 cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
-pnpm install
-pnpm dev            # http://localhost:5173
+# install dependencies and run the dev server
+npm ci
+npm run dev            # http://localhost:5173
 # build production assets
-pnpm build          # outputs to src/interface/web_client/dist/
+# outputs to src/interface/web_client/dist/
+npm run build
 # or run `make build_web` from the repo root
 # or use `npm install && npm run build`
 ```
@@ -438,19 +440,18 @@ Typical REST endpoints:
 
 ### 5.3 Rebuilding the React dashboard
 
-Install [Node.js](https://nodejs.org/) **≥ 20** and
-[pnpm](https://pnpm.io/installation) if you want to rebuild the front‑end.
+Install [Node.js](https://nodejs.org/) **≥ 20** if you want to rebuild the front‑end.
 From the repository root run:
 
 ```bash
 cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
-pnpm install && pnpm build
+npm ci && npm run build
 ```
 
 If the API runs on a different host, set `VITE_API_BASE_URL` when building:
 
 ```bash
-VITE_API_BASE_URL=http://api.example.com pnpm build
+VITE_API_BASE_URL=http://api.example.com npm run build
 ```
 
 Launch the container stack afterwards or serve `dist/` with any static server,
@@ -467,8 +468,8 @@ Run the following commands under `src/interface/web_client` to compile the
 React dashboard:
 
 ```bash
-pnpm install
-pnpm build
+npm ci
+npm run build
 ```
 
 This installs dependencies and outputs static files in `dist/`. The provided


### PR DESCRIPTION
## Summary
- unify Node package manager to npm
- update CI workflow to use npm
- rebuild docs and READMEs with npm commands
- tweak Makefile and Dockerfiles for npm
- adjust .gitignore and Playwright config

## Testing
- `pre-commit run --files .github/workflows/ci.yml .gitignore Dockerfile Makefile README.md alpha_factory_v1/core/interface/web_client/README.md alpha_factory_v1/core/interface/web_client/playwright.config.ts alpha_factory_v1/demos/alpha_agi_insight_v1/README.md alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md docs/README.md docs/demos/alpha_agi_insight_v1.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686aba7bf7d08333bd7fbfd94468c3ff