### PR TITLE
[alpha_factory] Fix build manifest path resolution

### DIFF
--- a/scripts/generate_build_manifest.py
+++ b/scripts/generate_build_manifest.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import sys
 
-import scripts.fetch_assets as fa
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.fetch_assets as fa  # noqa: E402
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add repo root to PYTHONPATH in `generate_build_manifest.py`

## Testing
- `python scripts/generate_build_manifest.py`
- `pre-commit run --files scripts/generate_build_manifest.py`
- `pytest -q` *(fails: cannot access submodule '...')*

------
https://chatgpt.com/codex/tasks/task_e_686bf1ffd20c83338dcee3ee374489e8