### PR TITLE
[alpha_factory] derive asset checksums from fetch script

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -37,14 +37,5 @@
     "lib/bundle.esm.min.js",
     "lib/workbox-sw.js"
   ],
-  "checksums": {
-    "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",
-    "lib/workbox-sw.js": "sha384-R7RXlLLrbRAy0JWTwv62SHZwpjwwc7C0wjnLGa5bRxm6YCl5zw87IRvhlleSM5zd",
-    "pyodide-lock.json": "sha384-0jg1cSxhjdgM3qp6WXMysptCeRCzlYI2HhY0Nqy1AFzfp3GnDIFLDs7MTlaJz+Nz",
-    "pyodide.asm.wasm": "sha384-EUqmec0z8Sj94lyhfS28Q0rsvZxo0lEPa3Nz2MQJz3NizgBcfd69cC2EluBQcA51",
-    "pyodide.js": "sha384-KQtL+EUxNlEbNm6gFVMiDz6Glmgq4QV4VZdSHIrcpw4tCRUGtjUeLJbuQAIfxFfM",
-    "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",
-    "service-worker.js": "sha384-o4otzwjbNKzpYYcqiTHOYyd9asjheSu1P8UVzmVl3HU8cvmE86GWhOgWUjkJ6gXT"
-  },
   "quickstart_pdf": "docs/insight_browser_quickstart.pdf"
 }

--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -89,6 +89,11 @@ All steps are idempotent; re‑running the script is safe.
 The ``import_dashboard.py`` helper requires ``GRAFANA_TOKEN`` and verifies the
 given JSON file exists before uploading.
 
+Run ``python scripts/fetch_assets.py`` to download the Insight browser assets.
+When any checksum in ``scripts/fetch_assets.py`` changes, execute
+``python scripts/generate_build_manifest.py`` so
+``build_assets.json`` stays in sync.
+
 ---
 
 ## Offline Setup

--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -13,9 +13,8 @@ def main() -> None:
     repo_root = Path(__file__).resolve().parent.parent
     manifest_path = repo_root / ("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json")
     manifest = json.loads(manifest_path.read_text())
-    checksums = manifest.get("checksums", {})
-    checksums.update(fa.CHECKSUMS)
-    manifest["checksums"] = {k: checksums[k] for k in sorted(checksums)}
+    manifest.pop("checksums", None)
+    manifest["checksums"] = {k: fa.CHECKSUMS[k] for k in sorted(fa.CHECKSUMS)}
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     print(f"Updated {manifest_path}")
 


### PR DESCRIPTION
## Summary
- update build manifest generator to rely solely on `fetch_assets.CHECKSUMS`
- drop manual checksum list from the browser demo
- mention how to regenerate the manifest in the scripts README

## Testing
- `pre-commit run --files scripts/generate_build_manifest.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json alpha_factory_v1/scripts/README.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686b33c1a00083339c173fe7e7665938