### PR TITLE
docs: fix disclaimer snippet paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Summary

--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/backend/README.md
+++ b/alpha_factory_v1/backend/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha-Factory Backend

--- a/alpha_factory_v1/backend/agents/README.md
+++ b/alpha_factory_v1/backend/agents/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha‑Factory v1 👁️✨ — Backend α‑AGI Agents Suite

--- a/alpha_factory_v1/backend/environments/README.md
+++ b/alpha_factory_v1/backend/environments/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Backend Environments

--- a/alpha_factory_v1/core/interface/web_client/README.md
+++ b/alpha_factory_v1/core/interface/web_client/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # React Web Client

--- a/alpha_factory_v1/dashboards/README.md
+++ b/alpha_factory_v1/dashboards/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha Factory Dashboards

--- a/alpha_factory_v1/demos/README.md
+++ b/alpha_factory_v1/demos/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha‑Factory v1 👁️✨ — **Interactive Demo & Agent Gallery**

--- a/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 🛠️ Production Deployment Guide — AI‑GA Meta‑Evolution

--- a/alpha_factory_v1/demos/aiga_meta_evolution/README.md
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/colab_aiga_meta_evolution.ipynb
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/colab_aiga_meta_evolution.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/alpha_agi_business_2_v1/colab_alpha_agi_business_2_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_2_v1/colab_alpha_agi_business_2_demo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/colab_alpha_agi_business_3_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/colab_alpha_agi_business_3_demo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Best Alpha Opportunity Workflow

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/CONCEPTUAL_FRAMEWORK.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/CONCEPTUAL_FRAMEWORK.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Conceptual Framework – Alpha‑AGI Business v1

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Quick Start – Alpha‑AGI Business v1 Demo

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v0/colab_alpha_agi_insight_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v0/colab_alpha_agi_insight_demo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 # API Overview
 
 This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Changelog

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # α‑AGI Insight v1 – Design Overview

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 # α‑AGI Insight Docs
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Bus TLS Setup

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/helm-chart/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 This chart deploys the α-AGI Insight demo.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ### 🔬 Browser-only Insight demo

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # GPT‑2 Small Weights

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/mermaid.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/mermaid.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ```mermaid

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha AGI Insight Web Client

--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Terms & Conditions

--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/colab_alpha_agi_marketplace_demo.ipynb
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/colab_alpha_agi_marketplace_demo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_colab.ipynb
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_colab.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 - 2025‑04‑25 Initial auto‑generated docs bundle

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Quick‑Start

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/helm_chart/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # α-ASI World-Model 🛰️ — Helm Chart 📦

--- a/alpha_factory_v1/demos/alpha_super_planner_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_super_planner_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha Super Planner V1 👁️✨

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/CONCEPTUAL_FRAMEWORK.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 <!-- SPDX-License-Identifier: Apache-2.0 -->

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/README.md
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 This directory contains supplementary assets for the **Cross‑Industry Alpha‑Factory** demo.

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/colab_deploy_alpha_factory_cross_industry_demo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "code",

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/cross_alpha_discovery_stub.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+# [See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 """Cross‑Industry alpha discovery helper.
 
 This script is part of a research prototype and does not implement real AGI.

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/openai_agents_bridge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # mypy: ignore-errors
-# [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+# [See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 # NOTE: This demo is a research prototype and does not implement real AGI.
 """OpenAI Agents SDK bridge for the cross-industry Alpha-Factory demo.
 

--- a/alpha_factory_v1/demos/cross_industry_alpha_factory/queue_cross_alpha.py
+++ b/alpha_factory_v1/demos/cross_industry_alpha_factory/queue_cross_alpha.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# [See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+# [See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 """Queue cross‑industry opportunities on the α‑AGI Marketplace.
 
 This helper script discovers potential opportunities using

--- a/alpha_factory_v1/demos/era_of_experience/README.md
+++ b/alpha_factory_v1/demos/era_of_experience/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
+++ b/alpha_factory_v1/demos/era_of_experience/colab_era_of_experience.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/finance_alpha/README.md
+++ b/alpha_factory_v1/demos/finance_alpha/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
+++ b/alpha_factory_v1/demos/finance_alpha/finance_alpha.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/gpt2_small_cli/README.md
+++ b/alpha_factory_v1/demos/gpt2_small_cli/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # GPT‑2 Small CLI Demo

--- a/alpha_factory_v1/demos/macro_sentinel/README.md
+++ b/alpha_factory_v1/demos/macro_sentinel/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
+++ b/alpha_factory_v1/demos/macro_sentinel/colab_macro_sentinel.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "code",

--- a/alpha_factory_v1/demos/meta_agentic_agi/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/meta_agentic_agi/colab_meta_agentic_agi.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_agi/colab_meta_agentic_agi.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/meta_agentic_agi/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/colab_meta_agentic_agi_v2.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/colab_meta_agentic_agi_v2.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ```mermaid

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/colab_meta_agentic_agi_v3.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/colab_meta_agentic_agi_v3.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/colab_meta_agentic_tree_search.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/muzero_planning/README.md
+++ b/alpha_factory_v1/demos/muzero_planning/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
+++ b/alpha_factory_v1/demos/muzero_planning/colab_muzero_planning.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md
+++ b/alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/omni_factory_demo/README.md
+++ b/alpha_factory_v1/demos/omni_factory_demo/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
+++ b/alpha_factory_v1/demos/omni_factory_demo/colab_omni_factory_demo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/self_healing_repo/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
+++ b/alpha_factory_v1/demos/self_healing_repo/colab_self_healing_repo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/README.md
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # sample_broken_calc

--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
+++ b/alpha_factory_v1/demos/solving_agi_governance/colab_solving_agi_governance.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)"
+   "source": "[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)"
   },
   {
    "cell_type": "markdown",

--- a/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
+++ b/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 Each demo package exposes its own `__version__` constant. The value marks the revision of that demo only and does not reflect the overall Alpha‑Factory release version.
 

--- a/alpha_factory_v1/demos/utils/README.md
+++ b/alpha_factory_v1/demos/utils/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Demo Utilities

--- a/alpha_factory_v1/docs/README.md
+++ b/alpha_factory_v1/docs/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Documentation Overview

--- a/alpha_factory_v1/docs/REMOTE_SWARM.md
+++ b/alpha_factory_v1/docs/REMOTE_SWARM.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Remote Swarm Quick‑start

--- a/alpha_factory_v1/docs/alpha_agi_agent.md
+++ b/alpha_factory_v1/docs/alpha_agi_agent.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/docs/alpha_agi_business.md
+++ b/alpha_factory_v1/docs/alpha_agi_business.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/helm/alpha-factory-remote/README.md
+++ b/alpha_factory_v1/helm/alpha-factory-remote/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # alpha-factory-remote Helm Chart

--- a/alpha_factory_v1/helm/alpha-factory/README.md
+++ b/alpha_factory_v1/helm/alpha-factory/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # alpha-factory Helm Chart

--- a/alpha_factory_v1/scripts/README.md
+++ b/alpha_factory_v1/scripts/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # `alpha_factory_v1/scripts` — Zero‑to‑Alpha in *One* Command ⚡️

--- a/alpha_factory_v1/tests/README.md
+++ b/alpha_factory_v1/tests/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 🧪 Test Suite · Alpha‑Factory v1 👁

--- a/infrastructure/helm-chart/README.md
+++ b/infrastructure/helm-chart/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 This chart deploys the orchestrator and optional web UI.

--- a/infrastructure/k8s/README.md
+++ b/infrastructure/k8s/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 This directory contains Kubernetes manifests for running background jobs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ packages = [
 include-package-data = true
 
 [tool.setuptools.package-data]
-"alpha_factory_v1" = ["py.typed", "../docs/DISCLAIMER_SNIPPET.md"]
+"alpha_factory_v1" = ["py.typed", "../DISCLAIMER_SNIPPET.md"]
 "alpha_factory_v1.demos.alpha_agi_insight_v1" = ["py.typed"]
 "alpha_factory_v1.core.interface.web_client" = ["dist/**"]
 "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_client" = ["dist/**"]

--- a/run_quickstart.sh
+++ b/run_quickstart.sh
@@ -8,7 +8,7 @@ trap 'echo -e "\n\u274c Error on line $LINENO" >&2' ERR
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-cat "$SCRIPT_DIR/docs/DISCLAIMER_SNIPPET.md"
+cat "$SCRIPT_DIR/DISCLAIMER_SNIPPET.md"
 
 IMAGE="alpha-factory-quickstart"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/fixtures/self_heal_repo/README.md
+++ b/tests/fixtures/self_heal_repo/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # sample_broken_calc

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../docs/DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Offline Wheelhouse


### PR DESCRIPTION
## Summary
- update links referencing `../docs/DISCLAIMER_SNIPPET.md`
- run `pre-commit` hooks and ensure MkDocs build still works

## Testing
- `pre-commit run --files $(git diff --name-only)`
- `mkdocs build --strict > /tmp/mkdocs.log 2>&1 && tail -n 20 /tmp/mkdocs.log`

------
https://chatgpt.com/codex/tasks/task_e_686c0f4e95a08333bbf6b25c9b990b21