### PR TITLE
[alpha_factory] fix size workflow deps

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Install required Python packages
-        run: pip install numpy pandas pytest
+        run: pip install numpy pandas pytest pyyaml
       - name: Run pre-commit checks
         run: pre-commit run --all-files
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab and
 provide a valid `run_token` matching the `DISPATCH_TOKEN` secret to authorize
 the run. The workflow caches pip and npm dependencies with `actions/cache`,
 keyed by `requirements.lock` and the browser `package-lock.json`, so repeat
-runs skip redundant downloads.
+runs skip redundant downloads. It preinstalls `numpy`, `pandas`, `pytest`
+and `PyYAML` so the environment check passes without network hiccups.
 
 ## Quickstart
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,8 @@ Downstream users should consult this section when upgrading.
 - Fixed internal documentation links so MkDocs builds without warnings.
 - The **📦 Browser Size** workflow now caches pip and npm dependencies so
   repeated runs skip redundant downloads.
+- The workflow preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` before
+  running pre-commit so the environment check passes reliably.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.


### PR DESCRIPTION
## Summary
- preinstall numpy, pandas, pytest and PyYAML in the Browser Size workflow
- document the new step in README
- mention the workflow improvement in the changelog

## Testing
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 64 failed, 79 passed, 31 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/size-check.yml README.md docs/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_686f3ee1752c8333ad59a83e1c315265