### PR TITLE
Fix docs build

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -122,13 +122,8 @@ copy_assets
 python scripts/generate_demo_docs.py
 python scripts/generate_gallery_html.py
 
-# Build the MkDocs site. Skip --strict in CI to avoid aborting on
-# non-critical warnings that do not affect the generated pages.
-if [[ "${CI:-}" == "true" ]]; then
-  mkdocs build
-else
-  mkdocs build --strict
-fi
+# Build the MkDocs site in strict mode so any warnings fail the build.
+mkdocs build --strict
 
 # Verify the Workbox hash again in the generated site directory
 if ! python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1; then


### PR DESCRIPTION
## Summary
- enforce MkDocs strict mode in docs build script

## Testing
- `pre-commit run --files scripts/build_insight_docs.sh`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686d58c161608333abf3714a749c55c1