### PR TITLE
[alpha_factory] update react plugin

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/package-lock.json
+++ b/alpha_factory_v1/core/interface/web_client/package-lock.json
@@ -24,7 +24,7 @@
         "@playwright/test": "^1.39.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
-        "@vitejs/plugin-react": "^4.2.0",
+        "@vitejs/plugin-react": "^4.6.0",
         "@vitejs/plugin-vue": "^5.0.0",
         "cypress": "^13.0.0",
         "typescript": "^5.3.0",
@@ -2764,9 +2764,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
-      "integrity": "sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==",
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
+      "integrity": "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3420,16 +3420,16 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz",
-      "integrity": "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.6.0.tgz",
+      "integrity": "sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.26.10",
-        "@babel/plugin-transform-react-jsx-self": "^7.25.9",
-        "@babel/plugin-transform-react-jsx-source": "^7.25.9",
-        "@rolldown/pluginutils": "1.0.0-beta.9",
+        "@babel/core": "^7.27.4",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.19",
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.17.0"
       },
@@ -3437,7 +3437,7 @@
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
       }
     },
     "node_modules/@vitejs/plugin-vue": {

--- a/alpha_factory_v1/core/interface/web_client/package.json
+++ b/alpha_factory_v1/core/interface/web_client/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@vitejs/plugin-react": "^4.2.0",
+    "@vitejs/plugin-react": "^4.6.0",
     "@vitejs/plugin-vue": "^5.0.0",
     "typescript": "^5.3.0",
     "vite": "^5.0.0",


### PR DESCRIPTION
## Summary
- bump `@vitejs/plugin-react` to `^4.6.0`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/core/interface/web_client/package.json alpha_factory_v1/core/interface/web_client/package-lock.json .github/workflows/docs.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `npm ci --prefix alpha_factory_v1/core/interface/web_client`
- `npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1`
- `npm run build --prefix alpha_factory_v1/core/interface/web_client`


------
https://chatgpt.com/codex/tasks/task_e_686ac398d9888333b350e07a5668f5ac