### PR TITLE
Add early asset verification

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,8 @@ jobs:
         run: pip install pre-commit
       - name: Fetch browser assets
         run: python scripts/fetch_assets.py
+      - name: Verify browser assets
+        run: python scripts/fetch_assets.py --verify-only
       - name: Update build manifest
         run: python scripts/generate_build_manifest.py
       - name: Run pre-commit checks


### PR DESCRIPTION
## Summary
- check browser assets immediately after fetching to fail early

## Testing
- `pre-commit run --files .github/workflows/docs.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686b0dc0aecc8333b514f02683af022e