### PR TITLE
[alpha_factory] skip env check in CI docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           PYODIDE_BASE_URL: ${{ env.PYODIDE_BASE_URL }}
           HF_GPT2_BASE_URL: ${{ env.HF_GPT2_BASE_URL }}
+          CI_SKIP_ENV_CHECK: '1'
         run: ./scripts/edge_human_knowledge_pages_sprint.sh
       - name: Verify downloaded assets
         run: python scripts/fetch_assets.py --verify-only

--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -16,7 +16,11 @@ BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
 python alpha_factory_v1/scripts/preflight.py
 node "$BROWSER_DIR/build/version_check.js"
 python scripts/check_python_deps.py
-python check_env.py --auto-install
+if [[ "${CI_SKIP_ENV_CHECK:-0}" == "1" && "${CI:-}" == "true" ]]; then
+  echo "CI_SKIP_ENV_CHECK set – skipping check_env.py" >&2
+else
+  python check_env.py --auto-install
+fi
 # disclaimer snippet verification removed; rely on documentation updates
 python -m alpha_factory_v1.demos.validate_demos
 

--- a/scripts/edge_of_knowledge_sprint.sh
+++ b/scripts/edge_of_knowledge_sprint.sh
@@ -13,7 +13,11 @@ cd "$REPO_ROOT"
 python alpha_factory_v1/scripts/preflight.py
 node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
 python scripts/check_python_deps.py
-python check_env.py --auto-install
+if [[ "${CI_SKIP_ENV_CHECK:-0}" == "1" && "${CI:-}" == "true" ]]; then
+  echo "CI_SKIP_ENV_CHECK set – skipping check_env.py" >&2
+else
+  python check_env.py --auto-install
+fi
 
 # Disclaimer snippet verification removed; rely on documentation updates
 


### PR DESCRIPTION
## Summary
- skip running `check_env.py` in CI within `edge_of_knowledge_sprint.sh`
- skip running `check_env.py` in CI within `deploy_gallery_pages.sh`
- pass `CI_SKIP_ENV_CHECK=1` in the docs workflow

## Testing
- `pre-commit run --files scripts/edge_of_knowledge_sprint.sh scripts/deploy_gallery_pages.sh .github/workflows/docs.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule)*

------
https://chatgpt.com/codex/tasks/task_e_686b392a1d04833385bd062c259561d6