### PR TITLE
Fix messaging imports

### DIFF
--- a/alpha_factory_v1/common/utils/logging.py
+++ b/alpha_factory_v1/common/utils/logging.py
@@ -27,9 +27,12 @@ except Exception:  # pragma: no cover - optional
     coloredlogs = None
 
 from . import messaging
-from alpha_factory_v1.core.utils.tracing import span
-from alpha_factory_v1.core.utils import a2a_pb2 as pb
 from google.protobuf import json_format
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from alpha_factory_v1.core.utils.tracing import span
+    from alpha_factory_v1.core.utils import a2a_pb2 as pb
 
 try:  # optional dependency
     from blake3 import blake3
@@ -188,6 +191,9 @@ class Ledger:
 
     def log(self, env: messaging.Envelope) -> None:
         """Hash ``env`` and append to the ledger."""
+        from alpha_factory_v1.core.utils.tracing import span
+        from alpha_factory_v1.core.utils import a2a_pb2 as pb
+
         with span("ledger.log"):
             assert self.conn is not None
             if dataclasses.is_dataclass(env) and not isinstance(env, type):

--- a/alpha_factory_v1/common/utils/messaging.py
+++ b/alpha_factory_v1/common/utils/messaging.py
@@ -18,12 +18,16 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Protocol, Typ
 from cachetools import TTLCache
 
 from .config import Settings
-from alpha_factory_v1.core.utils.tracing import span, bus_messages_total
-from alpha_factory_v1.core.utils import a2a_pb2 as pb
 from google.protobuf import json_format
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from alpha_factory_v1.core.utils.tracing import span, bus_messages_total
+    from alpha_factory_v1.core.utils import a2a_pb2 as pb
 
-Envelope: TypeAlias = pb.Envelope
+    Envelope: TypeAlias = pb.Envelope
+else:  # pragma: no cover - runtime fallback
+    Envelope: TypeAlias = Any
 
 
 class EnvelopeLike(Protocol):
@@ -92,6 +96,9 @@ class A2ABus:
             self._subs.pop(topic, None)
 
     def publish(self, topic: str, env: EnvelopeLike) -> None:
+        from alpha_factory_v1.core.utils.tracing import span, bus_messages_total
+        from alpha_factory_v1.core.utils import a2a_pb2 as pb
+
         with span("bus.publish"):
             bus_messages_total.labels(topic).inc()
             if self._producer:

--- a/alpha_factory_v1/core/orchestrator.py
+++ b/alpha_factory_v1/core/orchestrator.py
@@ -25,7 +25,8 @@ from .agents import (
     adk_summariser_agent,
 )
 from alpha_factory_v1.core.agents.self_improver_agent import SelfImproverAgent
-from .utils import config, messaging, logging as insight_logging
+from .utils import config, logging as insight_logging
+from alpha_factory_v1.common.utils import messaging
 from alpha_factory_v1.common.utils.logging import Ledger
 from .utils import alerts
 from alpha_factory_v1.core.archive.service import ArchiveService

--- a/alpha_factory_v1/core/utils/__init__.py
+++ b/alpha_factory_v1/core/utils/__init__.py
@@ -17,9 +17,6 @@ except Exception:  # pragma: no cover - optional dependency
 
 from .file_ops import view, str_replace
 from . import alerts, tracing
-from alpha_factory_v1.common import utils as common_utils
-
-messaging = common_utils.messaging
 from .snark import (
     generate_proof,
     publish_proof,
@@ -41,5 +38,4 @@ __all__ = [
     "verify_aggregate_proof",
     "alerts",
     "tracing",
-    "messaging",
 ]

--- a/tests/test_alert_webhook.py
+++ b/tests/test_alert_webhook.py
@@ -8,7 +8,8 @@ import logging
 import pytest
 
 from alpha_factory_v1.core import orchestrator
-from alpha_factory_v1.core.utils import alerts, messaging, config
+from alpha_factory_v1.core.utils import alerts, config
+from alpha_factory_v1.common.utils import messaging
 from alpha_factory_v1.core.agents.base_agent import BaseAgent
 
 

--- a/tests/test_insight_orchestrator_restart.py
+++ b/tests/test_insight_orchestrator_restart.py
@@ -8,7 +8,7 @@ import contextlib
 
 from alpha_factory_v1.core import orchestrator
 from alpha_factory_v1.core.utils import config
-from alpha_factory_v1.core.utils.messaging import A2ABus, Envelope
+from alpha_factory_v1.common.utils.messaging import A2ABus, Envelope
 from alpha_factory_v1.core.utils.logging import Ledger
 from alpha_factory_v1.core.agents.base_agent import BaseAgent
 

--- a/tests/test_orchestrator_bus_tls_env.py
+++ b/tests/test_orchestrator_bus_tls_env.py
@@ -22,7 +22,8 @@ except Exception:  # pragma: no cover - optional
     HAVE_CRYPTO = False
 
 from alpha_factory_v1.core import orchestrator
-from alpha_factory_v1.core.utils import config, messaging
+from alpha_factory_v1.core.utils import config
+from alpha_factory_v1.common.utils import messaging
 
 
 def _free_port() -> int:


### PR DESCRIPTION
## Summary
- remove messaging alias from `core.utils`
- lazy import tracing/a2a_pb2 in messaging & logging utilities
- use common.utils.messaging in orchestrator and tests

## Testing
- `pre-commit run --files alpha_factory_v1/core/orchestrator.py alpha_factory_v1/core/utils/__init__.py alpha_factory_v1/common/utils/messaging.py alpha_factory_v1/common/utils/logging.py tests/test_insight_orchestrator_restart.py tests/test_orchestrator_bus_tls_env.py tests/test_alert_webhook.py`
- `pytest tests/test_alert_webhook.py -k "" -q` *(fails: AttributeError: partially initialized module 'alpha_factory_v1.core.agents.base_agent' has no attribute 'BaseAgent')*

------
https://chatgpt.com/codex/tasks/task_e_686ee21825f483339ec387b4d644f583