### PR TITLE
[alpha_factory] restrict size-check access

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -2,10 +2,6 @@ name: "📦 Browser Size"
 
 on:
   workflow_dispatch:
-    inputs:
-      run_token:
-        description: 'Authorization token for maintainers'
-        required: false
 
 permissions:
   contents: read
@@ -14,13 +10,11 @@ jobs:
   build-and-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check dispatch token
+      - name: Ensure repository owner
         if: github.actor != github.repository_owner
         run: |
-          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
-            echo "Unauthorized"
-            exit 1
-          fi
+          echo "Unauthorized"
+          exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- restrict the browser size workflow so only the repository owner can run it

## Checks
- `pre-commit run --files .github/workflows/size-check.yml`
- `python check_env.py --auto-install`
- `pytest tests/test_assets_replaced.py::test_assets_replaced -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686fe34abc548333aa0cbae61190c4a1