### PR TITLE
[alpha_factory] Move Ruff install before env check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+      - name: Install Ruff
+        run: pip install ruff
       - name: Install project dependencies
         run: python check_env.py --auto-install
       - name: Build sandbox image
@@ -48,8 +50,6 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
       - name: Install pre-commit
         run: pip install pre-commit
-      - name: Install Ruff
-        run: pip install ruff
       - name: Fetch browser assets
         run: python scripts/fetch_assets.py
       - name: Run pre-commit checks


### PR DESCRIPTION
## Summary
- ensure docs workflow installs Ruff before running `check_env.py`

## Checks
- [x] `pre-commit run --files .github/workflows/docs.yml`
- [x] `python check_env.py --auto-install`
- [x] `pytest -q` *(fails: AttributeError circular import, 84 errors)*


------
https://chatgpt.com/codex/tasks/task_e_686aedc8c2488333aa808f489e9df86b