### PR TITLE
[alpha_factory] fix license link in Terms page

### DIFF
--- a/docs/demos/TERMS_AND_CONDITIONS.md
+++ b/docs/demos/TERMS_AND_CONDITIONS.md
@@ -10,4 +10,4 @@ This demonstration is provided for educational purposes only and comes with **no
 2. MONTREAL.AI and contributors accept no liability for damages arising from the use of this software.
 3. Usage must comply with all applicable laws and regulations in your jurisdiction.
 
-The project is distributed under the [Apache 2.0 license](../../../../LICENSE).
+The project is distributed under the [Apache 2.0 license](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE).


### PR DESCRIPTION
## Summary
- fix license link on the Terms and Conditions demo page

## Testing
- `pre-commit run --files docs/demos/TERMS_AND_CONDITIONS.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686d810306e88333acbb0a1262404fab