### PR TITLE
docs: ignore mirrored demo markdown

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,3 +72,4 @@ nav:
   - Insight Demo Bus TLS: alpha_agi_insight_v1/docs/bus_tls.md
 exclude_docs: |
   demos/TERMS_AND_CONDITIONS.md
+  alpha_factory_v1/demos/**/*.md


### PR DESCRIPTION
## Summary
- exclude Markdown files copied by `scripts/mirror_demo_pages.py` from the docs build

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686ed17b8c108333b9ff6e54b4c84770