### PR TITLE
[alpha_factory] secure docs workflow trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,12 +14,14 @@ permissions:
 jobs:
   build-deploy:
     # Allow maintainers to trigger with DISPATCH_TOKEN
+    if: github.actor == github.repository_owner || github.event.inputs.run_token == env.DISPATCH_TOKEN
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.26.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
+      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
       # Keep the asset mirrors pinned to official hosts.
       # Optional environment variables for asset downloads. See
       # scripts/fetch_assets.py for details.
@@ -28,7 +30,7 @@ jobs:
       - name: Check dispatch token
         if: github.actor != github.repository_owner
         run: |
-          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+          if [ "${{ github.event.inputs.run_token }}" != "${{ env.DISPATCH_TOKEN }}" ]; then
             echo "Unauthorized"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ for additional details.
 
 ### Manual Deployment
 
-The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) from the GitHub Actions tab. Simply click **Run workflow** and leave the token field blank to start the deployment. The job runs [`scripts/edge_human_knowledge_pages_sprint.sh`](scripts/edge_human_knowledge_pages_sprint.sh) to rebuild the Insight demo and MkDocs site, publishing the result to GitHub Pages. Once it finishes the live demo is available at <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>.
+The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) from the GitHub Actions tab. Simply click **Run workflow** and leave the token field blank to start the deployment. The workflow automatically validates the token and only continues when the value matches the repository secret. The job runs [`scripts/edge_human_knowledge_pages_sprint.sh`](scripts/edge_human_knowledge_pages_sprint.sh) to rebuild the Insight demo and MkDocs site, publishing the result to GitHub Pages. Once it finishes the live demo is available at <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>.
 
 Non‑owners must supply the **run_token** input when dispatching the workflow so it matches the `DISPATCH_TOKEN` secret. Enter the token in the **Run workflow** form:
 

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -117,6 +117,7 @@ The "📚 Docs" workflow
 The repository owner manually triggers [`docs.yml`](../.github/workflows/docs.yml), which runs
 `scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
 `gh-pages` branch. Open **Actions → 📚 Docs**, click **Run workflow**, leave the token field empty and confirm.
+The workflow validates the token automatically and stops early if it doesn't match the secret.
 The workflow restores a cache keyed by the Pyodide and GPT‑2 file checksums before
 running `npm run fetch-assets`. Once the assets pass verification the cache is
 saved so subsequent runs skip the downloads.


### PR DESCRIPTION
## Summary
- secure the docs workflow with a job-level `if` check
- clarify the trigger behaviour in README and Hosting instructions

## Testing
- `pre-commit run --files .github/workflows/docs.yml README.md docs/HOSTING_INSTRUCTIONS.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: cannot access submodule '...')*

------
https://chatgpt.com/codex/tasks/task_e_686acaa797dc8333a77c970f4f32d26c