### PR TITLE
fix docs workflow dispatch token

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,15 +13,12 @@ permissions:
 
 jobs:
   build-deploy:
-    # Allow maintainers to trigger with DISPATCH_TOKEN
-    if: github.actor == github.repository_owner || github.event.inputs.run_token == env.DISPATCH_TOKEN
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.26.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
-      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
       # Keep the asset mirrors pinned to official hosts.
       # Optional environment variables for asset downloads. See
       # scripts/fetch_assets.py for details.
@@ -30,7 +27,7 @@ jobs:
       - name: Check dispatch token
         if: github.actor != github.repository_owner
         run: |
-          if [ "${{ github.event.inputs.run_token }}" != "${{ env.DISPATCH_TOKEN }}" ]; then
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
             echo "Unauthorized"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- let the repo owner start the Docs workflow without token
- verify `run_token` against the secret like other workflows

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `python - <<'EOF'
import yaml, sys
yaml.safe_load(open('.github/workflows/docs.yml'))
print('OK')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686acd93bdc48333b77bc2dcadad8c95