### PR TITLE
[alpha_factory] increase smoke job timeout

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]


### PR DESCRIPTION
## Summary
- increase smoke test timeout from 5 to 15 minutes

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 84 errors during collection)*
- `pre-commit run --files .github/workflows/smoke.yml`

------
https://chatgpt.com/codex/tasks/task_e_686ed855a9f883339b5dc36e1e977b4e