### PR TITLE
fix paths for mirrored demos

### DIFF
--- a/scripts/mirror_demo_pages.py
+++ b/scripts/mirror_demo_pages.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+import os
+import re
 
 REPLACEMENTS = {
     "../assets/": "../../../assets/",
@@ -42,10 +44,11 @@ def fix_paths(target: Path) -> None:
         txt = txt.replace("../assets/", "../../../assets/")
         script.write_text(txt)
 
-    for md in target.glob("*.md"):
+    snippet = DOCS_DIR / "DISCLAIMER_SNIPPET.md"
+    for md in target.rglob("*.md"):
         txt = md.read_text()
-        txt = txt.replace("../DISCLAIMER_SNIPPET.md", "../../../DISCLAIMER_SNIPPET.md")
-        txt = txt.replace("../../DISCLAIMER_SNIPPET.md", "../../../../DISCLAIMER_SNIPPET.md")
+        rel = os.path.relpath(snippet, md.parent)
+        txt = re.sub(r"\((?:\./|\.\./)+DISCLAIMER_SNIPPET\.md\)", f"({rel})", txt)
         md.write_text(txt)
 
 


### PR DESCRIPTION
## Summary
- compute disclaimer snippet paths dynamically in `mirror_demo_pages.py`
- run `mkdocs build` to verify there are no disclaimer warnings

## Testing
- `pre-commit run --files scripts/mirror_demo_pages.py`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_686e89938f708333a4a6c1889098b875