### PR TITLE
Fix docs checksum error

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -222,7 +222,9 @@ async function bundle() {
         const actual =
             "sha384-" + createHash("sha384").update(buf).digest("base64");
         if (actual !== expected) {
-            throw new Error(`Checksum mismatch for ${name}`);
+            throw new Error(
+                `Checksum mismatch for ${name}: expected ${expected} got ${actual}`,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- show expected checksum in Insight Browser build script

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js`
- `pytest alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_manual_build_size_limit.py::test_check_gzip_call_present`


------
https://chatgpt.com/codex/tasks/task_e_686bbcea43a4833396830b7e77449c84