### PR TITLE
[alpha_factory] sync build manifest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,8 @@ jobs:
         run: pip install pre-commit
       - name: Fetch browser assets
         run: python scripts/fetch_assets.py
+      - name: Update build manifest
+        run: python scripts/generate_build_manifest.py
       - name: Run pre-commit checks
         run: pre-commit run --all-files
       - name: Install docs dependencies

--- a/docs/DEMO_GALLERY.md
+++ b/docs/DEMO_GALLERY.md
@@ -37,4 +37,6 @@ python scripts/build_service_worker.py
 ```
 
 The helper script `build_gallery_site.sh` automates this step, but rerun it
-whenever assets change to avoid stale caches.
+whenever assets change to avoid stale caches. If the Insight browser asset
+checksums change, also execute `python scripts/generate_build_manifest.py` to
+update `build_assets.json`.

--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -55,6 +55,8 @@ Verify the service worker caches assets for offline use and that the page includ
 - Re‑run the helper whenever demo docs or assets change.
 - If adding new demos manually, run `python scripts/build_service_worker.py` to
   refresh `docs/assets/service-worker.js`.
+- Run `python scripts/generate_build_manifest.py` whenever the asset checksums in
+  `scripts/fetch_assets.py` change so `build_assets.json` stays in sync.
 - Test with `mkdocs build --strict` before deploying.
 - Keep `pre-commit` hooks green so the gallery builds reproducibly.
 

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -84,7 +84,10 @@ Run it from the repository root to build the bundle, refresh
 
 Whenever demo assets change, rerun `python scripts/build_service_worker.py` to
 update `docs/assets/service-worker.js`. Otherwise visitors may see outdated
-files due to the service worker cache on GitHub Pages.
+files due to the service worker cache on GitHub Pages. If the checksum values in
+`scripts/fetch_assets.py` are updated, execute `python
+scripts/generate_build_manifest.py` so `build_assets.json` reflects the new
+hashes.
 
 
 ## Building the Site

--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synchronize build_assets.json checksums with fetch_assets.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import scripts.fetch_assets as fa
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    manifest_path = repo_root / ("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json")
+    manifest = json.loads(manifest_path.read_text())
+    checksums = manifest.get("checksums", {})
+    checksums.update(fa.CHECKSUMS)
+    manifest["checksums"] = {k: checksums[k] for k in sorted(checksums)}
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"Updated {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script for generating build_assets.json checksums
- note the script in the docs as a maintenance step
- call the helper in the docs workflow

## Testing
- `pre-commit run --files scripts/generate_build_manifest.py docs/HOSTING_INSTRUCTIONS.md docs/GITHUB_PAGES_DEMO_TASKS.md docs/DEMO_GALLERY.md .github/workflows/docs.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686b0ab9d0388333b16260795f67a21b