### PR TITLE
Fix docs links and images

### DIFF
--- a/docs/aiga_meta_evolution/bridge_overview.svg
+++ b/docs/aiga_meta_evolution/bridge_overview.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="200" font-family="Arial" font-size="14">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="20" y="60" width="120" height="40" fill="#e0e0ff" stroke="#000" />
+  <text x="80" y="85" text-anchor="middle">MetaEvolver</text>
+
+  <line x1="140" y1="80" x2="250" y2="80" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="250" y="60" width="140" height="40" fill="#ffe0e0" stroke="#000" />
+  <text x="320" y="85" text-anchor="middle">FastAPI + Gradio</text>
+
+  <line x1="390" y1="80" x2="500" y2="80" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="500" y="60" width="100" height="40" fill="#e0ffe0" stroke="#000" />
+  <text x="550" y="85" text-anchor="middle">Agents SDK</text>
+
+  <line x1="550" y1="100" x2="550" y2="140" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="480" y="140" width="140" height="40" fill="#ffffe0" stroke="#000" />
+  <text x="550" y="165" text-anchor="middle">ADK Gateway (opt)</text>
+
+  <line x1="320" y1="100" x2="320" y2="140" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="250" y="140" width="140" height="40" fill="#e0ffff" stroke="#000" />
+  <text x="320" y="165" text-anchor="middle">Ollama / OpenAI LLMs</text>
+</svg>

--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -224,7 +224,7 @@ curl -X POST http://localhost:9000/v1/tasks \
 The optional ADK gateway integrates with the OpenAI Agents SDK bridge and
 underlying LLM providers as shown below.
 
-![Bridge overview](../aiga_meta_evolution/assets/bridge_overview.svg)
+![Bridge overview](../aiga_meta_evolution/bridge_overview.svg)
 
 ## 🔐 API authentication
 
@@ -235,6 +235,7 @@ The `/health` and `/metrics` endpoints remain public.
 ---
 ## 🚀 Production deployment
 
+For step-by-step instructions on running the service in a production or workshop environment, see [PRODUCTION_GUIDE.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md).
 
 
 ## 🎓 Run in Colab

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -164,7 +164,7 @@ All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google ADK*
 <a id="quick"></a>
 ## 6 Quick Start 🚀
 
-*For a concise walkthrough see [QUICK_START.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md).*
+*For a concise walkthrough see [QUICK_START.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md).* 
 For a deployment checklist aimed at production environments consult
 [PRODUCTION_GUIDE.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md).
 ```bash
@@ -469,7 +469,7 @@ Apache 2.0 © 2025 **MONTREAL.AI**
 - [Google Agent Development Kit docs](https://google.github.io/adk-docs/)
 - [Agent‑to‑Agent protocol](https://github.com/google/A2A)
 - [Model Context Protocol](https://www.anthropic.com/news/model-context-protocol)
-- [Best Alpha Workflow](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md)
+ - [Best Alpha Workflow](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md)
 [open-colab-link]:
   https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/
 [guide-pdf]: https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -259,6 +259,7 @@ docker run -it --rm -p 8501:8501   -e OPENAI_API_KEY=$OPENAI_API_KEY   ghcr.io/m
 ```
 
 For offline builds or the browser-based PWA, see
+[insight_browser_v1 README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/README.md).
 
 ## Environment Setup
 
@@ -450,8 +451,9 @@ Launch the container stack afterwards or serve `dist/` with any static server,
 e.g. `python -m http.server --directory dist 8080`.
 
 For advanced options see
+[web_client README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/core/interface/web_client/README.md).
 
-For details see [../API.md](../API.md).
+For details see [API.md](../API.md).
 
 ### 5.4 Building the Web Dashboard
 
@@ -466,6 +468,7 @@ npm run build
 This installs dependencies and outputs static files in `dist/`. The provided
 `Dockerfile` already runs these steps, so manual builds are only needed for
 local development or customization. See the
+[web_client README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/core/interface/web_client/README.md) for advanced usage.
 
 ### 5.5 Exporting Visualization Data
 
@@ -523,6 +526,7 @@ default `changeme` placeholder.
 To secure the gRPC bus provide `AGI_INSIGHT_BUS_CERT`,
 `AGI_INSIGHT_BUS_KEY` and `AGI_INSIGHT_BUS_TOKEN`. When these are omitted set
 `AGI_INSIGHT_ALLOW_INSECURE=1` to run without TLS. See
+[bus_tls.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md) for detailed setup.
 
 Agents restart automatically when they fail or stop sending heartbeats.
 `AGENT_ERR_THRESHOLD` controls how many consecutive errors trigger a restart.

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -240,6 +240,7 @@ rac{reward_{success}}{reward_{total}}\)
 
 <a id="terms"></a>
 ## 14 Terms 🤝
+See [`TERMS & CONDITIONS.md`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- fix missing demo links
- add missing bridge overview asset
- update docs references to GitHub

## Testing
- `pre-commit run --files docs/demos/aiga_meta_evolution.md docs/demos/alpha_agi_business_v1.md docs/demos/alpha_agi_insight_v1.md docs/demos/alpha_agi_marketplace_v1.md docs/aiga_meta_evolution/bridge_overview.svg`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686d388c85608333b81f6a6783134248