### PR TITLE
[alpha_factory] fix build:dist asset check

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --config eslint.config.js src --ext .js,.ts",
     "build": "node build.js",
     "fetch-assets": "node -e \"console.log('Using PYODIDE_BASE_URL:', process.env.PYODIDE_BASE_URL)\" && python ../../../../scripts/fetch_assets.py",
-    "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js lib/workbox-sw.js manifest.json style.css insight_browser_quickstart.pdf && test -d assets && zip -r ../insight_browser.zip assets || true && rm service-worker.js",
+    "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js lib/workbox-sw.js manifest.json style.css insight_browser_quickstart.pdf && if [ -d assets ]; then zip -r ../insight_browser.zip assets; fi && rm service-worker.js",
     "size": "gzip-size-cli dist/insight.bundle.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- avoid zip warning when `assets` directory is absent

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: cannot access submodule)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json`


------
https://chatgpt.com/codex/tasks/task_e_686dc6a4a3f083338c902d5280376f2c