### PR TITLE
[alpha_factory] Update asset README links

### DIFF
--- a/docs/meta_agentic_agi/assets/README.md
+++ b/docs/meta_agentic_agi/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See ../../DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/docs/meta_agentic_agi_v2/assets/README.md
+++ b/docs/meta_agentic_agi_v2/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See ../../DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/docs/meta_agentic_agi_v3/assets/README.md
+++ b/docs/meta_agentic_agi_v3/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See ../../DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)


### PR DESCRIPTION
## Summary
- link to the snippet relative to each asset README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686dc49ed0e48333b6a2cabdccf4b49e