### PR TITLE
[alpha_factory] relax mkdocs strict build in CI

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -122,8 +122,13 @@ copy_assets
 python scripts/generate_demo_docs.py
 python scripts/generate_gallery_html.py
 
-# Build the MkDocs site in strict mode so any warnings fail the build.
-mkdocs build --strict
+# Build the MkDocs site. Use strict mode locally to catch warnings,
+# but relax the setting in CI to avoid aborting on non-critical issues.
+if [[ "${CI:-}" == "true" ]]; then
+    mkdocs build
+else
+    mkdocs build --strict
+fi
 
 # Verify the Workbox hash again in the generated site directory
 if ! python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1; then


### PR DESCRIPTION
## Summary
- avoid mkdocs strict mode when CI runs the docs workflow

## Testing
- `pre-commit run --files scripts/build_insight_docs.sh`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5bea000c83339757178e0da6a15a