### PR TITLE
[alpha_factory] run env check before pre-commit

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -34,8 +34,8 @@ jobs:
           cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
       - name: Install pre-commit
         run: pip install pre-commit
-      - name: Install required Python packages
-        run: pip install numpy pandas pytest pyyaml
+      - name: Run environment check
+        run: ./scripts/env_check.sh
       - name: Run pre-commit checks
         run: pre-commit run --all-files
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ deployment.
 The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
 Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab and
 provide a valid `run_token` matching the `DISPATCH_TOKEN` secret to authorize
-the run. The workflow caches pip and npm dependencies using `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and the browser `package-lock.json`, so repeat runs skip redundant downloads. It preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check passes without network hiccups.
+the run. The workflow caches pip and npm dependencies using `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and the browser `package-lock.json`, so repeat runs skip redundant downloads. It runs `scripts/env_check.sh` to install `numpy`, `pandas`, `pytest` and `PyYAML` as needed so the environment check passes without network hiccups.
 
 ## Quickstart
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,8 +56,9 @@ Downstream users should consult this section when upgrading.
 - The **📦 Browser Size** workflow now caches pip and npm dependencies using
   the built-in features of `actions/setup-python` and `actions/setup-node` so
   repeated runs skip redundant downloads.
-- The workflow preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` before
-  running pre-commit so the environment check passes reliably.
+- The workflow runs `scripts/env_check.sh` to install `numpy`, `pandas`, `pytest`
+  and `PyYAML` as needed before running pre-commit so the environment check
+  passes reliably.
 ## [0.1.0-alpha] - 2024-05-01
 - Initial alpha release.
 - Git tag `v0.1.0-alpha`.


### PR DESCRIPTION
## Summary
- call `scripts/env_check.sh` in the Browser Size workflow
- note the env check in README
- document the change in CHANGELOG

## Testing
- `pre-commit run --files .github/workflows/size-check.yml README.md docs/CHANGELOG.md`
- `pytest -q` *(fails: 265 failed, 511 passed, 73 skipped, 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f9db6e3ec833390ed6e25eff233d1