### PR TITLE
[alpha_factory] Update smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -40,10 +40,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
-          pip install -r requirements-dev.txt
+          if [ "${{ matrix.python-version }}" = "3.11" ]; then
+            pip install -r requirements-dev.txt
+          fi
       - name: Install pre-commit
+        if: matrix.python-version == '3.11'
         run: pip install pre-commit
       - name: Run pre-commit checks
+        if: matrix.python-version == '3.11'
         run: pre-commit run --all-files
       - name: Run 2-year simulation
         run: |


### PR DESCRIPTION
## Summary
- run pre-commit only on Python 3.11
- skip requirements-dev.txt install for other matrix entries

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: AttributeError: cannot access submodule 'messaging')*
- `pre-commit run --files .github/workflows/smoke.yml`


------
https://chatgpt.com/codex/tasks/task_e_686eda3bca148333919c1cee809fa252