### PR TITLE
fix: update docs workflow notes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ Downstream users should consult this section when upgrading.
 - Documented how to build a wheelhouse for offline installs and updated
   `tests/README.md` with the instructions.
 - Added `scripts/build_offline_wheels.sh` to gather wheels for all lock files.
+- Updated `@vitejs/plugin-vue` to version 6 so the Docs workflow builds with Vite 7.
 - Removed outdated `OPENAI_CONTEXT_WINDOW` reference from the self-healing repo demo.
 - Documented how to add new policies in `POLICY_RUNBOOK.md`.
 - Each demo README now clarifies that `__version__` denotes the demo revision, not the overall project release.


### PR DESCRIPTION
## Summary
- note @vitejs/plugin-vue 6 in changelog so docs build with Vite 7

## Testing
- `pre-commit run --files docs/CHANGELOG.md alpha_factory_v1/core/interface/web_client/package.json alpha_factory_v1/core/interface/web_client/package-lock.json`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686bff011a64833381657ce51357e1e8