### PR TITLE
[alpha_factory] Fix mirror disclaimer path

### DIFF
--- a/scripts/mirror_demo_pages.py
+++ b/scripts/mirror_demo_pages.py
@@ -10,6 +10,7 @@ REPLACEMENTS = {
     "../assets/": "../../../assets/",
     "../README/": "../../README/",
     "../gallery.html": "../../index.html",
+    "../DISCLAIMER_SNIPPET/": "../../DISCLAIMER_SNIPPET/",
 }
 
 REPO_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- update REPLACEMENTS in `mirror_demo_pages.py` to handle DISCLAIMER_SNIPPET pages

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*
- `pre-commit run --files scripts/mirror_demo_pages.py` *(failed to initialize semgrep environment)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f321a188333b2a06818b6e47c7f