### PR TITLE
[alpha_factory] Move Meta‑Agentic README assets

### DIFF
--- a/internal_docs/meta_agentic_agi/assets/README.md
+++ b/internal_docs/meta_agentic_agi/assets/README.md
@@ -1,4 +1,4 @@
-[See ../../DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/internal_docs/meta_agentic_agi_v2/assets/README.md
+++ b/internal_docs/meta_agentic_agi_v2/assets/README.md
@@ -1,4 +1,4 @@
-[See ../../DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/internal_docs/meta_agentic_agi_v3/assets/README.md
+++ b/internal_docs/meta_agentic_agi_v3/assets/README.md
@@ -1,4 +1,4 @@
-[See ../../DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../docs/DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,4 +72,3 @@ nav:
   - Insight Demo Bus TLS: alpha_agi_insight_v1/docs/bus_tls.md
 exclude_docs: |
   demos/TERMS_AND_CONDITIONS.md
-  meta_agentic_agi*/assets/README.md


### PR DESCRIPTION
## Summary
- relocate `docs/meta_agentic_agi*/assets/README.md` into `internal_docs`
- update links after moving
- remove unused exclude rule from MkDocs config

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*
- `pre-commit run --files mkdocs.yml internal_docs/meta_agentic_agi/assets/README.md internal_docs/meta_agentic_agi_v2/assets/README.md internal_docs/meta_agentic_agi_v3/assets/README.md`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686eb0fb2d5c8333adbd1fdcf73df622