### PR TITLE
[alpha_factory] cache pip & npm in size workflow

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -22,9 +22,21 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.lock') }}
+          restore-keys: ${{ runner.os }}-pip-
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+      - name: Cache npm
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Install required Python packages

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ Ensure **Python 3.11+**, **Node 20+** and `mkdocs` are installed. The
 script mirrors the [Docs workflow](.github/workflows/docs.yml) used for manual
 deployment.
 
+### Browser Size Workflow
+
+The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
+Insight archive stays below 3 MiB. It caches pip and npm dependencies with
+`actions/cache`, keyed by `requirements.lock` and the browser
+`package-lock.json`, so repeat runs skip redundant downloads.
+
 ## Quickstart
 
 ```bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,8 @@ Downstream users should consult this section when upgrading.
 - The browser bundle now defaults to the official Web3 Storage CDN. IPFS
   fallback has been removed.
 - Fixed internal documentation links so MkDocs builds without warnings.
+- The **📦 Browser Size** workflow now caches pip and npm dependencies so
+  repeated runs skip redundant downloads.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.


### PR DESCRIPTION
## Summary
- cache Python and Node dependencies in size-check workflow
- explain new cache in README
- note cache update in changelog

## Testing
- `pre-commit run --files .github/workflows/size-check.yml README.md docs/CHANGELOG.md`
- `pytest -q tests/test_checksum.py` *(fails: ImportError: sentence-transformers missing)*


------
https://chatgpt.com/codex/tasks/task_e_686f35f138608333a292795c7ed33d47