### PR TITLE
[alpha_factory] Fix docs links

### DIFF
--- a/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
+++ b/docs/aiga_meta_evolution/PRODUCTION_GUIDE.md
@@ -96,7 +96,7 @@ The bridge exposes health checks at
 
 3. **Run in Colab**
    - Open the notebook at
-     [colab_aiga_meta_evolution.ipynb](colab_aiga_meta_evolution.ipynb).
+     [colab_aiga_meta_evolution.ipynb](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/aiga_meta_evolution/colab_aiga_meta_evolution.ipynb).
      Click the “Open in Colab” badge and run the setup cell. The notebook
      launches the same service with a public Gradio URL and includes test
      and API usage examples.

--- a/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/docs/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -296,7 +296,7 @@ The archive bundles the production build along with the service worker and
 assets. It stays under **3&nbsp;MiB** so the entire demo can be shared easily.
 Extract the zip and open `index.html` directly—no additional dependencies are
 required. New users can review
-[dist/insight_browser_quickstart.pdf](dist/insight_browser_quickstart.pdf) after
+`dist/insight_browser_quickstart.pdf` after
 extraction for a brief walkthrough.
 
 A dedicated GitHub Actions workflow


### PR DESCRIPTION
## Summary
- update link to AIGA meta evolution colab
- reference quickstart PDF as code block instead of broken link

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/insight_browser_v1/index.md docs/aiga_meta_evolution/PRODUCTION_GUIDE.md`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_686dd9b3ac808333b0b5450bde696aea