### PR TITLE
[alpha_factory] fix orchestrator imports

### DIFF
--- a/alpha_factory_v1/core/orchestrator.py
+++ b/alpha_factory_v1/core/orchestrator.py
@@ -25,7 +25,8 @@ from .agents import (
     adk_summariser_agent,
 )
 from alpha_factory_v1.core.agents.self_improver_agent import SelfImproverAgent
-from .utils import config, logging as insight_logging
+from .utils import config
+from alpha_factory_v1.common.utils import logging as insight_logging
 from alpha_factory_v1.common.utils import messaging
 from alpha_factory_v1.common.utils.logging import Ledger
 from .utils import alerts

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evaluators/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evaluators/__init__.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Evaluation utilities for the Insight demo."""
 
+from alpha_factory_v1.core.evaluators import lead_time
+
 __all__ = ["lead_time"]

--- a/tests/test_insight_orchestrator_features.py
+++ b/tests/test_insight_orchestrator_features.py
@@ -7,11 +7,8 @@ import unittest
 from unittest import mock
 
 from alpha_factory_v1.core import orchestrator
-from alpha_factory_v1.core.utils import (
-    config,
-    messaging,
-    logging as insight_logging,
-)
+from alpha_factory_v1.core.utils import config
+from alpha_factory_v1.common.utils import messaging, logging as insight_logging
 
 
 class TestInsightOrchestrator(unittest.TestCase):

--- a/tests/test_insight_orchestrator_restart.py
+++ b/tests/test_insight_orchestrator_restart.py
@@ -9,7 +9,7 @@ import contextlib
 from alpha_factory_v1.core import orchestrator
 from alpha_factory_v1.core.utils import config
 from alpha_factory_v1.common.utils.messaging import A2ABus, Envelope
-from alpha_factory_v1.core.utils.logging import Ledger
+from alpha_factory_v1.common.utils.logging import Ledger
 from alpha_factory_v1.core.agents.base_agent import BaseAgent
 
 


### PR DESCRIPTION
## Summary
- fix orchestrator logging import
- expose lead_time evaluator from demo package
- update orchestrator tests

## Testing
- `pre-commit run --files alpha_factory_v1/core/orchestrator.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/evaluators/__init__.py tests/test_insight_orchestrator_features.py tests/test_insight_orchestrator_restart.py`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pytest -q` *(fails: 276 failed, 502 passed, 71 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686eeba1e6a88333ad45b653c0afb026