### PR TITLE
[alpha_factory] Add mkdocs-exclude plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,11 @@ site_name: Alpha-Factory Docs
 site_url: https://montrealai.github.io/AGI-Alpha-Agent-v0/
 repo_url: https://github.com/MontrealAI/AGI-Alpha-Agent-v0
 docs_dir: docs
+plugins:
+  - search
+  - exclude:
+      glob:
+        - alpha_factory_v1/demos/**/*.md
 theme:
   name: material
 extra_css:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,3 +2,5 @@ mkdocs==1.6.1
 mkdocs-material==9.6.15
 openai-agents==0.0.17
 google-adk==1.5.0
+
+mkdocs-exclude==1.0.2


### PR DESCRIPTION
## Summary
- add `mkdocs-exclude` to documentation requirements
- enable the plugin in `mkdocs.yml`
- ignore markdown under `alpha_factory_v1/demos` when building the docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging' of module 'alpha_factory_v1.common.utils')*
- `pre-commit run --files requirements-docs.txt mkdocs.yml`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_686e8db1bdcc83339b5425de7f5818dd