### PR TITLE
[alpha_factory] tighten docs deploy script

### DIFF
--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -25,8 +25,6 @@ fi
 python -m alpha_factory_v1.demos.validate_demos
 
 # Build the Insight docs and gallery
-npm --prefix "$BROWSER_DIR" run fetch-assets
-npm --prefix "$BROWSER_DIR" ci
 "$SCRIPT_DIR/build_insight_docs.sh"
 python scripts/mirror_demo_pages.py
 python scripts/build_service_worker.py


### PR DESCRIPTION
## Summary
- streamline gallery deployment workflow

## Testing
- `pre-commit run --files scripts/deploy_gallery_pages.sh`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686b44c809b48333a6bf01f49386686e