### PR TITLE
[alpha_factory] bump pyodide version in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     env:
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.26.0/full
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: ghcr.io/example/selfheal-sandbox:latest
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.26.0/full
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
       CI: 'true'

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -149,7 +149,7 @@ phase and reloads the page so users always run the latest version.
 The unbuilt `index.html` falls back to `'self'` for the IPFS and telemetry
 origins, but running `npm run build` (or `python manual_build.py`) replaces
 these defaults with the real values from `.env`.
-Place the Pyodide 0.26.0 files in `wasm/` before building. The script copies them
+Place the Pyodide 0.28.0 files in `wasm/` before building. The script copies them
 to `dist/wasm` so the demo can run offline. When preparing the environment
 offline run:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm/pyodide.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm/pyodide.js
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: Apache-2.0
-// Pyodide 0.26.0 placeholder
+// Pyodide 0.28.0 placeholder
 export async function loadPyodide() { throw new Error('Pyodide runtime unavailable'); }

--- a/docs/assets/pyodide/pyodide-lock.json
+++ b/docs/assets/pyodide/pyodide-lock.json
@@ -1,1 +1,1 @@
-{"placeholder": true, "pyodide": "0.26.0"}
+{"placeholder": true, "pyodide": "0.28.0"}

--- a/docs/assets/pyodide/pyodide.asm.wasm
+++ b/docs/assets/pyodide/pyodide.asm.wasm
@@ -1,1 +1,1 @@
-placeholder wasm binary (Pyodide 0.26.0) - fetch via scripts/fetch_assets.py
+placeholder wasm binary (Pyodide 0.28.0) - fetch via scripts/fetch_assets.py

--- a/docs/assets/pyodide/pyodide.js
+++ b/docs/assets/pyodide/pyodide.js
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: Apache-2.0
-// Pyodide 0.26.0 placeholder - use scripts/fetch_assets.py to download real assets
+// Pyodide 0.28.0 placeholder - use scripts/fetch_assets.py to download real assets
 export async function loadPyodide() { throw new Error('Pyodide runtime unavailable'); }

--- a/docs/assets/pyodide_demo.js
+++ b/docs/assets/pyodide_demo.js
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* eslint-env browser */
 /* eslint-disable no-undef */
-const CDN_BASE = 'https://cdn.jsdelivr.net/pyodide/v0.26.0/full/';
+const CDN_BASE = 'https://cdn.jsdelivr.net/pyodide/v0.28.0/full/';
 
 export async function loadRuntime() {
   const localBase = '../assets/pyodide/';


### PR DESCRIPTION
## Summary
- update Pyodide CDN links to v0.28.0
- adjust Insight demo instructions for the new runtime

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 267 failed, 511 passed, 71 skipped, 18 errors)*
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/docs.yml docs/assets/pyodide_demo.js docs/assets/pyodide/pyodide.js docs/assets/pyodide/pyodide.asm.wasm docs/assets/pyodide/pyodide-lock.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm/pyodide.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md`

------
https://chatgpt.com/codex/tasks/task_e_686fbf2688748333bdf8a83e70b0d946