### PR TITLE
[alpha_factory] fix docs workflow gating

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build-deploy:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
@@ -20,11 +21,6 @@ jobs:
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
     steps:
-      - name: Verify repository owner
-        if: github.actor != github.repository_owner
-        run: |
-          echo "Only the repository owner can dispatch this workflow."
-          exit 1
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -116,7 +116,7 @@ GitHub Pages.
 The "📚 Docs" workflow
 The repository owner manually triggers [`docs.yml`](../.github/workflows/docs.yml), which runs
 `scripts/edge_human_knowledge_pages_sprint.sh`, builds the site and pushes the result to the
-`gh-pages` branch. Open **Actions → 📚 Docs**, click **Run workflow**, leave the token field empty and confirm.
+`gh-pages` branch. Open **Actions → 📚 Docs**, click **Run workflow** and confirm.
 The workflow restores a cache keyed by the Pyodide and GPT‑2 file checksums before
 running `npm run fetch-assets`. Once the assets pass verification the cache is
 saved so subsequent runs skip the downloads. Only the repository owner can


### PR DESCRIPTION
## Summary
- restrict docs workflow via job-level condition
- remove outdated token instructions

## Testing
- `pre-commit run --files .github/workflows/docs.yml docs/HOSTING_INSTRUCTIONS.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686ad6b6fe04833387f27e107f54f5ee