### PR TITLE
fix docs gating

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   build-deploy:
-    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
@@ -21,6 +20,11 @@ jobs:
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
     steps:
+      - name: Verify repository owner
+        if: github.actor != github.repository_owner
+        run: |
+          echo "Only the repository owner can dispatch this workflow."
+          exit 1
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- verify repository owner before running the Docs workflow

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `pytest -q` *(fails: AttributeError cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686adb481b008333a2cfdfe2aa98119c