### PR TITLE
[alpha_factory] fix docs links

### DIFF
--- a/docs/INTRO_BASICS.md
+++ b/docs/INTRO_BASICS.md
@@ -18,4 +18,4 @@ This is the shortest path to run the demo locally.
 3. **Open the web UI**
    Visit [http://localhost:8000](http://localhost:8000) in your browser.
 
-For more details see [README.md](../README.md).
+For more details see the [project README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/README.md).

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -71,7 +71,7 @@ python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 
 Run `pytest -q` once the check succeeds.
 
-See [tests/README.md](../tests/README.md#offline-install) and [AGENTS.md](../AGENTS.md#offline-setup) for the full instructions.
+See the [tests README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/tests/README.md#offline-install) and [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md#offline-setup) for the full instructions.
 
 ## Tested platforms
 

--- a/docs/PROJECT_README.md
+++ b/docs/PROJECT_README.md
@@ -7,10 +7,6 @@
 [Deployment Quickstart](DEPLOYMENT_QUICKSTART.md)
 
 - [Browser Quickstart](insight_browser_quickstart.pdf) – run `./scripts/deploy_insight_full.sh` for a verified one-command deployment
-- [GH Pages Sprint](CODEX_INSIGHT_PAGES_SPRINT.md) – step‑by‑step tasks for Codex to publish the demo
-- [Demo Gallery Sprint](CODEX_DEMO_PAGES_SPRINT.md) – publish the entire gallery to GitHub Pages
-- [Advanced Demo Pages Sprint](CODEX_ADVANCED_DEMO_PAGES_SPRINT.md) – end‑to‑end tasks for the full demo gallery
-- [Edge‑of‑Knowledge Demo Sprint](EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md) – host every advanced demo via GitHub Pages
 - **One‑Command Deployment** – execute `./scripts/insight_sprint.sh` to build, verify and publish the GitHub Pages site automatically.
 - **Local Gallery Build** – run `./scripts/build_gallery_site.sh` to compile the full demo gallery under `site/` for offline review.
 - **Build & Open Gallery** – run `./scripts/build_open_gallery.sh` to regenerate the docs and open the gallery automatically.

--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -437,4 +437,4 @@ Huge thanks to:
 
 > **Alpha‑Factory** — forging intelligence that *invents* intelligence.
 
-[View README](../../alpha_factory_v1/demos/aiga_meta_evolution/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/aiga_meta_evolution/README.md)

--- a/docs/demos/alpha_agi_business_2_v1.md
+++ b/docs/demos/alpha_agi_business_2_v1.md
@@ -213,4 +213,4 @@ Apache‑2.0 © 2025 MONTREAL.AI.
 _“Outlearn · Outthink · Outdesign · Outstrategise · Outexecute.”_  
 Welcome to the era of **Large‑Scale α‑AGI Businesses** 🌸 — where autonomous swarms turn friction into alpha at planetary scale. 🚀
 
-[View README](../../alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_2_v1/README.md)

--- a/docs/demos/alpha_agi_business_3_v1.md
+++ b/docs/demos/alpha_agi_business_3_v1.md
@@ -420,4 +420,4 @@ Inherited **2017 Multi‑Agent AI DAO** prior‑art:
 *Forged by the MONTREAL.AI Agentic Ω‑Lattice team — bending entropy to will.*  
 Questions → **discord.gg/montrealai**
 
-[View README](../../alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_3_v1/README.md)

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -505,4 +505,4 @@ pre-commit run --files <paths>             # format only the staged files
 pytest -q ../../../tests                   # execute the root test suite
 ```
 
-[View README](../../alpha_factory_v1/demos/alpha_agi_business_v1/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/README.md)

--- a/docs/demos/alpha_agi_insight_v0.md
+++ b/docs/demos/alpha_agi_insight_v0.md
@@ -349,4 +349,4 @@ This best-effort persistence operates transparently and never blocks the
 search loop.
 For additional command details, run `python official_demo_production.py --help`.
 
-[View README](../../alpha_factory_v1/demos/alpha_agi_insight_v0/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v0/README.md)

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -711,4 +711,4 @@ This demo is released for **research & internal evaluation only**.
 ### ✨ See beyond human foresight. Build the future, today. ✨
 
 
-[View README](../../alpha_factory_v1/demos/alpha_agi_insight_v1/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md)

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -266,4 +266,4 @@ Apache 2.0 © 2025 **MONTREAL.AI**
 
 <p align="center"><sub>Made with ❤️, ☕ and <b>real</b> GPUs by the Alpha‑Factory core team.</sub></p>
 
-[View README](../../alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md)

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -285,4 +285,4 @@ Please cite **Alpha-Factory v1 👁️✨ — Multi-Agent AGENTIC α-AGI**:
 > MONTREAL.AI (2025). *Fully-Agentic α-AGI: Foundation World Models for α-ASI.*  
 > GitHub https://github.com/MontrealAI/AGI-Alpha-Agent-v0
 
-[View README](../../alpha_factory_v1/demos/alpha_asi_world_model/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_asi_world_model/README.md)

--- a/docs/demos/cross_industry_alpha_factory.md
+++ b/docs/demos/cross_industry_alpha_factory.md
@@ -284,4 +284,4 @@ Clune 2019 · Sutton & Silver 2024 · MuZero 2020
 
 © 2025 MONTREAL.AI — Apache‑2.0 License
 
-[View README](../../alpha_factory_v1/demos/cross_industry_alpha_factory/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/cross_industry_alpha_factory/README.md)

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -383,4 +383,4 @@ Apache 2.0. By using this repo you agree to cite **Montreal.AI Alpha‑Factory*
 
 **Contributor checklist** — run `pre-commit`, `python ../../../check_env.py --auto-install`, and `pytest -q` before submitting any changes. See [AGENTS.md](../../../AGENTS.md) for the full contributor guide.
 
-[View README](../../alpha_factory_v1/demos/era_of_experience/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/era_of_experience/README.md)

--- a/docs/demos/finance_alpha.md
+++ b/docs/demos/finance_alpha.md
@@ -146,4 +146,4 @@ educational purposes only**. They operate on a simulated exchange by
 default and **should not be used with real funds**. Nothing here
 liability for losses incurred from using this software.
 
-[View README](../../alpha_factory_v1/demos/finance_alpha/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/finance_alpha/README.md)

--- a/docs/demos/macro_sentinel.md
+++ b/docs/demos/macro_sentinel.md
@@ -264,4 +264,4 @@ Apache‑2.0 © 2025 **MONTREAL.AI**
 
 Happy alpha‑hunting 🚀
 
-[View README](../../alpha_factory_v1/demos/macro_sentinel/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/macro_sentinel/README.md)

--- a/docs/demos/meta_agentic_agi.md
+++ b/docs/demos/meta_agentic_agi.md
@@ -264,4 +264,4 @@ Wrapper normalises chat/completions, streams via **MCP**, and window‑slides to
 
 © 2025 MONTREAL.AI — Apache‑2.0
 
-[View README](../../alpha_factory_v1/demos/meta_agentic_agi/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/meta_agentic_agi/README.md)

--- a/docs/demos/meta_agentic_agi_v2.md
+++ b/docs/demos/meta_agentic_agi_v2.md
@@ -256,4 +256,4 @@ Change **provider** to:
 
 © 2025 MONTREAL.AI — Apache‑2.0
 
-[View README](../../alpha_factory_v1/demos/meta_agentic_agi_v2/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/meta_agentic_agi_v2/README.md)

--- a/docs/demos/meta_agentic_agi_v3.md
+++ b/docs/demos/meta_agentic_agi_v3.md
@@ -256,4 +256,4 @@ The included `agents/alpha_finder.py` continuously scans news/API feeds and trig
 
 © 2025 MONTREAL.AI — Apache‑2.0
 
-[View README](../../alpha_factory_v1/demos/meta_agentic_agi_v3/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/meta_agentic_agi_v3/README.md)

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -306,4 +306,4 @@ Apache 2.0 – see `LICENSE`.
 ---
 *This README belongs to the AGI‑Alpha‑Agent project.*
 
-[View README](../../alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/meta_agentic_tree_search_v0/README.md)

--- a/docs/demos/muzero_planning.md
+++ b/docs/demos/muzero_planning.md
@@ -193,4 +193,4 @@ Run `pre-commit run --files alpha_factory_v1/demos/muzero_planning` before commi
 
 > **Alpha‑Factory** — forging intelligence that **out‑learns, out‑thinks, out‑executes**.
 
-[View README](../../alpha_factory_v1/demos/muzero_planning/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/muzero_planning/README.md)

--- a/docs/demos/muzeromctsllmagent_v0.md
+++ b/docs/demos/muzeromctsllmagent_v0.md
@@ -27,4 +27,4 @@ This folder contains a prototype integration of a Monte Carlo Tree Search (MCTS)
 - Requires approximately 2GB RAM and basic Docker support.
 - Provided for research purposes only; not a production trading system.
 
-[View README](../../alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/muzeromctsllmagent_v0/README.md)

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -287,4 +287,4 @@ In sum, the OMNI-Factory city simulator stands as a **proof-of-concept** of how 
 
 Ultimately, success will be measured by the conversations and ideas this demo sparks. By presenting a clear, well-structured integration of advanced AI components addressing real societal challenges, we aim to inspire confidence that **open-ended AI coupled with careful design can be a force-multiplier for human decision-making** – a message delivered vividly through this interactive simulation.
 
-[View README](../../alpha_factory_v1/demos/omni_factory_demo/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/omni_factory_demo/README.md)

--- a/docs/demos/self_healing_repo.md
+++ b/docs/demos/self_healing_repo.md
@@ -276,4 +276,4 @@ clone repo → [sandbox pytest] → error log
 
 > **Alpha‑Factory** — shipping code that ships itself.
 
-[View README](../../alpha_factory_v1/demos/self_healing_repo/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/self_healing_repo/README.md)

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -228,4 +228,4 @@ governance-bridge --port 5005
     colab_solving_agi_governance.ipynb
 
 
-[View README](../../alpha_factory_v1/demos/solving_agi_governance/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/solving_agi_governance/README.md)

--- a/docs/demos/sovereign_agentic_agialpha_agent_v0.md
+++ b/docs/demos/sovereign_agentic_agialpha_agent_v0.md
@@ -31,4 +31,4 @@ Run `./deploy_sovereign_agentic_agialpha_agent_v0.sh` to build and launch the co
 - The script will guide you through optional model configuration.
 - Press `Ctrl+C` to stop logs after deployment if desired.
 
-[View README](../../alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/README.md)

--- a/docs/demos/utils.md
+++ b/docs/demos/utils.md
@@ -10,4 +10,4 @@
 
 This directory holds helper utilities shared across demos, such as `disclaimer.py` which exposes the standard project disclaimer.
 
-[View README](../../alpha_factory_v1/demos/utils/README.md)
+[View README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/utils/README.md)


### PR DESCRIPTION
## Summary
- remove references to internal sprint docs
- fix links to README and other files

## Testing
- `pre-commit run --hook-stage manual --files docs/INTRO_BASICS.md docs/OFFLINE_SETUP.md docs/PROJECT_README.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686c9e6ff460833389e4c624428e72f3