### PR TITLE
[alpha_factory] tidy docs

### DIFF
--- a/docs/demos/aiga_meta_evolution.md
+++ b/docs/demos/aiga_meta_evolution.md
@@ -225,7 +225,7 @@ curl -X POST http://localhost:9000/v1/tasks \
 The optional ADK gateway integrates with the OpenAI Agents SDK bridge and
 underlying LLM providers as shown below.
 
-![Bridge overview](../aiga_meta_evolution/bridge_overview.svg)
+![Bridge overview](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/aiga_meta_evolution/bridge_overview.svg)
 
 ## 🔐 API authentication
 
@@ -236,7 +236,7 @@ The `/health` and `/metrics` endpoints remain public.
 ---
 ## 🚀 Production deployment
 
-For step-by-step instructions on running the service in a production or workshop environment, see [PRODUCTION_GUIDE.md](../aiga_meta_evolution/PRODUCTION_GUIDE.md).
+For step-by-step instructions on running the service in a production or workshop environment, see [PRODUCTION_GUIDE.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/aiga_meta_evolution/PRODUCTION_GUIDE.md).
 
 
 ## 🎓 Run in Colab

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -164,9 +164,9 @@ All agents speak **A2A protobuf**, run on **OpenAI Agents SDK** or **Google ADK*
 <a id="quick"></a>
 ## 6 Quick Start 🚀
 
-*For a concise walkthrough see [QUICK_START.md](../alpha_agi_business_v1/QUICK_START.md).*
+*For a concise walkthrough see [QUICK_START.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/QUICK_START.md).*
 For a deployment checklist aimed at production environments consult
-[PRODUCTION_GUIDE.md](../alpha_agi_business_v1/PRODUCTION_GUIDE.md).
+[PRODUCTION_GUIDE.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md).
 ```bash
 git clone https://github.com/MontrealAI/AGI-Alpha-Agent-v0.git
 cd AGI-Alpha-Agent-v0/alpha_factory_v1/demos/alpha_agi_business_v1
@@ -333,7 +333,7 @@ python check_env.py --auto-install --wheelhouse /media/wheels
 WHEELHOUSE=/media/wheels python openai_agents_bridge.py --host http://localhost:8000
 ```
 
-See [PRODUCTION_GUIDE.md](../alpha_agi_business_v1/PRODUCTION_GUIDE.md) for detailed deployment tips.
+See [PRODUCTION_GUIDE.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/PRODUCTION_GUIDE.md) for detailed deployment tips.
 
 - The bridge exposes several helper tools:
 - `list_agents`
@@ -470,7 +470,7 @@ Apache 2.0 © 2025 **MONTREAL.AI**
 - [Google Agent Development Kit docs](https://google.github.io/adk-docs/)
 - [Agent‑to‑Agent protocol](https://github.com/google/A2A)
 - [Model Context Protocol](https://www.anthropic.com/news/model-context-protocol)
-- [Best Alpha Workflow](../alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md)
+- [Best Alpha Workflow](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/BEST_ALPHA_WORKFLOW.md)
 [open-colab-link]:
   https://colab.research.google.com/github/MontrealAI/AGI-Alpha-Agent-v0/blob/main/
   alpha_factory_v1/demos/alpha_agi_business_v1/colab_alpha_agi_business_v1_demo.ipynb

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -261,7 +261,7 @@ docker run -it --rm -p 8501:8501   -e OPENAI_API_KEY=$OPENAI_API_KEY   ghcr.io/m
 ```
 
 For offline builds or the browser-based PWA, see
-[insight_browser_v1/index.md](../alpha_agi_insight_v1/insight_browser_v1/index.md).
+[insight_browser_v1/index.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md).
 
 ## Environment Setup
 
@@ -453,9 +453,9 @@ Launch the container stack afterwards or serve `dist/` with any static server,
 e.g. `python -m http.server --directory dist 8080`.
 
 For advanced options see
-[src/interface/web_client/index.md](../alpha_agi_insight_v1/src/interface/web_client/index.md).
+[src/interface/web_client/index.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.md).
 
-For details see [docs/API.md](../alpha_agi_insight_v1/docs/API.md).
+For details see [docs/API.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md).
 
 ### 5.4 Building the Web Dashboard
 
@@ -470,7 +470,7 @@ npm run build
 This installs dependencies and outputs static files in `dist/`. The provided
 `Dockerfile` already runs these steps, so manual builds are only needed for
 local development or customization. See the
-[web_client/index.md](../alpha_agi_insight_v1/src/interface/web_client/index.md) for advanced usage.
+[web_client/index.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.md) for advanced usage.
 
 ### 5.5 Exporting Visualization Data
 
@@ -528,7 +528,7 @@ default `changeme` placeholder.
 To secure the gRPC bus provide `AGI_INSIGHT_BUS_CERT`,
 `AGI_INSIGHT_BUS_KEY` and `AGI_INSIGHT_BUS_TOKEN`. When these are omitted set
 `AGI_INSIGHT_ALLOW_INSECURE=1` to run without TLS. See
-[docs/bus_tls.md](../alpha_agi_insight_v1/docs/bus_tls.md) for detailed setup.
+[docs/bus_tls.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md) for detailed setup.
 
 Agents restart automatically when they fail or stop sending heartbeats.
 `AGENT_ERR_THRESHOLD` controls how many consecutive errors trigger a restart.

--- a/docs/demos/alpha_agi_marketplace_v1.md
+++ b/docs/demos/alpha_agi_marketplace_v1.md
@@ -241,7 +241,7 @@ rac{reward_{success}}{reward_{total}}\)
 
 <a id="terms"></a>
 ## 14 Terms 🤝
-See [`TERMS & CONDITIONS.md`](./TERMS_AND_CONDITIONS.md).
+See [`TERMS & CONDITIONS.md`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,3 +62,11 @@ nav:
   - Intro Basics: INTRO_BASICS.md
   - Offline Mode: OFFLINE.md
   - Quickstart Basics: QUICKSTART_BASICS.md
+exclude_docs: |
+  alpha_agi_business_v1/*.md
+  aiga_meta_evolution/PRODUCTION_GUIDE.md
+  alpha_agi_insight_v1/docs/*
+  alpha_agi_insight_v1/insight_browser_v1/index.md
+  alpha_agi_insight_v1/src/interface/web_client/index.md
+  demos/TERMS_AND_CONDITIONS.md
+  meta_agentic_agi*/assets/README.md


### PR DESCRIPTION
## Summary
- ignore non-public docs via `exclude_docs`
- regenerate demo pages so broken links point to GitHub

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError cannot access submodule 'messaging')*
- `pre-commit run --files mkdocs.yml docs/demos/aiga_meta_evolution.md docs/demos/alpha_agi_business_v1.md docs/demos/alpha_agi_insight_v1.md docs/demos/alpha_agi_marketplace_v1.md`

------
https://chatgpt.com/codex/tasks/task_e_686dde50a5ac8333a138a82c8d5de249