### PR TITLE
[alpha_factory] update pyodide runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ If the default mirrors are blocked, set `PYODIDE_BASE_URL` or
 `HF_GPT2_BASE_URL` before running `npm run fetch-assets`:
 
 ```bash
-export PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/v0.26.0/full"
+export PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/v0.28.0/full"
 export HF_GPT2_BASE_URL="https://huggingface.co/openai-community/gpt2/resolve/main"
 npm run fetch-assets
 ```
@@ -1220,7 +1220,7 @@ for instructions and example volume mounts.
 | `MAX_SIM_TASKS` | `4` | Maximum concurrent simulation tasks. |
 | `IPFS_GATEWAY` | `https://ipfs.io/ipfs` | Base URL for fetching pinned Insight demo runs. Not used for asset downloads. |
 | `HF_GPT2_BASE_URL` | `https://huggingface.co/openai-community/gpt2/resolve/main` | Base URL for the GPT‑2 checkpoints. |
-| `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.26.0/full` | Base URL for the Pyodide runtime files. |
+| `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.28.0/full` | Base URL for the Pyodide runtime files. |
 | `FETCH_ASSETS_ATTEMPTS` | `3` | Download retry count for `fetch_assets.py`. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -41,9 +41,9 @@
   "checksums": {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",
     "lib/workbox-sw.js": "sha384-R7RXlLLrbRAy0JWTwv62SHZwpjwwc7C0wjnLGa5bRxm6YCl5zw87IRvhlleSM5zd",
-    "pyodide-lock.json": "sha384-0jg1cSxhjdgM3qp6WXMysptCeRCzlYI2HhY0Nqy1AFzfp3GnDIFLDs7MTlaJz+Nz",
-    "pyodide.asm.wasm": "sha384-EUqmec0z8Sj94lyhfS28Q0rsvZxo0lEPa3Nz2MQJz3NizgBcfd69cC2EluBQcA51",
-    "pyodide.js": "sha384-KQtL+EUxNlEbNm6gFVMiDz6Glmgq4QV4VZdSHIrcpw4tCRUGtjUeLJbuQAIfxFfM",
+    "pyodide-lock.json": "sha384-2t7FpZqshEP49Av2AHAvKgiBBKi4lIjL2MqLocHFbE+bqa7/KYAhcqVPtO37bir1",
+    "pyodide.asm.wasm": "sha384-nmltu7flheCw5NzKFX44e8BEt8XM61Av/mLIbzbS4aOf2COxsQxE2u75buNoSrVg",
+    "pyodide.js": "sha384-aD6ek5pFVnSSMGK0qubk9ZJdMYGjPs8F6jdJaDJiyZbTcH9jLWR4LJNJ7yY430qI",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421"
   }
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -105,8 +105,8 @@ jsDelivr and GitHub mirrors when needed. You can also retrieve the runtime with
 `curl` when automation fails:
 
 ```bash
-curl -L https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.js -o wasm/pyodide.js
-curl -L https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.asm.wasm -o wasm/pyodide.asm.wasm
+curl -L https://cdn.jsdelivr.net/pyodide/v0.28.0/full/pyodide.js -o wasm/pyodide.js
+curl -L https://cdn.jsdelivr.net/pyodide/v0.28.0/full/pyodide.asm.wasm -o wasm/pyodide.asm.wasm
 ```
 Verify the downloads with:
 

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -30,8 +30,8 @@ DEFAULT_HF_GPT2_BASE_URL = "https://huggingface.co/openai-community/gpt2/resolve
 HF_GPT2_BASE_URL = os.environ.get("HF_GPT2_BASE_URL", DEFAULT_HF_GPT2_BASE_URL).rstrip("/")
 
 # Base URL for the Pyodide runtime
-# Updated to Pyodide 0.26.0
-DEFAULT_PYODIDE_BASE_URL = "https://cdn.jsdelivr.net/pyodide/v0.26.0/full"
+# Updated to Pyodide 0.28.0
+DEFAULT_PYODIDE_BASE_URL = "https://cdn.jsdelivr.net/pyodide/v0.28.0/full"
 PYODIDE_BASE_URL = os.environ.get("PYODIDE_BASE_URL", DEFAULT_PYODIDE_BASE_URL).rstrip("/")
 # Number of download attempts before giving up
 MAX_ATTEMPTS = int(os.environ.get("FETCH_ASSETS_ATTEMPTS", "3"))
@@ -43,7 +43,7 @@ PYODIDE_ASSETS = {
 }
 
 ASSETS = {
-    # Pyodide 0.26.0 runtime files
+    # Pyodide 0.28.0 runtime files
     "wasm/pyodide.js": f"{PYODIDE_BASE_URL}/pyodide.js",
     "wasm/pyodide.asm.wasm": f"{PYODIDE_BASE_URL}/pyodide.asm.wasm",
     "wasm/pyodide-lock.json": f"{PYODIDE_BASE_URL}/pyodide-lock.json",
@@ -61,9 +61,9 @@ ASSETS = {
 CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",  # noqa: E501
     "lib/workbox-sw.js": "sha384-R7RXlLLrbRAy0JWTwv62SHZwpjwwc7C0wjnLGa5bRxm6YCl5zw87IRvhlleSM5zd",  # noqa: E501
-    "pyodide.asm.wasm": "sha384-EUqmec0z8Sj94lyhfS28Q0rsvZxo0lEPa3Nz2MQJz3NizgBcfd69cC2EluBQcA51",
-    "pyodide.js": "sha384-KQtL+EUxNlEbNm6gFVMiDz6Glmgq4QV4VZdSHIrcpw4tCRUGtjUeLJbuQAIfxFfM",
-    "pyodide-lock.json": "sha384-0jg1cSxhjdgM3qp6WXMysptCeRCzlYI2HhY0Nqy1AFzfp3GnDIFLDs7MTlaJz+Nz",
+    "pyodide.asm.wasm": "sha384-nmltu7flheCw5NzKFX44e8BEt8XM61Av/mLIbzbS4aOf2COxsQxE2u75buNoSrVg",
+    "pyodide.js": "sha384-aD6ek5pFVnSSMGK0qubk9ZJdMYGjPs8F6jdJaDJiyZbTcH9jLWR4LJNJ7yY430qI",
+    "pyodide-lock.json": "sha384-2t7FpZqshEP49Av2AHAvKgiBBKi4lIjL2MqLocHFbE+bqa7/KYAhcqVPtO37bir1",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",
 }
 


### PR DESCRIPTION
## Summary
- bump `DEFAULT_PYODIDE_BASE_URL` to v0.28.0
- update associated checksums and regenerate manifest
- revise docs to reference the new Pyodide version
- tidy comment about runtime version

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 61 failed, 79 passed, 31 skipped, 55 warnings, 5 errors)*
- `pre-commit run --files scripts/fetch_assets.py README.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json`

------
https://chatgpt.com/codex/tasks/task_e_686fb06560188333b99b5f78696b53ca