### PR TITLE
[alpha_factory] Sync business demo docs

### DIFF
--- a/docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
+++ b/docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Best Alpha Opportunity Workflow

--- a/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 
@@ -73,9 +73,7 @@ curl http://localhost:${ALPHA_FACTORY_ADK_PORT}/healthz
    - Docker: `./run_business_v1_demo.sh --stop`
    - Native Python: press `Ctrl+C`; the orchestrator shuts down gracefully.
 
-For advanced options see
-[`README.md`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/README.md)
-in the same directory.
+For advanced options see [`README.md`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/README.md) in the same directory.
 
 ---
 

--- a/docs/alpha_agi_business_v1/QUICK_START.md
+++ b/docs/alpha_agi_business_v1/QUICK_START.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Quick Start – Alpha‑AGI Business v1 Demo
@@ -66,7 +66,7 @@ Verify dependencies offline:
 python ../../check_env.py --auto-install --wheelhouse /media/wheels
 ```
 
-See the [Offline Setup section](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md#offline-setup) for additional tips.
+See [docs/OFFLINE.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/docs/OFFLINE.md) for additional tips.
 
 ## Colab Notebook
 Open [`colab_alpha_agi_business_v1_demo.ipynb`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb) and run all cells. The notebook


### PR DESCRIPTION
## Summary
- copy Alpha-AGI business v1 docs from source demo
- fix disclaimer links
- use absolute GitHub URLs for internal references

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError cannot access submodule 'messaging')*
- `pre-commit run --files docs/alpha_agi_business_v1/QUICK_START.md docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md`

------
https://chatgpt.com/codex/tasks/task_e_686dba8261d483338a3de52f47df9193