### PR TITLE
[alpha_factory] Install Chromium for docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,8 @@ jobs:
         run: pre-commit run --all-files
       - name: Install docs dependencies
         run: pip install -r requirements-docs.txt
+      - name: Install Playwright browsers
+        run: playwright install chromium
       - name: Make scripts executable
         run: chmod +x ./scripts/*.sh
       - name: Compute asset cache key


### PR DESCRIPTION
## Summary
- add `playwright install chromium` in docs workflow

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 84 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686dce47d71083339e93bbcf95b64657