### PR TITLE
[alpha_factory] fix smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -51,6 +51,7 @@ jobs:
         if: matrix.python-version == '3.11'
         run: pre-commit run --all-files
       - name: Run smoke tests
+        if: matrix.python-version == '3.11'
         run: pytest tests/test_ping_agent.py tests/test_af_requests.py -q
       - name: Run 2-year simulation
         run: |


### PR DESCRIPTION
## Summary
- restrict smoke tests to Python 3.11

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 75 failed, 94 passed, 32 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/smoke.yml` *(fails to run due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_686f192ea29483339dee3f44214f8b3e