### PR TITLE
[alpha_factory] Improve docs workflow offline mode

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.26.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
+      AGI_INSIGHT_OFFLINE: '1'
       # Keep the asset mirrors pinned to official hosts.
       # Optional environment variables for asset downloads. See
       # scripts/fetch_assets.py for details.


### PR DESCRIPTION
## Summary
- enforce offline mode during docs build

## Checks
- [x] `pre-commit run --files .github/workflows/docs.yml`
- [x] `python check_env.py --auto-install`
- [ ] `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686afb9c8610833383bcedc6dde483a7