### PR TITLE
[alpha_factory] update docs about node and vite plugin

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/README.md
+++ b/alpha_factory_v1/core/interface/web_client/README.md
@@ -7,8 +7,12 @@ This directory contains a small React interface built with [Vite](https://vitejs
 
 ## Setup
 
+This project requires **Node.js ≥20**. The Vite build depends on
+`@vitejs/plugin-vue` 6 to support Vite 7.
+
 ```bash
 cd src/interface/web_client
+nvm use                # optional, selects the version from `.nvmrc`
 npm ci
 npm run dev        # start the development server
 npm run build      # build production assets in `dist/`


### PR DESCRIPTION
## Summary
- mention Node 20+ and plugin-vue 6 in the web client README

## Checks
- [x] `pre-commit run --files alpha_factory_v1/core/interface/web_client/README.md`
- [x] `python check_env.py --auto-install`
- [x] `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686bfba9da0883338dd9aea8ee5e79a8