### PR TITLE
[alpha_factory] update README links

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -107,7 +107,7 @@ Python standard library.
 ---
 
 ### Requirements
-* Python 3.11 or 3.12 (<3.13; see [AGENTS.md](../../../AGENTS.md))
+* Python 3.11 or 3.12 (<3.13). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
 * Install the optional runtime packages:
   ```bash
   pip install -r alpha_factory_v1/demos/solving_agi_governance/requirements.txt

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -113,7 +113,7 @@ Python standard library.
 ---
 
 ### Requirements
-* Python 3.11 or 3.12 (https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/solving_agi_governance/<3.13; see [AGENTS.md](https:/github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md))
+* Python 3.11 or 3.12 (<3.13). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
 * Install the optional runtime packages:
   ```bash
   pip install -r alpha_factory_v1/demos/solving_agi_governance/requirements.txt


### PR DESCRIPTION
## Summary
- update Python version bullet in solving_agi_governance demo docs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/README.md docs/demos/solving_agi_governance.md`
- `mkdocs build --strict`
- `lychee --offline --base ./site ./site/**/*.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9991a6788333827f8c41251306b6