### PR TITLE
[alpha_factory] sync build manifest via fetch script

### DIFF
--- a/docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -56,7 +56,9 @@ Verify the service worker caches assets for offline use and that the page includ
 - If adding new demos manually, run `python scripts/build_service_worker.py` to
   refresh `docs/assets/service-worker.js`.
 - Run `python scripts/generate_build_manifest.py` whenever the asset checksums in
-  `scripts/fetch_assets.py` change so `build_assets.json` stays in sync.
+  `scripts/fetch_assets.py` change so `build_assets.json` stays in sync. You can
+  also pass `--update-manifest` to `scripts/fetch_assets.py` to run this step
+  automatically after verifying downloads.
 - Test with `mkdocs build --strict` before deploying.
 - Keep `pre-commit` hooks green so the gallery builds reproducibly.
 

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -18,6 +18,7 @@ import argparse
 import base64
 import hashlib
 import os
+import subprocess
 from pathlib import Path
 import sys
 import requests  # type: ignore
@@ -164,7 +165,16 @@ def verify_assets(base: Path) -> list[str]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--verify-only", action="store_true", help="Verify asset checksums and exit")
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Verify asset checksums and exit",
+    )
+    parser.add_argument(
+        "--update-manifest",
+        action="store_true",
+        help="Synchronize build_assets.json after verifying assets",
+    )
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parent.parent
@@ -231,6 +241,10 @@ def main() -> None:
         joined = ", ".join(failures)
         sys.exit(f"verification failed for: {joined}")
     print("All assets verified successfully")
+    if args.update_manifest:
+        manifest_script = Path(__file__).resolve().parent / "generate_build_manifest.py"
+        if manifest_script.exists():
+            subprocess.run([sys.executable, str(manifest_script)], check=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--update-manifest` option to `fetch_assets.py`
- allow automatic manifest regeneration after fetching assets
- document new flag in GitHub Pages runbook

## Testing
- `pre-commit run --files docs/GITHUB_PAGES_DEMO_TASKS.md scripts/fetch_assets.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686bda4768dc833381807410489280a3