### PR TITLE
[alpha_factory] reorganize insight browser assets

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -63,7 +63,7 @@ export async function generateServiceWorker(outDir, manifest, version) {
   const swData = await fs.readFile(swDest);
   const swHash = createHash('sha384').update(swData).digest('base64');
   let wbPath = path.join(outDir, 'workbox-sw.js');
-  if (!fsSync.existsSync(wbPath)) wbPath = path.join(outDir, 'lib', 'workbox-sw.js');
+  if (!fsSync.existsSync(wbPath)) wbPath = path.join(outDir, 'assets', 'lib', 'workbox-sw.js');
   let wbHash = '';
   if (fsSync.existsSync(wbPath)) {
     wbHash = createHash('sha384').update(fsSync.readFileSync(wbPath)).digest('base64');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --config eslint.config.js src --ext .js,.ts",
     "build": "node build.js",
     "fetch-assets": "node -e \"console.log('Using PYODIDE_BASE_URL:', process.env.PYODIDE_BASE_URL)\" && python ../../../../scripts/fetch_assets.py",
-    "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js lib/workbox-sw.js manifest.json style.css insight_browser_quickstart.pdf && if [ -d assets ]; then zip -r ../insight_browser.zip assets; fi && rm service-worker.js",
+    "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js style.css && zip -r ../insight_browser.zip assets && rm service-worker.js",
     "size": "gzip-size-cli dist/insight.bundle.js --bytes",
     "start": "npx serve dist",
     "typecheck": "tsc --noEmit",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
@@ -8,12 +8,12 @@ import {CacheFirst} from 'workbox-strategies';
 // replaced during build
 const CACHE_VERSION = '__CACHE_VERSION__';
 async function init() {
-  const res = await fetch('lib/workbox-sw.js');
+  const res = await fetch('assets/lib/workbox-sw.js');
   const buf = await res.arrayBuffer();
   const digest = await crypto.subtle.digest('SHA-384', buf);
   const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
   if (`sha384-${b64}` !== WORKBOX_SW_HASH) {
-    throw new Error('lib/workbox-sw.js hash mismatch');
+    throw new Error('assets/lib/workbox-sw.js hash mismatch');
   }
   importScripts(URL.createObjectURL(new Blob([buf], {type: 'application/javascript'})));
   workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -51,15 +51,15 @@ rm -rf "$DOCS_DIR"
 mkdir -p "$DOCS_DIR"
 unzip -q -o "$BROWSER_DIR/insight_browser.zip" -d "$DOCS_DIR"
 # Copy the quickstart guide from the build output so the docs include it
-PDF_SRC="$BROWSER_DIR/dist/insight_browser_quickstart.pdf"
+PDF_SRC="$BROWSER_DIR/dist/assets/insight_browser_quickstart.pdf"
 if [[ -f "$PDF_SRC" ]]; then
     cp -a "$PDF_SRC" "$DOCS_DIR/"
 fi
 # Ensure the service worker and PWA files exist in the docs directory
 unzip -q -j -o "$BROWSER_DIR/insight_browser.zip" service-worker.js -d "$DOCS_DIR" || true
-unzip -q -j -o "$BROWSER_DIR/insight_browser.zip" manifest.json -d "$DOCS_DIR" || true
-mkdir -p "$DOCS_DIR/lib"
-unzip -q -j -o "$BROWSER_DIR/insight_browser.zip" lib/workbox-sw.js -d "$DOCS_DIR/lib" || true
+unzip -q -j -o "$BROWSER_DIR/insight_browser.zip" assets/manifest.json -d "$DOCS_DIR" || true
+mkdir -p "$DOCS_DIR/assets/lib"
+unzip -q -j -o "$BROWSER_DIR/insight_browser.zip" assets/lib/workbox-sw.js -d "$DOCS_DIR/assets/lib" || true
 if [[ -n "$OLD_DOCS_TEMP" ]]; then
     while IFS= read -r -d '' file; do
         rel="${file#"$OLD_DOCS_TEMP"/}"


### PR DESCRIPTION
## Summary
- move static directories under `dist/assets/`
- update asset paths in generated bundle and service worker
- zip browser distribution with assets folder
- refresh insight docs build script to extract new locations

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json scripts/build_insight_docs.sh alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb35e015083339cec23d73510dc2d