### PR TITLE
fix: update asset checksums

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -38,8 +38,8 @@ export async function copyAssets(manifest, repoRoot, outDir) {
 
 export { injectEnv };
 export async function checkGzipSize(file, maxBytes = 2 * 1024 * 1024) {
-  const gzipSize = (await import('gzip-size')).default;
-  const size = await gzipSize.file(file);
+  const {gzipSizeFromFile} = await import('gzip-size');
+  const size = await gzipSizeFromFile(file);
   if (size > maxBytes) {
     throw new Error(`gzip size ${size} bytes exceeds limit`);
   }
@@ -56,7 +56,6 @@ export async function generateServiceWorker(outDir, manifest, version) {
     swSrc: swTemp,
     swDest,
     globDirectory: outDir,
-    importWorkboxFrom: 'disabled',
     globPatterns: manifest.precache,
     injectionPoint: 'self.__WB_MANIFEST',
   });

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -37,5 +37,13 @@
     "lib/bundle.esm.min.js",
     "lib/workbox-sw.js"
   ],
-  "quickstart_pdf": "docs/insight_browser_quickstart.pdf"
+  "quickstart_pdf": "docs/insight_browser_quickstart.pdf",
+  "checksums": {
+    "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",
+    "lib/workbox-sw.js": "sha384-R7RXlLLrbRAy0JWTwv62SHZwpjwwc7C0wjnLGa5bRxm6YCl5zw87IRvhlleSM5zd",
+    "pyodide-lock.json": "sha384-0jg1cSxhjdgM3qp6WXMysptCeRCzlYI2HhY0Nqy1AFzfp3GnDIFLDs7MTlaJz+Nz",
+    "pyodide.asm.wasm": "sha384-EUqmec0z8Sj94lyhfS28Q0rsvZxo0lEPa3Nz2MQJz3NizgBcfd69cC2EluBQcA51",
+    "pyodide.js": "sha384-KQtL+EUxNlEbNm6gFVMiDz6Glmgq4QV4VZdSHIrcpw4tCRUGtjUeLJbuQAIfxFfM",
+    "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421"
+  }
 }


### PR DESCRIPTION
## Summary
- sync Insight Browser build manifest with `fetch_assets.py`
- update build script for newer `gzip-size` and `workbox-build`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json`

------
https://chatgpt.com/codex/tasks/task_e_686b3c97b9b88333b26055f20ed3b335