### PR TITLE
Fix docs quickstart link

### DIFF
--- a/docs/INTRO.md
+++ b/docs/INTRO.md
@@ -24,4 +24,4 @@ This short guide describes the quickest way to run the α‑AGI Insight demo.
    ```
    Set `AGI_INSIGHT_OFFLINE=1` to guarantee zero network access.
 
-See [docs/quickstart.md](quickstart.md) for more details and Docker instructions.
+See [quickstart.md](quickstart.md) for more details and Docker instructions.


### PR DESCRIPTION
## Summary
- fix quickstart link in INTRO page to remove redundant `docs/` prefix

## Testing
- `pre-commit run --files docs/INTRO.md`


------
https://chatgpt.com/codex/tasks/task_e_686d451381dc8333bbcbb1641c6b7bf1