### PR TITLE
[alpha_factory] clarify docs trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ for additional details.
 
 ### Manual Deployment
 
-The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) from the GitHub Actions tab. It runs [`scripts/edge_human_knowledge_pages_sprint.sh`](scripts/edge_human_knowledge_pages_sprint.sh) to rebuild the Insight demo and MkDocs site, publishing the result to GitHub Pages. Once it finishes the live demo is available at <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>.
+The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) from the GitHub Actions tab. Simply click **Run workflow** and leave the token field blank to start the deployment. The job runs [`scripts/edge_human_knowledge_pages_sprint.sh`](scripts/edge_human_knowledge_pages_sprint.sh) to rebuild the Insight demo and MkDocs site, publishing the result to GitHub Pages. Once it finishes the live demo is available at <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>.
 
 Non‑owners must supply the **run_token** input when dispatching the workflow so it matches the `DISPATCH_TOKEN` secret. Enter the token in the **Run workflow** form:
 

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -116,7 +116,7 @@ GitHub Pages.
 The "📚 Docs" workflow
 The repository owner manually triggers [`docs.yml`](../.github/workflows/docs.yml), which runs
 `scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
-`gh-pages` branch.
+`gh-pages` branch. Open **Actions → 📚 Docs**, click **Run workflow**, leave the token field empty and confirm.
 The workflow restores a cache keyed by the Pyodide and GPT‑2 file checksums before
 running `npm run fetch-assets`. Once the assets pass verification the cache is
 saved so subsequent runs skip the downloads.


### PR DESCRIPTION
## Summary
- document single-click Docs workflow trigger

## Testing
- `pre-commit run --files README.md docs/HOSTING_INSTRUCTIONS.md .github/workflows/docs.yml`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging' of module 'alpha_factory_v1.common.utils')*

------
https://chatgpt.com/codex/tasks/task_e_686ac6637ec883339e964aa8ce32631f