### PR TITLE
Add discovery run guard

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -34,6 +34,7 @@ from .discovery import (
     discover_entrypoints,
     discover_hot_dir,
     discover_adk,
+    run_discovery_once,
     _HOT_DIR,
     FAILED_AGENTS,
 )
@@ -41,10 +42,7 @@ from .discovery import discover_local as _discover_local
 from .health import start_background_tasks, stop_background_tasks
 
 # Perform initial discovery on import
-discover_local()
-discover_entrypoints()
-discover_hot_dir()
-discover_adk()
+run_discovery_once()
 
 logger.info(
     "\U0001f680 Agent registry ready \u2013 %3d agents, %3d distinct capabilities",


### PR DESCRIPTION
## Summary
- prevent duplicate discovery by gating `discover_*` functions with a module-level flag
- run all discovery steps via `run_discovery_once()`

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/backend/agents/discovery.py alpha_factory_v1/backend/agents/__init__.py`
- `pytest tests/test_agents_registry.py::TestDiscoverLocalIdempotent::test_no_duplicate_logs -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee5202be8833383589d0f2a40790e