### PR TITLE
[alpha_factory] remove redundant browserslist update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,8 +71,6 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Install Web client dependencies
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
-      - name: Update browserslist database
-        run: npx update-browserslist-db@latest --agree-to-terms
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit checks


### PR DESCRIPTION
## Summary
- remove Update browserslist database step from docs workflow
- the build script already updates Browserslist

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError cannot access submodule 'messaging' and others)*
- `pre-commit run --files .github/workflows/docs.yml scripts/build_insight_docs.sh`
- `CI=true npx --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 --yes browserslist@latest --update-db` *(fails: browserslist not found)*


------
https://chatgpt.com/codex/tasks/task_e_686ea99d3cfc8333ac3d3f870c00113b