### PR TITLE
[alpha_factory] update docs dependencies

### DIFF
--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -31,7 +31,7 @@ only affects loading pinned Insight demo runs.
 ## Prerequisites
 
 - **Python 3.11 or 3.12**
-- `mkdocs` and `mkdocs-material`
+- `mkdocs`, `mkdocs-material` and `playwright`
 - **Node.js 20+** *(optional, only for building the React dashboard)*
 - Run `node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js` to verify Node ≥20 before building
 - `unzip` to extract `insight_browser.zip`
@@ -39,7 +39,7 @@ only affects loading pinned Insight demo runs.
 Install MkDocs:
 
 ```bash
-pip install mkdocs mkdocs-material
+pip install mkdocs mkdocs-material playwright
 ```
 
 Before building the demo, ensure optional Python packages are available:

--- a/internal_docs/CODEX_DEMO_PAGES_SPRINT.md
+++ b/internal_docs/CODEX_DEMO_PAGES_SPRINT.md
@@ -7,9 +7,9 @@ This short guide outlines how Codex can publish the full Alpha‑Factory demo ga
 ## 1. Environment Setup
 
 1. Install **Python 3.11+** and **Node.js 20+**.
-2. Install `mkdocs` and `mkdocs-material` via `pip`:
+2. Install `mkdocs`, `mkdocs-material` and `playwright` via `pip`:
    ```bash
-   pip install mkdocs mkdocs-material
+   pip install mkdocs mkdocs-material playwright
    ```
 3. Verify Node version:
    ```bash

--- a/internal_docs/CODEX_INSIGHT_PAGES_SPRINT.md
+++ b/internal_docs/CODEX_INSIGHT_PAGES_SPRINT.md
@@ -7,9 +7,9 @@ This short guide provides a step-by-step sprint for Codex to ensure the **α‑A
 ## 1. Environment Setup
 
 1. Install **Python 3.11+** and **Node.js 20+**.
-2. Install `mkdocs` and `mkdocs-material` via `pip`:
+2. Install `mkdocs`, `mkdocs-material` and `playwright` via `pip`:
    ```bash
-   pip install mkdocs mkdocs-material
+   pip install mkdocs mkdocs-material playwright
    ```
 3. Verify Node version:
    ```bash

--- a/internal_docs/INSIGHT_ACCESS_SPRINT.md
+++ b/internal_docs/INSIGHT_ACCESS_SPRINT.md
@@ -7,9 +7,9 @@ This short guide distills the essential steps required to build and publish the 
 ## 1. Environment Preparation
 
 1. Install **Python 3.11+** and **Node.js 20+**.
-2. Install `mkdocs` and `mkdocs-material`:
+2. Install `mkdocs`, `mkdocs-material` and `playwright`:
    ```bash
-   pip install mkdocs mkdocs-material
+   pip install mkdocs mkdocs-material playwright
    ```
 3. Verify Node version:
    ```bash

--- a/internal_docs/INSIGHT_SPRINT_PLAN.md
+++ b/internal_docs/INSIGHT_SPRINT_PLAN.md
@@ -4,7 +4,7 @@
 This document outlines the minimal tasks required to publish the **α‑AGI Insight v1** demo to GitHub Pages so that users can experience the full browser-based simulation, including the animated meta‑agentic tree search.
 
 ## 1. Prepare the Environment
-- Install **Python 3.11+**, **Node.js 20+**, `mkdocs`, and `mkdocs-material`.
+- Install **Python 3.11+**, **Node.js 20+**, `mkdocs`, `mkdocs-material` and `playwright`.
 - Run `node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js` to confirm the Node version.
 - Execute `python scripts/check_python_deps.py` and `python check_env.py --auto-install` to install optional dependencies.
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,4 +3,6 @@ mkdocs-material==9.6.15
 openai-agents==0.0.17
 google-adk==1.5.0
 
+playwright
+
 mkdocs-exclude==1.0.2


### PR DESCRIPTION
## Summary
- add playwright to documentation requirements
- mention playwright in hosting and sprint guides

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging' of module 'alpha_factory_v1.common.utils')*
- `pre-commit run --files docs/HOSTING_INSTRUCTIONS.md internal_docs/CODEX_DEMO_PAGES_SPRINT.md internal_docs/CODEX_INSIGHT_PAGES_SPRINT.md internal_docs/INSIGHT_ACCESS_SPRINT.md internal_docs/INSIGHT_SPRINT_PLAN.md requirements-docs.txt`

------
https://chatgpt.com/codex/tasks/task_e_686e9ec915d88333898aa3ecdf3e8151