### PR TITLE
[alpha_factory] enhance browser size workflow caches

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -22,21 +22,16 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
-      - name: Cache pip
-        uses: actions/cache@v3
+      - uses: actions/setup-python@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.lock') }}
-          restore-keys: ${{ runner.os }}-pip-
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'requirements.lock'
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-      - name: Cache npm
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-npm-
+          cache: 'npm'
+          cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Install required Python packages

--- a/README.md
+++ b/README.md
@@ -116,10 +116,7 @@ deployment.
 The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
 Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab and
 provide a valid `run_token` matching the `DISPATCH_TOKEN` secret to authorize
-the run. The workflow caches pip and npm dependencies with `actions/cache`,
-keyed by `requirements.lock` and the browser `package-lock.json`, so repeat
-runs skip redundant downloads. It preinstalls `numpy`, `pandas`, `pytest`
-and `PyYAML` so the environment check passes without network hiccups.
+the run. The workflow caches pip and npm dependencies using `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and the browser `package-lock.json`, so repeat runs skip redundant downloads. It preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check passes without network hiccups.
 
 ## Quickstart
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,7 +53,8 @@ Downstream users should consult this section when upgrading.
 - The browser bundle now defaults to the official Web3 Storage CDN. IPFS
   fallback has been removed.
 - Fixed internal documentation links so MkDocs builds without warnings.
-- The **📦 Browser Size** workflow now caches pip and npm dependencies so
+- The **📦 Browser Size** workflow now caches pip and npm dependencies using
+  the built-in features of `actions/setup-python` and `actions/setup-node` so
   repeated runs skip redundant downloads.
 - The workflow preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` before
   running pre-commit so the environment check passes reliably.


### PR DESCRIPTION
## Summary
- reuse built-in pip cache via `actions/setup-python`
- cache npm dependencies with `actions/setup-node`
- mention updated caching approach in README
- document workflow improvement in CHANGELOG

## Testing
- `pre-commit run --files .github/workflows/size-check.yml README.md docs/CHANGELOG.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686f7a1b1c208333954f08c34c3a1d10