### PR TITLE
[alpha_factory] Fix docs workflow, update links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,8 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Install Web client dependencies
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
+      - name: Update browserslist database
+        run: npx update-browserslist-db@latest --agree-to-terms
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit checks
@@ -57,7 +59,9 @@ jobs:
       - name: Install docs dependencies
         run: pip install -r requirements-docs.txt
       - name: Install Playwright browsers
-        run: playwright install chromium
+        uses: microsoft/playwright-github-action@v1
+        with:
+          install-deps: true
       - name: Make scripts executable
         run: chmod +x ./scripts/*.sh
       - name: Compute asset cache key

--- a/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 🛠️ Production Deployment Guide — AI‑GA Meta‑Evolution

--- a/docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
+++ b/docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Best Alpha Opportunity Workflow

--- a/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
+++ b/docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/docs/alpha_agi_business_v1/QUICK_START.md
+++ b/docs/alpha_agi_business_v1/QUICK_START.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Quick Start – Alpha‑AGI Business v1 Demo

--- a/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -6,7 +6,7 @@ A zero-backend Pareto explorer lives in
 `demos/alpha_agi_insight_v1/insight_browser_v1/`. See the **Quick-Start** section below for a short walkthrough.
 
 ## Quick-Start
-Open [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf)
+Open [../../insight_browser_quickstart.pdf](../../insight_browser_quickstart.pdf)
 for a concise overview of the build and launch steps.
 
 ## Prerequisites
@@ -48,7 +48,7 @@ npm start
 ```
 
 ## Environment Setup
-Copy [`.env.sample`](.env.sample) to `.env` then review the variables. When `.env`
+Copy `.env.sample` to `.env` then review the variables. When `.env`
 is missing the build scripts continue with default empty values:
 
 - `PINNER_TOKEN` – Web3.Storage token used to pin results.
@@ -114,7 +114,7 @@ Verify the downloads with:
 python ../../../../scripts/fetch_assets.py --verify-only
 ```
 
-See [`.env.sample`](.env.sample) for the full list of supported variables.
+See `.env.sample` for the full list of supported variables.
 The compiled `dist/` directory is not version controlled. Run the build script
 to create it before launching the demo.
 
@@ -188,7 +188,7 @@ Open `index.html` directly or pin the built `dist/` directory to IPFS
 (`ipfs add -r dist`) and share the CID.
 The URL fragment encodes parameters such as `#/s=42&p=120&g=80`.
 
-See [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf) for a short walkthrough.
+See [../../insight_browser_quickstart.pdf](../../insight_browser_quickstart.pdf) for a short walkthrough.
 Running `npm run build` or `python manual_build.py` copies this file to
 `dist/insight_browser_quickstart.pdf` so the guide is available alongside
 `dist/index.html` when offline.
@@ -300,7 +300,7 @@ required. New users can review
 extraction for a brief walkthrough.
 
 A dedicated GitHub Actions workflow
-[`size-check.yml`](../../../../.github/workflows/size-check.yml) rebuilds the
+[`size-check.yml`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/.github/workflows/size-check.yml) rebuilds the
 archive when triggered manually and fails if `insight_browser.zip` grows beyond
 **3&nbsp;MiB**.
 
@@ -394,9 +394,9 @@ the same set of keys.
 
 - Run `pre-commit run --all-files` to format and lint the code.
 - `npm test` builds the bundle then launches Playwright and Python tests.
-- See [../../../../AGENTS.md](../../../../AGENTS.md) for full contributor guidelines.
+- See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md) for full contributor guidelines.
 
 ## License
 
 The Insight browser demo and its translation files are provided under the
-[Apache 2.0](../../../../LICENSE) license.
+[Apache 2.0](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE) license.

--- a/scripts/mirror_demo_pages.py
+++ b/scripts/mirror_demo_pages.py
@@ -41,6 +41,12 @@ def fix_paths(target: Path) -> None:
         txt = txt.replace("../assets/", "../../../assets/")
         script.write_text(txt)
 
+    for md in target.glob("*.md"):
+        txt = md.read_text()
+        txt = txt.replace("../DISCLAIMER_SNIPPET.md", "../../../DISCLAIMER_SNIPPET.md")
+        txt = txt.replace("../../DISCLAIMER_SNIPPET.md", "../../../../DISCLAIMER_SNIPPET.md")
+        md.write_text(txt)
+
 
 def main() -> None:
     SUBDIR_ROOT.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- fix relative links in several docs pages
- adjust disclaimer paths when mirroring demo docs
- update docs workflow to install Playwright via official action
- keep browserslist database up to date

## Testing
- `pre-commit run --files .github/workflows/docs.yml scripts/mirror_demo_pages.py docs/aiga_meta_evolution/PRODUCTION_GUIDE.md docs/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md docs/alpha_agi_business_v1/PRODUCTION_GUIDE.md docs/alpha_agi_business_v1/QUICK_START.md docs/alpha_agi_insight_v1/insight_browser_v1/index.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686dd443bfa083338d05fab731dab67c