### PR TITLE
fix smoke workflow imports

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
@@ -49,6 +50,9 @@ jobs:
       - name: Run pre-commit checks
         if: matrix.python-version == '3.11'
         run: pre-commit run --all-files
+      - name: Run unit tests
+        if: matrix.python-version == '3.11'
+        run: pytest -q
       - name: Run 2-year simulation
         run: |
           python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \

--- a/alpha_factory_v1/core/utils/__init__.py
+++ b/alpha_factory_v1/core/utils/__init__.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 from .file_ops import view, str_replace
 from . import alerts, tracing
+from alpha_factory_v1.common.utils import logging
 from .snark import (
     generate_proof,
     publish_proof,
@@ -37,5 +38,6 @@ __all__ = [
     "aggregate_proof",
     "verify_aggregate_proof",
     "alerts",
+    "logging",
     "tracing",
 ]


### PR DESCRIPTION
## Summary
- expose common logging utilities via `core.utils`
- run unit tests in smoke CI
- disable fail-fast in smoke matrix

## Testing
- `pre-commit run --files alpha_factory_v1/core/utils/__init__.py .github/workflows/smoke.yml`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 276 failed, 502 passed, 71 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686ef0c3cbc08333a9e49b9941cafd08