### PR TITLE
[alpha_factory] restrict docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build-deploy:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest


### PR DESCRIPTION
## Summary
- skip docs workflow jobs for external dispatches

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*
- `pre-commit run --files .github/workflows/docs.yml`


------
https://chatgpt.com/codex/tasks/task_e_686aeffd77588333ad3a8688bd409a4b