### PR TITLE
[alpha_factory] improve manifest generation

### DIFF
--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -15,8 +15,12 @@ def main() -> None:
     manifest = json.loads(manifest_path.read_text())
     manifest.pop("checksums", None)
     manifest["checksums"] = {k: fa.CHECKSUMS[k] for k in sorted(fa.CHECKSUMS)}
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
-    print(f"Updated {manifest_path}")
+    new_content = json.dumps(manifest, indent=2) + "\n"
+    if manifest_path.read_text() != new_content:
+        manifest_path.write_text(new_content)
+        print(f"Updated {manifest_path}")
+    else:
+        print(f"{manifest_path} already up to date")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid rewriting build manifest when unchanged

## Checks
- `pre-commit run --files scripts/generate_build_manifest.py`
- `python check_env.py --auto-install`
- `pytest tests/test_checksum.py -q` *(fails: AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686b3ff800bc8333a16289c9ce68cf13