### PR TITLE
[alpha_factory] ensure CI env for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -98,6 +98,8 @@ jobs:
           PYODIDE_BASE_URL: ${{ env.PYODIDE_BASE_URL }}
           HF_GPT2_BASE_URL: ${{ env.HF_GPT2_BASE_URL }}
           CI_SKIP_ENV_CHECK: '1'
-        run: ./scripts/edge_human_knowledge_pages_sprint.sh
+        run: |
+          export CI=true
+          ./scripts/edge_human_knowledge_pages_sprint.sh
       - name: Verify downloaded assets
         run: python scripts/fetch_assets.py --verify-only


### PR DESCRIPTION
## Summary
- explicitly export `CI=true` before running `edge_human_knowledge_pages_sprint.sh`
- confirm `deploy_gallery_pages.sh` uses `$CI` to drop `--strict`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*
- `pre-commit run --files .github/workflows/docs.yml` *(failed during environment install)*

------
https://chatgpt.com/codex/tasks/task_e_686d6b23bedc833392ed53a836f1ddfc