### PR TITLE
docs: fix internal links for mkdocs

### DIFF
--- a/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -96,7 +96,7 @@ The bridge exposes health checks at
 
 3. **Run in Colab**
    - Open the notebook at
-     [colab_aiga_meta_evolution.ipynb](colab_aiga_meta_evolution.ipynb).
+     [colab_aiga_meta_evolution.ipynb](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/aiga_meta_evolution/colab_aiga_meta_evolution.ipynb).
      Click the “Open in Colab” badge and run the setup cell. The notebook
      launches the same service with a public Gradio URL and includes test
      and API usage examples.

--- a/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -44,7 +44,7 @@ Run `pre-commit run --all-files` after the dependencies finish installing.
      ```
 
 3. **Run in Colab**
-   - Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb).
+   - Open [`colab_alpha_agi_business_v1_demo.ipynb`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb).
    - Run the setup cell; dependencies are installed automatically.
    - The notebook exposes a Gradio dashboard and OpenAI Agents SDK bridge.
 
@@ -73,7 +73,9 @@ curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz
    - Docker: `./run_business_v1_demo.sh --stop`
    - Native Python: press `Ctrl+C`; the orchestrator shuts down gracefully.
 
-For advanced options see [`README.md`](README.md) in the same directory.
+For advanced options see
+[`README.md`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/README.md)
+in the same directory.
 
 ---
 

--- a/docs/alpha_agi_business_v1/QUICK_START.md
+++ b/docs/alpha_agi_business_v1/QUICK_START.md
@@ -66,10 +66,10 @@ Verify dependencies offline:
 python ../../check_env.py --auto-install --wheelhouse /media/wheels
 ```
 
-See [docs/OFFLINE.md](../../../../docs/OFFLINE.md) for additional tips.
+See the [Offline Setup section](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md#offline-setup) for additional tips.
 
 ## Colab Notebook
-Open [`colab_alpha_agi_business_v1_demo.ipynb`](colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook
+Open [`colab_alpha_agi_business_v1_demo.ipynb`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook
   checks requirements, starts the orchestrator, and exposes helper tools via the OpenAI Agents SDK.
 
 ## ADK Bridge

--- a/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -6,7 +6,7 @@ A zero-backend Pareto explorer lives in
 `demos/alpha_agi_insight_v1/insight_browser_v1/`. See the **Quick-Start** section below for a short walkthrough.
 
 ## Quick-Start
-Open [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf)
+Open [insight_browser_quickstart.pdf](../../insight_browser_quickstart.pdf)
 for a concise overview of the build and launch steps.
 
 ## Prerequisites
@@ -48,7 +48,7 @@ npm start
 ```
 
 ## Environment Setup
-Copy [`.env.sample`](.env.sample) to `.env` then review the variables. When `.env`
+Copy [`.env.sample`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample) to `.env` then review the variables. When `.env`
 is missing the build scripts continue with default empty values:
 
 - `PINNER_TOKEN` – Web3.Storage token used to pin results.
@@ -114,7 +114,7 @@ Verify the downloads with:
 python ../../../../scripts/fetch_assets.py --verify-only
 ```
 
-See [`.env.sample`](.env.sample) for the full list of supported variables.
+See [`.env.sample`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/.env.sample) for the full list of supported variables.
 The compiled `dist/` directory is not version controlled. Run the build script
 to create it before launching the demo.
 
@@ -188,7 +188,7 @@ Open `index.html` directly or pin the built `dist/` directory to IPFS
 (`ipfs add -r dist`) and share the CID.
 The URL fragment encodes parameters such as `#/s=42&p=120&g=80`.
 
-See [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf) for a short walkthrough.
+See [insight_browser_quickstart.pdf](../../insight_browser_quickstart.pdf) for a short walkthrough.
 Running `npm run build` or `python manual_build.py` copies this file to
 `dist/insight_browser_quickstart.pdf` so the guide is available alongside
 `dist/index.html` when offline.
@@ -296,11 +296,11 @@ The archive bundles the production build along with the service worker and
 assets. It stays under **3&nbsp;MiB** so the entire demo can be shared easily.
 Extract the zip and open `index.html` directly—no additional dependencies are
 required. New users can review
-[dist/insight_browser_quickstart.pdf](dist/insight_browser_quickstart.pdf) after
+[insight_browser_quickstart.pdf](../../insight_browser_quickstart.pdf) after
 extraction for a brief walkthrough.
 
 A dedicated GitHub Actions workflow
-[`size-check.yml`](../../../../.github/workflows/size-check.yml) rebuilds the
+[`size-check.yml`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/.github/workflows/size-check.yml) rebuilds the
 archive when triggered manually and fails if `insight_browser.zip` grows beyond
 **3&nbsp;MiB**.
 
@@ -394,9 +394,9 @@ the same set of keys.
 
 - Run `pre-commit run --all-files` to format and lint the code.
 - `npm test` builds the bundle then launches Playwright and Python tests.
-- See [../../../../AGENTS.md](../../../../AGENTS.md) for full contributor guidelines.
+- See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md) for full contributor guidelines.
 
 ## License
 
 The Insight browser demo and its translation files are provided under the
-[Apache 2.0](../../../../LICENSE) license.
+[Apache 2.0](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE) license.


### PR DESCRIPTION
## Summary
- fix Colab link in AI-GA Meta Evolution production guide
- update Alpha AGI Business guides with external links
- fix broken references in Insight Browser docs

## Testing
- `pre-commit run --files docs/aiga_meta_evolution/PRODUCTION_GUIDE.md docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md docs/alpha_agi_business_v1/QUICK_START.md docs/alpha_agi_insight_v1/insight_browser_v1/index.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686d8440f09083339771d6fa767320b8