### PR TITLE
[alpha_factory] add build tools step

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - name: Prepare build tools
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- insert a preparation step in `smoke.yml` to upgrade `pip`, `setuptools` and `wheel`

## Testing
- `pre-commit run --files .github/workflows/smoke.yml`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*

------
https://chatgpt.com/codex/tasks/task_e_686ed676726c83339be641c22789706a