### PR TITLE
[alpha_factory] ensure validate_demos runs fresh

### DIFF
--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -49,6 +49,9 @@ class TestDemos(unittest.TestCase):
         import sys
         import subprocess
 
+        # Ensure the module is executed fresh by ``python -m``.
+        sys.modules.pop("alpha_factory_v1.demos.validate_demos", None)
+
         result = subprocess.run(
             [
                 sys.executable,


### PR DESCRIPTION
## Summary
- prevent reuse of `alpha_factory_v1.demos.validate_demos` before invoking as CLI

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686e91f490c08333b5c1c51596a8b664