### PR TITLE
[alpha_factory] Add SPDX header to self-healing repo init

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Self-healing demo package."""


### PR DESCRIPTION
## Summary
- add Apache 2.0 header and docstring to the self-healing repo package

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: cannot access submodules)*
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_686af4e548fc8333acce4cb5f2d5722d