### PR TITLE
ci: enforce strict docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.26.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
+      CI: 'true'
       # Keep the asset mirrors pinned to official hosts.
       # Optional environment variables for asset downloads. See
       # scripts/fetch_assets.py for details.

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -122,13 +122,8 @@ copy_assets
 python scripts/generate_demo_docs.py
 python scripts/generate_gallery_html.py
 
-# Build the MkDocs site. Only abort on warnings when running locally
-# so the CI job doesn't fail due to non-critical issues.
-if [[ "${CI:-}" == "true" ]]; then
-    mkdocs build
-else
-    mkdocs build --strict
-fi
+# Build the MkDocs site in strict mode so warnings fail the build
+mkdocs build --strict
 
 # Verify the Workbox hash again in the generated site directory
 if ! python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1; then


### PR DESCRIPTION
## Summary
- run `mkdocs build --strict` in `build_insight_docs.sh`
- set `CI=true` in docs workflow

## Testing
- `shellcheck scripts/build_insight_docs.sh`
- `pre-commit run --files scripts/build_insight_docs.sh .github/workflows/docs.yml`
- `pytest -m smoke -q` *(fails: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686d501d229c8333b26c37948b97148b