### PR TITLE
[alpha_factory] add SPDX header to self_healing_repo

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX license header to `alpha_factory_v1/demos/self_healing_repo/__init__.py`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/__init__.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError cannot access submodule)*

------
https://chatgpt.com/codex/tasks/task_e_686aec0307bc8333b31c1d9ba1035888