### PR TITLE
[alpha_factory] update license links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1612,7 +1612,7 @@ ultimate α‑signal engine.
 <a name="15-license"></a>
 ## 15 · License
 
-This project is distributed under the [Apache 2.0](LICENSE) license.
+This project is distributed under the [Apache 2.0](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE) license.
 All community members are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 Please report security issues via the process outlined in our [Security Policy](SECURITY.md).
 
@@ -1626,7 +1626,7 @@ Please report security issues via the process outlined in our [Security Policy](
 ## 16 · Final Note
 
 Please ensure all usage and contributions align with the project's
-[Apache 2.0 license](LICENSE).
+[Apache 2.0 license](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE).
 ---
 
 *Made with ❤️ by the Alpha‑Factory Agentic Core Team — forging the tools that forge tomorrow.*

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -399,4 +399,4 @@ the same set of keys.
 ## License
 
 The Insight browser demo and its translation files are provided under the
-[Apache 2.0](../../../../LICENSE) license.
+[Apache 2.0](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE) license.

--- a/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md
+++ b/alpha_factory_v1/demos/alpha_agi_marketplace_v1/TERMS_AND_CONDITIONS.md
@@ -9,4 +9,4 @@ This demonstration is provided for educational purposes only and comes with **no
 2. MONTREAL.AI and contributors accept no liability for damages arising from the use of this software.
 3. Usage must comply with all applicable laws and regulations in your jurisdiction.
 
-The project is distributed under the [Apache 2.0 license](../../../../LICENSE).
+The project is distributed under the [Apache 2.0 license](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE).

--- a/docs/demos/meta_agentic_tree_search_v0.md
+++ b/docs/demos/meta_agentic_tree_search_v0.md
@@ -300,7 +300,7 @@ the search loop while keeping the demo runnable completely offline.
 * **Self‑Referential Improvement in RL**, Müller et al., arXiv 2025  
 
 ## 11 License
-Apache 2.0 – see `LICENSE`.
+Apache 2.0 – see [LICENSE](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/LICENSE).
 
 ---
 *This README belongs to the AGI‑Alpha‑Agent project.*


### PR DESCRIPTION
## Summary
- use absolute GitHub link for the project license in docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 84 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e87c79de0833380ac1d12881dfb32