### PR TITLE
docs: enable strict mkdocs in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,12 @@ The **Deploy — Kind** workflow provisions a local kind cluster, builds the Ins
 1. Navigate to "Actions → 🚀 Deploy — Kind".
 2. Click "Run workflow" to launch the deployment.
 
+### Documentation Workflow
+The **📚 Docs** workflow builds the demo gallery and publishes the MkDocs site to
+GitHub Pages. The underlying scripts now run `mkdocs build --strict` in all
+environments, so any warnings or broken links will fail the build. Fix these
+issues locally before dispatching the workflow.
+
 ### PR Message Guidelines
 - Keep the subject line concise and under 72 characters.
 - Optionally include a short body explaining the rationale.

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -128,13 +128,9 @@ copy_assets
 python scripts/generate_demo_docs.py
 python scripts/generate_gallery_html.py
 
-# Build the MkDocs site. Use strict mode locally to catch warnings,
-# but relax the setting in CI to avoid aborting on non-critical issues.
-if [[ "${CI:-}" == "true" ]]; then
-    mkdocs build
-else
-    mkdocs build --strict
-fi
+# Build the MkDocs site. Strict mode is always enabled so any warnings
+# surface as errors both locally and in CI.
+mkdocs build --strict
 
 # Verify the Workbox hash again in the generated site directory
 if ! python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1; then

--- a/scripts/deploy_gallery_pages.sh
+++ b/scripts/deploy_gallery_pages.sh
@@ -29,13 +29,9 @@ python -m alpha_factory_v1.demos.validate_demos
 python scripts/mirror_demo_pages.py
 python scripts/build_service_worker.py
 
-# Compile and verify the MkDocs site. Skip --strict in CI to avoid aborting on
-# non-critical warnings that do not affect the generated pages.
-if [[ "${CI:-}" == "true" ]]; then
-  mkdocs build
-else
-  mkdocs build --strict
-fi
+# Compile and verify the MkDocs site. Strict mode is always enabled so
+# warnings fail the build in CI just like local runs.
+mkdocs build --strict
 python scripts/verify_workbox_hash.py site/alpha_agi_insight_v1
 
 # Optional offline smoke test


### PR DESCRIPTION
## Summary
- always run `mkdocs build --strict`
- keep deployment scripts consistent
- mention docs workflow in `AGENTS.md`

## Testing
- `pre-commit run --files AGENTS.md scripts/build_insight_docs.sh scripts/deploy_gallery_pages.sh`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686ea1d61d8883339f6f26a2dcda65ce