### PR TITLE
fix: verify docs assets before build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,12 +51,6 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
       - name: Install pre-commit
         run: pip install pre-commit
-      - name: Fetch browser assets
-        run: python scripts/fetch_assets.py
-      - name: Verify browser assets
-        run: python scripts/fetch_assets.py --verify-only
-      - name: Update build manifest
-        run: python scripts/generate_build_manifest.py
       - name: Run pre-commit checks
         run: pre-commit run --all-files
       - name: Install docs dependencies
@@ -92,6 +86,12 @@ jobs:
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
           key: assets-${{ steps.asset-key.outputs.key }}
           restore-keys: assets-
+      - name: Fetch browser assets
+        run: python scripts/fetch_assets.py
+      - name: Verify browser assets
+        run: python scripts/fetch_assets.py --verify-only
+      - name: Update build manifest
+        run: python scripts/generate_build_manifest.py
       - name: Build and deploy gallery
         env:
           PYODIDE_BASE_URL: ${{ env.PYODIDE_BASE_URL }}


### PR DESCRIPTION
## Summary
- verify asset checksums before reusing them
- re-order asset caching in docs workflow

## Checks
- `pre-commit run --files scripts/fetch_assets.py .github/workflows/docs.yml`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 84 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686b422757c48333b6ab7f31e3b840c9