### PR TITLE
[alpha_factory] Fix docs links

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -6,7 +6,7 @@ A zero-backend Pareto explorer lives in
 `demos/alpha_agi_insight_v1/insight_browser_v1/`. See the **Quick-Start** section below for a short walkthrough.
 
 ## Quick-Start
-Open [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf)
+Open [../../insight_browser_quickstart.pdf](../../insight_browser_quickstart.pdf)
 for a concise overview of the build and launch steps.
 
 ## Prerequisites
@@ -48,7 +48,7 @@ npm start
 ```
 
 ## Environment Setup
-Copy [`.env.sample`](.env.sample) to `.env` then review the variables. When `.env`
+Copy `.env.sample` to `.env` then review the variables. When `.env`
 is missing the build scripts continue with default empty values:
 
 - `PINNER_TOKEN` – Web3.Storage token used to pin results.
@@ -114,7 +114,7 @@ Verify the downloads with:
 python ../../../../scripts/fetch_assets.py --verify-only
 ```
 
-See [`.env.sample`](.env.sample) for the full list of supported variables.
+See `.env.sample` for the full list of supported variables.
 The compiled `dist/` directory is not version controlled. Run the build script
 to create it before launching the demo.
 
@@ -188,7 +188,7 @@ Open `index.html` directly or pin the built `dist/` directory to IPFS
 (`ipfs add -r dist`) and share the CID.
 The URL fragment encodes parameters such as `#/s=42&p=120&g=80`.
 
-See [docs/insight_browser_quickstart.pdf](docs/insight_browser_quickstart.pdf) for a short walkthrough.
+See [../../insight_browser_quickstart.pdf](../../insight_browser_quickstart.pdf) for a short walkthrough.
 Running `npm run build` or `python manual_build.py` copies this file to
 `dist/insight_browser_quickstart.pdf` so the guide is available alongside
 `dist/index.html` when offline.
@@ -300,7 +300,7 @@ required. New users can review
 extraction for a brief walkthrough.
 
 A dedicated GitHub Actions workflow
-[`size-check.yml`](../../../../.github/workflows/size-check.yml) rebuilds the
+[`size-check.yml`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/.github/workflows/size-check.yml) rebuilds the
 archive when triggered manually and fails if `insight_browser.zip` grows beyond
 **3&nbsp;MiB**.
 
@@ -394,7 +394,7 @@ the same set of keys.
 
 - Run `pre-commit run --all-files` to format and lint the code.
 - `npm test` builds the bundle then launches Playwright and Python tests.
-- See [../../../../AGENTS.md](../../../../AGENTS.md) for full contributor guidelines.
+- See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md) for full contributor guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary
- update insight browser quickstart links
- format `.env.sample` references
- link to GitHub for size-check workflow and AGENTS guide

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError in multiple tests)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md` *(fails: could not initialize semgrep environment)*

------
https://chatgpt.com/codex/tasks/task_e_686de220f9ec8333ba559549e62f0b60