### PR TITLE
Fix PDF copy for Insight docs

### DIFF
--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -50,6 +50,11 @@ fi
 rm -rf "$DOCS_DIR"
 mkdir -p "$DOCS_DIR"
 unzip -q -o "$BROWSER_DIR/insight_browser.zip" -d "$DOCS_DIR"
+# Copy the quickstart guide from the build output so the docs include it
+PDF_SRC="$BROWSER_DIR/dist/insight_browser_quickstart.pdf"
+if [[ -f "$PDF_SRC" ]]; then
+    cp -a "$PDF_SRC" "$DOCS_DIR/"
+fi
 # Ensure the service worker and PWA files exist in the docs directory
 unzip -q -j -o "$BROWSER_DIR/insight_browser.zip" service-worker.js -d "$DOCS_DIR" || true
 unzip -q -j -o "$BROWSER_DIR/insight_browser.zip" manifest.json -d "$DOCS_DIR" || true


### PR DESCRIPTION
## Summary
- update build script to copy `insight_browser_quickstart.pdf` from the build output into the Insight docs
- ensure MkDocs includes PDF assets

## Testing
- `pre-commit run --files scripts/build_insight_docs.sh mkdocs.yml`
- `mkdocs build --strict` *(fails without mkdocs-material; installed locally)*
- `pytest -k quickstart_pdf` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686e80ed28d88333b1b0efd18dab9ba2