### PR TITLE
[alpha_factory] Add Playwright cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,6 +79,7 @@ jobs:
         uses: microsoft/playwright-github-action@v1
         with:
           install-deps: true
+          cache: true
       - name: Make scripts executable
         run: chmod +x ./scripts/*.sh
       - name: Compute asset cache key


### PR DESCRIPTION
## Summary
- cache Playwright browsers in docs workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*
- `pre-commit run --files .github/workflows/docs.yml`


------
https://chatgpt.com/codex/tasks/task_e_686eae870d5483338a9cd32e2e8cfce4