### PR TITLE
[alpha_factory] fix asset check in Insight browser build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --config eslint.config.js src --ext .js,.ts",
     "build": "node build.js",
     "fetch-assets": "node -e \"console.log('Using PYODIDE_BASE_URL:', process.env.PYODIDE_BASE_URL)\" && python ../../../../scripts/fetch_assets.py",
-    "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js lib/workbox-sw.js manifest.json style.css assets insight_browser_quickstart.pdf && rm service-worker.js",
+    "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js lib/workbox-sw.js manifest.json style.css insight_browser_quickstart.pdf && test -d assets && zip -r ../insight_browser.zip assets || true && rm service-worker.js",
     "size": "gzip-size-cli dist/insight.bundle.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- avoid `zip` warning when the Insight browser `assets` folder is missing
- rebuilt the browser bundle without warnings

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pytest -q` *(fails: 84 errors during collection)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json`
- `npm run build:dist`

------
https://chatgpt.com/codex/tasks/task_e_686db19ab3a08333a1c9da31748be0e2