### PR TITLE
[alpha_factory] chore: pin optional packages for docs build

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,4 @@
 mkdocs==1.6.1
 mkdocs-material==9.6.15
+openai-agents==0.0.17
+google-adk==1.5.0


### PR DESCRIPTION
## Summary
- pin `openai-agents` and `google-adk` for the docs environment

## Testing
- `pre-commit run --files requirements-docs.txt requirements.lock`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_686ae920ab788333aeff8e207675d6d3