### PR TITLE
Add production docs and terms

### DIFF
--- a/docs/TERMS_AND_CONDITIONS/assets/preview.svg
+++ b/docs/TERMS_AND_CONDITIONS/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -1,0 +1,135 @@
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# 🛠️ Production Deployment Guide — AI‑GA Meta‑Evolution
+
+This short guide distils the steps required to run the **AI‑GA Meta‑Evolution** service in a production or workshop environment.
+The AI‑GA Meta‑Evolution service is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk.
+
+1. **Prepare the configuration**
+   - Copy `config.env.sample` to `config.env` and edit as needed.
+   - Set `OPENAI_API_KEY` to enable cloud models. Leave empty to run fully offline via the bundled Mixtral model.
+   - Optionally enable the Google ADK gateway by setting `ALPHA_FACTORY_ENABLE_ADK=true`. A token can be enforced with `ALPHA_FACTORY_ADK_TOKEN`.
+   - For API protection, set `AUTH_BEARER_TOKEN` or provide `JWT_PUBLIC_KEY`/`JWT_ISSUER` values.
+   - Verify all Python packages are available. Run from this directory:
+     ```bash
+     AUTO_INSTALL_MISSING=1 python ../../check_env.py --auto-install
+     ```
+     This installs `openai-agents` (or the alternative `agents` package) and
+     other requirements if they are missing.
+     **Running this command is mandatory before executing the demos or the unit
+     tests.** The LLM features depend on having either `openai-agents` or
+     `agents` available. The `google-adk` package is only needed when the ADK
+     gateway is enabled.
+
+### Building a wheelhouse
+
+Create a wheelhouse if the production host lacks internet access.
+From the repository root:
+
+```bash
+pip wheel -r alpha_factory_v1/demos/aiga_meta_evolution/requirements.txt -w wheels
+```
+
+Copy the `wheels/` directory to the target machine and set `WHEELHOUSE`
+before running the environment check:
+
+```bash
+export WHEELHOUSE=$(pwd)/wheels
+AUTO_INSTALL_MISSING=1 python ../../check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
+```
+
+Run `python scripts/check_python_deps.py` first to verify core packages,
+then `AUTO_INSTALL_MISSING=1 python ../../check_env.py --auto-install`.
+Provide this directory via `WHEELHOUSE` when installing on the production host.
+Regenerate the lock file whenever `requirements.txt` changes:
+
+```bash
+pip-compile --generate-hashes \
+    alpha_factory_v1/demos/aiga_meta_evolution/requirements.txt \
+    -o alpha_factory_v1/demos/aiga_meta_evolution/requirements.lock
+```
+Run `pre-commit run --all-files` after the dependencies finish installing.
+   - Install the OpenAI Agents SDK if not already present:
+    ```bash
+    pip install -U openai-agents
+    # offline
+    pip install --no-index --find-links /path/to/wheels openai-agents
+    ```
+    Some distributions package it as the simpler `agents` module; the demo
+    detects both. If `import openai_agents` fails, reinstall the SDK and
+     confirm your virtual environment is active.
+
+2. **Launch the service**
+   - Using Docker:
+     ```bash
+     ./run_aiga_demo.sh --pull           # add --gpu for NVIDIA runtime
+     ```
+   - Or natively via Python:
+     ```bash
+    pip install -r requirements.txt
+    python agent_aiga_entrypoint.py
+     ```
+
+### Launching the OpenAI Agents bridge
+
+Start the bridge if you wish to drive the evolver through the **OpenAI Agents**
+SDK.  Enable the ADK gateway by exporting `ALPHA_FACTORY_ENABLE_ADK=1` before
+launching the script.  A token can be enforced via
+`ALPHA_FACTORY_ADK_TOKEN`.
+
+```bash
+ALPHA_FACTORY_ENABLE_ADK=1 python openai_agents_bridge.py
+# optional token auth
+ALPHA_FACTORY_ADK_TOKEN=my_token python openai_agents_bridge.py
+```
+
+The runtime listens on port `5001` by default. Override it by exporting
+`AGENTS_RUNTIME_PORT` before launching:
+
+```bash
+AGENTS_RUNTIME_PORT=6001 python openai_agents_bridge.py
+```
+
+The bridge exposes health checks at
+`http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz` (or `/docs`).
+
+3. **Run in Colab**
+   - Open the notebook at
+     [colab_aiga_meta_evolution.ipynb](colab_aiga_meta_evolution.ipynb).
+     Click the “Open in Colab” badge and run the setup cell. The notebook
+     launches the same service with a public Gradio URL and includes test
+     and API usage examples.
+
+4. **Access the interface**
+   - Gradio dashboard: [http://localhost:7862](http://localhost:7862)
+   - OpenAPI docs: [http://localhost:8000/docs](http://localhost:8000/docs)
+   - Prometheus metrics: [http://localhost:8000/metrics](http://localhost:8000/metrics)
+
+### Verifying the ADK Gateway
+When `ALPHA_FACTORY_ENABLE_ADK=true` and the optional `google-adk` package are
+present, the orchestrator exposes an ADK gateway.  Check the logs for a line
+similar to:
+
+```
+ADK gateway listening on http://0.0.0.0:${ALPHA_FACTORY_ADK_PORT}  (A2A protocol)
+```
+
+Confirm the gateway is reachable:
+
+```bash
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/docs
+# or
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz
+```
+
+5. **Persisting state**
+   - Checkpoints are written to the directory specified by `CHECKPOINT_DIR` (default `./checkpoints`).
+   - The service automatically reloads the latest checkpoint on start-up.
+
+6. **Shutting down**
+   - Docker: `./run_aiga_demo.sh --stop`
+   - Python: send `SIGINT` or `SIGTERM`; the service will persist state before exiting.
+
+For troubleshooting or advanced options see `README.md` in the same directory.
+

--- a/docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
+++ b/docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
@@ -1,0 +1,69 @@
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Best Alpha Opportunity Workflow
+
+This short note summarises the highest ranked alpha signal included with the demo and how to act on it using the
+  provided multi‑agent stack. The goal is to show a concrete starting point for experimentation.
+
+## 1. Identified Alpha
+
+Using `examples/find_best_alpha.py` (run from the root of the project directory) the top opportunity from
+  `examples/alpha_opportunities.json` is:
+
+```
+gene therapy patent undervalued by market
+```
+with a score of **88**.
+
+## 2. Launch the Orchestrator
+
+Run the one‑click launcher which automatically installs any missing dependencies and starts the local orchestrator with
+  the OpenAI Agents bridge enabled:
+
+```bash
+python start_alpha_business.py
+```
+
+Open the REST docs at `http://localhost:8000/docs` to verify the service is running. The core agents (discovery,
+  opportunity, execution, risk, compliance, portfolio) start automatically.
+
+## 3. Submit the Opportunity
+
+Send a job definition to the orchestrator so the agents can evaluate and act on it. Replace `<PORT>` if you changed the
+  default 8000:
+
+```bash
+curl -X POST http://localhost:<PORT>/agent/alpha_execution/trigger \
+     -H 'Content-Type: application/json' \
+     -d '{"alpha": "gene therapy patent undervalued by market", "score": 88}'
+```
+
+Or trigger it via the OpenAI Agents bridge using the ``trigger_best_alpha``
+helper:
+
+```bash
+curl -X POST http://localhost:5001/v1/agents/business_helper/invoke \
+     -H 'Content-Type: application/json' \
+     -d '{"action": "best_alpha"}'
+```
+
+The execution agent will process the input and propagate tasks to downstream agents such as risk and compliance.
+
+## 4. Monitor Progress
+
+Use the built‑in dashboard or the OpenAI Agents bridge to query recent alpha items and check agent status:
+
+```bash
+python openai_agents_bridge.py --host http://localhost:<PORT> --open-ui
+```
+
+Replace `<PORT>` with the OpenAI Agents bridge port (default is 5001). Once the bridge is running, open
+  `http://localhost:5001/v1/agents` to interact via the OpenAI Agents SDK. The `recent_alpha` and `fetch_logs` tools
+  provide a quick view of system activity.
+
+---
+
+This workflow demonstrates how to take a discovered alpha signal and run it through the demo's multi‑agent pipeline. The
+  components are intentionally lightweight so you can extend them with domain‑specific logic or connect them to external
+  data sources.

--- a/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -1,0 +1,84 @@
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+
+# 🏭 Production Deployment Guide — Alpha‑AGI Business v1
+
+This guide summarises the minimal steps required to run the **Alpha‑AGI Business v1** demo in a production‑like
+  environment. The service works fully offline but upgrades automatically when `OPENAI_API_KEY` is present.
+
+1. **Prepare the configuration**
+   - Run `python scripts/setup_config.py` to create `config.env` if missing and edit as needed.
+   - Set `OPENAI_API_KEY` to enable cloud models or leave empty to use the bundled local fallbacks.
+   - Optionally enable the Google ADK gateway by setting `ALPHA_FACTORY_ENABLE_ADK=true`.
+   - Set `MCP_ENDPOINT` to push logs to a Model Context Protocol server (optional).
+   - Set `MCP_TIMEOUT_SEC` to adjust the timeout for MCP requests (default: 30 seconds).
+   - `API_TOKEN` defaults to `"demo-token"` *(for demonstrations only)*; always set a strong secret before deploying.
+   - For API protection set either `AUTH_BEARER_TOKEN` or `JWT_PUBLIC_KEY`/`JWT_ISSUER`.
+   - Validate that all Python packages are available. From the project root run:
+     ```bash
+     AUTO_INSTALL_MISSING=1 python check_env.py --auto-install
+     ```
+     Provide `WHEELHOUSE=/path/to/wheels` for air‑gapped setups. **Running this
+      command is mandatory before executing the demos or running the test suite.**
+      The `openai-agents` and `google-adk` packages are optional and are only
+      required when using the OpenAI Agents runtime or the Google ADK gateway.
+   - Build wheels for these optional packages when preparing an offline
+      deployment:
+      ```bash
+      pip wheel openai-agents google-adk -w /path/to/wheels
+      ```
+      Provide this directory via `WHEELHOUSE` during installation on the
+      production host.
+Run `pre-commit run --all-files` after the dependencies finish installing.
+
+2. **Launch the service**
+   - **Docker** (recommended for consistent environments):
+     ```bash
+     ./run_business_v1_demo.sh [--pull] [--gpu]
+     ```
+   - **Native Python**:
+     ```bash
+     pip install -r ../../requirements.txt
+     python run_business_v1_local.py --bridge
+     ```
+
+3. **Run in Colab**
+   - Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb).
+   - Run the setup cell; dependencies are installed automatically.
+   - The notebook exposes a Gradio dashboard and OpenAI Agents SDK bridge.
+
+4. **Access the interface**
+   - REST/Swagger docs: [http://localhost:8000/docs](http://localhost:8000/docs)
+   - Gradio dashboard: [http://localhost:7860](http://localhost:7860)
+   - Prometheus metrics: [http://localhost:8000/metrics](http://localhost:8000/metrics)
+
+### Verifying the ADK Gateway
+When `ALPHA_FACTORY_ENABLE_ADK=true` and the optional `google-adk` package are
+installed, the service spawns an ADK gateway.  Look for a log message like:
+
+```
+ADK gateway listening on http://0.0.0.0:${ALPHA_FACTORY_ADK_PORT}  (A2A protocol)
+```
+
+Confirm connectivity with:
+
+```bash
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/docs
+# or
+curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz
+```
+
+5. **Shutting down**
+   - Docker: `./run_business_v1_demo.sh --stop`
+   - Native Python: press `Ctrl+C`; the orchestrator shuts down gracefully.
+
+For advanced options see [`README.md`](README.md) in the same directory.
+
+---
+
+## Further Resources
+
+- [OpenAI Agents SDK docs](https://openai.github.io/openai-agents-python/)
+- [Google ADK reference](https://google.github.io/adk-docs/)
+- [Agent-to-Agent protocol](https://github.com/google/A2A)

--- a/docs/alpha_agi_business_v1/QUICK_START.md
+++ b/docs/alpha_agi_business_v1/QUICK_START.md
@@ -1,0 +1,83 @@
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Quick Start – Alpha‑AGI Business v1 Demo
+
+This short guide summarises how to launch the business demo either locally or in Google Colab.
+
+## Local Launch
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
+   cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
+   ```
+2. **Install requirements and check dependencies**
+   ```bash
+   pip install -r ../../requirements.txt -q
+   python ../../check_env.py --auto-install
+   ```
+3. **Run the demo**
+   ```bash
+   # one-click launcher (opens docs in your browser)
+   python start_alpha_business.py
+   # auto-submit the top ranked opportunity once running
+   python start_alpha_business.py --submit-best
+   # optional: choose a different port
+   PORT=9000 python start_alpha_business.py
+   ```
+   The dashboard is available at [http://localhost:<port>/docs](http://localhost:<port>/docs), where `<port>` is the
+     port number used (default is `8000`).
+   By default the orchestrator launches stub agents for planning, research,
+   strategy, market analysis, memory and safety in addition to the core
+   discovery/execution pipeline.
+
+   Alternatively, run the orchestrator directly with:
+   ```bash
+  python run_business_v1_local.py --bridge --open-ui
+  # customise the Agents runtime port
+  python run_business_v1_local.py --bridge --runtime-port 6001
+  ```
+   This starts the Agents bridge and opens the REST docs automatically once the service is ready.
+
+Set `OPENAI_API_KEY` to enable cloud models. Offline mode works automatically when the key is absent.
+Set `YFINANCE_SYMBOL` (e.g. `YFINANCE_SYMBOL=SPY`) to fetch a live price when `yfinance` is available.
+Set `ALPHA_BEST_ONLY=1` to emit the highest-scoring opportunity from `examples/alpha_opportunities.json`.
+Set `ALPHA_TOP_N=5` to publish the top 5 opportunities each cycle.
+For air-gapped setups provide pre-downloaded wheels and let `check_env.py` auto-install:
+```bash
+export WHEELHOUSE=/path/to/wheels
+export AUTO_INSTALL_MISSING=1
+python start_alpha_business.py
+```
+
+### Building a Wheelhouse
+Create wheels on a machine with internet access and copy the directory to the
+offline host:
+
+```bash
+mkdir -p /media/wheels
+pip wheel -r ../../requirements.txt -w /media/wheels
+pip wheel -r ../../requirements-dev.txt -w /media/wheels
+```
+
+Verify dependencies offline:
+
+```bash
+python ../../check_env.py --auto-install --wheelhouse /media/wheels
+```
+
+See [docs/OFFLINE.md](../../../../docs/OFFLINE.md) for additional tips.
+
+## Colab Notebook
+Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook
+  checks requirements, starts the orchestrator, and exposes helper tools via the OpenAI Agents SDK.
+
+## ADK Bridge
+To expose the helper agent via Google's Agent Development Kit (ADK), install the
+`google-adk` package and enable the bridge:
+```bash
+pip install google-adk  # optional dependency
+ALPHA_FACTORY_ENABLE_ADK=true python openai_agents_bridge.py --host http://localhost:8000
+```
+The ADK gateway listens on `ALPHA_FACTORY_ADK_PORT` (default `9000`) and supports
+Agent-to-Agent (A2A) messaging.

--- a/docs/alpha_agi_insight_v1/docs/API.md
+++ b/docs/alpha_agi_insight_v1/docs/API.md
@@ -1,0 +1,56 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+# API Overview
+
+This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.
+
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+| Endpoint | Query/Path Params | Payload | Example Response |
+|---------|------------------|---------|-----------------|
+| **POST `/simulate`** | – | `{ "horizon": 5, "pop_size": 6, "generations": 3 }` | `{ "id": "d4e5f6a7" }` |
+| **GET `/results/{sim_id}`** | `sim_id` (path) | – | `{ "id": "d4e5f6a7", "forecast": [{"year": 1, "capability": 0.1}], "population": [] }` |
+| **GET `/population/{sim_id}`** | `sim_id` (path) | – | `{ "id": "d4e5f6a7", "population": [] }` |
+| **GET `/runs`** | – | – | `{ "ids": ["d4e5f6a7"] }` |
+| **POST `/insight`** | – | `{ "ids": ["d4e5f6a7"] }` | `{ "forecast": [{"year": 1, "capability": 0.1}] }` |
+| **WS `/ws/progress`** | – | N/A | `{"id": "d4e5f6a7", "year": 1, "capability": 0.1}` |
+
+### `GET /population/{sim_id}`
+
+Retrieve only the final population for a completed run.
+
+```bash
+curl -H "Authorization: Bearer $API_TOKEN" \
+  http://localhost:8000/population/<sim_id>
+```
+
+Example response:
+
+```json
+{
+  "id": "<sim_id>",
+  "population": [
+    {"effectiveness": 0.5, "risk": 0.2, "complexity": 0.3, "rank": 0}
+  ]
+}
+```
+
+### `POST /insight`
+
+Compute aggregated forecast data across stored runs. Optionally pass a JSON
+payload with a list of run identifiers under `ids`. When omitted, all available
+runs are included.
+
+```json
+{
+  "ids": ["abc123", "def789"]
+}
+```
+
+The response contains the average capability value per year:
+
+```json
+{
+  "forecast": [{"year": 1, "capability": 0.5}]
+}
+```
+

--- a/docs/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/docs/alpha_agi_insight_v1/docs/bus_tls.md
@@ -1,0 +1,76 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Bus TLS Setup
+
+The Insight demo uses a gRPC message bus for communication between agents. When `AGI_INSIGHT_BUS_CERT` and `AGI_INSIGHT_BUS_KEY` are provided the bus requires TLS and authenticates requests with `AGI_INSIGHT_BUS_TOKEN`.
+
+## Generating a Self-Signed Certificate
+
+Use `openssl` to create a private key and certificate valid for one year. Run
+`infrastructure/gen_bus_certs.sh` to execute these commands automatically and
+print the environment variables, or run them manually:
+
+```bash
+mkdir -p certs
+openssl req -x509 -newkey rsa:4096 -nodes \
+  -keyout certs/bus.key \
+  -out certs/bus.crt \
+  -days 365 \
+  -subj "/CN=localhost"
+```
+
+Set the environment variables to the generated paths:
+
+```
+AGI_INSIGHT_BUS_CERT=/path/to/certs/bus.crt
+AGI_INSIGHT_BUS_KEY=/path/to/certs/bus.key
+AGI_INSIGHT_BUS_TOKEN=change_this_token
+```
+
+Change `AGI_INSIGHT_BUS_TOKEN` to a unique secret before starting the
+orchestrator. When TLS is enabled the application exits with a
+``ValueError`` if this variable is empty or still set to the default
+``change_this_token``.
+
+### Windows (PowerShell)
+
+Install the [OpenSSL Windows binaries](https://slproweb.com/products/Win32OpenSSL.html) and run the equivalent commands:
+
+```powershell
+New-Item -ItemType Directory -Force -Path certs
+openssl req -x509 -newkey rsa:4096 -nodes `
+  -keyout certs/bus.key `
+  -out certs/bus.crt `
+  -days 365 `
+  -subj "/CN=localhost"
+```
+
+## Docker and Docker Compose
+
+Place `bus.crt` and `bus.key` under `./certs` next to `docker-compose.yml` and mount the directory:
+
+```yaml
+services:
+  orchestrator:
+    volumes:
+      - ./certs:/certs:ro
+```
+
+Inside the container reference the mounted files:
+
+```
+AGI_INSIGHT_BUS_CERT=/certs/bus.crt
+AGI_INSIGHT_BUS_KEY=/certs/bus.key
+AGI_INSIGHT_BUS_TOKEN=<token>
+```
+
+For a single container run use:
+
+```bash
+docker run -v $(pwd)/certs:/certs:ro \
+  -e AGI_INSIGHT_BUS_CERT=/certs/bus.crt \
+  -e AGI_INSIGHT_BUS_KEY=/certs/bus.key \
+  -e AGI_INSIGHT_BUS_TOKEN=<token> \
+  alpha-demo
+```

--- a/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -1,0 +1,402 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+### 🔬 Browser-only Insight demo
+A zero-backend Pareto explorer lives in
+`demos/alpha_agi_insight_v1/insight_browser_v1/`. See the **Quick-Start** section below for a short walkthrough.
+
+## Quick-Start
+Open [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf)
+for a concise overview of the build and launch steps.
+
+## Prerequisites
+- **Node.js ≥20** is required for offline PWA support and by `manual_build.py`
+  to generate the service worker.
+- **Python ≥3.11** is required when using `manual_build.py`.
+- `package-lock.json` must remain checked in so `npm ci` installs the exact
+  versions specified.
+- Run `npm ci` before executing any lint or build script.
+
+Verify your Node.js version before running the build script:
+
+```bash
+node build/version_check.js
+```
+The output should be empty for a valid setup. Only run `manual_build.py` when
+this requirement is met. The `package.json` also enforces Node.js 20 or newer
+via the `engines` field.
+
+## Windows Setup
+
+Download and install [Node.js 20](https://nodejs.org/en/download) and
+[Python 3.11](https://www.python.org/downloads/) before running the build
+scripts. Open PowerShell in this directory and verify the versions:
+
+```powershell
+node --version
+python --version
+```
+
+Use `./setup.ps1` to install the Node modules when `node_modules` is missing.
+Build and launch the demo with:
+
+```powershell
+npm run fetch-assets
+./setup.ps1
+npm run build    # or ./manual_build.ps1 for offline builds
+npm start
+```
+
+## Environment Setup
+Copy [`.env.sample`](.env.sample) to `.env` then review the variables. When `.env`
+is missing the build scripts continue with default empty values:
+
+- `PINNER_TOKEN` – Web3.Storage token used to pin results.
+- `OPENAI_API_KEY` – optional OpenAI key for chat prompts. **For security, do not
+  embed the key in the built HTML.** Store it in `localStorage` or enter it at
+  runtime instead.
+- `IPFS_GATEWAY` – base URL of the IPFS gateway used to fetch pinned runs. Set
+  `IPFS_GATEWAY=<url>` to override the primary gateway.
+- `OTEL_ENDPOINT` – OTLP/HTTP endpoint for anonymous telemetry (leave blank to disable).
+- `WEB3_STORAGE_TOKEN` – build script token consumed by `npm run build`.
+- Browsers with WebGPU can accelerate the local model using the ONNX runtime.
+  Use the GPU toggle in the power panel to switch between WebGPU and WASM.
+- The power panel also includes an **Offline/API** selector. Choose
+  **Run Offline** to execute the bundled GPT‑2 model via Pyodide or
+  **Run with OpenAI API** when an `OPENAI_API_KEY` is available. The key is
+  stored in `localStorage` and the app falls back to offline mode when absent.
+- Set `window.DEBUG = true` before loading the page to expose debugging helpers
+  like `window.pop` and `window.coldZone`.
+
+Run `npm run fetch-assets` to download the Pyodide runtime and local model
+before installing dependencies. Execute this command in a fresh checkout—or
+remove the existing `wasm*/` directories—so placeholder files are replaced.
+After the download completes, verify each file with
+`python ../../../../scripts/fetch_assets.py --verify-only`. The script
+retrieves the official Pyodide runtime from the jsDelivr CDN and the GPT‑2
+small checkpoint from Hugging Face. If a custom `PYODIDE_BASE_URL` is unreachable the helper
+automatically retries using the official CDN. The deprecated `wasm-gpt2.tar`
+archive is no longer used.
+Set `FETCH_ASSETS_ATTEMPTS` to control the retry count when downloading assets.
+Override `PYODIDE_BASE_URL` or `HF_GPT2_BASE_URL` to change the mirrors, for example:
+
+```bash
+export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"
+```
+
+If `npm run fetch-assets` fails with a 401 or 404 error, download the checkpoint directly:
+```bash
+python ../../../../scripts/download_hf_gpt2.py models/gpt2
+```
+
+Alternatively, execute `python ../../../../scripts/download_hf_gpt2.py`,
+`python ../../../../scripts/download_gpt2_small.py`, or
+`python ../../../../scripts/download_openai_gpt2.py` to fetch the GPT‑2 model
+directly.
+
+If the Pyodide runtime fails to download, run the helper manually:
+
+```bash
+python ../../../../scripts/fetch_assets.py
+```
+
+The script fetches the official files from `PYODIDE_BASE_URL` and falls back to the
+jsDelivr and GitHub mirrors when needed. You can also retrieve the runtime with
+`curl` when automation fails:
+
+```bash
+curl -L https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.js -o wasm/pyodide.js
+curl -L https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.asm.wasm -o wasm/pyodide.asm.wasm
+```
+Verify the downloads with:
+
+```bash
+python ../../../../scripts/fetch_assets.py --verify-only
+```
+
+See [`.env.sample`](.env.sample) for the full list of supported variables.
+The compiled `dist/` directory is not version controlled. Run the build script
+to create it before launching the demo.
+
+## Build & Run
+Run `npm run fetch-assets` **before installing dependencies** to download the
+Pyodide runtime and GPT‑2 weights, then install the Node modules.
+`python ../../../../scripts/download_hf_gpt2.py` or
+`python ../../../../scripts/download_gpt2_small.py` can also fetch the model
+directly if you prefer,
+compile the bundle:
+```bash
+npm run fetch-assets
+./setup.sh        # installs dependencies when node_modules is missing (use `./setup.ps1` on Windows)
+npm run build     # or `python manual_build.py` or `./manual_build.ps1` for offline builds
+```
+Run the tests with:
+```bash
+./setup.sh && npm test    # on Windows use `./setup.ps1`
+```
+The build script reads `.env` automatically and injects the values into
+`dist/index.html` as `window.PINNER_TOKEN`, `window.IPFS_GATEWAY` and
+`window.OTEL_ENDPOINT`. `OPENAI_API_KEY` is **not** embedded by default.
+Set it in `localStorage` or provide it at runtime when prompted.
+It also copies `dist/sw.js` to `dist/service-worker.js` which `index.html`
+registers for offline support.
+`npm run build` (or `python manual_build.py`) also replaces the
+`__SW_HASH__` placeholder in `index.html` with the SHA-384 digest of
+`service-worker.js` so the browser can verify the script before
+registration.
+After rebuilding the demo, the service worker automatically skips the waiting
+phase and reloads the page so users always run the latest version.
+The unbuilt `index.html` falls back to `'self'` for the IPFS and telemetry
+origins, but running `npm run build` (or `python manual_build.py`) replaces
+these defaults with the real values from `.env`.
+Place the Pyodide 0.26.0 files in `wasm/` before building. The script copies them
+to `dist/wasm` so the demo can run offline. When preparing the environment
+offline run:
+
+```bash
+npm run fetch-assets
+```
+
+This downloads the Pyodide runtime and GPT‑2 model from the configured
+mirrors. Assets land in `wasm/` and `wasm_llm/`.
+It also retrieves `lib/bundle.esm.min.js` from the mirror. You may instead run
+`python ../../../../scripts/download_hf_gpt2.py` or
+`python ../../../../scripts/download_gpt2_small.py` to pull the model
+directly. The build and
+`manual_build.py` scripts scan every downloaded asset for the word
+`"placeholder"` and abort when any file still contains that marker.
+`npm run fetch-assets` also downloads `lib/workbox-sw.js` from
+Workbox 6.5.4 so the service worker can operate offline.
+Each file is retried up to three times. If a download fails the script exits
+with an error suggesting you check connectivity or the `IPFS_GATEWAY`
+setting.
+Run `npm run fetch-assets` if you encounter this error.
+```bash
+W3UP_EMAIL=<email> npm start
+```
+`npm start` serves the `dist/` folder on `http://localhost:3000` by default.
+Set `W3UP_EMAIL` to the address registered with
+[@web3-storage/w3up-client](https://github.com/storacha/w3up) so exported JSON
+results can be pinned.
+
+If `OPENAI_API_KEY` is stored in `localStorage`, the demo uses the OpenAI API for
+chat prompts. When no key is present a lightweight GPT‑2 model under
+`wasm_llm/` runs locally.
+Use the Offline/API selector in the power panel to switch modes at any time.
+
+Open `index.html` directly or pin the built `dist/` directory to IPFS
+(`ipfs add -r dist`) and share the CID.
+The URL fragment encodes parameters such as `#/s=42&p=120&g=80`.
+
+See [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf) for a short walkthrough.
+Running `npm run build` or `python manual_build.py` copies this file to
+`dist/insight_browser_quickstart.pdf` so the guide is available alongside
+`dist/index.html` when offline.
+
+## Manual Build
+Use `manual_build.py` for air‑gapped environments:
+
+1. `cp .env.sample .env` and edit the values if you haven't already, then `chmod 600 .env`.
+2. `npm run fetch-assets` to fetch Pyodide and the GPT‑2 model.
+   Alternatively run `python ../../../../scripts/download_gpt2_small.py`,
+   `python ../../../../scripts/download_openai_gpt2.py` or
+   `python ../../../../scripts/download_hf_gpt2.py` to grab
+   the model directly from the official mirror.
+   The build scripts verify these files no longer contain the word `"placeholder"`.
+   Failing to replace placeholders will break offline mode.
+3. Run `node build/version_check.js` to ensure Node.js **v20** or newer is
+   installed. `manual_build.py` exits if this check fails.
+4. `python manual_build.py` – or run `./manual_build.ps1` – bundles the app,
+   generates `dist/sw.js` and embeds your `.env` settings.
+5. `npm start` or open `dist/index.html` directly to run the demo.
+
+The script requires Python ≥3.11. It loads `.env` automatically and injects
+`PINNER_TOKEN`, `OPENAI_API_KEY`, `IPFS_GATEWAY` and `OTEL_ENDPOINT` into
+`dist/index.html`, mirroring `npm run build`.
+If `.env` is absent the script continues with empty defaults rather than aborting.
+
+### Offline Build
+
+Follow these steps when building without internet access:
+
+1. Run `npm run fetch-assets` (or `python ../../../../scripts/download_gpt2_small.py`, `python ../../../../scripts/download_openai_gpt2.py`).
+2. Verify checksums match `build_assets.json` with
+   `python ../../../../scripts/fetch_assets.py --verify-only` and ensure no
+   files under `wasm/` or `lib/` contain the word "placeholder".
+3. `npm ci` to install the locked dependencies.
+4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`.
+5. Launch with `npm start` or pin the directory with `ipfs add -r dist`.
+
+Failing to replace placeholders will break offline mode.
+
+### Offline build checklist
+
+1. Run `npm run fetch-assets`.
+   (`python ../../../../scripts/download_gpt2_small.py` or `python ../../../../scripts/download_openai_gpt2.py` also works.)
+2. `npm ci` to install dependencies from `package-lock.json`.
+3. Confirm no placeholder text remains in `lib/` or `wasm*/`.
+4. Execute `python manual_build.py` (or `./manual_build.ps1`) to generate the PWA in `dist/`. Use
+   `npm run build` when internet access is available.
+
+5. Run the tests offline:
+
+   ```bash
+   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test --offline
+   ```
+
+   Set `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` when using a custom
+   directory of Playwright binaries.
+
+Failing to run the fetch script leaves offline mode disabled.
+
+### Offline npm install
+
+Create a cache on a connected machine:
+
+```bash
+npm ci --cache /path/to/npm-cache
+```
+
+Copy the cache to the target machine then run:
+
+```bash
+npm ci --offline --cache /path/to/npm-cache
+```
+
+This installs dependencies without network access.
+
+
+### Fetching Assets Offline
+
+Set `WEB3_STORAGE_TOKEN` before running the helper script:
+
+```bash
+WEB3_STORAGE_TOKEN=<token> npm run fetch-assets
+```
+
+
+The script retrieves the WebAssembly runtime and supporting files from the
+IPFS mirror first and falls back to the OpenAI URL or configured
+gateway, verifying checksums to ensure each asset is intact.
+
+### Offline Build Steps
+
+Requires **Node.js ≥20** and **Python ≥3.11**.
+
+1. Copy `.env.sample` to `.env` and set the variables.
+2. Run `WEB3_STORAGE_TOKEN=<token> npm run fetch-assets` to download the WASM runtime and model files.
+3. Execute `python manual_build.py` (or `./manual_build.ps1`) to produce the `dist/` directory.
+4. Open `dist/index.html` to verify offline functionality.
+
+Run `node tests/run.mjs --offline` to confirm the build works without network access.
+
+## Distribution
+Run `npm run build:dist` to generate `insight_browser.zip` in this directory.
+The archive bundles the production build along with the service worker and
+assets. It stays under **3&nbsp;MiB** so the entire demo can be shared easily.
+Extract the zip and open `index.html` directly—no additional dependencies are
+required. New users can review
+[dist/insight_browser_quickstart.pdf](dist/insight_browser_quickstart.pdf) after
+extraction for a brief walkthrough.
+
+A dedicated GitHub Actions workflow
+[`size-check.yml`](../../../../.github/workflows/size-check.yml) rebuilds the
+archive when triggered manually and fails if `insight_browser.zip` grows beyond
+**3&nbsp;MiB**.
+
+## Locale Support
+The interface automatically loads French, Spanish or Chinese translations based
+on your browser preferences. Set `localStorage.lang` to override the detected
+language. When the chosen locale file is missing, a warning appears in the
+browser console and the demo falls back to the built‑in English strings.
+
+## Toolbar & Controls
+- **CSV** – export the current population as `population.csv`.
+- **PNG** – download a `frontier.png` screenshot of the chart.
+- **Share** – copy a permalink to the clipboard. When `PINNER_TOKEN` is set,
+  exported JSON is pinned to Web3.Storage and the CID appears in a toast.
+- **Theme** – toggle between light and dark mode.
+- **GPU** – enable or disable WebGPU acceleration. The app sends a
+  `{type:'gpu', available:<flag>}` message to the evolver worker which
+  forwards the flag to mutation functions.
+- **Offline/API** – toggle between the local Pyodide model and the
+  OpenAI API. When the key is missing the demo automatically reverts to
+  offline mode.
+
+  Set `localStorage.setItem('USE_GPU','1')` to force the GPU backend when
+  WebGPU is available.
+
+Drag a previously exported JSON state onto the drop zone to restore a
+simulation.
+
+## Darwin-Archive
+Every completed run is stored locally using IndexedDB. When storage access is
+unavailable, the archive falls back to an in-memory store and data is lost on
+refresh. The **Evolution** panel
+lists archived runs with their score and novelty. Click **Re-spawn** next to a
+row to restart the simulation using that seed.
+The method `selectParents(count, beta?, gamma?, rand?)` returns weighted
+samples from the archive. Pass a seeded `rand` function to ensure deterministic
+results in tests or simulations.
+
+## Arena & Meme Cloud
+The **Arena panel** allows quick debates between roles on any candidate in the
+frontier. Results appear ranked within the panel. The **Meme Cloud** below the
+archive table visualizes common strategy transitions across runs.
+
+## Running a Simulation
+Use the **Simulator** panel to launch a full run. Adjust the seed list, population
+size and number of generations, then press **Start**. When `PINNER_TOKEN` is set,
+the resulting `replay.json` is pinned to Web3.Storage and the CID appears once
+the run finishes. Keep this CID handy to share or reload the simulation later.
+
+## Load via CID
+Append `#/cid=&lt;CID&gt;` to the URL (or use the **Share** permalink) to replay a
+previous run. The simulator fetches the JSON from IPFS and populates the chart.
+
+## Privacy
+Anonymous telemetry is optional. On first use a random ID is generated and
+hashed with SHA-256 using the static salt `"insight"`. Only this salted hash and
+basic usage metrics are sent to the OTLP endpoint. Clearing browser storage
+resets the identifier.
+
+Use the **Analytics** panel to enable or disable telemetry at any time.
+
+See **Environment Setup** above for the list of supported variables.
+
+## Safari/iOS Support
+Pyodide is disabled on Safari and iOS devices because the runtime fails to load
+reliably. The demo automatically falls back to the JavaScript engine instead of
+executing Python code in the browser. Expect noticeably slower performance for
+LLM tasks and the absence of features that rely on the Python bridge, such as
+the local GPT‑2 critic.
+
+## Running Browser Tests
+
+The demo includes a small Playwright and Pytest suite. **Node.js ≥20** is
+required. After fetching the WebAssembly assets run the tests with Playwright in
+offline mode:
+
+```bash
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test --offline
+```
+
+This command builds the bundle automatically before running the tests. It
+launches Playwright to exercise `dist/index.html` and then runs the Python
+checks. `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` prevents Playwright from fetching
+browsers. Optionally set `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` when using
+pre‑downloaded binaries.
+
+The Jest test `locale_parity.test.js` verifies that all translation files share
+the same set of keys.
+
+## Development
+
+- Run `pre-commit run --all-files` to format and lint the code.
+- `npm test` builds the bundle then launches Playwright and Python tests.
+- See [../../../../AGENTS.md](../../../../AGENTS.md) for full contributor guidelines.
+
+## License
+
+The Insight browser demo and its translation files are provided under the
+[Apache 2.0](../../../../LICENSE) license.

--- a/docs/alpha_agi_insight_v1/src/interface/web_client/index.md
+++ b/docs/alpha_agi_insight_v1/src/interface/web_client/index.md
@@ -1,0 +1,24 @@
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Alpha AGI Insight Web Client
+
+This directory contains a minimal React application built with [Vite](https://vitejs.dev/).
+It connects to the API server at `/ws/progress` and logs messages to the console.
+
+## Development
+
+```bash
+cd alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client
+npm ci
+npm run dev       # open http://localhost:5173
+```
+
+## Build
+
+```bash
+npm run build  # outputs static files in dist/
+```
+
+The production bundle lives under `dist/` and is served automatically by the API
+server when present.

--- a/docs/demos/TERMS_AND_CONDITIONS.md
+++ b/docs/demos/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,13 @@
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+
+# Terms & Conditions
+![preview](../TERMS_AND_CONDITIONS/assets/preview.svg){.demo-preview}
+
+This demonstration is provided for educational purposes only and comes with **no warranty**. By using any part of the Alpha‑Factory demo you agree that:
+
+1. All outputs are experimental and should not be relied upon for financial or safety‑critical decisions.
+2. MONTREAL.AI and contributors accept no liability for damages arising from the use of this software.
+3. Usage must comply with all applicable laws and regulations in your jurisdiction.
+
+The project is distributed under the [Apache 2.0 license](../../../../LICENSE).


### PR DESCRIPTION
## Summary
- add aiga meta evolution production guide
- add alpha AGI business quick start and production docs
- add insight demo docs
- add Terms and Conditions to docs with preview asset

## Testing
- `pre-commit run --files docs/aiga_meta_evolution/PRODUCTION_GUIDE.md docs/alpha_agi_business_v1/QUICK_START.md docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md docs/alpha_agi_insight_v1/insight_browser_v1/index.md docs/alpha_agi_insight_v1/src/interface/web_client/index.md docs/alpha_agi_insight_v1/docs/API.md docs/alpha_agi_insight_v1/docs/bus_tls.md docs/demos/TERMS_AND_CONDITIONS.md docs/TERMS_AND_CONDITIONS/assets/preview.svg`

------
https://chatgpt.com/codex/tasks/task_e_686d77a370ac8333a04f31a4355befd0