### PR TITLE
fix: restrict docs workflow to repo owner

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,6 @@ name: "📚 Docs"
 
 on:
   workflow_dispatch:
-    inputs:
-      run_token:
-        description: 'Authorization token for maintainers'
-        required: false
 
 permissions:
   contents: write
@@ -24,13 +20,11 @@ jobs:
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
     steps:
-      - name: Check dispatch token
+      - name: Verify repository owner
         if: github.actor != github.repository_owner
         run: |
-          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
-            echo "Unauthorized"
-            exit 1
-          fi
+          echo "Only the repository owner can dispatch this workflow."
+          exit 1
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Non-technical users can try the project with zero setup. Simply visit
 browser. The [README](docs/README.md#α‑agi-insight-v1-demo) explains how this
 demo is built and deployed.
 
-See [Quick Deployment](docs/HOSTING_INSTRUCTIONS.md#quick-deployment) for build and deployment details. The [📚 Docs workflow](.github/workflows/docs.yml) is dispatched manually by the repository owner to publish the updated site to GitHub Pages. Contributors can run it by providing a **run_token** that matches the `DISPATCH_TOKEN` secret.
+See [Quick Deployment](docs/HOSTING_INSTRUCTIONS.md#quick-deployment) for build and deployment details. The [📚 Docs workflow](.github/workflows/docs.yml) is dispatched manually by the repository owner to publish the updated site to GitHub Pages.
 
 Full documentation: [https://montrealai.github.io/AGI-Alpha-Agent-v0/](https://montrealai.github.io/AGI-Alpha-Agent-v0/) (use the **Docs** link in the navigation bar)
 
@@ -61,14 +61,7 @@ for additional details.
 
 ### Manual Deployment
 
-The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) from the GitHub Actions tab. Simply click **Run workflow** and leave the token field blank to start the deployment. The workflow automatically validates the token and only continues when the value matches the repository secret. The job runs [`scripts/edge_human_knowledge_pages_sprint.sh`](scripts/edge_human_knowledge_pages_sprint.sh) to rebuild the Insight demo and MkDocs site, publishing the result to GitHub Pages. Once it finishes the live demo is available at <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>.
-
-Non‑owners must supply the **run_token** input when dispatching the workflow so it matches the `DISPATCH_TOKEN` secret. Enter the token in the **Run workflow** form:
-
-1. Open **Actions → 📚 Docs**.
-2. Click **Run workflow**.
-3. Paste your token into the **run_token** field.
-4. Click **Run workflow** again to start the build.
+The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) from the GitHub Actions tab. Simply click **Run workflow** to start the deployment. The job runs [`scripts/edge_human_knowledge_pages_sprint.sh`](scripts/edge_human_knowledge_pages_sprint.sh) to rebuild the Insight demo and MkDocs site, publishing the result to GitHub Pages. Once it finishes the live demo is available at <https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/>.
 
 ### Publish Demo Gallery
 

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -117,18 +117,11 @@ The "📚 Docs" workflow
 The repository owner manually triggers [`docs.yml`](../.github/workflows/docs.yml), which runs
 `scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
 `gh-pages` branch. Open **Actions → 📚 Docs**, click **Run workflow**, leave the token field empty and confirm.
-The workflow validates the token automatically and stops early if it doesn't match the secret.
 The workflow restores a cache keyed by the Pyodide and GPT‑2 file checksums before
 running `npm run fetch-assets`. Once the assets pass verification the cache is
-saved so subsequent runs skip the downloads.
-
-Other contributors can dispatch the workflow by supplying a **run_token** matching the
-`DISPATCH_TOKEN` secret. Enter the token in the **Run workflow** form:
-
-1. Navigate to **Actions → 📚 Docs**.
-2. Click **Run workflow**.
-3. Paste the token into the **run_token** field.
-4. Click **Run workflow** again to start the job.
+saved so subsequent runs skip the downloads. Only the repository owner can
+dispatch the workflow from the **Actions → 📚 Docs** page by clicking
+**Run workflow**.
 
 ### Manual Publish
 


### PR DESCRIPTION
## Summary
- lock docs workflow to repository owner only
- update README and hosting instructions to match

## Testing
- `pre-commit run --files .github/workflows/docs.yml README.md docs/HOSTING_INSTRUCTIONS.md`
- `pytest -q` *(fails: cannot access submodule)*

------
https://chatgpt.com/codex/tasks/task_e_686ad038fad48333b4af31c06b24f461