### PR TITLE
Fix asset links

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md
@@ -155,7 +155,7 @@ open http://localhost:7749           # Dashboard SPA
 python -m alpha_factory_v1.demos.alpha_agi_marketplace_v1.marketplace \
     examples/sample_job.json
 ```
-*Prefer a one-click experience?* Run the [colab_alpha_agi_marketplace_demo.ipynb](./colab_alpha_agi_marketplace_demo.ipynb) notebook on Google Colab.
+*Prefer a one-click experience?* Run the [colab_alpha_agi_marketplace_demo.ipynb](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_marketplace_v1/colab_alpha_agi_marketplace_demo.ipynb) notebook on Google Colab.
 *No Docker?* `bash <(curl -sL get.alpha-factory.ai/demo.sh)` boots an ephemeral VM.
 
 ---

--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -225,7 +225,7 @@ curl -X POST http://localhost:9000/v1/tasks \
 The optional ADK gateway integrates with the OpenAI Agents SDK bridge and
 underlying LLM providers as shown below.
 
-![Bridge overview](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/aiga_meta_evolution/bridge_overview.svg)
+![Bridge overview](../aiga_meta_evolution/assets/bridge_overview.svg)
 
 ## 🔐 API authentication
 


### PR DESCRIPTION
## Summary
- point `bridge_overview.svg` to docs asset
- use GitHub link for the marketplace demo notebook

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_marketplace_v1/README.md docs/demos/aiga_meta_evolution.md`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_686d7107ea1c8333b8e8ffe425bb812a