### PR TITLE
[alpha_factory] pin plugin-vue to avoid docs ci conflict

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/package-lock.json
+++ b/alpha_factory_v1/core/interface/web_client/package-lock.json
@@ -25,7 +25,7 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.6.0",
-        "@vitejs/plugin-vue": "^6.0.0",
+        "@vitejs/plugin-vue": "6.0.0",
         "cypress": "^13.0.0",
         "typescript": "^5.3.0",
         "vite": "^7.0.2",

--- a/alpha_factory_v1/core/interface/web_client/package.json
+++ b/alpha_factory_v1/core/interface/web_client/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.6.0",
-    "@vitejs/plugin-vue": "^6.0.0",
+    "@vitejs/plugin-vue": "6.0.0",
     "cypress": "^13.0.0",
     "typescript": "^5.3.0",
     "vite": "^7.0.2",


### PR DESCRIPTION
## Summary
- pin `@vitejs/plugin-vue` version so Vite 7 installs cleanly

## Testing
- `pre-commit run --files alpha_factory_v1/core/interface/web_client/package.json alpha_factory_v1/core/interface/web_client/package-lock.json`
- `python scripts/fetch_assets.py --verify-only`
- `pytest -q` *(fails: cannot access submodule 'messaging', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686bf8bcaf208333b8e1d98a52d88b47