### PR TITLE
Update Pyodide lock file

### DIFF
--- a/docs/assets/pyodide/pyodide-lock.json
+++ b/docs/assets/pyodide/pyodide-lock.json
@@ -1,1 +1,4938 @@
-{"info": {"abi_version": "2025_0", "arch": "wasm32", "platform": "emscripten_4_0_9", "python": "3.13.2", "version": "0.28.0.dev0"}, "packages": {"affine": {"depends": [], "file_name": "affine-2.4.0-py3-none-any.whl", "imports": ["affine"], "install_dir": "site", "name": "affine", "package_type": "package", "sha256": "4eb79a4c13799940b2cba40c9b72b46f627ea262e977b1d747dbb9e7244f4c93", "unvendored_tests": true, "version": "2.4.0"}, "affine-tests": {"depends": ["affine"], "file_name": "affine-tests.tar", "imports": [], "install_dir": "site", "name": "affine-tests", "package_type": "package", "sha256": "7ad2d207300ea69f1b4aa87ee81aac4674c77a2366e99333dcdfe0c3da45528a", "unvendored_tests": false, "version": "2.4.0"}, "aiohappyeyeballs": {"depends": [], "file_name": "aiohappyeyeballs-2.6.1-py3-none-any.whl", "imports": ["aiohappyeyeballs"], "install_dir": "site", "name": "aiohappyeyeballs", "package_type": "package", "sha256": "75ce7e895960634366cd8b322f312cc71cb54505082199853882dadcfa79c914", "unvendored_tests": false, "version": "2.6.1"}, "aiohttp": {"depends": ["aiohappyeyeballs", "aiosignal", "async-timeout", "attrs", "charset-normalizer", "frozenlist", "multidict", "yarl"], "file_name": "aiohttp-3.11.13-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["aiohttp"], "install_dir": "site", "name": "aiohttp", "package_type": "package", "sha256": "ab13fd7b6a023f899a6cff9bbf9cba1ceebfc2844b1214017612b644a5ca0298", "unvendored_tests": true, "version": "3.11.13"}, "aiohttp-tests": {"depends": ["aiohttp"], "file_name": "aiohttp-tests.tar", "imports": [], "install_dir": "site", "name": "aiohttp-tests", "package_type": "package", "sha256": "63444829db370eef249d61a4a46628bede2d9e9eb855fa1c045c77b106562723", "unvendored_tests": false, "version": "3.11.13"}, "aiosignal": {"depends": ["frozenlist"], "file_name": "aiosignal-1.3.2-py2.py3-none-any.whl", "imports": ["aiosignal"], "install_dir": "site", "name": "aiosignal", "package_type": "package", "sha256": "618c9eadea31dc1cbdbccee0db7af253f744547193d274f36f8481fa68e82d19", "unvendored_tests": false, "version": "1.3.2"}, "altair": {"depends": ["typing-extensions", "jinja2", "jsonschema", "packaging", "narwhals"], "file_name": "altair-5.5.0-py3-none-any.whl", "imports": ["altair"], "install_dir": "site", "name": "altair", "package_type": "package", "sha256": "5d0ec05045de574d7d4ff19c06aa4b98170b3ae31c43cd21d05164dd5f3a019f", "unvendored_tests": false, "version": "5.5.0"}, "annotated-types": {"depends": [], "file_name": "annotated_types-0.7.0-py3-none-any.whl", "imports": ["annotated_types"], "install_dir": "site", "name": "annotated-types", "package_type": "package", "sha256": "76075ce81f2f3ab010f54a17674c44e9606f1b1aaf014bbbd948d15379afdc05", "unvendored_tests": true, "version": "0.7.0"}, "annotated-types-tests": {"depends": ["annotated-types"], "file_name": "annotated-types-tests.tar", "imports": [], "install_dir": "site", "name": "annotated-types-tests", "package_type": "package", "sha256": "30fc57e8070f6b0885aaafaebed68d5ded2a27569ffb3e6ba6d05d757057cd04", "unvendored_tests": false, "version": "0.7.0"}, "anyio": {"depends": ["ssl", "sniffio", "typing-extensions"], "file_name": "anyio-4.9.0-py3-none-any.whl", "imports": ["anyio"], "install_dir": "site", "name": "anyio", "package_type": "package", "sha256": "393eccc66dacad1e22eee0c9f91f2da4cee2968111e625bfab52747d64d213ab", "unvendored_tests": false, "version": "4.9.0"}, "apsw": {"depends": [], "file_name": "apsw-3.49.1.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["apsw"], "install_dir": "site", "name": "apsw", "package_type": "package", "sha256": "6c204f13369a0788633da5905ed373798bb6765b0b92bcad8b2e20082f3a6aad", "unvendored_tests": false, "version": "3.49.1.0"}, "argon2-cffi": {"depends": ["argon2-cffi-bindings"], "file_name": "argon2_cffi-23.1.0-py3-none-any.whl", "imports": ["argon2"], "install_dir": "site", "name": "argon2-cffi", "package_type": "package", "sha256": "e89dc3c02b03ee61d50883f6aec169395b850e21765b0e26fef974b01e9c376b", "unvendored_tests": false, "version": "23.1.0"}, "argon2-cffi-bindings": {"depends": ["cffi"], "file_name": "argon2_cffi_bindings-21.2.0-cp313-abi3-pyodide_2025_0_wasm32.whl", "imports": ["_argon2_cffi_bindings"], "install_dir": "site", "name": "argon2-cffi-bindings", "package_type": "package", "sha256": "437d812d9371a4542631d40b859ac42f9587f9a7f4595d01fdb72be75640db27", "unvendored_tests": false, "version": "21.2.0"}, "asciitree": {"depends": [], "file_name": "asciitree-0.3.3-py3-none-any.whl", "imports": ["asciitree"], "install_dir": "site", "name": "asciitree", "package_type": "package", "sha256": "b1fb0a726d7ac5abd329215643cb24edd607e566a8f05c7ee880e22a4e8c44b1", "unvendored_tests": false, "version": "0.3.3"}, "astropy": {"depends": ["packaging", "numpy", "pyerfa", "pyyaml", "astropy_iers_data"], "file_name": "astropy-7.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["astropy"], "install_dir": "site", "name": "astropy", "package_type": "package", "sha256": "73573c7cc2787f1318a63541274f1149f09c663418116b494fa87b2ecb313aa9", "unvendored_tests": false, "version": "7.0.1"}, "astropy-iers-data": {"depends": [], "file_name": "astropy_iers_data-0.2025.3.10.0.29.26-py3-none-any.whl", "imports": ["astropy_iers_data"], "install_dir": "site", "name": "astropy_iers_data", "package_type": "package", "sha256": "1dc8e86457e511b569f56a01524af58c011f3a432f778deab3b27b0f42677e35", "unvendored_tests": true, "version": "0.2025.3.10.0.29.26"}, "astropy-iers-data-tests": {"depends": ["astropy_iers_data"], "file_name": "astropy-iers-data-tests.tar", "imports": [], "install_dir": "site", "name": "astropy_iers_data-tests", "package_type": "package", "sha256": "6896255a2da3a177a154b8b3797f56d15624ac84f6e0371c59103a804c452864", "unvendored_tests": false, "version": "0.2025.3.10.0.29.26"}, "asttokens": {"depends": ["six"], "file_name": "asttokens-3.0.0-py3-none-any.whl", "imports": ["asttokens"], "install_dir": "site", "name": "asttokens", "package_type": "package", "sha256": "9735891dc54944ece9b5fd2b4dd85dd043dc1fcf36c82ebea9ca34bb989f92b8", "unvendored_tests": false, "version": "3.0.0"}, "async-timeout": {"depends": [], "file_name": "async_timeout-5.0.1-py3-none-any.whl", "imports": ["async_timeout"], "install_dir": "site", "name": "async-timeout", "package_type": "package", "sha256": "bdc25a6350c5bc2e8ccfdd672d4226a2c9b41fa88a7604ab0fb1ad9da5e8316d", "unvendored_tests": false, "version": "5.0.1"}, "atomicwrites": {"depends": [], "file_name": "atomicwrites-1.4.1-py2.py3-none-any.whl", "imports": ["atomicwrites"], "install_dir": "site", "name": "atomicwrites", "package_type": "package", "sha256": "1ac42f755ef4c57cd752155ac1751fdc2c75c8d407844757cfc4e8c51cd646be", "unvendored_tests": false, "version": "1.4.1"}, "attrs": {"depends": ["six"], "file_name": "attrs-25.2.0-py3-none-any.whl", "imports": ["attr", "attrs"], "install_dir": "site", "name": "attrs", "package_type": "package", "sha256": "82cdc5a07e1d2f63fdafa96b6428d8a4f93644fc6beb9ef11476778ead45fcea", "unvendored_tests": false, "version": "25.2.0"}, "autograd": {"depends": ["numpy", "future"], "file_name": "autograd-1.7.0-py3-none-any.whl", "imports": ["autograd"], "install_dir": "site", "name": "autograd", "package_type": "package", "sha256": "7f60c8ad13ddf0e20f77a062ef89ded85bdb4bb0096e23326eab476eaf0edc6c", "unvendored_tests": true, "version": "1.7.0"}, "autograd-tests": {"depends": ["autograd"], "file_name": "autograd-tests.tar", "imports": [], "install_dir": "site", "name": "autograd-tests", "package_type": "package", "sha256": "ed50ec6352212738feb0fd219e0bbe53b3c06c199a1dbdf54d4e48300eb961ca", "unvendored_tests": false, "version": "1.7.0"}, "awkward-cpp": {"depends": ["numpy"], "file_name": "awkward_cpp-44-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["awkward_cpp"], "install_dir": "site", "name": "awkward-cpp", "package_type": "package", "sha256": "ccd2a1742dec5a3d4e131006ff209c8c3d8ebfd6ae37edbfb0115f5b022a337f", "unvendored_tests": false, "version": "44"}, "b2d": {"depends": ["numpy", "pydantic", "setuptools", "annotated-types"], "file_name": "b2d-0.7.4-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["b2d"], "install_dir": "site", "name": "b2d", "package_type": "package", "sha256": "a668e2b7a8d0a9f70b48371d1d5e766948c0ad4db961b18d0e8a4f312b2e0228", "unvendored_tests": false, "version": "0.7.4"}, "bcrypt": {"depends": [], "file_name": "bcrypt-4.3.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["bcrypt"], "install_dir": "site", "name": "bcrypt", "package_type": "package", "sha256": "25352fa4cba1c74fd42d9fe40917a33fda97b0d2e94b637d2728b096216ea9a6", "unvendored_tests": false, "version": "4.3.0"}, "beautifulsoup4": {"depends": ["soupsieve", "typing-extensions"], "file_name": "beautifulsoup4-4.13.3-py3-none-any.whl", "imports": ["bs4"], "install_dir": "site", "name": "beautifulsoup4", "package_type": "package", "sha256": "fe75cf3aa47f3b170ecb540c76d1485f4a25253f3c5af449f962eb18c62f81ef", "unvendored_tests": true, "version": "4.13.3"}, "beautifulsoup4-tests": {"depends": ["beautifulsoup4"], "file_name": "beautifulsoup4-tests.tar", "imports": [], "install_dir": "site", "name": "beautifulsoup4-tests", "package_type": "package", "sha256": "aa147920cbb967e99a3b628501a627d290372677991407f11d7caafeab772386", "unvendored_tests": false, "version": "4.13.3"}, "biopython": {"depends": ["numpy"], "file_name": "biopython-1.85-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["Bio", "BioSQL"], "install_dir": "site", "name": "biopython", "package_type": "package", "sha256": "a17b69c3ee4cf2f9e00758903ba98f58b37c4729b2f3b23e8c2949bc33fcc184", "unvendored_tests": false, "version": "1.85"}, "bitarray": {"depends": [], "file_name": "bitarray-3.4.3-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["bitarray"], "install_dir": "site", "name": "bitarray", "package_type": "package", "sha256": "a8a8e8ae607b6a275c5262733fcdf6c6ec08e3653b0bd7643288a96786924161", "unvendored_tests": true, "version": "3.4.3"}, "bitarray-tests": {"depends": ["bitarray"], "file_name": "bitarray-tests.tar", "imports": [], "install_dir": "site", "name": "bitarray-tests", "package_type": "package", "sha256": "3be51ab80c7c7a09b4d4849bb2ad45fa5d184e018a0f67e488632ac2536f1ca7", "unvendored_tests": false, "version": "3.4.3"}, "bitstring": {"depends": ["bitarray"], "file_name": "bitstring-4.3.1-py3-none-any.whl", "imports": ["bitstring"], "install_dir": "site", "name": "bitstring", "package_type": "package", "sha256": "49da61f3aa603f92188cfe720bb8b672fcdc69757af997935d41a127e884112e", "unvendored_tests": false, "version": "4.3.1"}, "bleach": {"depends": ["webencodings", "packaging", "six"], "file_name": "bleach-6.2.0-py3-none-any.whl", "imports": ["bleach"], "install_dir": "site", "name": "bleach", "package_type": "package", "sha256": "c11288a465a2a2ec3106ac793f3eaa0260150dad14864a1c5e8b86c7c338877e", "unvendored_tests": false, "version": "6.2.0"}, "blosc2": {"depends": ["numpy", "msgpack", "requests", "ndindex", "platformdirs"], "file_name": "blosc2-3.2.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["blosc2"], "install_dir": "site", "name": "blosc2", "package_type": "package", "sha256": "12f02342fe0b54fedf7cbdc87404b306e2d9d366c20be274beeadf20b0f6dc5d", "unvendored_tests": false, "version": "3.2.0"}, "bokeh": {"depends": ["contourpy", "numpy", "jinja2", "pandas", "pillow", "python-dateutil", "six", "typing-extensions", "pyyaml", "xyzservices"], "file_name": "bokeh-3.6.3-py3-none-any.whl", "imports": ["bokeh"], "install_dir": "site", "name": "bokeh", "package_type": "package", "sha256": "d2dc4b04e17f2edc47df972e4932243f27fd34e4beaa64a343cd0d243b0e6ae2", "unvendored_tests": false, "version": "3.6.3"}, "boost-histogram": {"depends": ["numpy"], "file_name": "boost_histogram-1.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["boost_histogram"], "install_dir": "site", "name": "boost-histogram", "package_type": "package", "sha256": "43d359caa1b1f81ee4917b2f1f25ff149fcbd46b7f73574b2c93b170ca201153", "unvendored_tests": false, "version": "1.5.0"}, "brotli": {"depends": [], "file_name": "brotli-1.1.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["brotli"], "install_dir": "site", "name": "brotli", "package_type": "package", "sha256": "5c560e9c1fd9de9a77b788b14e2862335583fe1c4e78dc3596ec8e459264ac22", "unvendored_tests": false, "version": "1.1.0"}, "cachetools": {"depends": [], "file_name": "cachetools-5.5.2-py3-none-any.whl", "imports": ["cachetools"], "install_dir": "site", "name": "cachetools", "package_type": "package", "sha256": "3705098c32ffef1f916dac2b4d9d2132ea3c1d2e2c40f2700d84db3ee2a2fd65", "unvendored_tests": false, "version": "5.5.2"}, "casadi": {"depends": ["numpy"], "file_name": "casadi-3.7.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["casadi"], "install_dir": "site", "name": "casadi", "package_type": "package", "sha256": "d74d9c77293a2c487a3e856a794975cbee98bd9c0a28de8f389622fe75fefe1f", "unvendored_tests": false, "version": "3.7.0"}, "cbor-diag": {"depends": [], "file_name": "cbor_diag-1.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cbor_diag"], "install_dir": "site", "name": "cbor-diag", "package_type": "package", "sha256": "fd5fe36a4538e2446dac42d8d5ef415c9f336be4066e69504d2f541fea9d099c", "unvendored_tests": false, "version": "1.0.1"}, "certifi": {"depends": [], "file_name": "certifi-2025.6.15-py3-none-any.whl", "imports": ["certifi"], "install_dir": "site", "name": "certifi", "package_type": "package", "sha256": "34f344ea116df36539073746484be3f2914f8e47fedcafde80883573b602f658", "unvendored_tests": false, "version": "2025.6.15"}, "cffi": {"depends": ["pycparser"], "file_name": "cffi-1.17.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cffi"], "install_dir": "site", "name": "cffi", "package_type": "package", "sha256": "dd100149a1a88593f1ec3d493d3cbad078cf8f731c801b8c6f192b1316f5ced2", "unvendored_tests": false, "version": "1.17.1"}, "cffi-example": {"depends": ["cffi"], "file_name": "cffi_example-0.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cffi_example"], "install_dir": "site", "name": "cffi_example", "package_type": "package", "sha256": "05fdca4056454ce1c40719e4fe15b63ae1217bd09fc0377369c6ec5515ef9861", "unvendored_tests": false, "version": "0.1"}, "cftime": {"depends": ["numpy"], "file_name": "cftime-1.6.4.post1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cftime"], "install_dir": "site", "name": "cftime", "package_type": "package", "sha256": "f9c0ce67ef6d5361c253e8dad559456b0070273779c3ba27c773ddb2e48cd52a", "unvendored_tests": false, "version": "1.6.4.post1"}, "charset-normalizer": {"depends": [], "file_name": "charset_normalizer-3.4.2-py3-none-any.whl", "imports": ["charset_normalizer"], "install_dir": "site", "name": "charset-normalizer", "package_type": "package", "sha256": "f739b10c6fea56128c644f0a77eb664d3d48150e66c265564455e5f2da11a68e", "unvendored_tests": false, "version": "3.4.2"}, "clarabel": {"depends": ["numpy", "scipy"], "file_name": "clarabel-0.11.0-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["clarabel"], "install_dir": "site", "name": "clarabel", "package_type": "package", "sha256": "37afbf23f26593d557f756b60b87ee3da4fbd16ee91e6f569550f845a7a5102b", "unvendored_tests": false, "version": "0.11.0"}, "click": {"depends": [], "file_name": "click-8.2.1-py3-none-any.whl", "imports": ["click"], "install_dir": "site", "name": "click", "package_type": "package", "sha256": "c65be2855aad0770696533b37fb4b2ab0ac34922170994988159c7f650cea421", "unvendored_tests": false, "version": "8.2.1"}, "cligj": {"depends": ["click"], "file_name": "cligj-0.7.2-py3-none-any.whl", "imports": ["cligj"], "install_dir": "site", "name": "cligj", "package_type": "package", "sha256": "5afdfcfc698099562593e31f26723ab962725399f19f34d9dcaa716516fdd517", "unvendored_tests": false, "version": "0.7.2"}, "clingo": {"depends": ["cffi"], "file_name": "clingo-5.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["clingo"], "install_dir": "site", "name": "clingo", "package_type": "package", "sha256": "f6191904da5969329d62f4ed0c1eceb9b582f712d94538600dcc40b3ad269a96", "unvendored_tests": false, "version": "5.7.1"}, "cloudpickle": {"depends": [], "file_name": "cloudpickle-3.1.1-py3-none-any.whl", "imports": ["cloudpickle"], "install_dir": "site", "name": "cloudpickle", "package_type": "package", "sha256": "f7b8dd1af13ee72e25accf6867f56192b70c8ab99e73f403f97130409afb2bb8", "unvendored_tests": false, "version": "3.1.1"}, "cmyt": {"depends": ["colorspacious", "matplotlib", "more-itertools", "numpy"], "file_name": "cmyt-2.0.2-py3-none-any.whl", "imports": ["cmyt"], "install_dir": "site", "name": "cmyt", "package_type": "package", "sha256": "87262e9c5824fcef985f363eed7beba1de4f40082b0886630a031a70b35f3acc", "unvendored_tests": false, "version": "2.0.2"}, "colorspacious": {"depends": ["numpy"], "file_name": "colorspacious-1.1.2-py2.py3-none-any.whl", "imports": ["colorspacious"], "install_dir": "site", "name": "colorspacious", "package_type": "package", "sha256": "e645eb0c1daa2fbeeca627832e5673be93d95a4a8b30a278b91aad807c0c678d", "unvendored_tests": false, "version": "1.1.2"}, "contourpy": {"depends": ["numpy"], "file_name": "contourpy-1.3.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["contourpy"], "install_dir": "site", "name": "contourpy", "package_type": "package", "sha256": "0ae34ad80db2785ed3287fbc2b12a13a28421468323a14199fc4b79276193ba2", "unvendored_tests": false, "version": "1.3.1"}, "coolprop": {"depends": ["numpy", "matplotlib"], "file_name": "coolprop-6.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["CoolProp"], "install_dir": "site", "name": "coolprop", "package_type": "package", "sha256": "f2e660b352c1f97b9eee9c80a00fefe37de0045a30a414131e50c726c8a9d802", "unvendored_tests": true, "version": "6.6.0"}, "coolprop-tests": {"depends": ["coolprop"], "file_name": "coolprop-tests.tar", "imports": [], "install_dir": "site", "name": "coolprop-tests", "package_type": "package", "sha256": "5edfdcab2a1326454adfe019fe1bc1091dd5f7db2c02ed7ca371b766d8108bfc", "unvendored_tests": false, "version": "6.6.0"}, "coverage": {"depends": ["sqlite3"], "file_name": "coverage-7.6.12-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["coverage"], "install_dir": "site", "name": "coverage", "package_type": "package", "sha256": "61f1acfff0f375af8e5dc7582c00e083f03b08bd5395c738c7f440b22b6bd597", "unvendored_tests": false, "version": "7.6.12"}, "cramjam": {"depends": [], "file_name": "cramjam-2.10.0rc1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cramjam"], "install_dir": "site", "name": "cramjam", "package_type": "package", "sha256": "c6b592d858f8eb4d6104f61b802aaa2358325a97990c56b32f1427164cd55c9e", "unvendored_tests": false, "version": "2.10.0rc1"}, "crc32c": {"depends": [], "file_name": "crc32c-2.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["crc32c"], "install_dir": "site", "name": "crc32c", "package_type": "package", "sha256": "88bf2eebc3e82e162a11f7d92f26e664917cf1223294b8f12b08bb885a55c484", "unvendored_tests": false, "version": "2.7.1"}, "cryptography": {"depends": ["openssl", "six", "cffi"], "file_name": "cryptography-45.0.4-cp313-abi3-pyodide_2025_0_wasm32.whl", "imports": ["cryptography"], "install_dir": "site", "name": "cryptography", "package_type": "package", "sha256": "5c1a0c742e855b1cdfa1d73d5d57d8d3961915ef67462bd46397b335f427ad58", "unvendored_tests": false, "version": "45.0.4"}, "css-inline": {"depends": [], "file_name": "css_inline-0.15.0-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["css_inline"], "install_dir": "site", "name": "css-inline", "package_type": "package", "sha256": "ec6e9544d33bac297c179f5c19c3d8c540b2e41e8534f7be59f49f05b3341607", "unvendored_tests": false, "version": "0.15.0"}, "cssselect": {"depends": [], "file_name": "cssselect-1.3.0-py3-none-any.whl", "imports": ["cssselect"], "install_dir": "site", "name": "cssselect", "package_type": "package", "sha256": "d2355faa0382b7fe97e77d0102e3450d5aac5357d23f3f9fef6141805fc5e8e3", "unvendored_tests": false, "version": "1.3.0"}, "cvxpy-base": {"depends": ["numpy", "scipy", "clarabel"], "file_name": "cvxpy_base-1.6.3-py3-none-any.whl", "imports": ["cvxpy"], "install_dir": "site", "name": "cvxpy-base", "package_type": "package", "sha256": "43bd3151bade968a1b8e9b047ec7170983cb88bf35145d6fccd5263fe341f08e", "unvendored_tests": true, "version": "1.6.3"}, "cvxpy-base-tests": {"depends": ["cvxpy-base"], "file_name": "cvxpy-base-tests.tar", "imports": [], "install_dir": "site", "name": "cvxpy-base-tests", "package_type": "package", "sha256": "744a6754f2b815cde377dd70a3f48db1da1c1628693dbc2e3484588e58dd09ec", "unvendored_tests": false, "version": "1.6.3"}, "cycler": {"depends": ["six"], "file_name": "cycler-0.12.1-py3-none-any.whl", "imports": ["cycler"], "install_dir": "site", "name": "cycler", "package_type": "package", "sha256": "60140c464c2871fe5f5fd1a5af60e6fa62afb6a45f21e461400ec9e233cb0067", "unvendored_tests": false, "version": "0.12.1"}, "cysignals": {"depends": [], "file_name": "cysignals-1.12.3-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cysignals"], "install_dir": "site", "name": "cysignals", "package_type": "package", "sha256": "5eef4fa816e53939080b4dfaae65b99bb42893ea6bc97080be28f70241f6bbb1", "unvendored_tests": false, "version": "1.12.3"}, "cytoolz": {"depends": ["toolz"], "file_name": "cytoolz-1.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cytoolz"], "install_dir": "site", "name": "cytoolz", "package_type": "package", "sha256": "681ecb04424b7195617a3e8ebaf71b99e9e4fed0fad32360996df8f5c53d9a0c", "unvendored_tests": true, "version": "1.0.1"}, "cytoolz-tests": {"depends": ["cytoolz"], "file_name": "cytoolz-tests.tar", "imports": [], "install_dir": "site", "name": "cytoolz-tests", "package_type": "package", "sha256": "286cabab5f97dd49effd1e5214e3070e4ced3ce877ed50dc338d31239d3e64d7", "unvendored_tests": false, "version": "1.0.1"}, "decorator": {"depends": [], "file_name": "decorator-5.2.1-py3-none-any.whl", "imports": ["decorator"], "install_dir": "site", "name": "decorator", "package_type": "package", "sha256": "1400a05889521c3e5f7c6ed0b1db4d27d4894fbe480dc44f58b4a9809d5bbf58", "unvendored_tests": false, "version": "5.2.1"}, "demes": {"depends": ["attrs", "ruamel.yaml"], "file_name": "demes-0.2.3-py3-none-any.whl", "imports": ["demes"], "install_dir": "site", "name": "demes", "package_type": "package", "sha256": "bdc3f3fac58e17214549d2c5932c83038ed1a6fefa551801b21b1dff3ae28114", "unvendored_tests": false, "version": "0.2.3"}, "deprecation": {"depends": ["packaging"], "file_name": "deprecation-2.1.0-py2.py3-none-any.whl", "imports": ["deprecation"], "install_dir": "site", "name": "deprecation", "package_type": "package", "sha256": "a3383a37fa64bc98b553486cdf8ac13119456a4991de6470295e9941731ba12c", "unvendored_tests": false, "version": "2.1.0"}, "diskcache": {"depends": ["sqlite3"], "file_name": "diskcache-5.6.3-py3-none-any.whl", "imports": ["diskcache"], "install_dir": "site", "name": "diskcache", "package_type": "package", "sha256": "af33b8960c5bef913cd9046517ecae0d1d5cff14f1907f7713173c7a54910d8e", "unvendored_tests": false, "version": "5.6.3"}, "distlib": {"depends": [], "file_name": "distlib-0.3.9-py2.py3-none-any.whl", "imports": ["distlib"], "install_dir": "site", "name": "distlib", "package_type": "package", "sha256": "4a84453e0b6d146e1e947996c118ba6601e457888bd75993f3f4459ab1e1e6d6", "unvendored_tests": false, "version": "0.3.9"}, "distro": {"depends": [], "file_name": "distro-1.9.0-py3-none-any.whl", "imports": ["distro"], "install_dir": "site", "name": "distro", "package_type": "package", "sha256": "8d73eb1ec31e96b5881b703c315ad563c5cdb4a10437c7700bd5f40c19a0b1dc", "unvendored_tests": false, "version": "1.9.0"}, "docutils": {"depends": [], "file_name": "docutils-0.21.2-py3-none-any.whl", "imports": ["docutils"], "install_dir": "site", "name": "docutils", "package_type": "package", "sha256": "49a3a930ceec10f2e27b0f921dd22f969d361c7deb7a4a89dfd2c5f939e1ae48", "unvendored_tests": false, "version": "0.21.2"}, "donfig": {"depends": ["pyyaml"], "file_name": "donfig-0.8.1.post1-py3-none-any.whl", "imports": ["donfig"], "install_dir": "site", "name": "donfig", "package_type": "package", "sha256": "ec67d0f05eed16c5c73dca230a64e958104f76fa53b9a9a5eca1e69aa595eaab", "unvendored_tests": true, "version": "0.8.1.post1"}, "donfig-tests": {"depends": ["donfig"], "file_name": "donfig-tests.tar", "imports": [], "install_dir": "site", "name": "donfig-tests", "package_type": "package", "sha256": "83fa5d3097958bf93842e65dd6682227af0cef1c8c56319f608635d214b98d69", "unvendored_tests": false, "version": "0.8.1.post1"}, "ewah-bool-utils": {"depends": ["numpy"], "file_name": "ewah_bool_utils-1.2.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["ewah_bool_utils"], "install_dir": "site", "name": "ewah_bool_utils", "package_type": "package", "sha256": "716c4c87193a310171ff97ca2f63fee40b8162e882032edec4619bbd57d4f0a0", "unvendored_tests": true, "version": "1.2.2"}, "ewah-bool-utils-tests": {"depends": ["ewah_bool_utils"], "file_name": "ewah-bool-utils-tests.tar", "imports": [], "install_dir": "site", "name": "ewah_bool_utils-tests", "package_type": "package", "sha256": "1353af4387ef97d6833a7aa38142d67777c7fbbff30a42743407ba4ba85825d3", "unvendored_tests": false, "version": "1.2.2"}, "exceptiongroup": {"depends": [], "file_name": "exceptiongroup-1.2.2-py3-none-any.whl", "imports": ["exceptiongroup"], "install_dir": "site", "name": "exceptiongroup", "package_type": "package", "sha256": "0317f3602a18d865726e990254d77559a96c3787bf13af8674364f7e720a9304", "unvendored_tests": false, "version": "1.2.2"}, "executing": {"depends": [], "file_name": "executing-2.2.0-py2.py3-none-any.whl", "imports": ["executing"], "install_dir": "site", "name": "executing", "package_type": "package", "sha256": "4d034f044c816cacc71402b83c42c355d83aeaf2628ffa7239c22914559ddff6", "unvendored_tests": false, "version": "2.2.0"}, "fastparquet": {"depends": ["numpy", "cramjam", "pandas", "fsspec", "packaging"], "file_name": "fastparquet-2024.11.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["fastparquet"], "install_dir": "site", "name": "fastparquet", "package_type": "package", "sha256": "96d109929c6a2e860eef6dc5df29e4469a67e06b5d29ac6bd4f853ce5a55c5d8", "unvendored_tests": false, "version": "2024.11.0"}, "fiona": {"depends": ["attrs", "certifi", "setuptools", "six", "click", "cligj"], "file_name": "fiona-1.9.5-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["fiona"], "install_dir": "site", "name": "fiona", "package_type": "package", "sha256": "ae6de09f68068cca47af39df0a60a356417ffa2312e9c046e508a47cbb0a9127", "unvendored_tests": false, "version": "1.9.5"}, "fonttools": {"depends": [], "file_name": "fonttools-4.56.0-py3-none-any.whl", "imports": ["fontTools"], "install_dir": "site", "name": "fonttools", "package_type": "package", "sha256": "83b9708f6441f6a0f2af6335bb8e069770e541e7b01854807ca550f26fe727ed", "unvendored_tests": false, "version": "4.56.0"}, "freesasa": {"depends": [], "file_name": "freesasa-2.2.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["freesasa"], "install_dir": "site", "name": "freesasa", "package_type": "package", "sha256": "a0a1cc352efdde6b7badbb105e42f2f3b4183942b1a1acd064a6044ed9745294", "unvendored_tests": false, "version": "2.2.1"}, "frozenlist": {"depends": [], "file_name": "frozenlist-1.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["frozenlist"], "install_dir": "site", "name": "frozenlist", "package_type": "package", "sha256": "e21b3e493e0c26e89940eddbadfd66f2f101f89f832443bb1f28d249717ad371", "unvendored_tests": false, "version": "1.6.0"}, "fsspec": {"depends": [], "file_name": "fsspec-2025.3.2-py3-none-any.whl", "imports": ["fsspec"], "install_dir": "site", "name": "fsspec", "package_type": "package", "sha256": "8b7c119b065b3b4ee0576ffc5c99e9a398d6e36edd79de4fef6db3215182ee57", "unvendored_tests": true, "version": "2025.3.2"}, "fsspec-tests": {"depends": ["fsspec"], "file_name": "fsspec-tests.tar", "imports": [], "install_dir": "site", "name": "fsspec-tests", "package_type": "package", "sha256": "4a5977df5c5b98378b89fd4522d4d7993d71842bdb139f50f2ecf6fd6f8dcb4d", "unvendored_tests": false, "version": "2025.3.2"}, "future": {"depends": [], "file_name": "future-1.0.0-py3-none-any.whl", "imports": ["future"], "install_dir": "site", "name": "future", "package_type": "package", "sha256": "8da835470ea2ecb0d61b56b7066aa269b1ffbd691776bde1f9a5f92f50eff5c6", "unvendored_tests": true, "version": "1.0.0"}, "future-tests": {"depends": ["future"], "file_name": "future-tests.tar", "imports": [], "install_dir": "site", "name": "future-tests", "package_type": "package", "sha256": "c56fbb3b3e9ed16eba5459f063d72580a07ec8ab3495dd9d2ac6bd3fbc186086", "unvendored_tests": false, "version": "1.0.0"}, "galpy": {"depends": ["numpy", "scipy", "matplotlib", "astropy", "future", "setuptools"], "file_name": "galpy-1.10.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["galpy"], "install_dir": "site", "name": "galpy", "package_type": "package", "sha256": "22676bf99298cf19700b8aa94d86faa8c83251574ca19141c2e463ec0b493fb3", "unvendored_tests": false, "version": "1.10.2"}, "gdal": {"depends": ["geos"], "file_name": "gdal-3.8.3.zip", "imports": [], "install_dir": "dynlib", "name": "gdal", "package_type": "shared_library", "sha256": "664f3dbfa278fdd7f6bc6174f46823b87ef2cf66b1e52c994a61e347ed840d06", "unvendored_tests": false, "version": "3.8.3"}, "geos": {"depends": [], "file_name": "geos-3.12.1.zip", "imports": [], "install_dir": "dynlib", "name": "geos", "package_type": "shared_library", "sha256": "0011df887be4d002cea5c04ed378e6cb39f387b33aff478cae3308cfd21ba744", "unvendored_tests": false, "version": "3.12.1"}, "gmpy2": {"depends": [], "file_name": "gmpy2-2.1.5-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["gmpy2"], "install_dir": "site", "name": "gmpy2", "package_type": "package", "sha256": "04c7f6f7f17dc2e84d8e7b2af2a9ea98c1282a4dd36183378476b5c73962389a", "unvendored_tests": false, "version": "2.1.5"}, "gsw": {"depends": ["numpy"], "file_name": "gsw-3.6.19-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["gsw"], "install_dir": "site", "name": "gsw", "package_type": "package", "sha256": "1c5bf7a83ef5328d2210214f1c0148100e532c68579ae902f0b8a744007189ec", "unvendored_tests": true, "version": "3.6.19"}, "gsw-tests": {"depends": ["gsw"], "file_name": "gsw-tests.tar", "imports": [], "install_dir": "site", "name": "gsw-tests", "package_type": "package", "sha256": "06ac5100474696aee38229b38cd6f1a7a75a0a9ce32b333244892b39cd201da4", "unvendored_tests": false, "version": "3.6.19"}, "h11": {"depends": [], "file_name": "h11-0.14.0-py3-none-any.whl", "imports": ["h11"], "install_dir": "site", "name": "h11", "package_type": "package", "sha256": "65b5e2ba4f61ba9b5a39bdf4d415bf59dcede6265bfd2ad9119b6f578aa5861f", "unvendored_tests": true, "version": "0.14.0"}, "h11-tests": {"depends": ["h11"], "file_name": "h11-tests.tar", "imports": [], "install_dir": "site", "name": "h11-tests", "package_type": "package", "sha256": "b2673fb8f96ae18f00850b30005e4d1dbf275f014f06449c26578c00de8a8a1b", "unvendored_tests": false, "version": "0.14.0"}, "h3": {"depends": [], "file_name": "h3-4.2.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["h3"], "install_dir": "site", "name": "h3", "package_type": "package", "sha256": "c9fcf27b86f7943f849fbd679d53580890bb4e366613074464c8c03d42aaead2", "unvendored_tests": false, "version": "4.2.2"}, "h5py": {"depends": ["numpy", "pkgconfig", "libhdf5"], "file_name": "h5py-3.13.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["h5py"], "install_dir": "site", "name": "h5py", "package_type": "package", "sha256": "e411d98215e91b3e2cdaa1931181f837a9bbd8d5adb74ce5f66675dfabbdf9dc", "unvendored_tests": true, "version": "3.13.0"}, "h5py-tests": {"depends": ["h5py"], "file_name": "h5py-tests.tar", "imports": [], "install_dir": "site", "name": "h5py-tests", "package_type": "package", "sha256": "f07228ea926ee31c8c1bf62a689c6c7bf12811cc53d68a787915c2ecfbf030a1", "unvendored_tests": false, "version": "3.13.0"}, "hashlib": {"depends": ["openssl"], "file_name": "hashlib-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["_hashlib"], "install_dir": "site", "name": "hashlib", "package_type": "cpython_module", "sha256": "deaade81d8c34674f2f15b9001865e1523023ab73d42343a55f28dbd40067708", "unvendored_tests": false, "version": "1.0.0"}, "html5lib": {"depends": ["webencodings", "six"], "file_name": "html5lib-1.1-py2.py3-none-any.whl", "imports": ["html5lib"], "install_dir": "site", "name": "html5lib", "package_type": "package", "sha256": "6d90a322f3af6e77bd84af39e1e9a54f9a6107633f33b02a39c261d3a83ca5d1", "unvendored_tests": false, "version": "1.1"}, "httpcore": {"depends": ["certifi", "h11", "ssl"], "file_name": "httpcore-1.0.7-py3-none-any.whl", "imports": ["httpcore"], "install_dir": "site", "name": "httpcore", "package_type": "package", "sha256": "eb1cf4c57497190439b4f882b13891bfdc5fdc62c95a2dd15a92986930225a58", "unvendored_tests": false, "version": "1.0.7"}, "httpx": {"depends": [], "file_name": "httpx-0.28.1-py3-none-any.whl", "imports": ["httpx"], "install_dir": "site", "name": "httpx", "package_type": "package", "sha256": "685478eeb6483ce1d2763b43a65a6cdfe5e896e1cbe06755ceb25a41faa0584b", "unvendored_tests": false, "version": "0.28.1"}, "idna": {"depends": [], "file_name": "idna-3.10-py3-none-any.whl", "imports": ["idna"], "install_dir": "site", "name": "idna", "package_type": "package", "sha256": "f888c1ff570957d24fb2065102bc8f62ba69ede4ef641783385c8e0c2bb56984", "unvendored_tests": false, "version": "3.10"}, "igraph": {"depends": ["texttable"], "file_name": "igraph-0.11.8-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["igraph"], "install_dir": "site", "name": "igraph", "package_type": "package", "sha256": "0a59cc54fa0a084db9caab5a99d5b87baf03280b72f0372761157f3d9cbc2dcb", "unvendored_tests": false, "version": "0.11.8"}, "imageio": {"depends": ["numpy", "pillow"], "file_name": "imageio-2.37.0-py3-none-any.whl", "imports": ["imageio"], "install_dir": "site", "name": "imageio", "package_type": "package", "sha256": "197c2454781c216c2cbebfc370bea23413a08ade1e78a3babd07eea9fa6f540f", "unvendored_tests": false, "version": "2.37.0"}, "imgui-bundle": {"depends": ["pydantic", "munch", "numpy"], "file_name": "imgui_bundle-1.92.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["imgui_bundle"], "install_dir": "site", "name": "imgui-bundle", "package_type": "package", "sha256": "aaadfc38ced1d79943e38df3ed09b637bc516c00d0a084107d2d06c27cddd750", "unvendored_tests": true, "version": "1.92.0"}, "imgui-bundle-tests": {"depends": ["imgui-bundle"], "file_name": "imgui-bundle-tests.tar", "imports": [], "install_dir": "site", "name": "imgui-bundle-tests", "package_type": "package", "sha256": "5f1be5d6a90f16ccf0682a956e5236cf13404f4fa80f6b25814cec0d23c52f09", "unvendored_tests": false, "version": "1.92.0"}, "iminuit": {"depends": ["numpy"], "file_name": "iminuit-2.30.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["iminuit"], "install_dir": "site", "name": "iminuit", "package_type": "package", "sha256": "835b5efeaf235d5ebd35d6cb507aa7fea1ea685048a24ff4e815e2db52852900", "unvendored_tests": false, "version": "2.30.1"}, "iniconfig": {"depends": [], "file_name": "iniconfig-2.1.0-py3-none-any.whl", "imports": ["iniconfig"], "install_dir": "site", "name": "iniconfig", "package_type": "package", "sha256": "d45d0eaa6ec4725afa4ae442473f2bc3a0f8568936bb93f028e6f217be1ac3c9", "unvendored_tests": false, "version": "2.1.0"}, "inspice": {"depends": ["numpy", "matplotlib", "pyyaml", "cffi", "diskcache", "h5py", "ply", "ngspice"], "file_name": "inspice-1.6.3.3-py3-none-any.whl", "imports": ["InSpice"], "install_dir": "site", "name": "inspice", "package_type": "package", "sha256": "c112eca96fb2130ce9c5e8f699e5c35578fa0f93b630c7643abc1b215b879f84", "unvendored_tests": false, "version": "1.6.3.3"}, "ipython": {"depends": ["asttokens", "decorator", "executing", "matplotlib-inline", "prompt_toolkit", "pure-eval", "pygments", "six", "stack-data", "traitlets", "sqlite3", "wcwidth"], "file_name": "ipython-9.0.2-py3-none-any.whl", "imports": ["IPython"], "install_dir": "site", "name": "ipython", "package_type": "package", "sha256": "59c578831b614587462fa22f3fc0ff243b31be5dc9b075f8c922cbe6315e559b", "unvendored_tests": true, "version": "9.0.2"}, "ipython-tests": {"depends": ["ipython"], "file_name": "ipython-tests.tar", "imports": [], "install_dir": "site", "name": "ipython-tests", "package_type": "package", "sha256": "cd83ccc4b6799eed27647090c5eb9efe3c78bca76a67524b8fb3f0e1b3c53395", "unvendored_tests": false, "version": "9.0.2"}, "jedi": {"depends": ["parso"], "file_name": "jedi-0.19.2-py2.py3-none-any.whl", "imports": ["jedi"], "install_dir": "site", "name": "jedi", "package_type": "package", "sha256": "0803be24e44929037a5dbdbda54094a1ff4d9096b4d1d6ae5ece3038cedf2ea8", "unvendored_tests": true, "version": "0.19.2"}, "jedi-tests": {"depends": ["jedi"], "file_name": "jedi-tests.tar", "imports": [], "install_dir": "site", "name": "jedi-tests", "package_type": "package", "sha256": "71b033ab89313e07089b1e5f0a64519d5d46a72a1a0b2d192faddf204ce7dbd1", "unvendored_tests": false, "version": "0.19.2"}, "jinja2": {"depends": ["markupsafe"], "file_name": "jinja2-3.1.6-py3-none-any.whl", "imports": ["jinja2"], "install_dir": "site", "name": "Jinja2", "package_type": "package", "sha256": "ff2978788e7e365a0c54db60c9148cce57faa47da58a85f5e5c59a9b3535548d", "unvendored_tests": false, "version": "3.1.6"}, "jiter": {"depends": [], "file_name": "jiter-0.9.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["jiter"], "install_dir": "site", "name": "jiter", "package_type": "package", "sha256": "8451fe067f065b36cb2827245cac0784be155e7fb190d04171a7576f578b4a85", "unvendored_tests": false, "version": "0.9.0"}, "joblib": {"depends": [], "file_name": "joblib-1.4.2-py3-none-any.whl", "imports": ["joblib"], "install_dir": "site", "name": "joblib", "package_type": "package", "sha256": "0442695c4d63401b25202dd7db4fb3027085612364ee5ce077a39f3329ca75a9", "unvendored_tests": true, "version": "1.4.2"}, "joblib-tests": {"depends": ["joblib"], "file_name": "joblib-tests.tar", "imports": [], "install_dir": "site", "name": "joblib-tests", "package_type": "package", "sha256": "6ab5173cd1f9c7647939a25f5ea9f4e2771a8d10155e2c9799268f69cb99bc43", "unvendored_tests": false, "version": "1.4.2"}, "jsonschema": {"depends": ["attrs", "pyrsistent", "referencing", "jsonschema_specifications"], "file_name": "jsonschema-4.23.0-py3-none-any.whl", "imports": ["jsonschema"], "install_dir": "site", "name": "jsonschema", "package_type": "package", "sha256": "32b026eff49092899a6d88ec14349c07f8d56a35314d6d50220f2852cb60706d", "unvendored_tests": true, "version": "4.23.0"}, "jsonschema-specifications": {"depends": ["referencing"], "file_name": "jsonschema_specifications-2024.10.1-py3-none-any.whl", "imports": ["jsonschema_specifications"], "install_dir": "site", "name": "jsonschema_specifications", "package_type": "package", "sha256": "1eadaf86253f6d69e7b340fe3669977f8649a5d186b114df0172d0897beb7826", "unvendored_tests": true, "version": "2024.10.1"}, "jsonschema-specifications-tests": {"depends": ["jsonschema_specifications"], "file_name": "jsonschema-specifications-tests.tar", "imports": [], "install_dir": "site", "name": "jsonschema_specifications-tests", "package_type": "package", "sha256": "8cfcdfe0dc5e9b8f2ea66e593720632271f808e7ccdd417b89a7f2432e0f02fe", "unvendored_tests": false, "version": "2024.10.1"}, "jsonschema-tests": {"depends": ["jsonschema"], "file_name": "jsonschema-tests.tar", "imports": [], "install_dir": "site", "name": "jsonschema-tests", "package_type": "package", "sha256": "546157d14a067366c86e8158dda940d98e928631a6e7b7864e3477ceed8df694", "unvendored_tests": false, "version": "4.23.0"}, "kiwisolver": {"depends": [], "file_name": "kiwisolver-1.4.8-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["kiwisolver"], "install_dir": "site", "name": "kiwisolver", "package_type": "package", "sha256": "1fa28ace818eca90ba628f4644f4481b161112519b166436822d0089b1c73b04", "unvendored_tests": false, "version": "1.4.8"}, "lakers-python": {"depends": [], "file_name": "lakers_python-0.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["lakers"], "install_dir": "site", "name": "lakers-python", "package_type": "package", "sha256": "706bbc442de92783f2231a5f722e7774da804c900043676ae39f4953a4640ad3", "unvendored_tests": false, "version": "0.5.0"}, "lazy-loader": {"depends": [], "file_name": "lazy_loader-0.4-py3-none-any.whl", "imports": ["lazy_loader"], "install_dir": "site", "name": "lazy_loader", "package_type": "package", "sha256": "922fd3357bd62c5dff8759a3be9b62d9da75aed5f94b8107b67898b566fe7136", "unvendored_tests": true, "version": "0.4"}, "lazy-loader-tests": {"depends": ["lazy_loader"], "file_name": "lazy-loader-tests.tar", "imports": [], "install_dir": "site", "name": "lazy_loader-tests", "package_type": "package", "sha256": "6b782454b8e8f383fa65919c5a647ac293b718cdf579b0404ac978ce4c8db942", "unvendored_tests": false, "version": "0.4"}, "lazy-object-proxy": {"depends": [], "file_name": "lazy_object_proxy-1.10.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["lazy_object_proxy"], "install_dir": "site", "name": "lazy-object-proxy", "package_type": "package", "sha256": "571f6f7589091a5eb8a065045c2d0440c9d82503c51c107720ccc9d11d1b9b2b", "unvendored_tests": false, "version": "1.10.0"}, "libcst": {"depends": ["pyyaml"], "file_name": "libcst-1.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["libcst"], "install_dir": "site", "name": "libcst", "package_type": "package", "sha256": "15d65ebc583c198a013f8afc4178ac81b206fc1c69b68faac0956cbd67b6f3f5", "unvendored_tests": true, "version": "1.6.0"}, "libcst-tests": {"depends": ["libcst"], "file_name": "libcst-tests.tar", "imports": [], "install_dir": "site", "name": "libcst-tests", "package_type": "package", "sha256": "4cf167627d6404df77ebba023c1ec0b6cbb4f35ca7c9e3c94aea01bde75a338d", "unvendored_tests": false, "version": "1.6.0"}, "libhdf5": {"depends": [], "file_name": "libhdf5-1.12.1.zip", "imports": [], "install_dir": "dynlib", "name": "libhdf5", "package_type": "shared_library", "sha256": "12980932a0c925031343f244966803d9b7427bc83c6968a0e9b8c9f8d06b98d6", "unvendored_tests": false, "version": "1.12.1"}, "libheif": {"depends": [], "file_name": "libheif-1.12.0.zip", "imports": [], "install_dir": "dynlib", "name": "libheif", "package_type": "shared_library", "sha256": "6dcdfe5d7b2143012664be71cb7322941d7defd81d91c576db0d3db1e0aebaac", "unvendored_tests": false, "version": "1.12.0"}, "libmagic": {"depends": [], "file_name": "libmagic-5.42.zip", "imports": [], "install_dir": "dynlib", "name": "libmagic", "package_type": "shared_library", "sha256": "b3ddfa4c7f31484f13ddaa77d6c1aaf755ecf1b757aa309957336a639f21a828", "unvendored_tests": false, "version": "5.42"}, "lightgbm": {"depends": ["numpy", "scipy", "scikit-learn"], "file_name": "lightgbm-4.6.0-py3-none-pyodide_2025_0_wasm32.whl", "imports": ["lightgbm"], "install_dir": "site", "name": "lightgbm", "package_type": "package", "sha256": "3d5f16949ccd99eb6fa9fa91fde7a4297b19a720bb0d6cd413656ab24730ff8e", "unvendored_tests": false, "version": "4.6.0"}, "logbook": {"depends": ["ssl"], "file_name": "logbook-1.8.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["logbook"], "install_dir": "site", "name": "logbook", "package_type": "package", "sha256": "838d3e2b16f6e31cb4076a71a6525781e55bc5724f21bc3899042cc9139b96b9", "unvendored_tests": false, "version": "1.8.0"}, "lxml": {"depends": [], "file_name": "lxml-5.4.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["lxml"], "install_dir": "site", "name": "lxml", "package_type": "package", "sha256": "9a1a420d50c623a1209e85cc8cb72080a3aca14871f05cca18ac5d7a85749c4a", "unvendored_tests": false, "version": "5.4.0"}, "lz4": {"depends": [], "file_name": "lz4-4.4.4-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["lz4"], "install_dir": "site", "name": "lz4", "package_type": "package", "sha256": "57ded573d726f83ed9448303d3eb6e24ce9691a95755fbd404bb19f5dc157402", "unvendored_tests": false, "version": "4.4.4"}, "lzma": {"depends": [], "file_name": "lzma-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["lzma", "_lzma"], "install_dir": "site", "name": "lzma", "package_type": "cpython_module", "sha256": "01c295e2371ee093c7d244282a12fd8c6072308720ef2b6487397be117bf5ec9", "unvendored_tests": false, "version": "1.0.0"}, "markupsafe": {"depends": [], "file_name": "markupsafe-3.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["markupsafe"], "install_dir": "site", "name": "MarkupSafe", "package_type": "package", "sha256": "c92ce58668bd643e4ab52002d037c1df6508e864d8b7c9a53e9e9472dc21ce8c", "unvendored_tests": false, "version": "3.0.2"}, "matplotlib": {"depends": ["contourpy", "cycler", "fonttools", "kiwisolver", "numpy", "packaging", "pillow", "pyparsing", "python-dateutil", "pytz"], "file_name": "matplotlib-3.8.4-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pylab", "mpl_toolkits", "matplotlib"], "install_dir": "site", "name": "matplotlib", "package_type": "package", "sha256": "73997b57b08e1f642f262fa20e426794abd8c0a156780b80bea21207e858d10a", "unvendored_tests": true, "version": "3.8.4"}, "matplotlib-inline": {"depends": ["traitlets", "matplotlib"], "file_name": "matplotlib_inline-0.1.7-py3-none-any.whl", "imports": ["matplotlib-inline"], "install_dir": "site", "name": "matplotlib-inline", "package_type": "package", "sha256": "a7de24488c384ba87d2675b02b1f283e6b38f6b5371966e9630dee4bc23f2f90", "unvendored_tests": false, "version": "0.1.7"}, "matplotlib-tests": {"depends": ["matplotlib"], "file_name": "matplotlib-tests.tar", "imports": [], "install_dir": "site", "name": "matplotlib-tests", "package_type": "package", "sha256": "99a75e3c16f24536be86cc7e434a2b114b326702434d6596b902761034976e53", "unvendored_tests": false, "version": "3.8.4"}, "memory-allocator": {"depends": [], "file_name": "memory_allocator-0.1.4-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["memory_allocator"], "install_dir": "site", "name": "memory-allocator", "package_type": "package", "sha256": "8574eafcef38a44a3b07f323e571123fada0856ea40fc40a0301ed0f8d019f73", "unvendored_tests": false, "version": "0.1.4"}, "micropip": {"depends": [], "file_name": "micropip-0.10.0-py3-none-any.whl", "imports": ["micropip"], "install_dir": "site", "name": "micropip", "package_type": "package", "sha256": "391c3d6d8a1c5c2cf4bd139427cac71efa546b7398e4a992149b5a137771e710", "unvendored_tests": false, "version": "0.10.0"}, "mmh3": {"depends": [], "file_name": "mmh3-5.1.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["mmh3"], "install_dir": "site", "name": "mmh3", "package_type": "package", "sha256": "84cb164e357f74b0728d0b770e0deb02c64945117d8c228f2a9f92705f94e9b2", "unvendored_tests": false, "version": "5.1.0"}, "more-itertools": {"depends": [], "file_name": "more_itertools-10.6.0-py3-none-any.whl", "imports": ["more_itertools"], "install_dir": "site", "name": "more-itertools", "package_type": "package", "sha256": "55f354455307636e51efb851011582611583a3639d9baa25b5abaf6158e29e2f", "unvendored_tests": false, "version": "10.6.0"}, "mpmath": {"depends": [], "file_name": "mpmath-1.3.0-py3-none-any.whl", "imports": ["mpmath"], "install_dir": "site", "name": "mpmath", "package_type": "package", "sha256": "74a1bf2ddcea83195b7e70d2af4365b030765058585d509ebe1e582f70b27fa1", "unvendored_tests": true, "version": "1.3.0"}, "mpmath-tests": {"depends": ["mpmath"], "file_name": "mpmath-tests.tar", "imports": [], "install_dir": "site", "name": "mpmath-tests", "package_type": "package", "sha256": "7d4f2c4caa8ece5b0ff6b17596959e995f409b781bbc11ced537aa3b0a0f4846", "unvendored_tests": false, "version": "1.3.0"}, "msgpack": {"depends": [], "file_name": "msgpack-1.1.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["msgpack"], "install_dir": "site", "name": "msgpack", "package_type": "package", "sha256": "e110bd4e9ab1ec13420a6d482aebaf6e77c238d94b47d345422d1a1499534c73", "unvendored_tests": false, "version": "1.1.1"}, "msgspec": {"depends": [], "file_name": "msgspec-0.19.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["msgspec"], "install_dir": "site", "name": "msgspec", "package_type": "package", "sha256": "2c54f89bda50cfbe4582cf436cc0505d862ac5e917e570e418b590f69de69d62", "unvendored_tests": false, "version": "0.19.0"}, "msprime": {"depends": ["numpy", "newick", "tskit", "demes", "rpds-py"], "file_name": "msprime-1.3.3-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["msprime"], "install_dir": "site", "name": "msprime", "package_type": "package", "sha256": "0b83984dd157af45b5c514c8d0e0cf6ac9c84c45b1e36862166b180f2215bc7f", "unvendored_tests": false, "version": "1.3.3"}, "multidict": {"depends": [], "file_name": "multidict-6.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["multidict"], "install_dir": "site", "name": "multidict", "package_type": "package", "sha256": "f13931b9db0912492a951c15d099f6b7ce124caa95ade9625301621f601eac5a", "unvendored_tests": false, "version": "6.5.0"}, "munch": {"depends": ["setuptools", "six"], "file_name": "munch-4.0.0-py2.py3-none-any.whl", "imports": ["munch"], "install_dir": "site", "name": "munch", "package_type": "package", "sha256": "04f4e30a751d4874b0139c4e4207d1e1670d5d6160f8d7c71f02d2557776f127", "unvendored_tests": false, "version": "4.0.0"}, "mypy": {"depends": [], "file_name": "mypy-1.15.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["mypyc", "mypy"], "install_dir": "site", "name": "mypy", "package_type": "package", "sha256": "7a50e07e64d966cbadc88243122ee86ececd2ee38fcf322c2958301b456544b8", "unvendored_tests": true, "version": "1.15.0"}, "mypy-tests": {"depends": ["mypy"], "file_name": "mypy-tests.tar", "imports": [], "install_dir": "site", "name": "mypy-tests", "package_type": "package", "sha256": "d6e7fa0e5f20288f419465415bb3bb2f2eac0971a92ce1a04564c5e6a4c14a09", "unvendored_tests": false, "version": "1.15.0"}, "narwhals": {"depends": [], "file_name": "narwhals-1.42.1-py3-none-any.whl", "imports": ["narwhals"], "install_dir": "site", "name": "narwhals", "package_type": "package", "sha256": "7cdfb8642b19f9aa8856db56aa7bb17e448d002d59b1eac6febfce72e09eadde", "unvendored_tests": false, "version": "1.42.1"}, "ndindex": {"depends": [], "file_name": "ndindex-1.9.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["ndindex"], "install_dir": "site", "name": "ndindex", "package_type": "package", "sha256": "94fa6189ab65642f3effb5f23d136a8f36b19c50c257dd9c35e3e976f3fea830", "unvendored_tests": true, "version": "1.9.2"}, "ndindex-tests": {"depends": ["ndindex"], "file_name": "ndindex-tests.tar", "imports": [], "install_dir": "site", "name": "ndindex-tests", "package_type": "package", "sha256": "137fe206c74a084e25c93d7d4c3f8a5707b01363962232876513b9377fd2ddb0", "unvendored_tests": false, "version": "1.9.2"}, "netcdf4": {"depends": ["numpy", "packaging", "h5py", "cftime", "certifi", "libhdf5"], "file_name": "netcdf4-1.7.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["netCDF4"], "install_dir": "site", "name": "netcdf4", "package_type": "package", "sha256": "8fa92daff7810cfe87931af5e22010e601812c52614d6b79de7dfb52009fef31", "unvendored_tests": false, "version": "1.7.2"}, "networkx": {"depends": ["decorator", "setuptools", "matplotlib", "numpy"], "file_name": "networkx-3.4.2-py3-none-any.whl", "imports": ["networkx"], "install_dir": "site", "name": "networkx", "package_type": "package", "sha256": "0beec83cfe4bbb369f63439d30f70e2082e4f74e3b2e18c3d91478c42a2e5cf5", "unvendored_tests": true, "version": "3.4.2"}, "networkx-tests": {"depends": ["networkx"], "file_name": "networkx-tests.tar", "imports": [], "install_dir": "site", "name": "networkx-tests", "package_type": "package", "sha256": "8f81fd08d6e0e895aa721efbdb916cb9fb77e8c5346253fc9e89b85b84dceec0", "unvendored_tests": false, "version": "3.4.2"}, "newick": {"depends": [], "file_name": "newick-1.9.0-py2.py3-none-any.whl", "imports": ["newick"], "install_dir": "site", "name": "newick", "package_type": "package", "sha256": "b83183cce5aa8fbf3470d7cc270ffaa3b3923f2f4beb5accc60f7c1f212d2667", "unvendored_tests": false, "version": "1.9.0"}, "ngspice": {"depends": [], "file_name": "ngspice-44.2.zip", "imports": [], "install_dir": "dynlib", "name": "ngspice", "package_type": "shared_library", "sha256": "de6e04d6029e379261285d1d2442dcdee65cdba2094355737bb711c82a612085", "unvendored_tests": false, "version": "44.2"}, "nh3": {"depends": [], "file_name": "nh3-0.2.21-cp38-abi3-pyodide_2025_0_wasm32.whl", "imports": ["nh3"], "install_dir": "site", "name": "nh3", "package_type": "package", "sha256": "bcf39a4b8fd817a106d4c75704f27da3e4628a5ffe80c6e7641e94ba5463c48e", "unvendored_tests": false, "version": "0.2.21"}, "nlopt": {"depends": ["numpy"], "file_name": "nlopt-2.9.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["nlopt"], "install_dir": "site", "name": "nlopt", "package_type": "package", "sha256": "a0583b15c418c9b4b4b6a97e7e620e45f92f8700a8e18c73becebc12f14c670b", "unvendored_tests": false, "version": "2.9.1"}, "nltk": {"depends": ["regex", "sqlite3"], "file_name": "nltk-3.9.1-py3-none-any.whl", "imports": ["nltk"], "install_dir": "site", "name": "nltk", "package_type": "package", "sha256": "254cd1944481e599ea8d87a247db4080859d859a4772598a3ce3884818332115", "unvendored_tests": true, "version": "3.9.1"}, "nltk-tests": {"depends": ["nltk"], "file_name": "nltk-tests.tar", "imports": [], "install_dir": "site", "name": "nltk-tests", "package_type": "package", "sha256": "8b3faf5c7e65dfa5cfa10a485c0c6ce85dc6b5ccc26530de716e7fcdd23f79ea", "unvendored_tests": false, "version": "3.9.1"}, "numcodecs": {"depends": ["numpy", "msgpack"], "file_name": "numcodecs-0.13.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["numcodecs"], "install_dir": "site", "name": "numcodecs", "package_type": "package", "sha256": "89f040b93d72090b4ddd7905a04706457f35505f65723004bb9753dd13a8e6e2", "unvendored_tests": true, "version": "0.13.1"}, "numcodecs-tests": {"depends": ["numcodecs"], "file_name": "numcodecs-tests.tar", "imports": [], "install_dir": "site", "name": "numcodecs-tests", "package_type": "package", "sha256": "cd73104ca08af3bf5447409f60822ac8c7047b417aa225dc2be26d3f994adffc", "unvendored_tests": false, "version": "0.13.1"}, "numpy": {"depends": [], "file_name": "numpy-2.2.5-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["numpy"], "install_dir": "site", "name": "numpy", "package_type": "package", "sha256": "467a88e8c79f9e10c8e7052bcc32dd12d44d51098beb3b8f970e1cfc965c6757", "unvendored_tests": false, "version": "2.2.5"}, "openai": {"depends": ["httpx", "pydantic", "typing-extensions", "distro", "anyio", "jiter"], "file_name": "openai-1.68.2-py3-none-any.whl", "imports": ["openai"], "install_dir": "site", "name": "openai", "package_type": "package", "sha256": "47f4bdd8bb36625279adc6109184d9464a98f96fff0c94d0b5b121cd3a47e0f4", "unvendored_tests": false, "version": "1.68.2"}, "openblas": {"depends": [], "file_name": "openblas-0.3.26.zip", "imports": [], "install_dir": "dynlib", "name": "openblas", "package_type": "shared_library", "sha256": "c0beb80dfe34e9c55f4da8a90bf7479278cc7833c20c4498dd0475a08457369e", "unvendored_tests": false, "version": "0.3.26"}, "opencv-python": {"depends": ["numpy"], "file_name": "opencv_python-4.11.0.86-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["cv2"], "install_dir": "site", "name": "opencv-python", "package_type": "package", "sha256": "4ff4d80e38ff539714df6909246301b28dc362a9fb8ad88bb731e0f4597bb7b8", "unvendored_tests": false, "version": "4.11.0.86"}, "openssl": {"depends": [], "file_name": "openssl-1.1.1w.zip", "imports": [], "install_dir": "dynlib", "name": "openssl", "package_type": "shared_library", "sha256": "b1275237ad89760b876d918d4e2b14c3b105bfe983dba5f521acd9be41900a21", "unvendored_tests": false, "version": "1.1.1w"}, "optlang": {"depends": ["sympy", "six", "swiglpk"], "file_name": "optlang-1.8.3-py2.py3-none-any.whl", "imports": ["optlang"], "install_dir": "site", "name": "optlang", "package_type": "package", "sha256": "99769db34685bbbdfef1e3d1d0f44bc08ea1ffe91813884233d6f49bdf50c536", "unvendored_tests": true, "version": "1.8.3"}, "optlang-tests": {"depends": ["optlang"], "file_name": "optlang-tests.tar", "imports": [], "install_dir": "site", "name": "optlang-tests", "package_type": "package", "sha256": "eeb9bc1813019a2cb86e39c3d7b10bdaf51a21ee77242d0943988c75026bfc26", "unvendored_tests": false, "version": "1.8.3"}, "orjson": {"depends": [], "file_name": "orjson-3.10.16-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["orjson"], "install_dir": "site", "name": "orjson", "package_type": "package", "sha256": "54c717f13a57d3e1a62d18943f71bf27ed58594e170b17d7644eb0d8a1a9ff36", "unvendored_tests": false, "version": "3.10.16"}, "packaging": {"depends": [], "file_name": "packaging-24.2-py3-none-any.whl", "imports": ["packaging"], "install_dir": "site", "name": "packaging", "package_type": "package", "sha256": "c0d9d97a17f70142e435a5c0ccbdb57f209823e325b0ce4893ceca8c36afe2b2", "unvendored_tests": false, "version": "24.2"}, "pandas": {"depends": ["numpy", "python-dateutil", "pytz"], "file_name": "pandas-2.3.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pandas"], "install_dir": "site", "name": "pandas", "package_type": "package", "sha256": "921a819fd1d60b69e46c74b09827d8c2405ade44ea278ba94c02d4d1b854c938", "unvendored_tests": true, "version": "2.3.0"}, "pandas-tests": {"depends": ["pandas"], "file_name": "pandas-tests.tar", "imports": [], "install_dir": "site", "name": "pandas-tests", "package_type": "package", "sha256": "90f29363722d314d5ddba1a709532a4c30f665804fea9bc75ec084d8e9fe4793", "unvendored_tests": false, "version": "2.3.0"}, "parso": {"depends": [], "file_name": "parso-0.8.4-py2.py3-none-any.whl", "imports": ["parso"], "install_dir": "site", "name": "parso", "package_type": "package", "sha256": "9d5ff6090528f77a2ba55d2ef1fc27e11e7dc8727ef251ce15ed0f511db58dfb", "unvendored_tests": false, "version": "0.8.4"}, "patsy": {"depends": ["numpy", "six"], "file_name": "patsy-1.0.1-py2.py3-none-any.whl", "imports": ["patsy"], "install_dir": "site", "name": "patsy", "package_type": "package", "sha256": "4ec184afa0b153f0f4cabf4a1603077df73c7a5c7392a0bd251f8a40171673a3", "unvendored_tests": true, "version": "1.0.1"}, "patsy-tests": {"depends": ["patsy"], "file_name": "patsy-tests.tar", "imports": [], "install_dir": "site", "name": "patsy-tests", "package_type": "package", "sha256": "b6953694092db92de7e8db2aab914dc444955467a80620636ccff303aba8606f", "unvendored_tests": false, "version": "1.0.1"}, "pcodec": {"depends": ["numpy"], "file_name": "pcodec-0.3.3-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pcodec"], "install_dir": "site", "name": "pcodec", "package_type": "package", "sha256": "8dbf3453048b997bc99c0369f5643a89c23367cd9824a58cad50461348e8c279", "unvendored_tests": false, "version": "0.3.3"}, "peewee": {"depends": ["sqlite3", "cffi"], "file_name": "peewee-3.17.9-py3-none-any.whl", "imports": ["peewee"], "install_dir": "site", "name": "peewee", "package_type": "package", "sha256": "ca8acdfaba7057aa6541917b18f50a5765fbb626ca7adc458f1c0bb29ff7a239", "unvendored_tests": true, "version": "3.17.9"}, "peewee-tests": {"depends": ["peewee"], "file_name": "peewee-tests.tar", "imports": [], "install_dir": "site", "name": "peewee-tests", "package_type": "package", "sha256": "e3183bd93f4fa9e7f5819ba4dfaabfba01b4717b140bd2d8bff36e9a299c7463", "unvendored_tests": false, "version": "3.17.9"}, "pi-heif": {"depends": ["cffi", "pillow", "libheif"], "file_name": "pi_heif-0.21.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pi_heif"], "install_dir": "site", "name": "pi-heif", "package_type": "package", "sha256": "98cb7a0e8ea55b806ba792db455a1c5d6db295af897c8ddff091a35edb813edc", "unvendored_tests": false, "version": "0.21.0"}, "pillow": {"depends": [], "file_name": "pillow-11.2.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["PIL"], "install_dir": "site", "name": "Pillow", "package_type": "package", "sha256": "426001442cb5ae22937e2eb7844c0a004c2e17daa8115de860e33d281da96a62", "unvendored_tests": false, "version": "11.2.1"}, "pillow-heif": {"depends": ["cffi", "pillow", "libheif"], "file_name": "pillow_heif-0.21.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pillow_heif"], "install_dir": "site", "name": "pillow-heif", "package_type": "package", "sha256": "59c865c040fbeb5c7ffca234560e99e34263fc29ace954e621525335994855c4", "unvendored_tests": false, "version": "0.21.0"}, "pkgconfig": {"depends": [], "file_name": "pkgconfig-1.5.5-py3-none-any.whl", "imports": ["pkgconfig"], "install_dir": "site", "name": "pkgconfig", "package_type": "package", "sha256": "53181805cfb4c868593263540cae84d3237a4ba5056ce1547fac115fc481e36f", "unvendored_tests": false, "version": "1.5.5"}, "platformdirs": {"depends": [], "file_name": "platformdirs-4.3.6-py3-none-any.whl", "imports": ["platformdirs"], "install_dir": "site", "name": "platformdirs", "package_type": "package", "sha256": "32b2be83ff5b2a0c545af3b052ab1323cb66cfc051b934b5c4f0c2d84794a7bf", "unvendored_tests": false, "version": "4.3.6"}, "pluggy": {"depends": [], "file_name": "pluggy-1.5.0-py3-none-any.whl", "imports": ["pluggy"], "install_dir": "site", "name": "pluggy", "package_type": "package", "sha256": "1b0dcaeae60603e712b6665dbc855a45fde15ec9f914d073fc2f92fc669d7810", "unvendored_tests": false, "version": "1.5.0"}, "ply": {"depends": [], "file_name": "ply-3.11-py2.py3-none-any.whl", "imports": ["ply"], "install_dir": "site", "name": "ply", "package_type": "package", "sha256": "5bc41d5d1bd8051ed6cb96a93164609b02921d1e07b620691186c99c326d14df", "unvendored_tests": false, "version": "3.11"}, "pplpy": {"depends": ["gmpy2", "cysignals"], "file_name": "pplpy-0.8.10-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["ppl"], "install_dir": "site", "name": "pplpy", "package_type": "package", "sha256": "362d03d12eaa5034682760e71cf8abc6f16226150d3e85a632cc35453ffcaca5", "unvendored_tests": false, "version": "0.8.10"}, "primecountpy": {"depends": ["cysignals"], "file_name": "primecountpy-0.1.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["primecountpy"], "install_dir": "site", "name": "primecountpy", "package_type": "package", "sha256": "43b9aa37bd709b22c53ca97485fdd3ca1a11bab8a44d0de03ef5847c21785479", "unvendored_tests": false, "version": "0.1.1"}, "prompt-toolkit": {"depends": ["wcwidth"], "file_name": "prompt_toolkit-3.0.50-py3-none-any.whl", "imports": ["prompt_toolkit"], "install_dir": "site", "name": "prompt_toolkit", "package_type": "package", "sha256": "fc193099734a944b3d43c876257fe58dbd41463053e21be83d3d5d9a54809354", "unvendored_tests": false, "version": "3.0.50"}, "propcache": {"depends": [], "file_name": "propcache-0.3.0-py3-none-any.whl", "imports": ["propcache"], "install_dir": "site", "name": "propcache", "package_type": "package", "sha256": "7e3cff0342e55663736d58196094db1b83b6e514a14adfafaaa6fcc5447f4e7b", "unvendored_tests": false, "version": "0.3.0"}, "protobuf": {"depends": [], "file_name": "protobuf-6.31.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["google"], "install_dir": "site", "name": "protobuf", "package_type": "package", "sha256": "a9c39951cdde3ff3ef691400077df5c9fc6e842a8d2cb1e35433dcd70e3eba91", "unvendored_tests": false, "version": "6.31.1"}, "pure-eval": {"depends": [], "file_name": "pure_eval-0.2.3-py3-none-any.whl", "imports": ["pure_eval"], "install_dir": "site", "name": "pure-eval", "package_type": "package", "sha256": "5b8dd92a1564116901bdabf08bbc93d5746965e34e67fc10d039731c1cc54077", "unvendored_tests": false, "version": "0.2.3"}, "py": {"depends": [], "file_name": "py-1.11.0-py2.py3-none-any.whl", "imports": ["py"], "install_dir": "site", "name": "py", "package_type": "package", "sha256": "6e2f2cb6f88abaa0a0ab07c752f566ea47bbfcad67a44cd69180b662633d11b6", "unvendored_tests": false, "version": "1.11.0"}, "pyclipper": {"depends": [], "file_name": "pyclipper-1.3.0.post6-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pyclipper"], "install_dir": "site", "name": "pyclipper", "package_type": "package", "sha256": "4473bb23969a0c69492399a85b88eebff408f5a82539b4b154a66cff55037ddc", "unvendored_tests": false, "version": "1.3.0.post6"}, "pycparser": {"depends": [], "file_name": "pycparser-2.22-py3-none-any.whl", "imports": ["pycparser"], "install_dir": "site", "name": "pycparser", "package_type": "package", "sha256": "994e363bdc4a8a103a1ba9fb507fe1b1bdcd1d5e17dac84c2861f0b4ee01514e", "unvendored_tests": false, "version": "2.22"}, "pycryptodome": {"depends": [], "file_name": "pycryptodome-3.21.0-cp36-abi3-pyodide_2025_0_wasm32.whl", "imports": ["Crypto"], "install_dir": "site", "name": "pycryptodome", "package_type": "package", "sha256": "23a4c54f51f206fe272d9f5e853e33f1763b1b3815701008a18a20b4ae38a39a", "unvendored_tests": true, "version": "3.21.0"}, "pycryptodome-tests": {"depends": ["pycryptodome"], "file_name": "pycryptodome-tests.tar", "imports": [], "install_dir": "site", "name": "pycryptodome-tests", "package_type": "package", "sha256": "5e50e9526c4bb4f9e34f59b2e4dd32bd3f7525672fe5055a4884b6637c3dad77", "unvendored_tests": false, "version": "3.21.0"}, "pydantic": {"depends": ["typing-extensions", "pydantic_core", "annotated-types"], "file_name": "pydantic-2.10.6-py3-none-any.whl", "imports": ["pydantic"], "install_dir": "site", "name": "pydantic", "package_type": "package", "sha256": "2126acce10ac2eb9ccddd0fbc2755ef8d8eda610dd7705694e899ca31a84cb25", "unvendored_tests": false, "version": "2.10.6"}, "pydantic-core": {"depends": ["typing-extensions"], "file_name": "pydantic_core-2.27.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pydantic_core"], "install_dir": "site", "name": "pydantic_core", "package_type": "package", "sha256": "bac5a11ac9b6c74e4674149ce247575057c857bd27ff7fc89df75b61c13e9a6e", "unvendored_tests": false, "version": "2.27.2"}, "pydecimal": {"depends": [], "file_name": "pydecimal-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["_pydecimal"], "install_dir": "site", "name": "pydecimal", "package_type": "cpython_module", "sha256": "49435742cc1553056d25b85e1dfb1c414f630a5e7605b6ae9f57cdca92262ba3", "unvendored_tests": false, "version": "1.0.0"}, "pydoc-data": {"depends": [], "file_name": "pydoc_data-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pydoc_data"], "install_dir": "site", "name": "pydoc_data", "package_type": "cpython_module", "sha256": "fbea0b930bf0ee8d0489565b5bc7f1f051bcb5044ceb7f304c360e0d6385eb05", "unvendored_tests": false, "version": "1.0.0"}, "pyerfa": {"depends": ["numpy"], "file_name": "pyerfa-2.0.1.5-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["erfa"], "install_dir": "site", "name": "pyerfa", "package_type": "package", "sha256": "b7dd4cfdda7784f2fe9cc5ec37c8c85925db658b84ab7acbfd01b5e0910e040f", "unvendored_tests": true, "version": "2.0.1.5"}, "pyerfa-tests": {"depends": ["pyerfa"], "file_name": "pyerfa-tests.tar", "imports": [], "install_dir": "site", "name": "pyerfa-tests", "package_type": "package", "sha256": "e398477fc85fc7d9dd6a26a467126d08bdbec2c23815d973ab6308e2ae6282c4", "unvendored_tests": false, "version": "2.0.1.5"}, "pygments": {"depends": [], "file_name": "pygments-2.19.1-py3-none-any.whl", "imports": ["pygments"], "install_dir": "site", "name": "Pygments", "package_type": "package", "sha256": "3b06ef8c12ff8426ab2c36e7ab72e34f9ad088685df4fb6154447bd93853d0c1", "unvendored_tests": false, "version": "2.19.1"}, "pyheif": {"depends": ["cffi"], "file_name": "pyheif-0.8.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pyheif"], "install_dir": "site", "name": "pyheif", "package_type": "package", "sha256": "23432cad9c287256419d00566f2652001702b114e3fe83f6a6c436d6d4bd31a0", "unvendored_tests": false, "version": "0.8.0"}, "pyiceberg": {"depends": ["click", "cachetools", "fsspec", "mmh3", "pydantic", "pyparsing", "requests", "rich", "sortedcontainers", "sqlalchemy", "strictyaml"], "file_name": "pyiceberg-0.9.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pyiceberg"], "install_dir": "site", "name": "pyiceberg", "package_type": "package", "sha256": "bbbd8f9c4d2beb22bdd2c1421c24488dd6ac41b9145d084c10befa0218b1fd7b", "unvendored_tests": false, "version": "0.9.0"}, "pyinstrument": {"depends": [], "file_name": "pyinstrument-5.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pyinstrument"], "install_dir": "site", "name": "pyinstrument", "package_type": "package", "sha256": "ccfb92db92978789a9e2427d22b2447bad8bf486dceeb4233406827b29094ef8", "unvendored_tests": false, "version": "5.0.1"}, "pynacl": {"depends": ["cffi"], "file_name": "pynacl-1.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["nacl"], "install_dir": "site", "name": "pynacl", "package_type": "package", "sha256": "aad8408990b2900123a099f590b87327c7fcdf7b9174fb39649038e49d96289f", "unvendored_tests": false, "version": "1.5.0"}, "pyodide-http": {"depends": [], "file_name": "pyodide_http-0.2.2-py3-none-any.whl", "imports": ["pyodide_http"], "install_dir": "site", "name": "pyodide-http", "package_type": "package", "sha256": "b3f0aee925e6b4bbc8af8c9d75be7a8a654b314848771835e561db1c660798fd", "unvendored_tests": false, "version": "0.2.2"}, "pyodide-unix-timezones": {"depends": [], "file_name": "pyodide_unix_timezones-1.0.0-py3-none-any.whl", "imports": ["unix_timezones"], "install_dir": "site", "name": "pyodide-unix-timezones", "package_type": "package", "sha256": "083b4e4fc2ec5f0ec1ae981e49d0a6ba9e7501990a0eb0b2be93089a9a3b0960", "unvendored_tests": false, "version": "1.0.0"}, "pyparsing": {"depends": [], "file_name": "pyparsing-3.2.1-py3-none-any.whl", "imports": ["pyparsing"], "install_dir": "site", "name": "pyparsing", "package_type": "package", "sha256": "49fe027c3f845d2565591edd3e25ea951a6e785e37a2486c1fd3896a45e37b79", "unvendored_tests": false, "version": "3.2.1"}, "pyrsistent": {"depends": [], "file_name": "pyrsistent-0.20.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["_pyrsistent_version", "pyrsistent"], "install_dir": "site", "name": "pyrsistent", "package_type": "package", "sha256": "46af19916d2927fa5cb226de3613698355b76b187393dfa94e6f3df9e4276ff9", "unvendored_tests": false, "version": "0.20.0"}, "pysam": {"depends": [], "file_name": "pysam-0.23.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pysam"], "install_dir": "site", "name": "pysam", "package_type": "package", "sha256": "32c419d016cfbd33508fb88e57d495bb29fbc0e9ea8f1a1ccf0dfaf1d4dd7cb5", "unvendored_tests": false, "version": "0.23.0"}, "pyshp": {"depends": [], "file_name": "pyshp-2.3.1-py2.py3-none-any.whl", "imports": ["shapefile"], "install_dir": "site", "name": "pyshp", "package_type": "package", "sha256": "8d181968809e65e3f0bff2eda34792ce8e59967ed7e132dbd5a25a9fd5ef7fcb", "unvendored_tests": false, "version": "2.3.1"}, "pytaglib": {"depends": ["taglib"], "file_name": "pytaglib-3.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["taglib"], "install_dir": "site", "name": "pytaglib", "package_type": "package", "sha256": "48c15dcb58323fa87be1330310a192222b59b04d9dab8228c1b106cbcd57b52a", "unvendored_tests": false, "version": "3.0.1"}, "pytest": {"depends": ["atomicwrites", "attrs", "more-itertools", "pluggy", "py", "setuptools", "six", "iniconfig", "exceptiongroup"], "file_name": "pytest-8.3.5-py3-none-any.whl", "imports": ["_pytest", "pytest"], "install_dir": "site", "name": "pytest", "package_type": "package", "sha256": "85aebcd03088f179151363c11faed059f3f1b1a4cb4adb673e0c679c4d6360bd", "unvendored_tests": false, "version": "8.3.5"}, "pytest-asyncio": {"depends": ["pytest"], "file_name": "pytest_asyncio-0.25.3-py3-none-any.whl", "imports": ["pytest_asyncio"], "install_dir": "site", "name": "pytest-asyncio", "package_type": "package", "sha256": "591cfd87f20dc36e9fb3767f1e730c31c79e5803b078bd9ebaff2890f41286fe", "unvendored_tests": false, "version": "0.25.3"}, "pytest-benchmark": {"depends": [], "file_name": "pytest_benchmark-4.0.0-py3-none-any.whl", "imports": ["pytest_benchmark"], "install_dir": "site", "name": "pytest-benchmark", "package_type": "package", "sha256": "1a45a7e8136140abe16ef5fc976b05d7359accf52ce18ffb75613fb7dfd8facc", "unvendored_tests": false, "version": "4.0.0"}, "pytest-httpx": {"depends": ["httpx", "pytest", "httpcore"], "file_name": "pytest_httpx-0.30.0-py3-none-any.whl", "imports": ["pytest_httpx"], "install_dir": "site", "name": "pytest_httpx", "package_type": "package", "sha256": "f2951e2ef4588c16fd4689ff54c3b20e3f5b7f7b4718589025587e2e026dd9bb", "unvendored_tests": false, "version": "0.30.0"}, "python-dateutil": {"depends": ["six"], "file_name": "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", "imports": ["dateutil"], "install_dir": "site", "name": "python-dateutil", "package_type": "package", "sha256": "9792745fdfff19fe681a2d2ccd1b72de71650d4b09151567ff85fb266ca86291", "unvendored_tests": false, "version": "2.9.0.post0"}, "python-flint": {"depends": [], "file_name": "python_flint-0.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["flint"], "install_dir": "site", "name": "python-flint", "package_type": "package", "sha256": "ef6c4ef8d0af971241df6b522349afb4982bbfc3c3cc576479a73fd3f8da66dc", "unvendored_tests": false, "version": "0.7.1"}, "python-magic": {"depends": ["libmagic"], "file_name": "python_magic-0.4.27-py2.py3-none-any.whl", "imports": ["magic"], "install_dir": "site", "name": "python-magic", "package_type": "package", "sha256": "e0546ace5a97dd47f3deb8d639431a731f3b44350a2f8d688d9553d1e841a234", "unvendored_tests": false, "version": "0.4.27"}, "python-sat": {"depends": ["six"], "file_name": "python_sat-1.8.dev17-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pysat"], "install_dir": "site", "name": "python-sat", "package_type": "package", "sha256": "870cd910cdd2ece298a83c64ea850c932326d6758727aaf3a372e6dd429e271c", "unvendored_tests": false, "version": "1.8.dev17"}, "python-solvespace": {"depends": [], "file_name": "python_solvespace-3.0.8-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["python_solvespace"], "install_dir": "site", "name": "python-solvespace", "package_type": "package", "sha256": "cd7ea8de8fc8307e3b6ff07e613e5610da72b53c35dfe2ee3e3a1cae2f869dc0", "unvendored_tests": false, "version": "3.0.8"}, "pytz": {"depends": [], "file_name": "pytz-2025.2-py2.py3-none-any.whl", "imports": ["pytz"], "install_dir": "site", "name": "pytz", "package_type": "package", "sha256": "4a449e011aa4eacfa58b6c06cd4db6581cf86f62d4caa320b8c30e54f4a1accb", "unvendored_tests": false, "version": "2025.2"}, "pywavelets": {"depends": ["numpy"], "file_name": "pywavelets-1.8.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pywt"], "install_dir": "site", "name": "pywavelets", "package_type": "package", "sha256": "0d1b002b5e46494236973dc9b5a8dae21c97a82654fe18ee4892eecbfd0e21c0", "unvendored_tests": true, "version": "1.8.0"}, "pywavelets-tests": {"depends": ["pywavelets"], "file_name": "pywavelets-tests.tar", "imports": [], "install_dir": "site", "name": "pywavelets-tests", "package_type": "package", "sha256": "aa427d4a88db6450132836b40e6f917917f9709b5f30945d25a752d14e46e131", "unvendored_tests": false, "version": "1.8.0"}, "pyxel": {"depends": [], "file_name": "pyxel-1.9.10-cp37-abi3-pyodide_2025_0_wasm32.whl", "imports": ["pyxel"], "install_dir": "site", "name": "pyxel", "package_type": "package", "sha256": "c505c21a7445c13467477aa42f9e0f8bdfd93b6bcdc42c79036611cac4599fe2", "unvendored_tests": false, "version": "1.9.10"}, "pyxirr": {"depends": [], "file_name": "pyxirr-0.10.6-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["pyxirr"], "install_dir": "site", "name": "pyxirr", "package_type": "package", "sha256": "9457cdaf20902ef70c9d05d07825bf4f7b4e4bfe73b1e6a23c2ce55b1fdba5b4", "unvendored_tests": false, "version": "0.10.6"}, "pyyaml": {"depends": [], "file_name": "pyyaml-6.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["_yaml", "yaml"], "install_dir": "site", "name": "pyyaml", "package_type": "package", "sha256": "197966da9f20f23b9ea37b7fee8019a39585ba78e75ac28ca0d9f7a85e098369", "unvendored_tests": false, "version": "6.0.2"}, "rasterio": {"depends": ["numpy", "affine", "gdal", "attrs", "certifi", "click", "cligj"], "file_name": "rasterio-1.4.3-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["rasterio"], "install_dir": "site", "name": "rasterio", "package_type": "package", "sha256": "fc5b14bab8daf0de63645640e3ea2db53cea106e1f80d563428ce6780e6aeb31", "unvendored_tests": false, "version": "1.4.3"}, "rateslib": {"depends": ["numpy", "pandas", "matplotlib"], "file_name": "rateslib-2.0.1-cp310-abi3-pyodide_2025_0_wasm32.whl", "imports": ["rateslib"], "install_dir": "site", "name": "rateslib", "package_type": "package", "sha256": "76d1c5f49828b6a78841dffb3210565ade82d915a60173614dc852299ed5ff22", "unvendored_tests": false, "version": "2.0.1"}, "rebound": {"depends": ["numpy"], "file_name": "rebound-4.4.7-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["rebound"], "install_dir": "site", "name": "rebound", "package_type": "package", "sha256": "ee280fc7680b59f91181440fcd813bf329c4579770c651e427fddc79c09d6916", "unvendored_tests": false, "version": "4.4.7"}, "reboundx": {"depends": ["rebound", "numpy"], "file_name": "reboundx-4.4.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["reboundx"], "install_dir": "site", "name": "reboundx", "package_type": "package", "sha256": "dfb6b87ef32c85f2bfab8e95557ce522ae550c6d69c764c6a1b39705755e5dee", "unvendored_tests": false, "version": "4.4.1"}, "referencing": {"depends": ["attrs", "rpds-py", "typing-extensions"], "file_name": "referencing-0.36.2-py3-none-any.whl", "imports": ["referencing"], "install_dir": "site", "name": "referencing", "package_type": "package", "sha256": "00fbd85e1e8ad073a099495db05e52263e0c6ee5a5cf5e6aa2b3478cfcb6f74e", "unvendored_tests": true, "version": "0.36.2"}, "referencing-tests": {"depends": ["referencing"], "file_name": "referencing-tests.tar", "imports": [], "install_dir": "site", "name": "referencing-tests", "package_type": "package", "sha256": "0f125ecd8d3da4af69e4d9eb759f21cfaabb6171ff94b185fa48f279853725c6", "unvendored_tests": false, "version": "0.36.2"}, "regex": {"depends": [], "file_name": "regex-2024.11.6-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["regex"], "install_dir": "site", "name": "regex", "package_type": "package", "sha256": "7cca3952b831bfb92f9c1ab9717e20bad13684044c13cacce83cb3f823a9003f", "unvendored_tests": true, "version": "2024.11.6"}, "regex-tests": {"depends": ["regex"], "file_name": "regex-tests.tar", "imports": [], "install_dir": "site", "name": "regex-tests", "package_type": "package", "sha256": "83754d31e65c7c01c4461aed6ad8ec57ad63e364e74d086fcacc7985a1e81ce1", "unvendored_tests": false, "version": "2024.11.6"}, "requests": {"depends": ["charset-normalizer", "idna", "urllib3", "certifi"], "file_name": "requests-2.32.3-py3-none-any.whl", "imports": ["requests"], "install_dir": "site", "name": "requests", "package_type": "package", "sha256": "d3a7e98f61896015484938be512e1f88902268727c7687bbd96c0c052a3cc4a6", "unvendored_tests": false, "version": "2.32.3"}, "retrying": {"depends": ["six"], "file_name": "retrying-1.3.4-py3-none-any.whl", "imports": ["retrying"], "install_dir": "site", "name": "retrying", "package_type": "package", "sha256": "432834c0e8b3438adb9969cd9d2fc6a805375090a2e9cde208fd216dcc89e7f5", "unvendored_tests": false, "version": "1.3.4"}, "rich": {"depends": [], "file_name": "rich-13.9.4-py3-none-any.whl", "imports": ["rich"], "install_dir": "site", "name": "rich", "package_type": "package", "sha256": "335e36fb5df8524cef9ae1808d45a81d54db0bdf852bb4d51ea9e991a28fe000", "unvendored_tests": false, "version": "13.9.4"}, "river": {"depends": ["numpy", "pandas", "scipy"], "file_name": "river-0.22.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["river"], "install_dir": "site", "name": "river", "package_type": "package", "sha256": "faf49244eaa2d92d317ab5e7517b944862b04e5f8979715592291ec66d7b7863", "unvendored_tests": true, "version": "0.22.0"}, "river-tests": {"depends": ["river"], "file_name": "river-tests.tar", "imports": [], "install_dir": "site", "name": "river-tests", "package_type": "package", "sha256": "4e44e5b4b50905e5fc0175c4db22c8be0e3c5bf74e63fa441922a07ef60855bd", "unvendored_tests": false, "version": "0.22.0"}, "robotraconteur": {"depends": ["numpy"], "file_name": "robotraconteur-1.2.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["RobotRaconteur"], "install_dir": "site", "name": "RobotRaconteur", "package_type": "package", "sha256": "3bf41492d66d95f0baffe92ff7b822093b20bd8c5df27053b70949e547c6dd36", "unvendored_tests": false, "version": "1.2.2"}, "rpds-py": {"depends": [], "file_name": "rpds_py-0.23.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["rpds"], "install_dir": "site", "name": "rpds-py", "package_type": "package", "sha256": "b9603aa100a599a3ba07eac422ed0be5cec67e516279ecccc998e8ac25191e44", "unvendored_tests": false, "version": "0.23.1"}, "ruamel-yaml": {"depends": [], "file_name": "ruamel.yaml-0.18.10-py3-none-any.whl", "imports": ["ruamel"], "install_dir": "site", "name": "ruamel.yaml", "package_type": "package", "sha256": "65ac790b6e0682cd66c994f406dfb8734ce871083a2503d449301e698b2b66f0", "unvendored_tests": false, "version": "0.18.10"}, "rustworkx": {"depends": [], "file_name": "rustworkx-0.17.0a3-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["rustworkx"], "install_dir": "site", "name": "rustworkx", "package_type": "package", "sha256": "25f59bb168391db0d8a700a052a239011a5215bf81eec9837cd0d001749dc2e3", "unvendored_tests": false, "version": "0.17.0a3"}, "scikit-image": {"depends": ["packaging", "numpy", "scipy", "networkx", "pillow", "imageio", "pywavelets", "lazy_loader"], "file_name": "scikit_image-0.25.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["skimage"], "install_dir": "site", "name": "scikit-image", "package_type": "package", "sha256": "edeb5b71745a84ad52162eb2b8223d5e5f4755291ab62d22a81409a09d7547de", "unvendored_tests": true, "version": "0.25.2"}, "scikit-image-tests": {"depends": ["scikit-image"], "file_name": "scikit-image-tests.tar", "imports": [], "install_dir": "site", "name": "scikit-image-tests", "package_type": "package", "sha256": "6272993e0c369165d694bc631ba4d4845a86a2b7067d59cad3d3500e77958386", "unvendored_tests": false, "version": "0.25.2"}, "scikit-learn": {"depends": ["scipy", "joblib", "threadpoolctl"], "file_name": "scikit_learn-1.7.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["sklearn"], "install_dir": "site", "name": "scikit-learn", "package_type": "package", "sha256": "71a6ad732e0d7e52aa4b81cc4ef4f26a1c45917f38a6ca296d5b33737dd56b2e", "unvendored_tests": true, "version": "1.7.0"}, "scikit-learn-tests": {"depends": ["scikit-learn"], "file_name": "scikit-learn-tests.tar", "imports": [], "install_dir": "site", "name": "scikit-learn-tests", "package_type": "package", "sha256": "7bf75c6b1a95282bbdb3550f42a6ac0e95459f8393d921d3cad723ffd0994356", "unvendored_tests": false, "version": "1.7.0"}, "scipy": {"depends": ["numpy", "openblas"], "file_name": "scipy-1.14.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["scipy"], "install_dir": "site", "name": "scipy", "package_type": "package", "sha256": "4e1b9bf1d135ab3f81e65653988cdfe6fb05a703938b35d1397ab7b327dc2251", "unvendored_tests": true, "version": "1.14.1"}, "scipy-tests": {"depends": ["scipy"], "file_name": "scipy-tests.tar", "imports": [], "install_dir": "site", "name": "scipy-tests", "package_type": "package", "sha256": "ef57bc9ce5a32cf88d8173b72fc9e8cb521910edc6cbe73d80144f997053043c", "unvendored_tests": false, "version": "1.14.1"}, "screed": {"depends": [], "file_name": "screed-1.1.3-py2.py3-none-any.whl", "imports": ["bigtests", "screed"], "install_dir": "site", "name": "screed", "package_type": "package", "sha256": "6a5c6bb0d7f34302399b30c52e0a040d5c5b4ca5f25dd03a6370d11ba982e04c", "unvendored_tests": true, "version": "1.1.3"}, "screed-tests": {"depends": ["screed"], "file_name": "screed-tests.tar", "imports": [], "install_dir": "site", "name": "screed-tests", "package_type": "package", "sha256": "cf50628e39fc24b1c42a5f9a5e2a2b8ea79fd734424f52943dd7d4b014fa047b", "unvendored_tests": false, "version": "1.1.3"}, "setuptools": {"depends": ["pyparsing"], "file_name": "setuptools-76.0.0-py3-none-any.whl", "imports": ["_distutils_hack", "pkg_resources", "setuptools"], "install_dir": "site", "name": "setuptools", "package_type": "package", "sha256": "d16138f727bab0f71aa6537e08354301e0c55d97dc20f91e4fa2bded65ffb007", "unvendored_tests": true, "version": "76.0.0"}, "setuptools-tests": {"depends": ["setuptools"], "file_name": "setuptools-tests.tar", "imports": [], "install_dir": "site", "name": "setuptools-tests", "package_type": "package", "sha256": "20e1cac685660b65ede47c0bfaed4024b4e784743680c55d3d98b213bdee31c4", "unvendored_tests": false, "version": "76.0.0"}, "shapely": {"depends": ["numpy"], "file_name": "shapely-2.0.7-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["shapely"], "install_dir": "site", "name": "shapely", "package_type": "package", "sha256": "0ec7d8203eb4506bcfe3bb17cfcaec2ead852b5b5a3fba2d0d8920de425aa963", "unvendored_tests": true, "version": "2.0.7"}, "shapely-tests": {"depends": ["shapely"], "file_name": "shapely-tests.tar", "imports": [], "install_dir": "site", "name": "shapely-tests", "package_type": "package", "sha256": "29eab39bd8f474bbe8c4042d6ce992e11bb79fc493c3bdb77b0077ea4beb5243", "unvendored_tests": false, "version": "2.0.7"}, "simplejson": {"depends": [], "file_name": "simplejson-3.20.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["simplejson"], "install_dir": "site", "name": "simplejson", "package_type": "package", "sha256": "c5884ab81866a337e4d797f4f269a9ad26513097d2993d09bc90e80dfa1ccbbe", "unvendored_tests": true, "version": "3.20.1"}, "simplejson-tests": {"depends": ["simplejson"], "file_name": "simplejson-tests.tar", "imports": [], "install_dir": "site", "name": "simplejson-tests", "package_type": "package", "sha256": "a29c96d1ce4a5091a42330d0c6c60b622ce857c55fde14dcb45c8f08b3220942", "unvendored_tests": false, "version": "3.20.1"}, "sisl": {"depends": ["pyparsing", "numpy", "scipy", "tqdm", "xarray", "pandas", "matplotlib"], "file_name": "sisl-0.16.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["sisl_toolbox", "sisl"], "install_dir": "site", "name": "sisl", "package_type": "package", "sha256": "4204c92155f297c37f4f7260d33fe81f5b4f6c1f8a5feac21022d3238e5107e6", "unvendored_tests": true, "version": "0.16.2"}, "sisl-tests": {"depends": ["sisl"], "file_name": "sisl-tests.tar", "imports": [], "install_dir": "site", "name": "sisl-tests", "package_type": "package", "sha256": "d2a66f63f45085091d45d977a3ea82ee874cb9579fd82003bc31ee9ac1788813", "unvendored_tests": false, "version": "0.16.2"}, "six": {"depends": [], "file_name": "six-1.17.0-py2.py3-none-any.whl", "imports": ["six"], "install_dir": "site", "name": "six", "package_type": "package", "sha256": "f213e36bbaae4640f256c86a6626e9122ce2b02b8b02e88a82053d0e4c50c02a", "unvendored_tests": false, "version": "1.17.0"}, "smart-open": {"depends": ["wrapt"], "file_name": "smart_open-7.1.0-py3-none-any.whl", "imports": ["smart_open"], "install_dir": "site", "name": "smart-open", "package_type": "package", "sha256": "edea899558b272cc5abf46f6ff6e16a2766a9eeccaa92174bafe1115574e8b81", "unvendored_tests": false, "version": "7.1.0"}, "sniffio": {"depends": [], "file_name": "sniffio-1.3.1-py3-none-any.whl", "imports": ["sniffio"], "install_dir": "site", "name": "sniffio", "package_type": "package", "sha256": "bb2f3c751f0b1aac4a0a718ce8a4a21b51f79ce172e55ad37827235db11c7ca1", "unvendored_tests": true, "version": "1.3.1"}, "sniffio-tests": {"depends": ["sniffio"], "file_name": "sniffio-tests.tar", "imports": [], "install_dir": "site", "name": "sniffio-tests", "package_type": "package", "sha256": "2c3c2ddb702e72f432d8d80a9913868dc29cf75604b3375a801c06389736b808", "unvendored_tests": false, "version": "1.3.1"}, "sortedcontainers": {"depends": [], "file_name": "sortedcontainers-2.4.0-py2.py3-none-any.whl", "imports": ["sortedcontainers"], "install_dir": "site", "name": "sortedcontainers", "package_type": "package", "sha256": "a63e673698fe3f8b9eb34891a6fa481951048f4534a2e86513df3f6f1fbdc75e", "unvendored_tests": false, "version": "2.4.0"}, "soundfile": {"depends": ["cffi", "numpy"], "file_name": "soundfile-0.12.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["soundfile"], "install_dir": "site", "name": "soundfile", "package_type": "package", "sha256": "e9f91008cd95b9af018efe7a685835fc62eb1ad39ea186820d41e777798afd7c", "unvendored_tests": false, "version": "0.12.1"}, "soupsieve": {"depends": [], "file_name": "soupsieve-2.6-py3-none-any.whl", "imports": ["soupsieve"], "install_dir": "site", "name": "soupsieve", "package_type": "package", "sha256": "ddb7d7fc10b3edb4a689e453b51b2b805d8851ca7f1dcffe2ada624f032360b4", "unvendored_tests": false, "version": "2.6"}, "sourmash": {"depends": ["screed", "cffi", "deprecation", "cachetools", "numpy", "matplotlib", "scipy", "sqlite3", "bitstring"], "file_name": "sourmash-4.8.14-py3-none-pyodide_2025_0_wasm32.whl", "imports": ["sourmash"], "install_dir": "site", "name": "sourmash", "package_type": "package", "sha256": "abd4d4ce0b04af3d8fdf00ab23bfcab30d457dacc6429a617c15dc705b38abac", "unvendored_tests": false, "version": "4.8.14"}, "soxr": {"depends": ["numpy"], "file_name": "soxr-0.5.0.post1-cp312-abi3-pyodide_2025_0_wasm32.whl", "imports": ["soxr"], "install_dir": "site", "name": "soxr", "package_type": "package", "sha256": "0970c84abfc9b476e649f6c523545c1a53fd778474663a3bf59feb7a91780028", "unvendored_tests": false, "version": "0.5.0.post1"}, "sparseqr": {"depends": ["pycparser", "cffi", "numpy", "scipy", "suitesparse"], "file_name": "sparseqr-1.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["sparseqr"], "install_dir": "site", "name": "sparseqr", "package_type": "package", "sha256": "bc14d2df81135f07a5dafb8b1480c7feb3073ad57906d5facdd83de8655c68a0", "unvendored_tests": false, "version": "1.2"}, "sqlalchemy": {"depends": ["sqlite3", "typing-extensions"], "file_name": "sqlalchemy-2.0.39-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["sqlalchemy"], "install_dir": "site", "name": "sqlalchemy", "package_type": "package", "sha256": "0a40c6751e723b8e300bd05d0c5f233b3ce98a1cda8dec62b88b4bfb1a9e76e5", "unvendored_tests": true, "version": "2.0.39"}, "sqlalchemy-tests": {"depends": ["sqlalchemy"], "file_name": "sqlalchemy-tests.tar", "imports": [], "install_dir": "site", "name": "sqlalchemy-tests", "package_type": "package", "sha256": "2644c0080fdf457d3255c9591751868851adc51de8792c71692b1151fee98a5d", "unvendored_tests": false, "version": "2.0.39"}, "sqlite3": {"depends": [], "file_name": "sqlite3-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["sqlite3", "_sqlite3"], "install_dir": "site", "name": "sqlite3", "package_type": "cpython_module", "sha256": "dfb82f242c6226f078e2d422d9b07292df9395ced2732bf0f1d893f6e88e9a2b", "unvendored_tests": false, "version": "1.0.0"}, "ssl": {"depends": ["openssl"], "file_name": "ssl-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["ssl", "_ssl"], "install_dir": "site", "name": "ssl", "package_type": "cpython_module", "sha256": "66a777d12bbdd3ecbdc8a8d5ba78b42f71a5cefe01ef514dadd63757d463c015", "unvendored_tests": false, "version": "1.0.0"}, "stack-data": {"depends": ["executing", "asttokens", "pure-eval"], "file_name": "stack_data-0.6.3-py3-none-any.whl", "imports": ["stack_data"], "install_dir": "site", "name": "stack-data", "package_type": "package", "sha256": "1342f587130b8ea506ab816c0bdfefac42d44e0b2fe0d8afd07e6d8ab5411c7f", "unvendored_tests": false, "version": "0.6.3"}, "statsmodels": {"depends": ["numpy", "scipy", "pandas", "patsy", "packaging"], "file_name": "statsmodels-0.14.4-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["statsmodels"], "install_dir": "site", "name": "statsmodels", "package_type": "package", "sha256": "6a5762920de3429abb587771320355cd4b8c5023b04f7f0c4cd9ea6bbcdbc0ba", "unvendored_tests": false, "version": "0.14.4"}, "strictyaml": {"depends": ["python-dateutil"], "file_name": "strictyaml-1.7.3-py3-none-any.whl", "imports": ["strictyaml"], "install_dir": "site", "name": "strictyaml", "package_type": "package", "sha256": "c626c273ffb645c836915629268124f42f87e230f44f987159a25fa51e3e48a7", "unvendored_tests": false, "version": "1.7.3"}, "suitesparse": {"depends": ["openblas"], "file_name": "suitesparse-5.11.0.zip", "imports": [], "install_dir": "dynlib", "name": "suitesparse", "package_type": "shared_library", "sha256": "53ee82bef9e5a8228305f8a1834809d0ce686e27ae594c0774f32afb0044af2d", "unvendored_tests": false, "version": "5.11.0"}, "svgwrite": {"depends": [], "file_name": "svgwrite-1.4.3-py3-none-any.whl", "imports": ["svgwrite"], "install_dir": "site", "name": "svgwrite", "package_type": "package", "sha256": "bb5a0785d271b72e58241ef0d2daaa551e46696ad97ce6808f4f603af5662885", "unvendored_tests": false, "version": "1.4.3"}, "swiglpk": {"depends": [], "file_name": "swiglpk-5.0.12-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["swiglpk"], "install_dir": "site", "name": "swiglpk", "package_type": "package", "sha256": "bc1053d1d1f714c0a42cb0f34886a7b39531f41be66d9b1122dc9a5bcb3c5f8a", "unvendored_tests": false, "version": "5.0.12"}, "sympy": {"depends": ["mpmath"], "file_name": "sympy-1.13.3-py3-none-any.whl", "imports": ["isympy", "sympy"], "install_dir": "site", "name": "sympy", "package_type": "package", "sha256": "10b7c79a00da21aa340c1fee6017ea526b8f5ddc92daef56de37f446daa88c83", "unvendored_tests": true, "version": "1.13.3"}, "sympy-tests": {"depends": ["sympy"], "file_name": "sympy-tests.tar", "imports": [], "install_dir": "site", "name": "sympy-tests", "package_type": "package", "sha256": "ea23ee4d94a8e9206497d6970d028948c39d82eed1f57e8f059351fa77eff6b2", "unvendored_tests": false, "version": "1.13.3"}, "taglib": {"depends": [], "file_name": "taglib-2.1.1.zip", "imports": [], "install_dir": "dynlib", "name": "taglib", "package_type": "shared_library", "sha256": "d19c421e54bb0f2d4f764ba14013e8bed2ebeb5a6724f8e4d63aef21c1dd09bf", "unvendored_tests": false, "version": "2.1.1"}, "tblib": {"depends": [], "file_name": "tblib-3.0.0-py3-none-any.whl", "imports": ["tblib"], "install_dir": "site", "name": "tblib", "package_type": "package", "sha256": "58856f16edd8a01b879cd98ac7c6d573395f3e4f61009b46eeece0ec64667768", "unvendored_tests": false, "version": "3.0.0"}, "termcolor": {"depends": [], "file_name": "termcolor-2.5.0-py3-none-any.whl", "imports": ["termcolor"], "install_dir": "site", "name": "termcolor", "package_type": "package", "sha256": "7cebdf1e4e550dea158860f5b1fd0ad99a86a069aabf7c82dfd74ef804abf467", "unvendored_tests": false, "version": "2.5.0"}, "test": {"depends": [], "file_name": "test-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["test"], "install_dir": "site", "name": "test", "package_type": "cpython_module", "sha256": "ad2b465b487aac6bf4ce39e9e95028ca22f628285a66446f88b52179609689cb", "unvendored_tests": false, "version": "1.0.0"}, "texttable": {"depends": [], "file_name": "texttable-1.7.0-py2.py3-none-any.whl", "imports": ["texttable"], "install_dir": "site", "name": "texttable", "package_type": "package", "sha256": "a366ef149d93f3d7716df490d86970a8c80b9d1781f7fb158c5ccef114b43dc6", "unvendored_tests": false, "version": "1.7.0"}, "texture2ddecoder": {"depends": [], "file_name": "texture2ddecoder-1.0.5-cp37-abi3-pyodide_2025_0_wasm32.whl", "imports": ["texture2ddecoder"], "install_dir": "site", "name": "texture2ddecoder", "package_type": "package", "sha256": "6e0b92fa4642fbc5bab3aecff0413b6a6b1f04f7fcf282607413f435857d12a4", "unvendored_tests": false, "version": "1.0.5"}, "threadpoolctl": {"depends": [], "file_name": "threadpoolctl-3.5.0-py3-none-any.whl", "imports": ["threadpoolctl"], "install_dir": "site", "name": "threadpoolctl", "package_type": "package", "sha256": "4c7afd9a403c3ac4db535d6aca2090cfde391c0883b15080cbc3c573e4fcae9b", "unvendored_tests": false, "version": "3.5.0"}, "tiktoken": {"depends": ["regex", "requests"], "file_name": "tiktoken-0.9.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["tiktoken", "tiktoken_ext"], "install_dir": "site", "name": "tiktoken", "package_type": "package", "sha256": "f0d7009f5354ca649350bf26cf35082ac2322fb868b6cd48728ae708d5d314c9", "unvendored_tests": false, "version": "0.9.0"}, "tomli": {"depends": [], "file_name": "tomli-2.2.1-py3-none-any.whl", "imports": ["tomli"], "install_dir": "site", "name": "tomli", "package_type": "package", "sha256": "2d3948b81c540e927698c21daaf54ec0c15d76f3d6c1a4d97043df2024c9e754", "unvendored_tests": false, "version": "2.2.1"}, "tomli-w": {"depends": [], "file_name": "tomli_w-1.2.0-py3-none-any.whl", "imports": ["tomli_w"], "install_dir": "site", "name": "tomli-w", "package_type": "package", "sha256": "f4d654c609d9ee6ac43e812935a331c4af11e5e78b93493de943b4cccab66b33", "unvendored_tests": false, "version": "1.2.0"}, "toolz": {"depends": [], "file_name": "toolz-1.0.0-py3-none-any.whl", "imports": ["tlz", "toolz"], "install_dir": "site", "name": "toolz", "package_type": "package", "sha256": "d9b13e3696feb93ea4729d677f08deb108d0cb238157b12eb5c47787502f5857", "unvendored_tests": true, "version": "1.0.0"}, "toolz-tests": {"depends": ["toolz"], "file_name": "toolz-tests.tar", "imports": [], "install_dir": "site", "name": "toolz-tests", "package_type": "package", "sha256": "e6e8112849c8818d38f867ba3013389a3c0b5754d73001c01517e985b88cd5f4", "unvendored_tests": false, "version": "1.0.0"}, "tqdm": {"depends": [], "file_name": "tqdm-4.67.1-py3-none-any.whl", "imports": ["tqdm"], "install_dir": "site", "name": "tqdm", "package_type": "package", "sha256": "c7cb7731e708943d4383072b7281a20938c2a56be651ca6feb8feb8148d77f6a", "unvendored_tests": false, "version": "4.67.1"}, "traitlets": {"depends": [], "file_name": "traitlets-5.14.3-py3-none-any.whl", "imports": ["traitlets"], "install_dir": "site", "name": "traitlets", "package_type": "package", "sha256": "e77db6ca3d6d5bbe3acaa6ede6fe582e0736a4ed152ef0ba3c0bdde6af42565d", "unvendored_tests": true, "version": "5.14.3"}, "traitlets-tests": {"depends": ["traitlets"], "file_name": "traitlets-tests.tar", "imports": [], "install_dir": "site", "name": "traitlets-tests", "package_type": "package", "sha256": "e213bfbb711f46f8151986a0e39224cf5d6fb951afc406c50e17a993068ceb8d", "unvendored_tests": false, "version": "5.14.3"}, "traits": {"depends": [], "file_name": "traits-7.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["traits"], "install_dir": "site", "name": "traits", "package_type": "package", "sha256": "4814ed02cfe2751f8727109024b3d8fca03dfcb93583014386a5426c13bd2308", "unvendored_tests": true, "version": "7.0.2"}, "traits-tests": {"depends": ["traits"], "file_name": "traits-tests.tar", "imports": [], "install_dir": "site", "name": "traits-tests", "package_type": "package", "sha256": "19cc75c854a661c3ea9da5f76db1ba7f0407c23ac27e8ae2faf439aa378426df", "unvendored_tests": false, "version": "7.0.2"}, "tree-sitter": {"depends": [], "file_name": "tree_sitter-0.23.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["tree_sitter"], "install_dir": "site", "name": "tree-sitter", "package_type": "package", "sha256": "811a8d2aa859191b975fc606624d52485bbcd4518fe38305f541aff08709ea88", "unvendored_tests": false, "version": "0.23.2"}, "tree-sitter-go": {"depends": ["tree-sitter"], "file_name": "tree_sitter_go-0.23.3-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["tree_sitter_go"], "install_dir": "site", "name": "tree-sitter-go", "package_type": "package", "sha256": "4f041bf2036c6261bd80e72eb2bd42daa9aaa682ef038bfd41bea3a6857968c7", "unvendored_tests": false, "version": "0.23.3"}, "tree-sitter-java": {"depends": ["tree-sitter"], "file_name": "tree_sitter_java-0.23.4-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["tree_sitter_java"], "install_dir": "site", "name": "tree-sitter-java", "package_type": "package", "sha256": "44e7d0c23184d252aa33e057ae44fd6a8f3800def8c2ceb6fb40879aafd00b2c", "unvendored_tests": false, "version": "0.23.4"}, "tree-sitter-python": {"depends": ["tree-sitter"], "file_name": "tree_sitter_python-0.23.4-cp39-abi3-pyodide_2025_0_wasm32.whl", "imports": ["tree_sitter_python"], "install_dir": "site", "name": "tree-sitter-python", "package_type": "package", "sha256": "3da26ee514001cb726069b0398121139096476fd6af76c87e0f5de06da0f7d9f", "unvendored_tests": false, "version": "0.23.4"}, "tskit": {"depends": ["numpy", "svgwrite", "jsonschema", "rpds-py"], "file_name": "tskit-0.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["tskit"], "install_dir": "site", "name": "tskit", "package_type": "package", "sha256": "82a755003bb87e94ab00c15422e1a0d0377d5b9610d786d2b0db2c34796163a9", "unvendored_tests": false, "version": "0.6.0"}, "typing-extensions": {"depends": [], "file_name": "typing_extensions-4.14.0-py3-none-any.whl", "imports": ["typing_extensions"], "install_dir": "site", "name": "typing-extensions", "package_type": "package", "sha256": "ea55f317ad44571eea7bfaa916b81c857181f0a0971ab97b2fe251c01b510f90", "unvendored_tests": false, "version": "4.14.0"}, "tzdata": {"depends": [], "file_name": "tzdata-2025.2-py2.py3-none-any.whl", "imports": ["tzdata"], "install_dir": "site", "name": "tzdata", "package_type": "package", "sha256": "0701e11f6d1a30d77913de74b915df3cd08ad4590fad6b670d6f6228b5d001d2", "unvendored_tests": false, "version": "2025.2"}, "ujson": {"depends": [], "file_name": "ujson-5.10.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["ujson"], "install_dir": "site", "name": "ujson", "package_type": "package", "sha256": "cc01072badf51e68bc14efa57f892e11354c76be28813cc51fe483f3c899508c", "unvendored_tests": false, "version": "5.10.0"}, "uncertainties": {"depends": ["future"], "file_name": "uncertainties-3.2.2-py3-none-any.whl", "imports": ["uncertainties"], "install_dir": "site", "name": "uncertainties", "package_type": "package", "sha256": "e17a6eb4c16d964c93b72c4802f521cbc430d350ca3a4541aadb21b92de07c16", "unvendored_tests": false, "version": "3.2.2"}, "unyt": {"depends": ["numpy", "packaging", "sympy"], "file_name": "unyt-3.0.3-py3-none-any.whl", "imports": ["unyt"], "install_dir": "site", "name": "unyt", "package_type": "package", "sha256": "2d66e96ca928743de94f880b36122e5164616ded4fb1feb6e6b1e2c272fa6f79", "unvendored_tests": true, "version": "3.0.3"}, "unyt-tests": {"depends": ["unyt"], "file_name": "unyt-tests.tar", "imports": [], "install_dir": "site", "name": "unyt-tests", "package_type": "package", "sha256": "2546fc0f1f734c76c1ed65ef894126b1fae20fecf5d811200c15e8645415541d", "unvendored_tests": false, "version": "3.0.3"}, "urllib3": {"depends": [], "file_name": "urllib3-2.3.0-py3-none-any.whl", "imports": ["urllib3"], "install_dir": "site", "name": "urllib3", "package_type": "package", "sha256": "2b347fd6e69835a1c53f8c2263aca2efb493d5d1d85563b3f2a7499ff7b3944f", "unvendored_tests": false, "version": "2.3.0"}, "vega-datasets": {"depends": ["pandas"], "file_name": "vega_datasets-0.9.0-py3-none-any.whl", "imports": ["vega_datasets"], "install_dir": "site", "name": "vega-datasets", "package_type": "package", "sha256": "c2031bcf493df9094eeec393dfda992933daf804c4f0117add037991baa8ebf1", "unvendored_tests": true, "version": "0.9.0"}, "vega-datasets-tests": {"depends": ["vega-datasets"], "file_name": "vega-datasets-tests.tar", "imports": [], "install_dir": "site", "name": "vega-datasets-tests", "package_type": "package", "sha256": "10ce4f10db8360b4d3a7cd23fd1d1feef161f8edff4d9e7d3721600a69afc9a4", "unvendored_tests": false, "version": "0.9.0"}, "wcwidth": {"depends": [], "file_name": "wcwidth-0.2.13-py2.py3-none-any.whl", "imports": ["wcwidth"], "install_dir": "site", "name": "wcwidth", "package_type": "package", "sha256": "db9afdada79bb146dd4681fcb7c065dc1a3bc5c32f750542e695e1aa1fe3a956", "unvendored_tests": false, "version": "0.2.13"}, "webencodings": {"depends": [], "file_name": "webencodings-0.5.1-py2.py3-none-any.whl", "imports": ["webencodings"], "install_dir": "site", "name": "webencodings", "package_type": "package", "sha256": "cbc9dcbcc91190df72990e2f5d5effc2f3aaf2dc09f23a7f073cfdb2adc08c58", "unvendored_tests": false, "version": "0.5.1"}, "wordcloud": {"depends": ["matplotlib"], "file_name": "wordcloud-1.9.4-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["wordcloud"], "install_dir": "site", "name": "wordcloud", "package_type": "package", "sha256": "e67706f11c85cd8ef767eddd806952e5cc8cd88469f531f8e11d433d24dd6904", "unvendored_tests": false, "version": "1.9.4"}, "wrapt": {"depends": [], "file_name": "wrapt-1.17.2-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["wrapt"], "install_dir": "site", "name": "wrapt", "package_type": "package", "sha256": "749ad6578f49a76218f7b9a081d22610752a8f76cbb845dc604c364bcdf8d828", "unvendored_tests": false, "version": "1.17.2"}, "xarray": {"depends": ["numpy", "packaging", "pandas"], "file_name": "xarray-2025.1.2-py3-none-any.whl", "imports": ["xarray"], "install_dir": "site", "name": "xarray", "package_type": "package", "sha256": "02a4f88148fcfb864a8261197662906763b7b087f347cee12144ed5779dde482", "unvendored_tests": true, "version": "2025.1.2"}, "xarray-tests": {"depends": ["xarray"], "file_name": "xarray-tests.tar", "imports": [], "install_dir": "site", "name": "xarray-tests", "package_type": "package", "sha256": "71890d21b7637e9ad6931160e0aace010866e25a75fb506e3b28d66f6ef6a579", "unvendored_tests": false, "version": "2025.1.2"}, "xgboost": {"depends": ["numpy", "scipy", "setuptools"], "file_name": "xgboost-2.1.4-py3-none-pyodide_2025_0_wasm32.whl", "imports": ["xgboost"], "install_dir": "site", "name": "xgboost", "package_type": "package", "sha256": "28de4d26a38c0df1c1674a344e0bcfda312503dc234b552dc0aac1efc2c42874", "unvendored_tests": false, "version": "2.1.4"}, "xlrd": {"depends": [], "file_name": "xlrd-2.0.1-py2.py3-none-any.whl", "imports": ["xlrd"], "install_dir": "site", "name": "xlrd", "package_type": "package", "sha256": "92990ecbefdfce5123e9110c59394c8b0d4fc1fe6da8fd84b7d0a22974e8d058", "unvendored_tests": false, "version": "2.0.1"}, "xxhash": {"depends": [], "file_name": "xxhash-3.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["xxhash"], "install_dir": "site", "name": "xxhash", "package_type": "package", "sha256": "984d65f4843568e03cee2190838b9c97c68731eee0193babdd3d4480fc84829d", "unvendored_tests": false, "version": "3.5.0"}, "xyzservices": {"depends": [], "file_name": "xyzservices-2025.1.0-py3-none-any.whl", "imports": ["xyzservices"], "install_dir": "site", "name": "xyzservices", "package_type": "package", "sha256": "9174331356c325b80367ad54267388bfd11dd80f57f9aeac6d2e26c2a6a5d1f1", "unvendored_tests": true, "version": "2025.1.0"}, "xyzservices-tests": {"depends": ["xyzservices"], "file_name": "xyzservices-tests.tar", "imports": [], "install_dir": "site", "name": "xyzservices-tests", "package_type": "package", "sha256": "e3010e0aab7eb2179a405bc97e3c0b8f247ac480ed72e22c4eab1aff308491ea", "unvendored_tests": false, "version": "2025.1.0"}, "yarl": {"depends": ["multidict", "idna", "propcache"], "file_name": "yarl-1.18.3-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["yarl"], "install_dir": "site", "name": "yarl", "package_type": "package", "sha256": "e2a82d7d0f11fc7a718745b38bcc6fdf59f1e8a888cfd09f9a9b0f015b694ad8", "unvendored_tests": false, "version": "1.18.3"}, "yt": {"depends": ["ewah_bool_utils", "numpy", "matplotlib", "sympy", "setuptools", "packaging", "unyt", "cmyt", "colorspacious", "tqdm", "tomli", "tomli-w"], "file_name": "yt-4.4.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["yt"], "install_dir": "site", "name": "yt", "package_type": "package", "sha256": "76e50dafa4be8c07e57c57779c8705394c6d27311cc3859802176e5a9d5291f2", "unvendored_tests": false, "version": "4.4.0"}, "zengl": {"depends": [], "file_name": "zengl-2.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["zengl", "_zengl"], "install_dir": "site", "name": "zengl", "package_type": "package", "sha256": "1b5e48a8c79a7d99d7d8c080a5c9200190274f49c45241df61838afc1851e4c4", "unvendored_tests": false, "version": "2.7.1"}, "zfpy": {"depends": ["numpy"], "file_name": "zfpy-1.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["zfpy"], "install_dir": "site", "name": "zfpy", "package_type": "package", "sha256": "3a023b0d5b95eb7f38cde29f0a8b149f6471889ef8d040b460541c88ea754362", "unvendored_tests": false, "version": "1.0.1"}, "zstandard": {"depends": ["cffi"], "file_name": "zstandard-0.23.0-cp313-cp313-pyodide_2025_0_wasm32.whl", "imports": ["zstandard"], "install_dir": "site", "name": "zstandard", "package_type": "package", "sha256": "3146aab03772fdb30ce4b56f8993a49ce61632e3d0581c17f3212b69a977e103", "unvendored_tests": false, "version": "0.23.0"}}}
+{
+  "info": {
+    "abi_version": "2025_0",
+    "arch": "wasm32",
+    "platform": "emscripten_4_0_9",
+    "python": "3.13.2",
+    "version": "0.28.0"
+  },
+  "packages": {
+    "affine": {
+      "depends": [],
+      "file_name": "affine-2.4.0-py3-none-any.whl",
+      "imports": [
+        "affine"
+      ],
+      "install_dir": "site",
+      "name": "affine",
+      "package_type": "package",
+      "sha256": "4eb79a4c13799940b2cba40c9b72b46f627ea262e977b1d747dbb9e7244f4c93",
+      "unvendored_tests": true,
+      "version": "2.4.0"
+    },
+    "affine-tests": {
+      "depends": [
+        "affine"
+      ],
+      "file_name": "affine-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "affine-tests",
+      "package_type": "package",
+      "sha256": "7ad2d207300ea69f1b4aa87ee81aac4674c77a2366e99333dcdfe0c3da45528a",
+      "unvendored_tests": false,
+      "version": "2.4.0"
+    },
+    "aiohappyeyeballs": {
+      "depends": [],
+      "file_name": "aiohappyeyeballs-2.6.1-py3-none-any.whl",
+      "imports": [
+        "aiohappyeyeballs"
+      ],
+      "install_dir": "site",
+      "name": "aiohappyeyeballs",
+      "package_type": "package",
+      "sha256": "75ce7e895960634366cd8b322f312cc71cb54505082199853882dadcfa79c914",
+      "unvendored_tests": false,
+      "version": "2.6.1"
+    },
+    "aiohttp": {
+      "depends": [
+        "aiohappyeyeballs",
+        "aiosignal",
+        "async-timeout",
+        "attrs",
+        "charset-normalizer",
+        "frozenlist",
+        "multidict",
+        "yarl"
+      ],
+      "file_name": "aiohttp-3.11.13-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "aiohttp"
+      ],
+      "install_dir": "site",
+      "name": "aiohttp",
+      "package_type": "package",
+      "sha256": "ab13fd7b6a023f899a6cff9bbf9cba1ceebfc2844b1214017612b644a5ca0298",
+      "unvendored_tests": true,
+      "version": "3.11.13"
+    },
+    "aiohttp-tests": {
+      "depends": [
+        "aiohttp"
+      ],
+      "file_name": "aiohttp-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "aiohttp-tests",
+      "package_type": "package",
+      "sha256": "63444829db370eef249d61a4a46628bede2d9e9eb855fa1c045c77b106562723",
+      "unvendored_tests": false,
+      "version": "3.11.13"
+    },
+    "aiosignal": {
+      "depends": [
+        "frozenlist"
+      ],
+      "file_name": "aiosignal-1.3.2-py2.py3-none-any.whl",
+      "imports": [
+        "aiosignal"
+      ],
+      "install_dir": "site",
+      "name": "aiosignal",
+      "package_type": "package",
+      "sha256": "618c9eadea31dc1cbdbccee0db7af253f744547193d274f36f8481fa68e82d19",
+      "unvendored_tests": false,
+      "version": "1.3.2"
+    },
+    "altair": {
+      "depends": [
+        "typing-extensions",
+        "jinja2",
+        "jsonschema",
+        "packaging",
+        "narwhals"
+      ],
+      "file_name": "altair-5.5.0-py3-none-any.whl",
+      "imports": [
+        "altair"
+      ],
+      "install_dir": "site",
+      "name": "altair",
+      "package_type": "package",
+      "sha256": "5d0ec05045de574d7d4ff19c06aa4b98170b3ae31c43cd21d05164dd5f3a019f",
+      "unvendored_tests": false,
+      "version": "5.5.0"
+    },
+    "annotated-types": {
+      "depends": [],
+      "file_name": "annotated_types-0.7.0-py3-none-any.whl",
+      "imports": [
+        "annotated_types"
+      ],
+      "install_dir": "site",
+      "name": "annotated-types",
+      "package_type": "package",
+      "sha256": "76075ce81f2f3ab010f54a17674c44e9606f1b1aaf014bbbd948d15379afdc05",
+      "unvendored_tests": true,
+      "version": "0.7.0"
+    },
+    "annotated-types-tests": {
+      "depends": [
+        "annotated-types"
+      ],
+      "file_name": "annotated-types-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "annotated-types-tests",
+      "package_type": "package",
+      "sha256": "30fc57e8070f6b0885aaafaebed68d5ded2a27569ffb3e6ba6d05d757057cd04",
+      "unvendored_tests": false,
+      "version": "0.7.0"
+    },
+    "anyio": {
+      "depends": [
+        "ssl",
+        "sniffio",
+        "typing-extensions"
+      ],
+      "file_name": "anyio-4.9.0-py3-none-any.whl",
+      "imports": [
+        "anyio"
+      ],
+      "install_dir": "site",
+      "name": "anyio",
+      "package_type": "package",
+      "sha256": "393eccc66dacad1e22eee0c9f91f2da4cee2968111e625bfab52747d64d213ab",
+      "unvendored_tests": false,
+      "version": "4.9.0"
+    },
+    "apsw": {
+      "depends": [],
+      "file_name": "apsw-3.49.1.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "apsw"
+      ],
+      "install_dir": "site",
+      "name": "apsw",
+      "package_type": "package",
+      "sha256": "6c204f13369a0788633da5905ed373798bb6765b0b92bcad8b2e20082f3a6aad",
+      "unvendored_tests": false,
+      "version": "3.49.1.0"
+    },
+    "argon2-cffi": {
+      "depends": [
+        "argon2-cffi-bindings"
+      ],
+      "file_name": "argon2_cffi-23.1.0-py3-none-any.whl",
+      "imports": [
+        "argon2"
+      ],
+      "install_dir": "site",
+      "name": "argon2-cffi",
+      "package_type": "package",
+      "sha256": "e89dc3c02b03ee61d50883f6aec169395b850e21765b0e26fef974b01e9c376b",
+      "unvendored_tests": false,
+      "version": "23.1.0"
+    },
+    "argon2-cffi-bindings": {
+      "depends": [
+        "cffi"
+      ],
+      "file_name": "argon2_cffi_bindings-21.2.0-cp313-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "_argon2_cffi_bindings"
+      ],
+      "install_dir": "site",
+      "name": "argon2-cffi-bindings",
+      "package_type": "package",
+      "sha256": "437d812d9371a4542631d40b859ac42f9587f9a7f4595d01fdb72be75640db27",
+      "unvendored_tests": false,
+      "version": "21.2.0"
+    },
+    "asciitree": {
+      "depends": [],
+      "file_name": "asciitree-0.3.3-py3-none-any.whl",
+      "imports": [
+        "asciitree"
+      ],
+      "install_dir": "site",
+      "name": "asciitree",
+      "package_type": "package",
+      "sha256": "b1fb0a726d7ac5abd329215643cb24edd607e566a8f05c7ee880e22a4e8c44b1",
+      "unvendored_tests": false,
+      "version": "0.3.3"
+    },
+    "astropy": {
+      "depends": [
+        "packaging",
+        "numpy",
+        "pyerfa",
+        "pyyaml",
+        "astropy_iers_data"
+      ],
+      "file_name": "astropy-7.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "astropy"
+      ],
+      "install_dir": "site",
+      "name": "astropy",
+      "package_type": "package",
+      "sha256": "73573c7cc2787f1318a63541274f1149f09c663418116b494fa87b2ecb313aa9",
+      "unvendored_tests": false,
+      "version": "7.0.1"
+    },
+    "astropy-iers-data": {
+      "depends": [],
+      "file_name": "astropy_iers_data-0.2025.3.10.0.29.26-py3-none-any.whl",
+      "imports": [
+        "astropy_iers_data"
+      ],
+      "install_dir": "site",
+      "name": "astropy_iers_data",
+      "package_type": "package",
+      "sha256": "1dc8e86457e511b569f56a01524af58c011f3a432f778deab3b27b0f42677e35",
+      "unvendored_tests": true,
+      "version": "0.2025.3.10.0.29.26"
+    },
+    "astropy-iers-data-tests": {
+      "depends": [
+        "astropy_iers_data"
+      ],
+      "file_name": "astropy-iers-data-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "astropy_iers_data-tests",
+      "package_type": "package",
+      "sha256": "6896255a2da3a177a154b8b3797f56d15624ac84f6e0371c59103a804c452864",
+      "unvendored_tests": false,
+      "version": "0.2025.3.10.0.29.26"
+    },
+    "asttokens": {
+      "depends": [
+        "six"
+      ],
+      "file_name": "asttokens-3.0.0-py3-none-any.whl",
+      "imports": [
+        "asttokens"
+      ],
+      "install_dir": "site",
+      "name": "asttokens",
+      "package_type": "package",
+      "sha256": "9735891dc54944ece9b5fd2b4dd85dd043dc1fcf36c82ebea9ca34bb989f92b8",
+      "unvendored_tests": false,
+      "version": "3.0.0"
+    },
+    "async-timeout": {
+      "depends": [],
+      "file_name": "async_timeout-5.0.1-py3-none-any.whl",
+      "imports": [
+        "async_timeout"
+      ],
+      "install_dir": "site",
+      "name": "async-timeout",
+      "package_type": "package",
+      "sha256": "bdc25a6350c5bc2e8ccfdd672d4226a2c9b41fa88a7604ab0fb1ad9da5e8316d",
+      "unvendored_tests": false,
+      "version": "5.0.1"
+    },
+    "atomicwrites": {
+      "depends": [],
+      "file_name": "atomicwrites-1.4.1-py2.py3-none-any.whl",
+      "imports": [
+        "atomicwrites"
+      ],
+      "install_dir": "site",
+      "name": "atomicwrites",
+      "package_type": "package",
+      "sha256": "1ac42f755ef4c57cd752155ac1751fdc2c75c8d407844757cfc4e8c51cd646be",
+      "unvendored_tests": false,
+      "version": "1.4.1"
+    },
+    "attrs": {
+      "depends": [
+        "six"
+      ],
+      "file_name": "attrs-25.2.0-py3-none-any.whl",
+      "imports": [
+        "attr",
+        "attrs"
+      ],
+      "install_dir": "site",
+      "name": "attrs",
+      "package_type": "package",
+      "sha256": "82cdc5a07e1d2f63fdafa96b6428d8a4f93644fc6beb9ef11476778ead45fcea",
+      "unvendored_tests": false,
+      "version": "25.2.0"
+    },
+    "autograd": {
+      "depends": [
+        "numpy",
+        "future"
+      ],
+      "file_name": "autograd-1.7.0-py3-none-any.whl",
+      "imports": [
+        "autograd"
+      ],
+      "install_dir": "site",
+      "name": "autograd",
+      "package_type": "package",
+      "sha256": "7f60c8ad13ddf0e20f77a062ef89ded85bdb4bb0096e23326eab476eaf0edc6c",
+      "unvendored_tests": true,
+      "version": "1.7.0"
+    },
+    "autograd-tests": {
+      "depends": [
+        "autograd"
+      ],
+      "file_name": "autograd-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "autograd-tests",
+      "package_type": "package",
+      "sha256": "ed50ec6352212738feb0fd219e0bbe53b3c06c199a1dbdf54d4e48300eb961ca",
+      "unvendored_tests": false,
+      "version": "1.7.0"
+    },
+    "awkward-cpp": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "awkward_cpp-44-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "awkward_cpp"
+      ],
+      "install_dir": "site",
+      "name": "awkward-cpp",
+      "package_type": "package",
+      "sha256": "ccd2a1742dec5a3d4e131006ff209c8c3d8ebfd6ae37edbfb0115f5b022a337f",
+      "unvendored_tests": false,
+      "version": "44"
+    },
+    "b2d": {
+      "depends": [
+        "numpy",
+        "pydantic",
+        "setuptools",
+        "annotated-types"
+      ],
+      "file_name": "b2d-0.7.4-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "b2d"
+      ],
+      "install_dir": "site",
+      "name": "b2d",
+      "package_type": "package",
+      "sha256": "a668e2b7a8d0a9f70b48371d1d5e766948c0ad4db961b18d0e8a4f312b2e0228",
+      "unvendored_tests": false,
+      "version": "0.7.4"
+    },
+    "bcrypt": {
+      "depends": [],
+      "file_name": "bcrypt-4.3.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "bcrypt"
+      ],
+      "install_dir": "site",
+      "name": "bcrypt",
+      "package_type": "package",
+      "sha256": "25352fa4cba1c74fd42d9fe40917a33fda97b0d2e94b637d2728b096216ea9a6",
+      "unvendored_tests": false,
+      "version": "4.3.0"
+    },
+    "beautifulsoup4": {
+      "depends": [
+        "soupsieve",
+        "typing-extensions"
+      ],
+      "file_name": "beautifulsoup4-4.13.3-py3-none-any.whl",
+      "imports": [
+        "bs4"
+      ],
+      "install_dir": "site",
+      "name": "beautifulsoup4",
+      "package_type": "package",
+      "sha256": "fe75cf3aa47f3b170ecb540c76d1485f4a25253f3c5af449f962eb18c62f81ef",
+      "unvendored_tests": true,
+      "version": "4.13.3"
+    },
+    "beautifulsoup4-tests": {
+      "depends": [
+        "beautifulsoup4"
+      ],
+      "file_name": "beautifulsoup4-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "beautifulsoup4-tests",
+      "package_type": "package",
+      "sha256": "aa147920cbb967e99a3b628501a627d290372677991407f11d7caafeab772386",
+      "unvendored_tests": false,
+      "version": "4.13.3"
+    },
+    "biopython": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "biopython-1.85-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "Bio",
+        "BioSQL"
+      ],
+      "install_dir": "site",
+      "name": "biopython",
+      "package_type": "package",
+      "sha256": "a17b69c3ee4cf2f9e00758903ba98f58b37c4729b2f3b23e8c2949bc33fcc184",
+      "unvendored_tests": false,
+      "version": "1.85"
+    },
+    "bitarray": {
+      "depends": [],
+      "file_name": "bitarray-3.4.3-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "bitarray"
+      ],
+      "install_dir": "site",
+      "name": "bitarray",
+      "package_type": "package",
+      "sha256": "a8a8e8ae607b6a275c5262733fcdf6c6ec08e3653b0bd7643288a96786924161",
+      "unvendored_tests": true,
+      "version": "3.4.3"
+    },
+    "bitarray-tests": {
+      "depends": [
+        "bitarray"
+      ],
+      "file_name": "bitarray-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "bitarray-tests",
+      "package_type": "package",
+      "sha256": "3be51ab80c7c7a09b4d4849bb2ad45fa5d184e018a0f67e488632ac2536f1ca7",
+      "unvendored_tests": false,
+      "version": "3.4.3"
+    },
+    "bitstring": {
+      "depends": [
+        "bitarray"
+      ],
+      "file_name": "bitstring-4.3.1-py3-none-any.whl",
+      "imports": [
+        "bitstring"
+      ],
+      "install_dir": "site",
+      "name": "bitstring",
+      "package_type": "package",
+      "sha256": "49da61f3aa603f92188cfe720bb8b672fcdc69757af997935d41a127e884112e",
+      "unvendored_tests": false,
+      "version": "4.3.1"
+    },
+    "bleach": {
+      "depends": [
+        "webencodings",
+        "packaging",
+        "six"
+      ],
+      "file_name": "bleach-6.2.0-py3-none-any.whl",
+      "imports": [
+        "bleach"
+      ],
+      "install_dir": "site",
+      "name": "bleach",
+      "package_type": "package",
+      "sha256": "c11288a465a2a2ec3106ac793f3eaa0260150dad14864a1c5e8b86c7c338877e",
+      "unvendored_tests": false,
+      "version": "6.2.0"
+    },
+    "blosc2": {
+      "depends": [
+        "numpy",
+        "msgpack",
+        "requests",
+        "ndindex",
+        "platformdirs"
+      ],
+      "file_name": "blosc2-3.2.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "blosc2"
+      ],
+      "install_dir": "site",
+      "name": "blosc2",
+      "package_type": "package",
+      "sha256": "12f02342fe0b54fedf7cbdc87404b306e2d9d366c20be274beeadf20b0f6dc5d",
+      "unvendored_tests": false,
+      "version": "3.2.0"
+    },
+    "bokeh": {
+      "depends": [
+        "contourpy",
+        "numpy",
+        "jinja2",
+        "pandas",
+        "pillow",
+        "python-dateutil",
+        "six",
+        "typing-extensions",
+        "pyyaml",
+        "xyzservices"
+      ],
+      "file_name": "bokeh-3.6.3-py3-none-any.whl",
+      "imports": [
+        "bokeh"
+      ],
+      "install_dir": "site",
+      "name": "bokeh",
+      "package_type": "package",
+      "sha256": "d2dc4b04e17f2edc47df972e4932243f27fd34e4beaa64a343cd0d243b0e6ae2",
+      "unvendored_tests": false,
+      "version": "3.6.3"
+    },
+    "boost-histogram": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "boost_histogram-1.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "boost_histogram"
+      ],
+      "install_dir": "site",
+      "name": "boost-histogram",
+      "package_type": "package",
+      "sha256": "43d359caa1b1f81ee4917b2f1f25ff149fcbd46b7f73574b2c93b170ca201153",
+      "unvendored_tests": false,
+      "version": "1.5.0"
+    },
+    "brotli": {
+      "depends": [],
+      "file_name": "brotli-1.1.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "brotli"
+      ],
+      "install_dir": "site",
+      "name": "brotli",
+      "package_type": "package",
+      "sha256": "5c560e9c1fd9de9a77b788b14e2862335583fe1c4e78dc3596ec8e459264ac22",
+      "unvendored_tests": false,
+      "version": "1.1.0"
+    },
+    "cachetools": {
+      "depends": [],
+      "file_name": "cachetools-5.5.2-py3-none-any.whl",
+      "imports": [
+        "cachetools"
+      ],
+      "install_dir": "site",
+      "name": "cachetools",
+      "package_type": "package",
+      "sha256": "3705098c32ffef1f916dac2b4d9d2132ea3c1d2e2c40f2700d84db3ee2a2fd65",
+      "unvendored_tests": false,
+      "version": "5.5.2"
+    },
+    "casadi": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "casadi-3.7.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "casadi"
+      ],
+      "install_dir": "site",
+      "name": "casadi",
+      "package_type": "package",
+      "sha256": "d74d9c77293a2c487a3e856a794975cbee98bd9c0a28de8f389622fe75fefe1f",
+      "unvendored_tests": false,
+      "version": "3.7.0"
+    },
+    "cbor-diag": {
+      "depends": [],
+      "file_name": "cbor_diag-1.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cbor_diag"
+      ],
+      "install_dir": "site",
+      "name": "cbor-diag",
+      "package_type": "package",
+      "sha256": "fd5fe36a4538e2446dac42d8d5ef415c9f336be4066e69504d2f541fea9d099c",
+      "unvendored_tests": false,
+      "version": "1.0.1"
+    },
+    "certifi": {
+      "depends": [],
+      "file_name": "certifi-2025.6.15-py3-none-any.whl",
+      "imports": [
+        "certifi"
+      ],
+      "install_dir": "site",
+      "name": "certifi",
+      "package_type": "package",
+      "sha256": "34f344ea116df36539073746484be3f2914f8e47fedcafde80883573b602f658",
+      "unvendored_tests": false,
+      "version": "2025.6.15"
+    },
+    "cffi": {
+      "depends": [
+        "pycparser"
+      ],
+      "file_name": "cffi-1.17.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cffi"
+      ],
+      "install_dir": "site",
+      "name": "cffi",
+      "package_type": "package",
+      "sha256": "dd100149a1a88593f1ec3d493d3cbad078cf8f731c801b8c6f192b1316f5ced2",
+      "unvendored_tests": false,
+      "version": "1.17.1"
+    },
+    "cffi-example": {
+      "depends": [
+        "cffi"
+      ],
+      "file_name": "cffi_example-0.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cffi_example"
+      ],
+      "install_dir": "site",
+      "name": "cffi_example",
+      "package_type": "package",
+      "sha256": "05fdca4056454ce1c40719e4fe15b63ae1217bd09fc0377369c6ec5515ef9861",
+      "unvendored_tests": false,
+      "version": "0.1"
+    },
+    "cftime": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "cftime-1.6.4.post1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cftime"
+      ],
+      "install_dir": "site",
+      "name": "cftime",
+      "package_type": "package",
+      "sha256": "f9c0ce67ef6d5361c253e8dad559456b0070273779c3ba27c773ddb2e48cd52a",
+      "unvendored_tests": false,
+      "version": "1.6.4.post1"
+    },
+    "charset-normalizer": {
+      "depends": [],
+      "file_name": "charset_normalizer-3.4.2-py3-none-any.whl",
+      "imports": [
+        "charset_normalizer"
+      ],
+      "install_dir": "site",
+      "name": "charset-normalizer",
+      "package_type": "package",
+      "sha256": "f739b10c6fea56128c644f0a77eb664d3d48150e66c265564455e5f2da11a68e",
+      "unvendored_tests": false,
+      "version": "3.4.2"
+    },
+    "clarabel": {
+      "depends": [
+        "numpy",
+        "scipy"
+      ],
+      "file_name": "clarabel-0.11.0-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "clarabel"
+      ],
+      "install_dir": "site",
+      "name": "clarabel",
+      "package_type": "package",
+      "sha256": "37afbf23f26593d557f756b60b87ee3da4fbd16ee91e6f569550f845a7a5102b",
+      "unvendored_tests": false,
+      "version": "0.11.0"
+    },
+    "click": {
+      "depends": [],
+      "file_name": "click-8.2.1-py3-none-any.whl",
+      "imports": [
+        "click"
+      ],
+      "install_dir": "site",
+      "name": "click",
+      "package_type": "package",
+      "sha256": "c65be2855aad0770696533b37fb4b2ab0ac34922170994988159c7f650cea421",
+      "unvendored_tests": false,
+      "version": "8.2.1"
+    },
+    "cligj": {
+      "depends": [
+        "click"
+      ],
+      "file_name": "cligj-0.7.2-py3-none-any.whl",
+      "imports": [
+        "cligj"
+      ],
+      "install_dir": "site",
+      "name": "cligj",
+      "package_type": "package",
+      "sha256": "5afdfcfc698099562593e31f26723ab962725399f19f34d9dcaa716516fdd517",
+      "unvendored_tests": false,
+      "version": "0.7.2"
+    },
+    "clingo": {
+      "depends": [
+        "cffi"
+      ],
+      "file_name": "clingo-5.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "clingo"
+      ],
+      "install_dir": "site",
+      "name": "clingo",
+      "package_type": "package",
+      "sha256": "f6191904da5969329d62f4ed0c1eceb9b582f712d94538600dcc40b3ad269a96",
+      "unvendored_tests": false,
+      "version": "5.7.1"
+    },
+    "cloudpickle": {
+      "depends": [],
+      "file_name": "cloudpickle-3.1.1-py3-none-any.whl",
+      "imports": [
+        "cloudpickle"
+      ],
+      "install_dir": "site",
+      "name": "cloudpickle",
+      "package_type": "package",
+      "sha256": "f7b8dd1af13ee72e25accf6867f56192b70c8ab99e73f403f97130409afb2bb8",
+      "unvendored_tests": false,
+      "version": "3.1.1"
+    },
+    "cmyt": {
+      "depends": [
+        "colorspacious",
+        "matplotlib",
+        "more-itertools",
+        "numpy"
+      ],
+      "file_name": "cmyt-2.0.2-py3-none-any.whl",
+      "imports": [
+        "cmyt"
+      ],
+      "install_dir": "site",
+      "name": "cmyt",
+      "package_type": "package",
+      "sha256": "87262e9c5824fcef985f363eed7beba1de4f40082b0886630a031a70b35f3acc",
+      "unvendored_tests": false,
+      "version": "2.0.2"
+    },
+    "colorspacious": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "colorspacious-1.1.2-py2.py3-none-any.whl",
+      "imports": [
+        "colorspacious"
+      ],
+      "install_dir": "site",
+      "name": "colorspacious",
+      "package_type": "package",
+      "sha256": "e645eb0c1daa2fbeeca627832e5673be93d95a4a8b30a278b91aad807c0c678d",
+      "unvendored_tests": false,
+      "version": "1.1.2"
+    },
+    "contourpy": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "contourpy-1.3.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "contourpy"
+      ],
+      "install_dir": "site",
+      "name": "contourpy",
+      "package_type": "package",
+      "sha256": "0ae34ad80db2785ed3287fbc2b12a13a28421468323a14199fc4b79276193ba2",
+      "unvendored_tests": false,
+      "version": "1.3.1"
+    },
+    "coolprop": {
+      "depends": [
+        "numpy",
+        "matplotlib"
+      ],
+      "file_name": "coolprop-6.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "CoolProp"
+      ],
+      "install_dir": "site",
+      "name": "coolprop",
+      "package_type": "package",
+      "sha256": "f2e660b352c1f97b9eee9c80a00fefe37de0045a30a414131e50c726c8a9d802",
+      "unvendored_tests": true,
+      "version": "6.6.0"
+    },
+    "coolprop-tests": {
+      "depends": [
+        "coolprop"
+      ],
+      "file_name": "coolprop-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "coolprop-tests",
+      "package_type": "package",
+      "sha256": "5edfdcab2a1326454adfe019fe1bc1091dd5f7db2c02ed7ca371b766d8108bfc",
+      "unvendored_tests": false,
+      "version": "6.6.0"
+    },
+    "coverage": {
+      "depends": [
+        "sqlite3"
+      ],
+      "file_name": "coverage-7.6.12-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "coverage"
+      ],
+      "install_dir": "site",
+      "name": "coverage",
+      "package_type": "package",
+      "sha256": "61f1acfff0f375af8e5dc7582c00e083f03b08bd5395c738c7f440b22b6bd597",
+      "unvendored_tests": false,
+      "version": "7.6.12"
+    },
+    "cramjam": {
+      "depends": [],
+      "file_name": "cramjam-2.10.0rc1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cramjam"
+      ],
+      "install_dir": "site",
+      "name": "cramjam",
+      "package_type": "package",
+      "sha256": "c6b592d858f8eb4d6104f61b802aaa2358325a97990c56b32f1427164cd55c9e",
+      "unvendored_tests": false,
+      "version": "2.10.0rc1"
+    },
+    "crc32c": {
+      "depends": [],
+      "file_name": "crc32c-2.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "crc32c"
+      ],
+      "install_dir": "site",
+      "name": "crc32c",
+      "package_type": "package",
+      "sha256": "88bf2eebc3e82e162a11f7d92f26e664917cf1223294b8f12b08bb885a55c484",
+      "unvendored_tests": false,
+      "version": "2.7.1"
+    },
+    "cryptography": {
+      "depends": [
+        "openssl",
+        "six",
+        "cffi"
+      ],
+      "file_name": "cryptography-45.0.4-cp313-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cryptography"
+      ],
+      "install_dir": "site",
+      "name": "cryptography",
+      "package_type": "package",
+      "sha256": "5c1a0c742e855b1cdfa1d73d5d57d8d3961915ef67462bd46397b335f427ad58",
+      "unvendored_tests": false,
+      "version": "45.0.4"
+    },
+    "css-inline": {
+      "depends": [],
+      "file_name": "css_inline-0.15.0-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "css_inline"
+      ],
+      "install_dir": "site",
+      "name": "css-inline",
+      "package_type": "package",
+      "sha256": "ec6e9544d33bac297c179f5c19c3d8c540b2e41e8534f7be59f49f05b3341607",
+      "unvendored_tests": false,
+      "version": "0.15.0"
+    },
+    "cssselect": {
+      "depends": [],
+      "file_name": "cssselect-1.3.0-py3-none-any.whl",
+      "imports": [
+        "cssselect"
+      ],
+      "install_dir": "site",
+      "name": "cssselect",
+      "package_type": "package",
+      "sha256": "d2355faa0382b7fe97e77d0102e3450d5aac5357d23f3f9fef6141805fc5e8e3",
+      "unvendored_tests": false,
+      "version": "1.3.0"
+    },
+    "cvxpy-base": {
+      "depends": [
+        "numpy",
+        "scipy",
+        "clarabel"
+      ],
+      "file_name": "cvxpy_base-1.6.3-py3-none-any.whl",
+      "imports": [
+        "cvxpy"
+      ],
+      "install_dir": "site",
+      "name": "cvxpy-base",
+      "package_type": "package",
+      "sha256": "43bd3151bade968a1b8e9b047ec7170983cb88bf35145d6fccd5263fe341f08e",
+      "unvendored_tests": true,
+      "version": "1.6.3"
+    },
+    "cvxpy-base-tests": {
+      "depends": [
+        "cvxpy-base"
+      ],
+      "file_name": "cvxpy-base-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "cvxpy-base-tests",
+      "package_type": "package",
+      "sha256": "744a6754f2b815cde377dd70a3f48db1da1c1628693dbc2e3484588e58dd09ec",
+      "unvendored_tests": false,
+      "version": "1.6.3"
+    },
+    "cycler": {
+      "depends": [
+        "six"
+      ],
+      "file_name": "cycler-0.12.1-py3-none-any.whl",
+      "imports": [
+        "cycler"
+      ],
+      "install_dir": "site",
+      "name": "cycler",
+      "package_type": "package",
+      "sha256": "60140c464c2871fe5f5fd1a5af60e6fa62afb6a45f21e461400ec9e233cb0067",
+      "unvendored_tests": false,
+      "version": "0.12.1"
+    },
+    "cysignals": {
+      "depends": [],
+      "file_name": "cysignals-1.12.3-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cysignals"
+      ],
+      "install_dir": "site",
+      "name": "cysignals",
+      "package_type": "package",
+      "sha256": "5eef4fa816e53939080b4dfaae65b99bb42893ea6bc97080be28f70241f6bbb1",
+      "unvendored_tests": false,
+      "version": "1.12.3"
+    },
+    "cytoolz": {
+      "depends": [
+        "toolz"
+      ],
+      "file_name": "cytoolz-1.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cytoolz"
+      ],
+      "install_dir": "site",
+      "name": "cytoolz",
+      "package_type": "package",
+      "sha256": "681ecb04424b7195617a3e8ebaf71b99e9e4fed0fad32360996df8f5c53d9a0c",
+      "unvendored_tests": true,
+      "version": "1.0.1"
+    },
+    "cytoolz-tests": {
+      "depends": [
+        "cytoolz"
+      ],
+      "file_name": "cytoolz-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "cytoolz-tests",
+      "package_type": "package",
+      "sha256": "286cabab5f97dd49effd1e5214e3070e4ced3ce877ed50dc338d31239d3e64d7",
+      "unvendored_tests": false,
+      "version": "1.0.1"
+    },
+    "decorator": {
+      "depends": [],
+      "file_name": "decorator-5.2.1-py3-none-any.whl",
+      "imports": [
+        "decorator"
+      ],
+      "install_dir": "site",
+      "name": "decorator",
+      "package_type": "package",
+      "sha256": "1400a05889521c3e5f7c6ed0b1db4d27d4894fbe480dc44f58b4a9809d5bbf58",
+      "unvendored_tests": false,
+      "version": "5.2.1"
+    },
+    "demes": {
+      "depends": [
+        "attrs",
+        "ruamel.yaml"
+      ],
+      "file_name": "demes-0.2.3-py3-none-any.whl",
+      "imports": [
+        "demes"
+      ],
+      "install_dir": "site",
+      "name": "demes",
+      "package_type": "package",
+      "sha256": "bdc3f3fac58e17214549d2c5932c83038ed1a6fefa551801b21b1dff3ae28114",
+      "unvendored_tests": false,
+      "version": "0.2.3"
+    },
+    "deprecation": {
+      "depends": [
+        "packaging"
+      ],
+      "file_name": "deprecation-2.1.0-py2.py3-none-any.whl",
+      "imports": [
+        "deprecation"
+      ],
+      "install_dir": "site",
+      "name": "deprecation",
+      "package_type": "package",
+      "sha256": "a3383a37fa64bc98b553486cdf8ac13119456a4991de6470295e9941731ba12c",
+      "unvendored_tests": false,
+      "version": "2.1.0"
+    },
+    "diskcache": {
+      "depends": [
+        "sqlite3"
+      ],
+      "file_name": "diskcache-5.6.3-py3-none-any.whl",
+      "imports": [
+        "diskcache"
+      ],
+      "install_dir": "site",
+      "name": "diskcache",
+      "package_type": "package",
+      "sha256": "af33b8960c5bef913cd9046517ecae0d1d5cff14f1907f7713173c7a54910d8e",
+      "unvendored_tests": false,
+      "version": "5.6.3"
+    },
+    "distlib": {
+      "depends": [],
+      "file_name": "distlib-0.3.9-py2.py3-none-any.whl",
+      "imports": [
+        "distlib"
+      ],
+      "install_dir": "site",
+      "name": "distlib",
+      "package_type": "package",
+      "sha256": "4a84453e0b6d146e1e947996c118ba6601e457888bd75993f3f4459ab1e1e6d6",
+      "unvendored_tests": false,
+      "version": "0.3.9"
+    },
+    "distro": {
+      "depends": [],
+      "file_name": "distro-1.9.0-py3-none-any.whl",
+      "imports": [
+        "distro"
+      ],
+      "install_dir": "site",
+      "name": "distro",
+      "package_type": "package",
+      "sha256": "8d73eb1ec31e96b5881b703c315ad563c5cdb4a10437c7700bd5f40c19a0b1dc",
+      "unvendored_tests": false,
+      "version": "1.9.0"
+    },
+    "docutils": {
+      "depends": [],
+      "file_name": "docutils-0.21.2-py3-none-any.whl",
+      "imports": [
+        "docutils"
+      ],
+      "install_dir": "site",
+      "name": "docutils",
+      "package_type": "package",
+      "sha256": "49a3a930ceec10f2e27b0f921dd22f969d361c7deb7a4a89dfd2c5f939e1ae48",
+      "unvendored_tests": false,
+      "version": "0.21.2"
+    },
+    "donfig": {
+      "depends": [
+        "pyyaml"
+      ],
+      "file_name": "donfig-0.8.1.post1-py3-none-any.whl",
+      "imports": [
+        "donfig"
+      ],
+      "install_dir": "site",
+      "name": "donfig",
+      "package_type": "package",
+      "sha256": "ec67d0f05eed16c5c73dca230a64e958104f76fa53b9a9a5eca1e69aa595eaab",
+      "unvendored_tests": true,
+      "version": "0.8.1.post1"
+    },
+    "donfig-tests": {
+      "depends": [
+        "donfig"
+      ],
+      "file_name": "donfig-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "donfig-tests",
+      "package_type": "package",
+      "sha256": "83fa5d3097958bf93842e65dd6682227af0cef1c8c56319f608635d214b98d69",
+      "unvendored_tests": false,
+      "version": "0.8.1.post1"
+    },
+    "ewah-bool-utils": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "ewah_bool_utils-1.2.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "ewah_bool_utils"
+      ],
+      "install_dir": "site",
+      "name": "ewah_bool_utils",
+      "package_type": "package",
+      "sha256": "716c4c87193a310171ff97ca2f63fee40b8162e882032edec4619bbd57d4f0a0",
+      "unvendored_tests": true,
+      "version": "1.2.2"
+    },
+    "ewah-bool-utils-tests": {
+      "depends": [
+        "ewah_bool_utils"
+      ],
+      "file_name": "ewah-bool-utils-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "ewah_bool_utils-tests",
+      "package_type": "package",
+      "sha256": "1353af4387ef97d6833a7aa38142d67777c7fbbff30a42743407ba4ba85825d3",
+      "unvendored_tests": false,
+      "version": "1.2.2"
+    },
+    "exceptiongroup": {
+      "depends": [],
+      "file_name": "exceptiongroup-1.2.2-py3-none-any.whl",
+      "imports": [
+        "exceptiongroup"
+      ],
+      "install_dir": "site",
+      "name": "exceptiongroup",
+      "package_type": "package",
+      "sha256": "0317f3602a18d865726e990254d77559a96c3787bf13af8674364f7e720a9304",
+      "unvendored_tests": false,
+      "version": "1.2.2"
+    },
+    "executing": {
+      "depends": [],
+      "file_name": "executing-2.2.0-py2.py3-none-any.whl",
+      "imports": [
+        "executing"
+      ],
+      "install_dir": "site",
+      "name": "executing",
+      "package_type": "package",
+      "sha256": "4d034f044c816cacc71402b83c42c355d83aeaf2628ffa7239c22914559ddff6",
+      "unvendored_tests": false,
+      "version": "2.2.0"
+    },
+    "fastparquet": {
+      "depends": [
+        "numpy",
+        "cramjam",
+        "pandas",
+        "fsspec",
+        "packaging"
+      ],
+      "file_name": "fastparquet-2024.11.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "fastparquet"
+      ],
+      "install_dir": "site",
+      "name": "fastparquet",
+      "package_type": "package",
+      "sha256": "96d109929c6a2e860eef6dc5df29e4469a67e06b5d29ac6bd4f853ce5a55c5d8",
+      "unvendored_tests": false,
+      "version": "2024.11.0"
+    },
+    "fiona": {
+      "depends": [
+        "attrs",
+        "certifi",
+        "setuptools",
+        "six",
+        "click",
+        "cligj"
+      ],
+      "file_name": "fiona-1.9.5-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "fiona"
+      ],
+      "install_dir": "site",
+      "name": "fiona",
+      "package_type": "package",
+      "sha256": "ae6de09f68068cca47af39df0a60a356417ffa2312e9c046e508a47cbb0a9127",
+      "unvendored_tests": false,
+      "version": "1.9.5"
+    },
+    "fonttools": {
+      "depends": [],
+      "file_name": "fonttools-4.56.0-py3-none-any.whl",
+      "imports": [
+        "fontTools"
+      ],
+      "install_dir": "site",
+      "name": "fonttools",
+      "package_type": "package",
+      "sha256": "83b9708f6441f6a0f2af6335bb8e069770e541e7b01854807ca550f26fe727ed",
+      "unvendored_tests": false,
+      "version": "4.56.0"
+    },
+    "freesasa": {
+      "depends": [],
+      "file_name": "freesasa-2.2.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "freesasa"
+      ],
+      "install_dir": "site",
+      "name": "freesasa",
+      "package_type": "package",
+      "sha256": "a0a1cc352efdde6b7badbb105e42f2f3b4183942b1a1acd064a6044ed9745294",
+      "unvendored_tests": false,
+      "version": "2.2.1"
+    },
+    "frozenlist": {
+      "depends": [],
+      "file_name": "frozenlist-1.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "frozenlist"
+      ],
+      "install_dir": "site",
+      "name": "frozenlist",
+      "package_type": "package",
+      "sha256": "e21b3e493e0c26e89940eddbadfd66f2f101f89f832443bb1f28d249717ad371",
+      "unvendored_tests": false,
+      "version": "1.6.0"
+    },
+    "fsspec": {
+      "depends": [],
+      "file_name": "fsspec-2025.3.2-py3-none-any.whl",
+      "imports": [
+        "fsspec"
+      ],
+      "install_dir": "site",
+      "name": "fsspec",
+      "package_type": "package",
+      "sha256": "8b7c119b065b3b4ee0576ffc5c99e9a398d6e36edd79de4fef6db3215182ee57",
+      "unvendored_tests": true,
+      "version": "2025.3.2"
+    },
+    "fsspec-tests": {
+      "depends": [
+        "fsspec"
+      ],
+      "file_name": "fsspec-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "fsspec-tests",
+      "package_type": "package",
+      "sha256": "4a5977df5c5b98378b89fd4522d4d7993d71842bdb139f50f2ecf6fd6f8dcb4d",
+      "unvendored_tests": false,
+      "version": "2025.3.2"
+    },
+    "future": {
+      "depends": [],
+      "file_name": "future-1.0.0-py3-none-any.whl",
+      "imports": [
+        "future"
+      ],
+      "install_dir": "site",
+      "name": "future",
+      "package_type": "package",
+      "sha256": "8da835470ea2ecb0d61b56b7066aa269b1ffbd691776bde1f9a5f92f50eff5c6",
+      "unvendored_tests": true,
+      "version": "1.0.0"
+    },
+    "future-tests": {
+      "depends": [
+        "future"
+      ],
+      "file_name": "future-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "future-tests",
+      "package_type": "package",
+      "sha256": "c56fbb3b3e9ed16eba5459f063d72580a07ec8ab3495dd9d2ac6bd3fbc186086",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "galpy": {
+      "depends": [
+        "numpy",
+        "scipy",
+        "matplotlib",
+        "astropy",
+        "future",
+        "setuptools"
+      ],
+      "file_name": "galpy-1.10.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "galpy"
+      ],
+      "install_dir": "site",
+      "name": "galpy",
+      "package_type": "package",
+      "sha256": "22676bf99298cf19700b8aa94d86faa8c83251574ca19141c2e463ec0b493fb3",
+      "unvendored_tests": false,
+      "version": "1.10.2"
+    },
+    "gdal": {
+      "depends": [
+        "geos"
+      ],
+      "file_name": "gdal-3.8.3.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "gdal",
+      "package_type": "shared_library",
+      "sha256": "664f3dbfa278fdd7f6bc6174f46823b87ef2cf66b1e52c994a61e347ed840d06",
+      "unvendored_tests": false,
+      "version": "3.8.3"
+    },
+    "geos": {
+      "depends": [],
+      "file_name": "geos-3.12.1.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "geos",
+      "package_type": "shared_library",
+      "sha256": "0011df887be4d002cea5c04ed378e6cb39f387b33aff478cae3308cfd21ba744",
+      "unvendored_tests": false,
+      "version": "3.12.1"
+    },
+    "gmpy2": {
+      "depends": [],
+      "file_name": "gmpy2-2.1.5-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "gmpy2"
+      ],
+      "install_dir": "site",
+      "name": "gmpy2",
+      "package_type": "package",
+      "sha256": "04c7f6f7f17dc2e84d8e7b2af2a9ea98c1282a4dd36183378476b5c73962389a",
+      "unvendored_tests": false,
+      "version": "2.1.5"
+    },
+    "gsw": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "gsw-3.6.19-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "gsw"
+      ],
+      "install_dir": "site",
+      "name": "gsw",
+      "package_type": "package",
+      "sha256": "1c5bf7a83ef5328d2210214f1c0148100e532c68579ae902f0b8a744007189ec",
+      "unvendored_tests": true,
+      "version": "3.6.19"
+    },
+    "gsw-tests": {
+      "depends": [
+        "gsw"
+      ],
+      "file_name": "gsw-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "gsw-tests",
+      "package_type": "package",
+      "sha256": "06ac5100474696aee38229b38cd6f1a7a75a0a9ce32b333244892b39cd201da4",
+      "unvendored_tests": false,
+      "version": "3.6.19"
+    },
+    "h11": {
+      "depends": [],
+      "file_name": "h11-0.14.0-py3-none-any.whl",
+      "imports": [
+        "h11"
+      ],
+      "install_dir": "site",
+      "name": "h11",
+      "package_type": "package",
+      "sha256": "65b5e2ba4f61ba9b5a39bdf4d415bf59dcede6265bfd2ad9119b6f578aa5861f",
+      "unvendored_tests": true,
+      "version": "0.14.0"
+    },
+    "h11-tests": {
+      "depends": [
+        "h11"
+      ],
+      "file_name": "h11-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "h11-tests",
+      "package_type": "package",
+      "sha256": "b2673fb8f96ae18f00850b30005e4d1dbf275f014f06449c26578c00de8a8a1b",
+      "unvendored_tests": false,
+      "version": "0.14.0"
+    },
+    "h3": {
+      "depends": [],
+      "file_name": "h3-4.2.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "h3"
+      ],
+      "install_dir": "site",
+      "name": "h3",
+      "package_type": "package",
+      "sha256": "c9fcf27b86f7943f849fbd679d53580890bb4e366613074464c8c03d42aaead2",
+      "unvendored_tests": false,
+      "version": "4.2.2"
+    },
+    "h5py": {
+      "depends": [
+        "numpy",
+        "pkgconfig",
+        "libhdf5"
+      ],
+      "file_name": "h5py-3.13.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "h5py"
+      ],
+      "install_dir": "site",
+      "name": "h5py",
+      "package_type": "package",
+      "sha256": "e411d98215e91b3e2cdaa1931181f837a9bbd8d5adb74ce5f66675dfabbdf9dc",
+      "unvendored_tests": true,
+      "version": "3.13.0"
+    },
+    "h5py-tests": {
+      "depends": [
+        "h5py"
+      ],
+      "file_name": "h5py-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "h5py-tests",
+      "package_type": "package",
+      "sha256": "f07228ea926ee31c8c1bf62a689c6c7bf12811cc53d68a787915c2ecfbf030a1",
+      "unvendored_tests": false,
+      "version": "3.13.0"
+    },
+    "hashlib": {
+      "depends": [
+        "openssl"
+      ],
+      "file_name": "hashlib-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "_hashlib"
+      ],
+      "install_dir": "site",
+      "name": "hashlib",
+      "package_type": "cpython_module",
+      "sha256": "deaade81d8c34674f2f15b9001865e1523023ab73d42343a55f28dbd40067708",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "html5lib": {
+      "depends": [
+        "webencodings",
+        "six"
+      ],
+      "file_name": "html5lib-1.1-py2.py3-none-any.whl",
+      "imports": [
+        "html5lib"
+      ],
+      "install_dir": "site",
+      "name": "html5lib",
+      "package_type": "package",
+      "sha256": "6d90a322f3af6e77bd84af39e1e9a54f9a6107633f33b02a39c261d3a83ca5d1",
+      "unvendored_tests": false,
+      "version": "1.1"
+    },
+    "httpcore": {
+      "depends": [
+        "certifi",
+        "h11",
+        "ssl"
+      ],
+      "file_name": "httpcore-1.0.7-py3-none-any.whl",
+      "imports": [
+        "httpcore"
+      ],
+      "install_dir": "site",
+      "name": "httpcore",
+      "package_type": "package",
+      "sha256": "eb1cf4c57497190439b4f882b13891bfdc5fdc62c95a2dd15a92986930225a58",
+      "unvendored_tests": false,
+      "version": "1.0.7"
+    },
+    "httpx": {
+      "depends": [],
+      "file_name": "httpx-0.28.1-py3-none-any.whl",
+      "imports": [
+        "httpx"
+      ],
+      "install_dir": "site",
+      "name": "httpx",
+      "package_type": "package",
+      "sha256": "685478eeb6483ce1d2763b43a65a6cdfe5e896e1cbe06755ceb25a41faa0584b",
+      "unvendored_tests": false,
+      "version": "0.28.1"
+    },
+    "idna": {
+      "depends": [],
+      "file_name": "idna-3.10-py3-none-any.whl",
+      "imports": [
+        "idna"
+      ],
+      "install_dir": "site",
+      "name": "idna",
+      "package_type": "package",
+      "sha256": "f888c1ff570957d24fb2065102bc8f62ba69ede4ef641783385c8e0c2bb56984",
+      "unvendored_tests": false,
+      "version": "3.10"
+    },
+    "igraph": {
+      "depends": [
+        "texttable"
+      ],
+      "file_name": "igraph-0.11.8-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "igraph"
+      ],
+      "install_dir": "site",
+      "name": "igraph",
+      "package_type": "package",
+      "sha256": "0a59cc54fa0a084db9caab5a99d5b87baf03280b72f0372761157f3d9cbc2dcb",
+      "unvendored_tests": false,
+      "version": "0.11.8"
+    },
+    "imageio": {
+      "depends": [
+        "numpy",
+        "pillow"
+      ],
+      "file_name": "imageio-2.37.0-py3-none-any.whl",
+      "imports": [
+        "imageio"
+      ],
+      "install_dir": "site",
+      "name": "imageio",
+      "package_type": "package",
+      "sha256": "197c2454781c216c2cbebfc370bea23413a08ade1e78a3babd07eea9fa6f540f",
+      "unvendored_tests": false,
+      "version": "2.37.0"
+    },
+    "imgui-bundle": {
+      "depends": [
+        "pydantic",
+        "munch",
+        "numpy"
+      ],
+      "file_name": "imgui_bundle-1.92.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "imgui_bundle"
+      ],
+      "install_dir": "site",
+      "name": "imgui-bundle",
+      "package_type": "package",
+      "sha256": "aaadfc38ced1d79943e38df3ed09b637bc516c00d0a084107d2d06c27cddd750",
+      "unvendored_tests": true,
+      "version": "1.92.0"
+    },
+    "imgui-bundle-tests": {
+      "depends": [
+        "imgui-bundle"
+      ],
+      "file_name": "imgui-bundle-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "imgui-bundle-tests",
+      "package_type": "package",
+      "sha256": "5f1be5d6a90f16ccf0682a956e5236cf13404f4fa80f6b25814cec0d23c52f09",
+      "unvendored_tests": false,
+      "version": "1.92.0"
+    },
+    "iminuit": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "iminuit-2.30.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "iminuit"
+      ],
+      "install_dir": "site",
+      "name": "iminuit",
+      "package_type": "package",
+      "sha256": "835b5efeaf235d5ebd35d6cb507aa7fea1ea685048a24ff4e815e2db52852900",
+      "unvendored_tests": false,
+      "version": "2.30.1"
+    },
+    "iniconfig": {
+      "depends": [],
+      "file_name": "iniconfig-2.1.0-py3-none-any.whl",
+      "imports": [
+        "iniconfig"
+      ],
+      "install_dir": "site",
+      "name": "iniconfig",
+      "package_type": "package",
+      "sha256": "d45d0eaa6ec4725afa4ae442473f2bc3a0f8568936bb93f028e6f217be1ac3c9",
+      "unvendored_tests": false,
+      "version": "2.1.0"
+    },
+    "inspice": {
+      "depends": [
+        "numpy",
+        "matplotlib",
+        "pyyaml",
+        "cffi",
+        "diskcache",
+        "h5py",
+        "ply",
+        "ngspice"
+      ],
+      "file_name": "inspice-1.6.3.3-py3-none-any.whl",
+      "imports": [
+        "InSpice"
+      ],
+      "install_dir": "site",
+      "name": "inspice",
+      "package_type": "package",
+      "sha256": "c112eca96fb2130ce9c5e8f699e5c35578fa0f93b630c7643abc1b215b879f84",
+      "unvendored_tests": false,
+      "version": "1.6.3.3"
+    },
+    "ipython": {
+      "depends": [
+        "asttokens",
+        "decorator",
+        "executing",
+        "matplotlib-inline",
+        "prompt_toolkit",
+        "pure-eval",
+        "pygments",
+        "six",
+        "stack-data",
+        "traitlets",
+        "sqlite3",
+        "wcwidth"
+      ],
+      "file_name": "ipython-9.0.2-py3-none-any.whl",
+      "imports": [
+        "IPython"
+      ],
+      "install_dir": "site",
+      "name": "ipython",
+      "package_type": "package",
+      "sha256": "59c578831b614587462fa22f3fc0ff243b31be5dc9b075f8c922cbe6315e559b",
+      "unvendored_tests": true,
+      "version": "9.0.2"
+    },
+    "ipython-tests": {
+      "depends": [
+        "ipython"
+      ],
+      "file_name": "ipython-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "ipython-tests",
+      "package_type": "package",
+      "sha256": "cd83ccc4b6799eed27647090c5eb9efe3c78bca76a67524b8fb3f0e1b3c53395",
+      "unvendored_tests": false,
+      "version": "9.0.2"
+    },
+    "jedi": {
+      "depends": [
+        "parso"
+      ],
+      "file_name": "jedi-0.19.2-py2.py3-none-any.whl",
+      "imports": [
+        "jedi"
+      ],
+      "install_dir": "site",
+      "name": "jedi",
+      "package_type": "package",
+      "sha256": "0803be24e44929037a5dbdbda54094a1ff4d9096b4d1d6ae5ece3038cedf2ea8",
+      "unvendored_tests": true,
+      "version": "0.19.2"
+    },
+    "jedi-tests": {
+      "depends": [
+        "jedi"
+      ],
+      "file_name": "jedi-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "jedi-tests",
+      "package_type": "package",
+      "sha256": "71b033ab89313e07089b1e5f0a64519d5d46a72a1a0b2d192faddf204ce7dbd1",
+      "unvendored_tests": false,
+      "version": "0.19.2"
+    },
+    "jinja2": {
+      "depends": [
+        "markupsafe"
+      ],
+      "file_name": "jinja2-3.1.6-py3-none-any.whl",
+      "imports": [
+        "jinja2"
+      ],
+      "install_dir": "site",
+      "name": "Jinja2",
+      "package_type": "package",
+      "sha256": "ff2978788e7e365a0c54db60c9148cce57faa47da58a85f5e5c59a9b3535548d",
+      "unvendored_tests": false,
+      "version": "3.1.6"
+    },
+    "jiter": {
+      "depends": [],
+      "file_name": "jiter-0.9.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "jiter"
+      ],
+      "install_dir": "site",
+      "name": "jiter",
+      "package_type": "package",
+      "sha256": "8451fe067f065b36cb2827245cac0784be155e7fb190d04171a7576f578b4a85",
+      "unvendored_tests": false,
+      "version": "0.9.0"
+    },
+    "joblib": {
+      "depends": [],
+      "file_name": "joblib-1.4.2-py3-none-any.whl",
+      "imports": [
+        "joblib"
+      ],
+      "install_dir": "site",
+      "name": "joblib",
+      "package_type": "package",
+      "sha256": "0442695c4d63401b25202dd7db4fb3027085612364ee5ce077a39f3329ca75a9",
+      "unvendored_tests": true,
+      "version": "1.4.2"
+    },
+    "joblib-tests": {
+      "depends": [
+        "joblib"
+      ],
+      "file_name": "joblib-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "joblib-tests",
+      "package_type": "package",
+      "sha256": "6ab5173cd1f9c7647939a25f5ea9f4e2771a8d10155e2c9799268f69cb99bc43",
+      "unvendored_tests": false,
+      "version": "1.4.2"
+    },
+    "jsonschema": {
+      "depends": [
+        "attrs",
+        "pyrsistent",
+        "referencing",
+        "jsonschema_specifications"
+      ],
+      "file_name": "jsonschema-4.23.0-py3-none-any.whl",
+      "imports": [
+        "jsonschema"
+      ],
+      "install_dir": "site",
+      "name": "jsonschema",
+      "package_type": "package",
+      "sha256": "32b026eff49092899a6d88ec14349c07f8d56a35314d6d50220f2852cb60706d",
+      "unvendored_tests": true,
+      "version": "4.23.0"
+    },
+    "jsonschema-specifications": {
+      "depends": [
+        "referencing"
+      ],
+      "file_name": "jsonschema_specifications-2024.10.1-py3-none-any.whl",
+      "imports": [
+        "jsonschema_specifications"
+      ],
+      "install_dir": "site",
+      "name": "jsonschema_specifications",
+      "package_type": "package",
+      "sha256": "1eadaf86253f6d69e7b340fe3669977f8649a5d186b114df0172d0897beb7826",
+      "unvendored_tests": true,
+      "version": "2024.10.1"
+    },
+    "jsonschema-specifications-tests": {
+      "depends": [
+        "jsonschema_specifications"
+      ],
+      "file_name": "jsonschema-specifications-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "jsonschema_specifications-tests",
+      "package_type": "package",
+      "sha256": "8cfcdfe0dc5e9b8f2ea66e593720632271f808e7ccdd417b89a7f2432e0f02fe",
+      "unvendored_tests": false,
+      "version": "2024.10.1"
+    },
+    "jsonschema-tests": {
+      "depends": [
+        "jsonschema"
+      ],
+      "file_name": "jsonschema-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "jsonschema-tests",
+      "package_type": "package",
+      "sha256": "546157d14a067366c86e8158dda940d98e928631a6e7b7864e3477ceed8df694",
+      "unvendored_tests": false,
+      "version": "4.23.0"
+    },
+    "kiwisolver": {
+      "depends": [],
+      "file_name": "kiwisolver-1.4.8-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "kiwisolver"
+      ],
+      "install_dir": "site",
+      "name": "kiwisolver",
+      "package_type": "package",
+      "sha256": "1fa28ace818eca90ba628f4644f4481b161112519b166436822d0089b1c73b04",
+      "unvendored_tests": false,
+      "version": "1.4.8"
+    },
+    "lakers-python": {
+      "depends": [],
+      "file_name": "lakers_python-0.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "lakers"
+      ],
+      "install_dir": "site",
+      "name": "lakers-python",
+      "package_type": "package",
+      "sha256": "706bbc442de92783f2231a5f722e7774da804c900043676ae39f4953a4640ad3",
+      "unvendored_tests": false,
+      "version": "0.5.0"
+    },
+    "lazy-loader": {
+      "depends": [],
+      "file_name": "lazy_loader-0.4-py3-none-any.whl",
+      "imports": [
+        "lazy_loader"
+      ],
+      "install_dir": "site",
+      "name": "lazy_loader",
+      "package_type": "package",
+      "sha256": "922fd3357bd62c5dff8759a3be9b62d9da75aed5f94b8107b67898b566fe7136",
+      "unvendored_tests": true,
+      "version": "0.4"
+    },
+    "lazy-loader-tests": {
+      "depends": [
+        "lazy_loader"
+      ],
+      "file_name": "lazy-loader-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "lazy_loader-tests",
+      "package_type": "package",
+      "sha256": "6b782454b8e8f383fa65919c5a647ac293b718cdf579b0404ac978ce4c8db942",
+      "unvendored_tests": false,
+      "version": "0.4"
+    },
+    "lazy-object-proxy": {
+      "depends": [],
+      "file_name": "lazy_object_proxy-1.10.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "lazy_object_proxy"
+      ],
+      "install_dir": "site",
+      "name": "lazy-object-proxy",
+      "package_type": "package",
+      "sha256": "571f6f7589091a5eb8a065045c2d0440c9d82503c51c107720ccc9d11d1b9b2b",
+      "unvendored_tests": false,
+      "version": "1.10.0"
+    },
+    "libcst": {
+      "depends": [
+        "pyyaml"
+      ],
+      "file_name": "libcst-1.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "libcst"
+      ],
+      "install_dir": "site",
+      "name": "libcst",
+      "package_type": "package",
+      "sha256": "15d65ebc583c198a013f8afc4178ac81b206fc1c69b68faac0956cbd67b6f3f5",
+      "unvendored_tests": true,
+      "version": "1.6.0"
+    },
+    "libcst-tests": {
+      "depends": [
+        "libcst"
+      ],
+      "file_name": "libcst-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "libcst-tests",
+      "package_type": "package",
+      "sha256": "4cf167627d6404df77ebba023c1ec0b6cbb4f35ca7c9e3c94aea01bde75a338d",
+      "unvendored_tests": false,
+      "version": "1.6.0"
+    },
+    "libhdf5": {
+      "depends": [],
+      "file_name": "libhdf5-1.12.1.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "libhdf5",
+      "package_type": "shared_library",
+      "sha256": "12980932a0c925031343f244966803d9b7427bc83c6968a0e9b8c9f8d06b98d6",
+      "unvendored_tests": false,
+      "version": "1.12.1"
+    },
+    "libheif": {
+      "depends": [],
+      "file_name": "libheif-1.12.0.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "libheif",
+      "package_type": "shared_library",
+      "sha256": "6dcdfe5d7b2143012664be71cb7322941d7defd81d91c576db0d3db1e0aebaac",
+      "unvendored_tests": false,
+      "version": "1.12.0"
+    },
+    "libmagic": {
+      "depends": [],
+      "file_name": "libmagic-5.42.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "libmagic",
+      "package_type": "shared_library",
+      "sha256": "b3ddfa4c7f31484f13ddaa77d6c1aaf755ecf1b757aa309957336a639f21a828",
+      "unvendored_tests": false,
+      "version": "5.42"
+    },
+    "lightgbm": {
+      "depends": [
+        "numpy",
+        "scipy",
+        "scikit-learn"
+      ],
+      "file_name": "lightgbm-4.6.0-py3-none-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "lightgbm"
+      ],
+      "install_dir": "site",
+      "name": "lightgbm",
+      "package_type": "package",
+      "sha256": "3d5f16949ccd99eb6fa9fa91fde7a4297b19a720bb0d6cd413656ab24730ff8e",
+      "unvendored_tests": false,
+      "version": "4.6.0"
+    },
+    "logbook": {
+      "depends": [
+        "ssl"
+      ],
+      "file_name": "logbook-1.8.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "logbook"
+      ],
+      "install_dir": "site",
+      "name": "logbook",
+      "package_type": "package",
+      "sha256": "838d3e2b16f6e31cb4076a71a6525781e55bc5724f21bc3899042cc9139b96b9",
+      "unvendored_tests": false,
+      "version": "1.8.0"
+    },
+    "lxml": {
+      "depends": [],
+      "file_name": "lxml-5.4.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "lxml"
+      ],
+      "install_dir": "site",
+      "name": "lxml",
+      "package_type": "package",
+      "sha256": "9a1a420d50c623a1209e85cc8cb72080a3aca14871f05cca18ac5d7a85749c4a",
+      "unvendored_tests": false,
+      "version": "5.4.0"
+    },
+    "lz4": {
+      "depends": [],
+      "file_name": "lz4-4.4.4-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "lz4"
+      ],
+      "install_dir": "site",
+      "name": "lz4",
+      "package_type": "package",
+      "sha256": "57ded573d726f83ed9448303d3eb6e24ce9691a95755fbd404bb19f5dc157402",
+      "unvendored_tests": false,
+      "version": "4.4.4"
+    },
+    "lzma": {
+      "depends": [],
+      "file_name": "lzma-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "lzma",
+        "_lzma"
+      ],
+      "install_dir": "site",
+      "name": "lzma",
+      "package_type": "cpython_module",
+      "sha256": "01c295e2371ee093c7d244282a12fd8c6072308720ef2b6487397be117bf5ec9",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "markupsafe": {
+      "depends": [],
+      "file_name": "markupsafe-3.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "markupsafe"
+      ],
+      "install_dir": "site",
+      "name": "MarkupSafe",
+      "package_type": "package",
+      "sha256": "c92ce58668bd643e4ab52002d037c1df6508e864d8b7c9a53e9e9472dc21ce8c",
+      "unvendored_tests": false,
+      "version": "3.0.2"
+    },
+    "matplotlib": {
+      "depends": [
+        "contourpy",
+        "cycler",
+        "fonttools",
+        "kiwisolver",
+        "numpy",
+        "packaging",
+        "pillow",
+        "pyparsing",
+        "python-dateutil",
+        "pytz"
+      ],
+      "file_name": "matplotlib-3.8.4-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pylab",
+        "mpl_toolkits",
+        "matplotlib"
+      ],
+      "install_dir": "site",
+      "name": "matplotlib",
+      "package_type": "package",
+      "sha256": "73997b57b08e1f642f262fa20e426794abd8c0a156780b80bea21207e858d10a",
+      "unvendored_tests": true,
+      "version": "3.8.4"
+    },
+    "matplotlib-inline": {
+      "depends": [
+        "traitlets",
+        "matplotlib"
+      ],
+      "file_name": "matplotlib_inline-0.1.7-py3-none-any.whl",
+      "imports": [
+        "matplotlib-inline"
+      ],
+      "install_dir": "site",
+      "name": "matplotlib-inline",
+      "package_type": "package",
+      "sha256": "a7de24488c384ba87d2675b02b1f283e6b38f6b5371966e9630dee4bc23f2f90",
+      "unvendored_tests": false,
+      "version": "0.1.7"
+    },
+    "matplotlib-tests": {
+      "depends": [
+        "matplotlib"
+      ],
+      "file_name": "matplotlib-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "matplotlib-tests",
+      "package_type": "package",
+      "sha256": "99a75e3c16f24536be86cc7e434a2b114b326702434d6596b902761034976e53",
+      "unvendored_tests": false,
+      "version": "3.8.4"
+    },
+    "memory-allocator": {
+      "depends": [],
+      "file_name": "memory_allocator-0.1.4-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "memory_allocator"
+      ],
+      "install_dir": "site",
+      "name": "memory-allocator",
+      "package_type": "package",
+      "sha256": "8574eafcef38a44a3b07f323e571123fada0856ea40fc40a0301ed0f8d019f73",
+      "unvendored_tests": false,
+      "version": "0.1.4"
+    },
+    "micropip": {
+      "depends": [],
+      "file_name": "micropip-0.10.0-py3-none-any.whl",
+      "imports": [
+        "micropip"
+      ],
+      "install_dir": "site",
+      "name": "micropip",
+      "package_type": "package",
+      "sha256": "391c3d6d8a1c5c2cf4bd139427cac71efa546b7398e4a992149b5a137771e710",
+      "unvendored_tests": false,
+      "version": "0.10.0"
+    },
+    "mmh3": {
+      "depends": [],
+      "file_name": "mmh3-5.1.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "mmh3"
+      ],
+      "install_dir": "site",
+      "name": "mmh3",
+      "package_type": "package",
+      "sha256": "84cb164e357f74b0728d0b770e0deb02c64945117d8c228f2a9f92705f94e9b2",
+      "unvendored_tests": false,
+      "version": "5.1.0"
+    },
+    "more-itertools": {
+      "depends": [],
+      "file_name": "more_itertools-10.6.0-py3-none-any.whl",
+      "imports": [
+        "more_itertools"
+      ],
+      "install_dir": "site",
+      "name": "more-itertools",
+      "package_type": "package",
+      "sha256": "55f354455307636e51efb851011582611583a3639d9baa25b5abaf6158e29e2f",
+      "unvendored_tests": false,
+      "version": "10.6.0"
+    },
+    "mpmath": {
+      "depends": [],
+      "file_name": "mpmath-1.3.0-py3-none-any.whl",
+      "imports": [
+        "mpmath"
+      ],
+      "install_dir": "site",
+      "name": "mpmath",
+      "package_type": "package",
+      "sha256": "74a1bf2ddcea83195b7e70d2af4365b030765058585d509ebe1e582f70b27fa1",
+      "unvendored_tests": true,
+      "version": "1.3.0"
+    },
+    "mpmath-tests": {
+      "depends": [
+        "mpmath"
+      ],
+      "file_name": "mpmath-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "mpmath-tests",
+      "package_type": "package",
+      "sha256": "7d4f2c4caa8ece5b0ff6b17596959e995f409b781bbc11ced537aa3b0a0f4846",
+      "unvendored_tests": false,
+      "version": "1.3.0"
+    },
+    "msgpack": {
+      "depends": [],
+      "file_name": "msgpack-1.1.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "msgpack"
+      ],
+      "install_dir": "site",
+      "name": "msgpack",
+      "package_type": "package",
+      "sha256": "e110bd4e9ab1ec13420a6d482aebaf6e77c238d94b47d345422d1a1499534c73",
+      "unvendored_tests": false,
+      "version": "1.1.1"
+    },
+    "msgspec": {
+      "depends": [],
+      "file_name": "msgspec-0.19.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "msgspec"
+      ],
+      "install_dir": "site",
+      "name": "msgspec",
+      "package_type": "package",
+      "sha256": "2c54f89bda50cfbe4582cf436cc0505d862ac5e917e570e418b590f69de69d62",
+      "unvendored_tests": false,
+      "version": "0.19.0"
+    },
+    "msprime": {
+      "depends": [
+        "numpy",
+        "newick",
+        "tskit",
+        "demes",
+        "rpds-py"
+      ],
+      "file_name": "msprime-1.3.3-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "msprime"
+      ],
+      "install_dir": "site",
+      "name": "msprime",
+      "package_type": "package",
+      "sha256": "0b83984dd157af45b5c514c8d0e0cf6ac9c84c45b1e36862166b180f2215bc7f",
+      "unvendored_tests": false,
+      "version": "1.3.3"
+    },
+    "multidict": {
+      "depends": [],
+      "file_name": "multidict-6.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "multidict"
+      ],
+      "install_dir": "site",
+      "name": "multidict",
+      "package_type": "package",
+      "sha256": "f13931b9db0912492a951c15d099f6b7ce124caa95ade9625301621f601eac5a",
+      "unvendored_tests": false,
+      "version": "6.5.0"
+    },
+    "munch": {
+      "depends": [
+        "setuptools",
+        "six"
+      ],
+      "file_name": "munch-4.0.0-py2.py3-none-any.whl",
+      "imports": [
+        "munch"
+      ],
+      "install_dir": "site",
+      "name": "munch",
+      "package_type": "package",
+      "sha256": "04f4e30a751d4874b0139c4e4207d1e1670d5d6160f8d7c71f02d2557776f127",
+      "unvendored_tests": false,
+      "version": "4.0.0"
+    },
+    "mypy": {
+      "depends": [],
+      "file_name": "mypy-1.15.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "mypyc",
+        "mypy"
+      ],
+      "install_dir": "site",
+      "name": "mypy",
+      "package_type": "package",
+      "sha256": "7a50e07e64d966cbadc88243122ee86ececd2ee38fcf322c2958301b456544b8",
+      "unvendored_tests": true,
+      "version": "1.15.0"
+    },
+    "mypy-tests": {
+      "depends": [
+        "mypy"
+      ],
+      "file_name": "mypy-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "mypy-tests",
+      "package_type": "package",
+      "sha256": "d6e7fa0e5f20288f419465415bb3bb2f2eac0971a92ce1a04564c5e6a4c14a09",
+      "unvendored_tests": false,
+      "version": "1.15.0"
+    },
+    "narwhals": {
+      "depends": [],
+      "file_name": "narwhals-1.42.1-py3-none-any.whl",
+      "imports": [
+        "narwhals"
+      ],
+      "install_dir": "site",
+      "name": "narwhals",
+      "package_type": "package",
+      "sha256": "7cdfb8642b19f9aa8856db56aa7bb17e448d002d59b1eac6febfce72e09eadde",
+      "unvendored_tests": false,
+      "version": "1.42.1"
+    },
+    "ndindex": {
+      "depends": [],
+      "file_name": "ndindex-1.9.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "ndindex"
+      ],
+      "install_dir": "site",
+      "name": "ndindex",
+      "package_type": "package",
+      "sha256": "94fa6189ab65642f3effb5f23d136a8f36b19c50c257dd9c35e3e976f3fea830",
+      "unvendored_tests": true,
+      "version": "1.9.2"
+    },
+    "ndindex-tests": {
+      "depends": [
+        "ndindex"
+      ],
+      "file_name": "ndindex-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "ndindex-tests",
+      "package_type": "package",
+      "sha256": "137fe206c74a084e25c93d7d4c3f8a5707b01363962232876513b9377fd2ddb0",
+      "unvendored_tests": false,
+      "version": "1.9.2"
+    },
+    "netcdf4": {
+      "depends": [
+        "numpy",
+        "packaging",
+        "h5py",
+        "cftime",
+        "certifi",
+        "libhdf5"
+      ],
+      "file_name": "netcdf4-1.7.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "netCDF4"
+      ],
+      "install_dir": "site",
+      "name": "netcdf4",
+      "package_type": "package",
+      "sha256": "8fa92daff7810cfe87931af5e22010e601812c52614d6b79de7dfb52009fef31",
+      "unvendored_tests": false,
+      "version": "1.7.2"
+    },
+    "networkx": {
+      "depends": [
+        "decorator",
+        "setuptools",
+        "matplotlib",
+        "numpy"
+      ],
+      "file_name": "networkx-3.4.2-py3-none-any.whl",
+      "imports": [
+        "networkx"
+      ],
+      "install_dir": "site",
+      "name": "networkx",
+      "package_type": "package",
+      "sha256": "0beec83cfe4bbb369f63439d30f70e2082e4f74e3b2e18c3d91478c42a2e5cf5",
+      "unvendored_tests": true,
+      "version": "3.4.2"
+    },
+    "networkx-tests": {
+      "depends": [
+        "networkx"
+      ],
+      "file_name": "networkx-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "networkx-tests",
+      "package_type": "package",
+      "sha256": "8f81fd08d6e0e895aa721efbdb916cb9fb77e8c5346253fc9e89b85b84dceec0",
+      "unvendored_tests": false,
+      "version": "3.4.2"
+    },
+    "newick": {
+      "depends": [],
+      "file_name": "newick-1.9.0-py2.py3-none-any.whl",
+      "imports": [
+        "newick"
+      ],
+      "install_dir": "site",
+      "name": "newick",
+      "package_type": "package",
+      "sha256": "b83183cce5aa8fbf3470d7cc270ffaa3b3923f2f4beb5accc60f7c1f212d2667",
+      "unvendored_tests": false,
+      "version": "1.9.0"
+    },
+    "ngspice": {
+      "depends": [],
+      "file_name": "ngspice-44.2.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "ngspice",
+      "package_type": "shared_library",
+      "sha256": "de6e04d6029e379261285d1d2442dcdee65cdba2094355737bb711c82a612085",
+      "unvendored_tests": false,
+      "version": "44.2"
+    },
+    "nh3": {
+      "depends": [],
+      "file_name": "nh3-0.2.21-cp38-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "nh3"
+      ],
+      "install_dir": "site",
+      "name": "nh3",
+      "package_type": "package",
+      "sha256": "bcf39a4b8fd817a106d4c75704f27da3e4628a5ffe80c6e7641e94ba5463c48e",
+      "unvendored_tests": false,
+      "version": "0.2.21"
+    },
+    "nlopt": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "nlopt-2.9.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "nlopt"
+      ],
+      "install_dir": "site",
+      "name": "nlopt",
+      "package_type": "package",
+      "sha256": "a0583b15c418c9b4b4b6a97e7e620e45f92f8700a8e18c73becebc12f14c670b",
+      "unvendored_tests": false,
+      "version": "2.9.1"
+    },
+    "nltk": {
+      "depends": [
+        "regex",
+        "sqlite3"
+      ],
+      "file_name": "nltk-3.9.1-py3-none-any.whl",
+      "imports": [
+        "nltk"
+      ],
+      "install_dir": "site",
+      "name": "nltk",
+      "package_type": "package",
+      "sha256": "254cd1944481e599ea8d87a247db4080859d859a4772598a3ce3884818332115",
+      "unvendored_tests": true,
+      "version": "3.9.1"
+    },
+    "nltk-tests": {
+      "depends": [
+        "nltk"
+      ],
+      "file_name": "nltk-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "nltk-tests",
+      "package_type": "package",
+      "sha256": "8b3faf5c7e65dfa5cfa10a485c0c6ce85dc6b5ccc26530de716e7fcdd23f79ea",
+      "unvendored_tests": false,
+      "version": "3.9.1"
+    },
+    "numcodecs": {
+      "depends": [
+        "numpy",
+        "msgpack"
+      ],
+      "file_name": "numcodecs-0.13.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "numcodecs"
+      ],
+      "install_dir": "site",
+      "name": "numcodecs",
+      "package_type": "package",
+      "sha256": "89f040b93d72090b4ddd7905a04706457f35505f65723004bb9753dd13a8e6e2",
+      "unvendored_tests": true,
+      "version": "0.13.1"
+    },
+    "numcodecs-tests": {
+      "depends": [
+        "numcodecs"
+      ],
+      "file_name": "numcodecs-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "numcodecs-tests",
+      "package_type": "package",
+      "sha256": "cd73104ca08af3bf5447409f60822ac8c7047b417aa225dc2be26d3f994adffc",
+      "unvendored_tests": false,
+      "version": "0.13.1"
+    },
+    "numpy": {
+      "depends": [],
+      "file_name": "numpy-2.2.5-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "numpy"
+      ],
+      "install_dir": "site",
+      "name": "numpy",
+      "package_type": "package",
+      "sha256": "467a88e8c79f9e10c8e7052bcc32dd12d44d51098beb3b8f970e1cfc965c6757",
+      "unvendored_tests": false,
+      "version": "2.2.5"
+    },
+    "openai": {
+      "depends": [
+        "httpx",
+        "pydantic",
+        "typing-extensions",
+        "distro",
+        "anyio",
+        "jiter"
+      ],
+      "file_name": "openai-1.68.2-py3-none-any.whl",
+      "imports": [
+        "openai"
+      ],
+      "install_dir": "site",
+      "name": "openai",
+      "package_type": "package",
+      "sha256": "47f4bdd8bb36625279adc6109184d9464a98f96fff0c94d0b5b121cd3a47e0f4",
+      "unvendored_tests": false,
+      "version": "1.68.2"
+    },
+    "openblas": {
+      "depends": [],
+      "file_name": "openblas-0.3.26.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "openblas",
+      "package_type": "shared_library",
+      "sha256": "c0beb80dfe34e9c55f4da8a90bf7479278cc7833c20c4498dd0475a08457369e",
+      "unvendored_tests": false,
+      "version": "0.3.26"
+    },
+    "opencv-python": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "opencv_python-4.11.0.86-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "cv2"
+      ],
+      "install_dir": "site",
+      "name": "opencv-python",
+      "package_type": "package",
+      "sha256": "4ff4d80e38ff539714df6909246301b28dc362a9fb8ad88bb731e0f4597bb7b8",
+      "unvendored_tests": false,
+      "version": "4.11.0.86"
+    },
+    "openssl": {
+      "depends": [],
+      "file_name": "openssl-1.1.1w.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "openssl",
+      "package_type": "shared_library",
+      "sha256": "b1275237ad89760b876d918d4e2b14c3b105bfe983dba5f521acd9be41900a21",
+      "unvendored_tests": false,
+      "version": "1.1.1w"
+    },
+    "optlang": {
+      "depends": [
+        "sympy",
+        "six",
+        "swiglpk"
+      ],
+      "file_name": "optlang-1.8.3-py2.py3-none-any.whl",
+      "imports": [
+        "optlang"
+      ],
+      "install_dir": "site",
+      "name": "optlang",
+      "package_type": "package",
+      "sha256": "99769db34685bbbdfef1e3d1d0f44bc08ea1ffe91813884233d6f49bdf50c536",
+      "unvendored_tests": true,
+      "version": "1.8.3"
+    },
+    "optlang-tests": {
+      "depends": [
+        "optlang"
+      ],
+      "file_name": "optlang-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "optlang-tests",
+      "package_type": "package",
+      "sha256": "eeb9bc1813019a2cb86e39c3d7b10bdaf51a21ee77242d0943988c75026bfc26",
+      "unvendored_tests": false,
+      "version": "1.8.3"
+    },
+    "orjson": {
+      "depends": [],
+      "file_name": "orjson-3.10.16-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "orjson"
+      ],
+      "install_dir": "site",
+      "name": "orjson",
+      "package_type": "package",
+      "sha256": "54c717f13a57d3e1a62d18943f71bf27ed58594e170b17d7644eb0d8a1a9ff36",
+      "unvendored_tests": false,
+      "version": "3.10.16"
+    },
+    "packaging": {
+      "depends": [],
+      "file_name": "packaging-24.2-py3-none-any.whl",
+      "imports": [
+        "packaging"
+      ],
+      "install_dir": "site",
+      "name": "packaging",
+      "package_type": "package",
+      "sha256": "c0d9d97a17f70142e435a5c0ccbdb57f209823e325b0ce4893ceca8c36afe2b2",
+      "unvendored_tests": false,
+      "version": "24.2"
+    },
+    "pandas": {
+      "depends": [
+        "numpy",
+        "python-dateutil",
+        "pytz"
+      ],
+      "file_name": "pandas-2.3.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pandas"
+      ],
+      "install_dir": "site",
+      "name": "pandas",
+      "package_type": "package",
+      "sha256": "921a819fd1d60b69e46c74b09827d8c2405ade44ea278ba94c02d4d1b854c938",
+      "unvendored_tests": true,
+      "version": "2.3.0"
+    },
+    "pandas-tests": {
+      "depends": [
+        "pandas"
+      ],
+      "file_name": "pandas-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "pandas-tests",
+      "package_type": "package",
+      "sha256": "90f29363722d314d5ddba1a709532a4c30f665804fea9bc75ec084d8e9fe4793",
+      "unvendored_tests": false,
+      "version": "2.3.0"
+    },
+    "parso": {
+      "depends": [],
+      "file_name": "parso-0.8.4-py2.py3-none-any.whl",
+      "imports": [
+        "parso"
+      ],
+      "install_dir": "site",
+      "name": "parso",
+      "package_type": "package",
+      "sha256": "9d5ff6090528f77a2ba55d2ef1fc27e11e7dc8727ef251ce15ed0f511db58dfb",
+      "unvendored_tests": false,
+      "version": "0.8.4"
+    },
+    "patsy": {
+      "depends": [
+        "numpy",
+        "six"
+      ],
+      "file_name": "patsy-1.0.1-py2.py3-none-any.whl",
+      "imports": [
+        "patsy"
+      ],
+      "install_dir": "site",
+      "name": "patsy",
+      "package_type": "package",
+      "sha256": "4ec184afa0b153f0f4cabf4a1603077df73c7a5c7392a0bd251f8a40171673a3",
+      "unvendored_tests": true,
+      "version": "1.0.1"
+    },
+    "patsy-tests": {
+      "depends": [
+        "patsy"
+      ],
+      "file_name": "patsy-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "patsy-tests",
+      "package_type": "package",
+      "sha256": "b6953694092db92de7e8db2aab914dc444955467a80620636ccff303aba8606f",
+      "unvendored_tests": false,
+      "version": "1.0.1"
+    },
+    "pcodec": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "pcodec-0.3.3-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pcodec"
+      ],
+      "install_dir": "site",
+      "name": "pcodec",
+      "package_type": "package",
+      "sha256": "8dbf3453048b997bc99c0369f5643a89c23367cd9824a58cad50461348e8c279",
+      "unvendored_tests": false,
+      "version": "0.3.3"
+    },
+    "peewee": {
+      "depends": [
+        "sqlite3",
+        "cffi"
+      ],
+      "file_name": "peewee-3.17.9-py3-none-any.whl",
+      "imports": [
+        "peewee"
+      ],
+      "install_dir": "site",
+      "name": "peewee",
+      "package_type": "package",
+      "sha256": "ca8acdfaba7057aa6541917b18f50a5765fbb626ca7adc458f1c0bb29ff7a239",
+      "unvendored_tests": true,
+      "version": "3.17.9"
+    },
+    "peewee-tests": {
+      "depends": [
+        "peewee"
+      ],
+      "file_name": "peewee-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "peewee-tests",
+      "package_type": "package",
+      "sha256": "e3183bd93f4fa9e7f5819ba4dfaabfba01b4717b140bd2d8bff36e9a299c7463",
+      "unvendored_tests": false,
+      "version": "3.17.9"
+    },
+    "pi-heif": {
+      "depends": [
+        "cffi",
+        "pillow",
+        "libheif"
+      ],
+      "file_name": "pi_heif-0.21.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pi_heif"
+      ],
+      "install_dir": "site",
+      "name": "pi-heif",
+      "package_type": "package",
+      "sha256": "98cb7a0e8ea55b806ba792db455a1c5d6db295af897c8ddff091a35edb813edc",
+      "unvendored_tests": false,
+      "version": "0.21.0"
+    },
+    "pillow": {
+      "depends": [],
+      "file_name": "pillow-11.2.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "PIL"
+      ],
+      "install_dir": "site",
+      "name": "Pillow",
+      "package_type": "package",
+      "sha256": "426001442cb5ae22937e2eb7844c0a004c2e17daa8115de860e33d281da96a62",
+      "unvendored_tests": false,
+      "version": "11.2.1"
+    },
+    "pillow-heif": {
+      "depends": [
+        "cffi",
+        "pillow",
+        "libheif"
+      ],
+      "file_name": "pillow_heif-0.21.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pillow_heif"
+      ],
+      "install_dir": "site",
+      "name": "pillow-heif",
+      "package_type": "package",
+      "sha256": "59c865c040fbeb5c7ffca234560e99e34263fc29ace954e621525335994855c4",
+      "unvendored_tests": false,
+      "version": "0.21.0"
+    },
+    "pkgconfig": {
+      "depends": [],
+      "file_name": "pkgconfig-1.5.5-py3-none-any.whl",
+      "imports": [
+        "pkgconfig"
+      ],
+      "install_dir": "site",
+      "name": "pkgconfig",
+      "package_type": "package",
+      "sha256": "53181805cfb4c868593263540cae84d3237a4ba5056ce1547fac115fc481e36f",
+      "unvendored_tests": false,
+      "version": "1.5.5"
+    },
+    "platformdirs": {
+      "depends": [],
+      "file_name": "platformdirs-4.3.6-py3-none-any.whl",
+      "imports": [
+        "platformdirs"
+      ],
+      "install_dir": "site",
+      "name": "platformdirs",
+      "package_type": "package",
+      "sha256": "32b2be83ff5b2a0c545af3b052ab1323cb66cfc051b934b5c4f0c2d84794a7bf",
+      "unvendored_tests": false,
+      "version": "4.3.6"
+    },
+    "pluggy": {
+      "depends": [],
+      "file_name": "pluggy-1.5.0-py3-none-any.whl",
+      "imports": [
+        "pluggy"
+      ],
+      "install_dir": "site",
+      "name": "pluggy",
+      "package_type": "package",
+      "sha256": "1b0dcaeae60603e712b6665dbc855a45fde15ec9f914d073fc2f92fc669d7810",
+      "unvendored_tests": false,
+      "version": "1.5.0"
+    },
+    "ply": {
+      "depends": [],
+      "file_name": "ply-3.11-py2.py3-none-any.whl",
+      "imports": [
+        "ply"
+      ],
+      "install_dir": "site",
+      "name": "ply",
+      "package_type": "package",
+      "sha256": "5bc41d5d1bd8051ed6cb96a93164609b02921d1e07b620691186c99c326d14df",
+      "unvendored_tests": false,
+      "version": "3.11"
+    },
+    "pplpy": {
+      "depends": [
+        "gmpy2",
+        "cysignals"
+      ],
+      "file_name": "pplpy-0.8.10-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "ppl"
+      ],
+      "install_dir": "site",
+      "name": "pplpy",
+      "package_type": "package",
+      "sha256": "362d03d12eaa5034682760e71cf8abc6f16226150d3e85a632cc35453ffcaca5",
+      "unvendored_tests": false,
+      "version": "0.8.10"
+    },
+    "primecountpy": {
+      "depends": [
+        "cysignals"
+      ],
+      "file_name": "primecountpy-0.1.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "primecountpy"
+      ],
+      "install_dir": "site",
+      "name": "primecountpy",
+      "package_type": "package",
+      "sha256": "43b9aa37bd709b22c53ca97485fdd3ca1a11bab8a44d0de03ef5847c21785479",
+      "unvendored_tests": false,
+      "version": "0.1.1"
+    },
+    "prompt-toolkit": {
+      "depends": [
+        "wcwidth"
+      ],
+      "file_name": "prompt_toolkit-3.0.50-py3-none-any.whl",
+      "imports": [
+        "prompt_toolkit"
+      ],
+      "install_dir": "site",
+      "name": "prompt_toolkit",
+      "package_type": "package",
+      "sha256": "fc193099734a944b3d43c876257fe58dbd41463053e21be83d3d5d9a54809354",
+      "unvendored_tests": false,
+      "version": "3.0.50"
+    },
+    "propcache": {
+      "depends": [],
+      "file_name": "propcache-0.3.0-py3-none-any.whl",
+      "imports": [
+        "propcache"
+      ],
+      "install_dir": "site",
+      "name": "propcache",
+      "package_type": "package",
+      "sha256": "7e3cff0342e55663736d58196094db1b83b6e514a14adfafaaa6fcc5447f4e7b",
+      "unvendored_tests": false,
+      "version": "0.3.0"
+    },
+    "protobuf": {
+      "depends": [],
+      "file_name": "protobuf-6.31.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "google"
+      ],
+      "install_dir": "site",
+      "name": "protobuf",
+      "package_type": "package",
+      "sha256": "a9c39951cdde3ff3ef691400077df5c9fc6e842a8d2cb1e35433dcd70e3eba91",
+      "unvendored_tests": false,
+      "version": "6.31.1"
+    },
+    "pure-eval": {
+      "depends": [],
+      "file_name": "pure_eval-0.2.3-py3-none-any.whl",
+      "imports": [
+        "pure_eval"
+      ],
+      "install_dir": "site",
+      "name": "pure-eval",
+      "package_type": "package",
+      "sha256": "5b8dd92a1564116901bdabf08bbc93d5746965e34e67fc10d039731c1cc54077",
+      "unvendored_tests": false,
+      "version": "0.2.3"
+    },
+    "py": {
+      "depends": [],
+      "file_name": "py-1.11.0-py2.py3-none-any.whl",
+      "imports": [
+        "py"
+      ],
+      "install_dir": "site",
+      "name": "py",
+      "package_type": "package",
+      "sha256": "6e2f2cb6f88abaa0a0ab07c752f566ea47bbfcad67a44cd69180b662633d11b6",
+      "unvendored_tests": false,
+      "version": "1.11.0"
+    },
+    "pyclipper": {
+      "depends": [],
+      "file_name": "pyclipper-1.3.0.post6-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pyclipper"
+      ],
+      "install_dir": "site",
+      "name": "pyclipper",
+      "package_type": "package",
+      "sha256": "4473bb23969a0c69492399a85b88eebff408f5a82539b4b154a66cff55037ddc",
+      "unvendored_tests": false,
+      "version": "1.3.0.post6"
+    },
+    "pycparser": {
+      "depends": [],
+      "file_name": "pycparser-2.22-py3-none-any.whl",
+      "imports": [
+        "pycparser"
+      ],
+      "install_dir": "site",
+      "name": "pycparser",
+      "package_type": "package",
+      "sha256": "994e363bdc4a8a103a1ba9fb507fe1b1bdcd1d5e17dac84c2861f0b4ee01514e",
+      "unvendored_tests": false,
+      "version": "2.22"
+    },
+    "pycryptodome": {
+      "depends": [],
+      "file_name": "pycryptodome-3.21.0-cp36-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "Crypto"
+      ],
+      "install_dir": "site",
+      "name": "pycryptodome",
+      "package_type": "package",
+      "sha256": "23a4c54f51f206fe272d9f5e853e33f1763b1b3815701008a18a20b4ae38a39a",
+      "unvendored_tests": true,
+      "version": "3.21.0"
+    },
+    "pycryptodome-tests": {
+      "depends": [
+        "pycryptodome"
+      ],
+      "file_name": "pycryptodome-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "pycryptodome-tests",
+      "package_type": "package",
+      "sha256": "5e50e9526c4bb4f9e34f59b2e4dd32bd3f7525672fe5055a4884b6637c3dad77",
+      "unvendored_tests": false,
+      "version": "3.21.0"
+    },
+    "pydantic": {
+      "depends": [
+        "typing-extensions",
+        "pydantic_core",
+        "annotated-types"
+      ],
+      "file_name": "pydantic-2.10.6-py3-none-any.whl",
+      "imports": [
+        "pydantic"
+      ],
+      "install_dir": "site",
+      "name": "pydantic",
+      "package_type": "package",
+      "sha256": "2126acce10ac2eb9ccddd0fbc2755ef8d8eda610dd7705694e899ca31a84cb25",
+      "unvendored_tests": false,
+      "version": "2.10.6"
+    },
+    "pydantic-core": {
+      "depends": [
+        "typing-extensions"
+      ],
+      "file_name": "pydantic_core-2.27.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pydantic_core"
+      ],
+      "install_dir": "site",
+      "name": "pydantic_core",
+      "package_type": "package",
+      "sha256": "bac5a11ac9b6c74e4674149ce247575057c857bd27ff7fc89df75b61c13e9a6e",
+      "unvendored_tests": false,
+      "version": "2.27.2"
+    },
+    "pydecimal": {
+      "depends": [],
+      "file_name": "pydecimal-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "_pydecimal"
+      ],
+      "install_dir": "site",
+      "name": "pydecimal",
+      "package_type": "cpython_module",
+      "sha256": "49435742cc1553056d25b85e1dfb1c414f630a5e7605b6ae9f57cdca92262ba3",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "pydoc-data": {
+      "depends": [],
+      "file_name": "pydoc_data-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pydoc_data"
+      ],
+      "install_dir": "site",
+      "name": "pydoc_data",
+      "package_type": "cpython_module",
+      "sha256": "fbea0b930bf0ee8d0489565b5bc7f1f051bcb5044ceb7f304c360e0d6385eb05",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "pyerfa": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "pyerfa-2.0.1.5-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "erfa"
+      ],
+      "install_dir": "site",
+      "name": "pyerfa",
+      "package_type": "package",
+      "sha256": "b7dd4cfdda7784f2fe9cc5ec37c8c85925db658b84ab7acbfd01b5e0910e040f",
+      "unvendored_tests": true,
+      "version": "2.0.1.5"
+    },
+    "pyerfa-tests": {
+      "depends": [
+        "pyerfa"
+      ],
+      "file_name": "pyerfa-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "pyerfa-tests",
+      "package_type": "package",
+      "sha256": "e398477fc85fc7d9dd6a26a467126d08bdbec2c23815d973ab6308e2ae6282c4",
+      "unvendored_tests": false,
+      "version": "2.0.1.5"
+    },
+    "pygments": {
+      "depends": [],
+      "file_name": "pygments-2.19.1-py3-none-any.whl",
+      "imports": [
+        "pygments"
+      ],
+      "install_dir": "site",
+      "name": "Pygments",
+      "package_type": "package",
+      "sha256": "3b06ef8c12ff8426ab2c36e7ab72e34f9ad088685df4fb6154447bd93853d0c1",
+      "unvendored_tests": false,
+      "version": "2.19.1"
+    },
+    "pyheif": {
+      "depends": [
+        "cffi"
+      ],
+      "file_name": "pyheif-0.8.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pyheif"
+      ],
+      "install_dir": "site",
+      "name": "pyheif",
+      "package_type": "package",
+      "sha256": "23432cad9c287256419d00566f2652001702b114e3fe83f6a6c436d6d4bd31a0",
+      "unvendored_tests": false,
+      "version": "0.8.0"
+    },
+    "pyiceberg": {
+      "depends": [
+        "click",
+        "cachetools",
+        "fsspec",
+        "mmh3",
+        "pydantic",
+        "pyparsing",
+        "requests",
+        "rich",
+        "sortedcontainers",
+        "sqlalchemy",
+        "strictyaml"
+      ],
+      "file_name": "pyiceberg-0.9.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pyiceberg"
+      ],
+      "install_dir": "site",
+      "name": "pyiceberg",
+      "package_type": "package",
+      "sha256": "bbbd8f9c4d2beb22bdd2c1421c24488dd6ac41b9145d084c10befa0218b1fd7b",
+      "unvendored_tests": false,
+      "version": "0.9.0"
+    },
+    "pyinstrument": {
+      "depends": [],
+      "file_name": "pyinstrument-5.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pyinstrument"
+      ],
+      "install_dir": "site",
+      "name": "pyinstrument",
+      "package_type": "package",
+      "sha256": "ccfb92db92978789a9e2427d22b2447bad8bf486dceeb4233406827b29094ef8",
+      "unvendored_tests": false,
+      "version": "5.0.1"
+    },
+    "pynacl": {
+      "depends": [
+        "cffi"
+      ],
+      "file_name": "pynacl-1.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "nacl"
+      ],
+      "install_dir": "site",
+      "name": "pynacl",
+      "package_type": "package",
+      "sha256": "aad8408990b2900123a099f590b87327c7fcdf7b9174fb39649038e49d96289f",
+      "unvendored_tests": false,
+      "version": "1.5.0"
+    },
+    "pyodide-http": {
+      "depends": [],
+      "file_name": "pyodide_http-0.2.2-py3-none-any.whl",
+      "imports": [
+        "pyodide_http"
+      ],
+      "install_dir": "site",
+      "name": "pyodide-http",
+      "package_type": "package",
+      "sha256": "b3f0aee925e6b4bbc8af8c9d75be7a8a654b314848771835e561db1c660798fd",
+      "unvendored_tests": false,
+      "version": "0.2.2"
+    },
+    "pyodide-unix-timezones": {
+      "depends": [],
+      "file_name": "pyodide_unix_timezones-1.0.0-py3-none-any.whl",
+      "imports": [
+        "unix_timezones"
+      ],
+      "install_dir": "site",
+      "name": "pyodide-unix-timezones",
+      "package_type": "package",
+      "sha256": "083b4e4fc2ec5f0ec1ae981e49d0a6ba9e7501990a0eb0b2be93089a9a3b0960",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "pyparsing": {
+      "depends": [],
+      "file_name": "pyparsing-3.2.1-py3-none-any.whl",
+      "imports": [
+        "pyparsing"
+      ],
+      "install_dir": "site",
+      "name": "pyparsing",
+      "package_type": "package",
+      "sha256": "49fe027c3f845d2565591edd3e25ea951a6e785e37a2486c1fd3896a45e37b79",
+      "unvendored_tests": false,
+      "version": "3.2.1"
+    },
+    "pyrsistent": {
+      "depends": [],
+      "file_name": "pyrsistent-0.20.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "_pyrsistent_version",
+        "pyrsistent"
+      ],
+      "install_dir": "site",
+      "name": "pyrsistent",
+      "package_type": "package",
+      "sha256": "46af19916d2927fa5cb226de3613698355b76b187393dfa94e6f3df9e4276ff9",
+      "unvendored_tests": false,
+      "version": "0.20.0"
+    },
+    "pysam": {
+      "depends": [],
+      "file_name": "pysam-0.23.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pysam"
+      ],
+      "install_dir": "site",
+      "name": "pysam",
+      "package_type": "package",
+      "sha256": "32c419d016cfbd33508fb88e57d495bb29fbc0e9ea8f1a1ccf0dfaf1d4dd7cb5",
+      "unvendored_tests": false,
+      "version": "0.23.0"
+    },
+    "pyshp": {
+      "depends": [],
+      "file_name": "pyshp-2.3.1-py2.py3-none-any.whl",
+      "imports": [
+        "shapefile"
+      ],
+      "install_dir": "site",
+      "name": "pyshp",
+      "package_type": "package",
+      "sha256": "8d181968809e65e3f0bff2eda34792ce8e59967ed7e132dbd5a25a9fd5ef7fcb",
+      "unvendored_tests": false,
+      "version": "2.3.1"
+    },
+    "pytaglib": {
+      "depends": [
+        "taglib"
+      ],
+      "file_name": "pytaglib-3.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "taglib"
+      ],
+      "install_dir": "site",
+      "name": "pytaglib",
+      "package_type": "package",
+      "sha256": "48c15dcb58323fa87be1330310a192222b59b04d9dab8228c1b106cbcd57b52a",
+      "unvendored_tests": false,
+      "version": "3.0.1"
+    },
+    "pytest": {
+      "depends": [
+        "atomicwrites",
+        "attrs",
+        "more-itertools",
+        "pluggy",
+        "py",
+        "setuptools",
+        "six",
+        "iniconfig",
+        "exceptiongroup"
+      ],
+      "file_name": "pytest-8.3.5-py3-none-any.whl",
+      "imports": [
+        "_pytest",
+        "pytest"
+      ],
+      "install_dir": "site",
+      "name": "pytest",
+      "package_type": "package",
+      "sha256": "85aebcd03088f179151363c11faed059f3f1b1a4cb4adb673e0c679c4d6360bd",
+      "unvendored_tests": false,
+      "version": "8.3.5"
+    },
+    "pytest-asyncio": {
+      "depends": [
+        "pytest"
+      ],
+      "file_name": "pytest_asyncio-0.25.3-py3-none-any.whl",
+      "imports": [
+        "pytest_asyncio"
+      ],
+      "install_dir": "site",
+      "name": "pytest-asyncio",
+      "package_type": "package",
+      "sha256": "591cfd87f20dc36e9fb3767f1e730c31c79e5803b078bd9ebaff2890f41286fe",
+      "unvendored_tests": false,
+      "version": "0.25.3"
+    },
+    "pytest-benchmark": {
+      "depends": [],
+      "file_name": "pytest_benchmark-4.0.0-py3-none-any.whl",
+      "imports": [
+        "pytest_benchmark"
+      ],
+      "install_dir": "site",
+      "name": "pytest-benchmark",
+      "package_type": "package",
+      "sha256": "1a45a7e8136140abe16ef5fc976b05d7359accf52ce18ffb75613fb7dfd8facc",
+      "unvendored_tests": false,
+      "version": "4.0.0"
+    },
+    "pytest-httpx": {
+      "depends": [
+        "httpx",
+        "pytest",
+        "httpcore"
+      ],
+      "file_name": "pytest_httpx-0.30.0-py3-none-any.whl",
+      "imports": [
+        "pytest_httpx"
+      ],
+      "install_dir": "site",
+      "name": "pytest_httpx",
+      "package_type": "package",
+      "sha256": "f2951e2ef4588c16fd4689ff54c3b20e3f5b7f7b4718589025587e2e026dd9bb",
+      "unvendored_tests": false,
+      "version": "0.30.0"
+    },
+    "python-dateutil": {
+      "depends": [
+        "six"
+      ],
+      "file_name": "python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+      "imports": [
+        "dateutil"
+      ],
+      "install_dir": "site",
+      "name": "python-dateutil",
+      "package_type": "package",
+      "sha256": "9792745fdfff19fe681a2d2ccd1b72de71650d4b09151567ff85fb266ca86291",
+      "unvendored_tests": false,
+      "version": "2.9.0.post0"
+    },
+    "python-flint": {
+      "depends": [],
+      "file_name": "python_flint-0.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "flint"
+      ],
+      "install_dir": "site",
+      "name": "python-flint",
+      "package_type": "package",
+      "sha256": "ef6c4ef8d0af971241df6b522349afb4982bbfc3c3cc576479a73fd3f8da66dc",
+      "unvendored_tests": false,
+      "version": "0.7.1"
+    },
+    "python-magic": {
+      "depends": [
+        "libmagic"
+      ],
+      "file_name": "python_magic-0.4.27-py2.py3-none-any.whl",
+      "imports": [
+        "magic"
+      ],
+      "install_dir": "site",
+      "name": "python-magic",
+      "package_type": "package",
+      "sha256": "e0546ace5a97dd47f3deb8d639431a731f3b44350a2f8d688d9553d1e841a234",
+      "unvendored_tests": false,
+      "version": "0.4.27"
+    },
+    "python-sat": {
+      "depends": [
+        "six"
+      ],
+      "file_name": "python_sat-1.8.dev17-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pysat"
+      ],
+      "install_dir": "site",
+      "name": "python-sat",
+      "package_type": "package",
+      "sha256": "870cd910cdd2ece298a83c64ea850c932326d6758727aaf3a372e6dd429e271c",
+      "unvendored_tests": false,
+      "version": "1.8.dev17"
+    },
+    "python-solvespace": {
+      "depends": [],
+      "file_name": "python_solvespace-3.0.8-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "python_solvespace"
+      ],
+      "install_dir": "site",
+      "name": "python-solvespace",
+      "package_type": "package",
+      "sha256": "cd7ea8de8fc8307e3b6ff07e613e5610da72b53c35dfe2ee3e3a1cae2f869dc0",
+      "unvendored_tests": false,
+      "version": "3.0.8"
+    },
+    "pytz": {
+      "depends": [],
+      "file_name": "pytz-2025.2-py2.py3-none-any.whl",
+      "imports": [
+        "pytz"
+      ],
+      "install_dir": "site",
+      "name": "pytz",
+      "package_type": "package",
+      "sha256": "4a449e011aa4eacfa58b6c06cd4db6581cf86f62d4caa320b8c30e54f4a1accb",
+      "unvendored_tests": false,
+      "version": "2025.2"
+    },
+    "pywavelets": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "pywavelets-1.8.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pywt"
+      ],
+      "install_dir": "site",
+      "name": "pywavelets",
+      "package_type": "package",
+      "sha256": "0d1b002b5e46494236973dc9b5a8dae21c97a82654fe18ee4892eecbfd0e21c0",
+      "unvendored_tests": true,
+      "version": "1.8.0"
+    },
+    "pywavelets-tests": {
+      "depends": [
+        "pywavelets"
+      ],
+      "file_name": "pywavelets-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "pywavelets-tests",
+      "package_type": "package",
+      "sha256": "aa427d4a88db6450132836b40e6f917917f9709b5f30945d25a752d14e46e131",
+      "unvendored_tests": false,
+      "version": "1.8.0"
+    },
+    "pyxel": {
+      "depends": [],
+      "file_name": "pyxel-1.9.10-cp37-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pyxel"
+      ],
+      "install_dir": "site",
+      "name": "pyxel",
+      "package_type": "package",
+      "sha256": "c505c21a7445c13467477aa42f9e0f8bdfd93b6bcdc42c79036611cac4599fe2",
+      "unvendored_tests": false,
+      "version": "1.9.10"
+    },
+    "pyxirr": {
+      "depends": [],
+      "file_name": "pyxirr-0.10.6-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "pyxirr"
+      ],
+      "install_dir": "site",
+      "name": "pyxirr",
+      "package_type": "package",
+      "sha256": "9457cdaf20902ef70c9d05d07825bf4f7b4e4bfe73b1e6a23c2ce55b1fdba5b4",
+      "unvendored_tests": false,
+      "version": "0.10.6"
+    },
+    "pyyaml": {
+      "depends": [],
+      "file_name": "pyyaml-6.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "_yaml",
+        "yaml"
+      ],
+      "install_dir": "site",
+      "name": "pyyaml",
+      "package_type": "package",
+      "sha256": "197966da9f20f23b9ea37b7fee8019a39585ba78e75ac28ca0d9f7a85e098369",
+      "unvendored_tests": false,
+      "version": "6.0.2"
+    },
+    "rasterio": {
+      "depends": [
+        "numpy",
+        "affine",
+        "gdal",
+        "attrs",
+        "certifi",
+        "click",
+        "cligj"
+      ],
+      "file_name": "rasterio-1.4.3-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "rasterio"
+      ],
+      "install_dir": "site",
+      "name": "rasterio",
+      "package_type": "package",
+      "sha256": "fc5b14bab8daf0de63645640e3ea2db53cea106e1f80d563428ce6780e6aeb31",
+      "unvendored_tests": false,
+      "version": "1.4.3"
+    },
+    "rateslib": {
+      "depends": [
+        "numpy",
+        "pandas",
+        "matplotlib"
+      ],
+      "file_name": "rateslib-2.0.1-cp310-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "rateslib"
+      ],
+      "install_dir": "site",
+      "name": "rateslib",
+      "package_type": "package",
+      "sha256": "76d1c5f49828b6a78841dffb3210565ade82d915a60173614dc852299ed5ff22",
+      "unvendored_tests": false,
+      "version": "2.0.1"
+    },
+    "rebound": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "rebound-4.4.7-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "rebound"
+      ],
+      "install_dir": "site",
+      "name": "rebound",
+      "package_type": "package",
+      "sha256": "ee280fc7680b59f91181440fcd813bf329c4579770c651e427fddc79c09d6916",
+      "unvendored_tests": false,
+      "version": "4.4.7"
+    },
+    "reboundx": {
+      "depends": [
+        "rebound",
+        "numpy"
+      ],
+      "file_name": "reboundx-4.4.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "reboundx"
+      ],
+      "install_dir": "site",
+      "name": "reboundx",
+      "package_type": "package",
+      "sha256": "dfb6b87ef32c85f2bfab8e95557ce522ae550c6d69c764c6a1b39705755e5dee",
+      "unvendored_tests": false,
+      "version": "4.4.1"
+    },
+    "referencing": {
+      "depends": [
+        "attrs",
+        "rpds-py",
+        "typing-extensions"
+      ],
+      "file_name": "referencing-0.36.2-py3-none-any.whl",
+      "imports": [
+        "referencing"
+      ],
+      "install_dir": "site",
+      "name": "referencing",
+      "package_type": "package",
+      "sha256": "00fbd85e1e8ad073a099495db05e52263e0c6ee5a5cf5e6aa2b3478cfcb6f74e",
+      "unvendored_tests": true,
+      "version": "0.36.2"
+    },
+    "referencing-tests": {
+      "depends": [
+        "referencing"
+      ],
+      "file_name": "referencing-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "referencing-tests",
+      "package_type": "package",
+      "sha256": "0f125ecd8d3da4af69e4d9eb759f21cfaabb6171ff94b185fa48f279853725c6",
+      "unvendored_tests": false,
+      "version": "0.36.2"
+    },
+    "regex": {
+      "depends": [],
+      "file_name": "regex-2024.11.6-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "regex"
+      ],
+      "install_dir": "site",
+      "name": "regex",
+      "package_type": "package",
+      "sha256": "7cca3952b831bfb92f9c1ab9717e20bad13684044c13cacce83cb3f823a9003f",
+      "unvendored_tests": true,
+      "version": "2024.11.6"
+    },
+    "regex-tests": {
+      "depends": [
+        "regex"
+      ],
+      "file_name": "regex-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "regex-tests",
+      "package_type": "package",
+      "sha256": "83754d31e65c7c01c4461aed6ad8ec57ad63e364e74d086fcacc7985a1e81ce1",
+      "unvendored_tests": false,
+      "version": "2024.11.6"
+    },
+    "requests": {
+      "depends": [
+        "charset-normalizer",
+        "idna",
+        "urllib3",
+        "certifi"
+      ],
+      "file_name": "requests-2.32.3-py3-none-any.whl",
+      "imports": [
+        "requests"
+      ],
+      "install_dir": "site",
+      "name": "requests",
+      "package_type": "package",
+      "sha256": "d3a7e98f61896015484938be512e1f88902268727c7687bbd96c0c052a3cc4a6",
+      "unvendored_tests": false,
+      "version": "2.32.3"
+    },
+    "retrying": {
+      "depends": [
+        "six"
+      ],
+      "file_name": "retrying-1.3.4-py3-none-any.whl",
+      "imports": [
+        "retrying"
+      ],
+      "install_dir": "site",
+      "name": "retrying",
+      "package_type": "package",
+      "sha256": "432834c0e8b3438adb9969cd9d2fc6a805375090a2e9cde208fd216dcc89e7f5",
+      "unvendored_tests": false,
+      "version": "1.3.4"
+    },
+    "rich": {
+      "depends": [],
+      "file_name": "rich-13.9.4-py3-none-any.whl",
+      "imports": [
+        "rich"
+      ],
+      "install_dir": "site",
+      "name": "rich",
+      "package_type": "package",
+      "sha256": "335e36fb5df8524cef9ae1808d45a81d54db0bdf852bb4d51ea9e991a28fe000",
+      "unvendored_tests": false,
+      "version": "13.9.4"
+    },
+    "river": {
+      "depends": [
+        "numpy",
+        "pandas",
+        "scipy"
+      ],
+      "file_name": "river-0.22.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "river"
+      ],
+      "install_dir": "site",
+      "name": "river",
+      "package_type": "package",
+      "sha256": "faf49244eaa2d92d317ab5e7517b944862b04e5f8979715592291ec66d7b7863",
+      "unvendored_tests": true,
+      "version": "0.22.0"
+    },
+    "river-tests": {
+      "depends": [
+        "river"
+      ],
+      "file_name": "river-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "river-tests",
+      "package_type": "package",
+      "sha256": "4e44e5b4b50905e5fc0175c4db22c8be0e3c5bf74e63fa441922a07ef60855bd",
+      "unvendored_tests": false,
+      "version": "0.22.0"
+    },
+    "robotraconteur": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "robotraconteur-1.2.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "RobotRaconteur"
+      ],
+      "install_dir": "site",
+      "name": "RobotRaconteur",
+      "package_type": "package",
+      "sha256": "3bf41492d66d95f0baffe92ff7b822093b20bd8c5df27053b70949e547c6dd36",
+      "unvendored_tests": false,
+      "version": "1.2.2"
+    },
+    "rpds-py": {
+      "depends": [],
+      "file_name": "rpds_py-0.23.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "rpds"
+      ],
+      "install_dir": "site",
+      "name": "rpds-py",
+      "package_type": "package",
+      "sha256": "b9603aa100a599a3ba07eac422ed0be5cec67e516279ecccc998e8ac25191e44",
+      "unvendored_tests": false,
+      "version": "0.23.1"
+    },
+    "ruamel-yaml": {
+      "depends": [],
+      "file_name": "ruamel.yaml-0.18.10-py3-none-any.whl",
+      "imports": [
+        "ruamel"
+      ],
+      "install_dir": "site",
+      "name": "ruamel.yaml",
+      "package_type": "package",
+      "sha256": "65ac790b6e0682cd66c994f406dfb8734ce871083a2503d449301e698b2b66f0",
+      "unvendored_tests": false,
+      "version": "0.18.10"
+    },
+    "rustworkx": {
+      "depends": [],
+      "file_name": "rustworkx-0.17.0a3-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "rustworkx"
+      ],
+      "install_dir": "site",
+      "name": "rustworkx",
+      "package_type": "package",
+      "sha256": "25f59bb168391db0d8a700a052a239011a5215bf81eec9837cd0d001749dc2e3",
+      "unvendored_tests": false,
+      "version": "0.17.0a3"
+    },
+    "scikit-image": {
+      "depends": [
+        "packaging",
+        "numpy",
+        "scipy",
+        "networkx",
+        "pillow",
+        "imageio",
+        "pywavelets",
+        "lazy_loader"
+      ],
+      "file_name": "scikit_image-0.25.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "skimage"
+      ],
+      "install_dir": "site",
+      "name": "scikit-image",
+      "package_type": "package",
+      "sha256": "edeb5b71745a84ad52162eb2b8223d5e5f4755291ab62d22a81409a09d7547de",
+      "unvendored_tests": true,
+      "version": "0.25.2"
+    },
+    "scikit-image-tests": {
+      "depends": [
+        "scikit-image"
+      ],
+      "file_name": "scikit-image-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "scikit-image-tests",
+      "package_type": "package",
+      "sha256": "6272993e0c369165d694bc631ba4d4845a86a2b7067d59cad3d3500e77958386",
+      "unvendored_tests": false,
+      "version": "0.25.2"
+    },
+    "scikit-learn": {
+      "depends": [
+        "scipy",
+        "joblib",
+        "threadpoolctl"
+      ],
+      "file_name": "scikit_learn-1.7.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "sklearn"
+      ],
+      "install_dir": "site",
+      "name": "scikit-learn",
+      "package_type": "package",
+      "sha256": "71a6ad732e0d7e52aa4b81cc4ef4f26a1c45917f38a6ca296d5b33737dd56b2e",
+      "unvendored_tests": true,
+      "version": "1.7.0"
+    },
+    "scikit-learn-tests": {
+      "depends": [
+        "scikit-learn"
+      ],
+      "file_name": "scikit-learn-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "scikit-learn-tests",
+      "package_type": "package",
+      "sha256": "7bf75c6b1a95282bbdb3550f42a6ac0e95459f8393d921d3cad723ffd0994356",
+      "unvendored_tests": false,
+      "version": "1.7.0"
+    },
+    "scipy": {
+      "depends": [
+        "numpy",
+        "openblas"
+      ],
+      "file_name": "scipy-1.14.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "scipy"
+      ],
+      "install_dir": "site",
+      "name": "scipy",
+      "package_type": "package",
+      "sha256": "4e1b9bf1d135ab3f81e65653988cdfe6fb05a703938b35d1397ab7b327dc2251",
+      "unvendored_tests": true,
+      "version": "1.14.1"
+    },
+    "scipy-tests": {
+      "depends": [
+        "scipy"
+      ],
+      "file_name": "scipy-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "scipy-tests",
+      "package_type": "package",
+      "sha256": "ef57bc9ce5a32cf88d8173b72fc9e8cb521910edc6cbe73d80144f997053043c",
+      "unvendored_tests": false,
+      "version": "1.14.1"
+    },
+    "screed": {
+      "depends": [],
+      "file_name": "screed-1.1.3-py2.py3-none-any.whl",
+      "imports": [
+        "bigtests",
+        "screed"
+      ],
+      "install_dir": "site",
+      "name": "screed",
+      "package_type": "package",
+      "sha256": "6a5c6bb0d7f34302399b30c52e0a040d5c5b4ca5f25dd03a6370d11ba982e04c",
+      "unvendored_tests": true,
+      "version": "1.1.3"
+    },
+    "screed-tests": {
+      "depends": [
+        "screed"
+      ],
+      "file_name": "screed-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "screed-tests",
+      "package_type": "package",
+      "sha256": "cf50628e39fc24b1c42a5f9a5e2a2b8ea79fd734424f52943dd7d4b014fa047b",
+      "unvendored_tests": false,
+      "version": "1.1.3"
+    },
+    "setuptools": {
+      "depends": [
+        "pyparsing"
+      ],
+      "file_name": "setuptools-76.0.0-py3-none-any.whl",
+      "imports": [
+        "_distutils_hack",
+        "pkg_resources",
+        "setuptools"
+      ],
+      "install_dir": "site",
+      "name": "setuptools",
+      "package_type": "package",
+      "sha256": "d16138f727bab0f71aa6537e08354301e0c55d97dc20f91e4fa2bded65ffb007",
+      "unvendored_tests": true,
+      "version": "76.0.0"
+    },
+    "setuptools-tests": {
+      "depends": [
+        "setuptools"
+      ],
+      "file_name": "setuptools-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "setuptools-tests",
+      "package_type": "package",
+      "sha256": "20e1cac685660b65ede47c0bfaed4024b4e784743680c55d3d98b213bdee31c4",
+      "unvendored_tests": false,
+      "version": "76.0.0"
+    },
+    "shapely": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "shapely-2.0.7-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "shapely"
+      ],
+      "install_dir": "site",
+      "name": "shapely",
+      "package_type": "package",
+      "sha256": "0ec7d8203eb4506bcfe3bb17cfcaec2ead852b5b5a3fba2d0d8920de425aa963",
+      "unvendored_tests": true,
+      "version": "2.0.7"
+    },
+    "shapely-tests": {
+      "depends": [
+        "shapely"
+      ],
+      "file_name": "shapely-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "shapely-tests",
+      "package_type": "package",
+      "sha256": "29eab39bd8f474bbe8c4042d6ce992e11bb79fc493c3bdb77b0077ea4beb5243",
+      "unvendored_tests": false,
+      "version": "2.0.7"
+    },
+    "simplejson": {
+      "depends": [],
+      "file_name": "simplejson-3.20.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "simplejson"
+      ],
+      "install_dir": "site",
+      "name": "simplejson",
+      "package_type": "package",
+      "sha256": "c5884ab81866a337e4d797f4f269a9ad26513097d2993d09bc90e80dfa1ccbbe",
+      "unvendored_tests": true,
+      "version": "3.20.1"
+    },
+    "simplejson-tests": {
+      "depends": [
+        "simplejson"
+      ],
+      "file_name": "simplejson-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "simplejson-tests",
+      "package_type": "package",
+      "sha256": "a29c96d1ce4a5091a42330d0c6c60b622ce857c55fde14dcb45c8f08b3220942",
+      "unvendored_tests": false,
+      "version": "3.20.1"
+    },
+    "sisl": {
+      "depends": [
+        "pyparsing",
+        "numpy",
+        "scipy",
+        "tqdm",
+        "xarray",
+        "pandas",
+        "matplotlib"
+      ],
+      "file_name": "sisl-0.16.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "sisl_toolbox",
+        "sisl"
+      ],
+      "install_dir": "site",
+      "name": "sisl",
+      "package_type": "package",
+      "sha256": "4204c92155f297c37f4f7260d33fe81f5b4f6c1f8a5feac21022d3238e5107e6",
+      "unvendored_tests": true,
+      "version": "0.16.2"
+    },
+    "sisl-tests": {
+      "depends": [
+        "sisl"
+      ],
+      "file_name": "sisl-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "sisl-tests",
+      "package_type": "package",
+      "sha256": "d2a66f63f45085091d45d977a3ea82ee874cb9579fd82003bc31ee9ac1788813",
+      "unvendored_tests": false,
+      "version": "0.16.2"
+    },
+    "six": {
+      "depends": [],
+      "file_name": "six-1.17.0-py2.py3-none-any.whl",
+      "imports": [
+        "six"
+      ],
+      "install_dir": "site",
+      "name": "six",
+      "package_type": "package",
+      "sha256": "f213e36bbaae4640f256c86a6626e9122ce2b02b8b02e88a82053d0e4c50c02a",
+      "unvendored_tests": false,
+      "version": "1.17.0"
+    },
+    "smart-open": {
+      "depends": [
+        "wrapt"
+      ],
+      "file_name": "smart_open-7.1.0-py3-none-any.whl",
+      "imports": [
+        "smart_open"
+      ],
+      "install_dir": "site",
+      "name": "smart-open",
+      "package_type": "package",
+      "sha256": "edea899558b272cc5abf46f6ff6e16a2766a9eeccaa92174bafe1115574e8b81",
+      "unvendored_tests": false,
+      "version": "7.1.0"
+    },
+    "sniffio": {
+      "depends": [],
+      "file_name": "sniffio-1.3.1-py3-none-any.whl",
+      "imports": [
+        "sniffio"
+      ],
+      "install_dir": "site",
+      "name": "sniffio",
+      "package_type": "package",
+      "sha256": "bb2f3c751f0b1aac4a0a718ce8a4a21b51f79ce172e55ad37827235db11c7ca1",
+      "unvendored_tests": true,
+      "version": "1.3.1"
+    },
+    "sniffio-tests": {
+      "depends": [
+        "sniffio"
+      ],
+      "file_name": "sniffio-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "sniffio-tests",
+      "package_type": "package",
+      "sha256": "2c3c2ddb702e72f432d8d80a9913868dc29cf75604b3375a801c06389736b808",
+      "unvendored_tests": false,
+      "version": "1.3.1"
+    },
+    "sortedcontainers": {
+      "depends": [],
+      "file_name": "sortedcontainers-2.4.0-py2.py3-none-any.whl",
+      "imports": [
+        "sortedcontainers"
+      ],
+      "install_dir": "site",
+      "name": "sortedcontainers",
+      "package_type": "package",
+      "sha256": "a63e673698fe3f8b9eb34891a6fa481951048f4534a2e86513df3f6f1fbdc75e",
+      "unvendored_tests": false,
+      "version": "2.4.0"
+    },
+    "soundfile": {
+      "depends": [
+        "cffi",
+        "numpy"
+      ],
+      "file_name": "soundfile-0.12.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "soundfile"
+      ],
+      "install_dir": "site",
+      "name": "soundfile",
+      "package_type": "package",
+      "sha256": "e9f91008cd95b9af018efe7a685835fc62eb1ad39ea186820d41e777798afd7c",
+      "unvendored_tests": false,
+      "version": "0.12.1"
+    },
+    "soupsieve": {
+      "depends": [],
+      "file_name": "soupsieve-2.6-py3-none-any.whl",
+      "imports": [
+        "soupsieve"
+      ],
+      "install_dir": "site",
+      "name": "soupsieve",
+      "package_type": "package",
+      "sha256": "ddb7d7fc10b3edb4a689e453b51b2b805d8851ca7f1dcffe2ada624f032360b4",
+      "unvendored_tests": false,
+      "version": "2.6"
+    },
+    "sourmash": {
+      "depends": [
+        "screed",
+        "cffi",
+        "deprecation",
+        "cachetools",
+        "numpy",
+        "matplotlib",
+        "scipy",
+        "sqlite3",
+        "bitstring"
+      ],
+      "file_name": "sourmash-4.8.14-py3-none-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "sourmash"
+      ],
+      "install_dir": "site",
+      "name": "sourmash",
+      "package_type": "package",
+      "sha256": "abd4d4ce0b04af3d8fdf00ab23bfcab30d457dacc6429a617c15dc705b38abac",
+      "unvendored_tests": false,
+      "version": "4.8.14"
+    },
+    "soxr": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "soxr-0.5.0.post1-cp312-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "soxr"
+      ],
+      "install_dir": "site",
+      "name": "soxr",
+      "package_type": "package",
+      "sha256": "0970c84abfc9b476e649f6c523545c1a53fd778474663a3bf59feb7a91780028",
+      "unvendored_tests": false,
+      "version": "0.5.0.post1"
+    },
+    "sparseqr": {
+      "depends": [
+        "pycparser",
+        "cffi",
+        "numpy",
+        "scipy",
+        "suitesparse"
+      ],
+      "file_name": "sparseqr-1.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "sparseqr"
+      ],
+      "install_dir": "site",
+      "name": "sparseqr",
+      "package_type": "package",
+      "sha256": "bc14d2df81135f07a5dafb8b1480c7feb3073ad57906d5facdd83de8655c68a0",
+      "unvendored_tests": false,
+      "version": "1.2"
+    },
+    "sqlalchemy": {
+      "depends": [
+        "sqlite3",
+        "typing-extensions"
+      ],
+      "file_name": "sqlalchemy-2.0.39-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "sqlalchemy"
+      ],
+      "install_dir": "site",
+      "name": "sqlalchemy",
+      "package_type": "package",
+      "sha256": "0a40c6751e723b8e300bd05d0c5f233b3ce98a1cda8dec62b88b4bfb1a9e76e5",
+      "unvendored_tests": true,
+      "version": "2.0.39"
+    },
+    "sqlalchemy-tests": {
+      "depends": [
+        "sqlalchemy"
+      ],
+      "file_name": "sqlalchemy-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "sqlalchemy-tests",
+      "package_type": "package",
+      "sha256": "2644c0080fdf457d3255c9591751868851adc51de8792c71692b1151fee98a5d",
+      "unvendored_tests": false,
+      "version": "2.0.39"
+    },
+    "sqlite3": {
+      "depends": [],
+      "file_name": "sqlite3-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "sqlite3",
+        "_sqlite3"
+      ],
+      "install_dir": "site",
+      "name": "sqlite3",
+      "package_type": "cpython_module",
+      "sha256": "dfb82f242c6226f078e2d422d9b07292df9395ced2732bf0f1d893f6e88e9a2b",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "ssl": {
+      "depends": [
+        "openssl"
+      ],
+      "file_name": "ssl-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "ssl",
+        "_ssl"
+      ],
+      "install_dir": "site",
+      "name": "ssl",
+      "package_type": "cpython_module",
+      "sha256": "66a777d12bbdd3ecbdc8a8d5ba78b42f71a5cefe01ef514dadd63757d463c015",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "stack-data": {
+      "depends": [
+        "executing",
+        "asttokens",
+        "pure-eval"
+      ],
+      "file_name": "stack_data-0.6.3-py3-none-any.whl",
+      "imports": [
+        "stack_data"
+      ],
+      "install_dir": "site",
+      "name": "stack-data",
+      "package_type": "package",
+      "sha256": "1342f587130b8ea506ab816c0bdfefac42d44e0b2fe0d8afd07e6d8ab5411c7f",
+      "unvendored_tests": false,
+      "version": "0.6.3"
+    },
+    "statsmodels": {
+      "depends": [
+        "numpy",
+        "scipy",
+        "pandas",
+        "patsy",
+        "packaging"
+      ],
+      "file_name": "statsmodels-0.14.4-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "statsmodels"
+      ],
+      "install_dir": "site",
+      "name": "statsmodels",
+      "package_type": "package",
+      "sha256": "6a5762920de3429abb587771320355cd4b8c5023b04f7f0c4cd9ea6bbcdbc0ba",
+      "unvendored_tests": false,
+      "version": "0.14.4"
+    },
+    "strictyaml": {
+      "depends": [
+        "python-dateutil"
+      ],
+      "file_name": "strictyaml-1.7.3-py3-none-any.whl",
+      "imports": [
+        "strictyaml"
+      ],
+      "install_dir": "site",
+      "name": "strictyaml",
+      "package_type": "package",
+      "sha256": "c626c273ffb645c836915629268124f42f87e230f44f987159a25fa51e3e48a7",
+      "unvendored_tests": false,
+      "version": "1.7.3"
+    },
+    "suitesparse": {
+      "depends": [
+        "openblas"
+      ],
+      "file_name": "suitesparse-5.11.0.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "suitesparse",
+      "package_type": "shared_library",
+      "sha256": "53ee82bef9e5a8228305f8a1834809d0ce686e27ae594c0774f32afb0044af2d",
+      "unvendored_tests": false,
+      "version": "5.11.0"
+    },
+    "svgwrite": {
+      "depends": [],
+      "file_name": "svgwrite-1.4.3-py3-none-any.whl",
+      "imports": [
+        "svgwrite"
+      ],
+      "install_dir": "site",
+      "name": "svgwrite",
+      "package_type": "package",
+      "sha256": "bb5a0785d271b72e58241ef0d2daaa551e46696ad97ce6808f4f603af5662885",
+      "unvendored_tests": false,
+      "version": "1.4.3"
+    },
+    "swiglpk": {
+      "depends": [],
+      "file_name": "swiglpk-5.0.12-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "swiglpk"
+      ],
+      "install_dir": "site",
+      "name": "swiglpk",
+      "package_type": "package",
+      "sha256": "bc1053d1d1f714c0a42cb0f34886a7b39531f41be66d9b1122dc9a5bcb3c5f8a",
+      "unvendored_tests": false,
+      "version": "5.0.12"
+    },
+    "sympy": {
+      "depends": [
+        "mpmath"
+      ],
+      "file_name": "sympy-1.13.3-py3-none-any.whl",
+      "imports": [
+        "isympy",
+        "sympy"
+      ],
+      "install_dir": "site",
+      "name": "sympy",
+      "package_type": "package",
+      "sha256": "10b7c79a00da21aa340c1fee6017ea526b8f5ddc92daef56de37f446daa88c83",
+      "unvendored_tests": true,
+      "version": "1.13.3"
+    },
+    "sympy-tests": {
+      "depends": [
+        "sympy"
+      ],
+      "file_name": "sympy-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "sympy-tests",
+      "package_type": "package",
+      "sha256": "ea23ee4d94a8e9206497d6970d028948c39d82eed1f57e8f059351fa77eff6b2",
+      "unvendored_tests": false,
+      "version": "1.13.3"
+    },
+    "taglib": {
+      "depends": [],
+      "file_name": "taglib-2.1.1.zip",
+      "imports": [],
+      "install_dir": "dynlib",
+      "name": "taglib",
+      "package_type": "shared_library",
+      "sha256": "d19c421e54bb0f2d4f764ba14013e8bed2ebeb5a6724f8e4d63aef21c1dd09bf",
+      "unvendored_tests": false,
+      "version": "2.1.1"
+    },
+    "tblib": {
+      "depends": [],
+      "file_name": "tblib-3.0.0-py3-none-any.whl",
+      "imports": [
+        "tblib"
+      ],
+      "install_dir": "site",
+      "name": "tblib",
+      "package_type": "package",
+      "sha256": "58856f16edd8a01b879cd98ac7c6d573395f3e4f61009b46eeece0ec64667768",
+      "unvendored_tests": false,
+      "version": "3.0.0"
+    },
+    "termcolor": {
+      "depends": [],
+      "file_name": "termcolor-2.5.0-py3-none-any.whl",
+      "imports": [
+        "termcolor"
+      ],
+      "install_dir": "site",
+      "name": "termcolor",
+      "package_type": "package",
+      "sha256": "7cebdf1e4e550dea158860f5b1fd0ad99a86a069aabf7c82dfd74ef804abf467",
+      "unvendored_tests": false,
+      "version": "2.5.0"
+    },
+    "test": {
+      "depends": [],
+      "file_name": "test-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "test"
+      ],
+      "install_dir": "site",
+      "name": "test",
+      "package_type": "cpython_module",
+      "sha256": "ad2b465b487aac6bf4ce39e9e95028ca22f628285a66446f88b52179609689cb",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "texttable": {
+      "depends": [],
+      "file_name": "texttable-1.7.0-py2.py3-none-any.whl",
+      "imports": [
+        "texttable"
+      ],
+      "install_dir": "site",
+      "name": "texttable",
+      "package_type": "package",
+      "sha256": "a366ef149d93f3d7716df490d86970a8c80b9d1781f7fb158c5ccef114b43dc6",
+      "unvendored_tests": false,
+      "version": "1.7.0"
+    },
+    "texture2ddecoder": {
+      "depends": [],
+      "file_name": "texture2ddecoder-1.0.5-cp37-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "texture2ddecoder"
+      ],
+      "install_dir": "site",
+      "name": "texture2ddecoder",
+      "package_type": "package",
+      "sha256": "6e0b92fa4642fbc5bab3aecff0413b6a6b1f04f7fcf282607413f435857d12a4",
+      "unvendored_tests": false,
+      "version": "1.0.5"
+    },
+    "threadpoolctl": {
+      "depends": [],
+      "file_name": "threadpoolctl-3.5.0-py3-none-any.whl",
+      "imports": [
+        "threadpoolctl"
+      ],
+      "install_dir": "site",
+      "name": "threadpoolctl",
+      "package_type": "package",
+      "sha256": "4c7afd9a403c3ac4db535d6aca2090cfde391c0883b15080cbc3c573e4fcae9b",
+      "unvendored_tests": false,
+      "version": "3.5.0"
+    },
+    "tiktoken": {
+      "depends": [
+        "regex",
+        "requests"
+      ],
+      "file_name": "tiktoken-0.9.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "tiktoken",
+        "tiktoken_ext"
+      ],
+      "install_dir": "site",
+      "name": "tiktoken",
+      "package_type": "package",
+      "sha256": "f0d7009f5354ca649350bf26cf35082ac2322fb868b6cd48728ae708d5d314c9",
+      "unvendored_tests": false,
+      "version": "0.9.0"
+    },
+    "tomli": {
+      "depends": [],
+      "file_name": "tomli-2.2.1-py3-none-any.whl",
+      "imports": [
+        "tomli"
+      ],
+      "install_dir": "site",
+      "name": "tomli",
+      "package_type": "package",
+      "sha256": "2d3948b81c540e927698c21daaf54ec0c15d76f3d6c1a4d97043df2024c9e754",
+      "unvendored_tests": false,
+      "version": "2.2.1"
+    },
+    "tomli-w": {
+      "depends": [],
+      "file_name": "tomli_w-1.2.0-py3-none-any.whl",
+      "imports": [
+        "tomli_w"
+      ],
+      "install_dir": "site",
+      "name": "tomli-w",
+      "package_type": "package",
+      "sha256": "f4d654c609d9ee6ac43e812935a331c4af11e5e78b93493de943b4cccab66b33",
+      "unvendored_tests": false,
+      "version": "1.2.0"
+    },
+    "toolz": {
+      "depends": [],
+      "file_name": "toolz-1.0.0-py3-none-any.whl",
+      "imports": [
+        "tlz",
+        "toolz"
+      ],
+      "install_dir": "site",
+      "name": "toolz",
+      "package_type": "package",
+      "sha256": "d9b13e3696feb93ea4729d677f08deb108d0cb238157b12eb5c47787502f5857",
+      "unvendored_tests": true,
+      "version": "1.0.0"
+    },
+    "toolz-tests": {
+      "depends": [
+        "toolz"
+      ],
+      "file_name": "toolz-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "toolz-tests",
+      "package_type": "package",
+      "sha256": "e6e8112849c8818d38f867ba3013389a3c0b5754d73001c01517e985b88cd5f4",
+      "unvendored_tests": false,
+      "version": "1.0.0"
+    },
+    "tqdm": {
+      "depends": [],
+      "file_name": "tqdm-4.67.1-py3-none-any.whl",
+      "imports": [
+        "tqdm"
+      ],
+      "install_dir": "site",
+      "name": "tqdm",
+      "package_type": "package",
+      "sha256": "c7cb7731e708943d4383072b7281a20938c2a56be651ca6feb8feb8148d77f6a",
+      "unvendored_tests": false,
+      "version": "4.67.1"
+    },
+    "traitlets": {
+      "depends": [],
+      "file_name": "traitlets-5.14.3-py3-none-any.whl",
+      "imports": [
+        "traitlets"
+      ],
+      "install_dir": "site",
+      "name": "traitlets",
+      "package_type": "package",
+      "sha256": "e77db6ca3d6d5bbe3acaa6ede6fe582e0736a4ed152ef0ba3c0bdde6af42565d",
+      "unvendored_tests": true,
+      "version": "5.14.3"
+    },
+    "traitlets-tests": {
+      "depends": [
+        "traitlets"
+      ],
+      "file_name": "traitlets-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "traitlets-tests",
+      "package_type": "package",
+      "sha256": "e213bfbb711f46f8151986a0e39224cf5d6fb951afc406c50e17a993068ceb8d",
+      "unvendored_tests": false,
+      "version": "5.14.3"
+    },
+    "traits": {
+      "depends": [],
+      "file_name": "traits-7.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "traits"
+      ],
+      "install_dir": "site",
+      "name": "traits",
+      "package_type": "package",
+      "sha256": "4814ed02cfe2751f8727109024b3d8fca03dfcb93583014386a5426c13bd2308",
+      "unvendored_tests": true,
+      "version": "7.0.2"
+    },
+    "traits-tests": {
+      "depends": [
+        "traits"
+      ],
+      "file_name": "traits-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "traits-tests",
+      "package_type": "package",
+      "sha256": "19cc75c854a661c3ea9da5f76db1ba7f0407c23ac27e8ae2faf439aa378426df",
+      "unvendored_tests": false,
+      "version": "7.0.2"
+    },
+    "tree-sitter": {
+      "depends": [],
+      "file_name": "tree_sitter-0.23.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "tree_sitter"
+      ],
+      "install_dir": "site",
+      "name": "tree-sitter",
+      "package_type": "package",
+      "sha256": "811a8d2aa859191b975fc606624d52485bbcd4518fe38305f541aff08709ea88",
+      "unvendored_tests": false,
+      "version": "0.23.2"
+    },
+    "tree-sitter-go": {
+      "depends": [
+        "tree-sitter"
+      ],
+      "file_name": "tree_sitter_go-0.23.3-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "tree_sitter_go"
+      ],
+      "install_dir": "site",
+      "name": "tree-sitter-go",
+      "package_type": "package",
+      "sha256": "4f041bf2036c6261bd80e72eb2bd42daa9aaa682ef038bfd41bea3a6857968c7",
+      "unvendored_tests": false,
+      "version": "0.23.3"
+    },
+    "tree-sitter-java": {
+      "depends": [
+        "tree-sitter"
+      ],
+      "file_name": "tree_sitter_java-0.23.4-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "tree_sitter_java"
+      ],
+      "install_dir": "site",
+      "name": "tree-sitter-java",
+      "package_type": "package",
+      "sha256": "44e7d0c23184d252aa33e057ae44fd6a8f3800def8c2ceb6fb40879aafd00b2c",
+      "unvendored_tests": false,
+      "version": "0.23.4"
+    },
+    "tree-sitter-python": {
+      "depends": [
+        "tree-sitter"
+      ],
+      "file_name": "tree_sitter_python-0.23.4-cp39-abi3-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "tree_sitter_python"
+      ],
+      "install_dir": "site",
+      "name": "tree-sitter-python",
+      "package_type": "package",
+      "sha256": "3da26ee514001cb726069b0398121139096476fd6af76c87e0f5de06da0f7d9f",
+      "unvendored_tests": false,
+      "version": "0.23.4"
+    },
+    "tskit": {
+      "depends": [
+        "numpy",
+        "svgwrite",
+        "jsonschema",
+        "rpds-py"
+      ],
+      "file_name": "tskit-0.6.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "tskit"
+      ],
+      "install_dir": "site",
+      "name": "tskit",
+      "package_type": "package",
+      "sha256": "82a755003bb87e94ab00c15422e1a0d0377d5b9610d786d2b0db2c34796163a9",
+      "unvendored_tests": false,
+      "version": "0.6.0"
+    },
+    "typing-extensions": {
+      "depends": [],
+      "file_name": "typing_extensions-4.14.0-py3-none-any.whl",
+      "imports": [
+        "typing_extensions"
+      ],
+      "install_dir": "site",
+      "name": "typing-extensions",
+      "package_type": "package",
+      "sha256": "ea55f317ad44571eea7bfaa916b81c857181f0a0971ab97b2fe251c01b510f90",
+      "unvendored_tests": false,
+      "version": "4.14.0"
+    },
+    "tzdata": {
+      "depends": [],
+      "file_name": "tzdata-2025.2-py2.py3-none-any.whl",
+      "imports": [
+        "tzdata"
+      ],
+      "install_dir": "site",
+      "name": "tzdata",
+      "package_type": "package",
+      "sha256": "0701e11f6d1a30d77913de74b915df3cd08ad4590fad6b670d6f6228b5d001d2",
+      "unvendored_tests": false,
+      "version": "2025.2"
+    },
+    "ujson": {
+      "depends": [],
+      "file_name": "ujson-5.10.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "ujson"
+      ],
+      "install_dir": "site",
+      "name": "ujson",
+      "package_type": "package",
+      "sha256": "cc01072badf51e68bc14efa57f892e11354c76be28813cc51fe483f3c899508c",
+      "unvendored_tests": false,
+      "version": "5.10.0"
+    },
+    "uncertainties": {
+      "depends": [
+        "future"
+      ],
+      "file_name": "uncertainties-3.2.2-py3-none-any.whl",
+      "imports": [
+        "uncertainties"
+      ],
+      "install_dir": "site",
+      "name": "uncertainties",
+      "package_type": "package",
+      "sha256": "e17a6eb4c16d964c93b72c4802f521cbc430d350ca3a4541aadb21b92de07c16",
+      "unvendored_tests": false,
+      "version": "3.2.2"
+    },
+    "unyt": {
+      "depends": [
+        "numpy",
+        "packaging",
+        "sympy"
+      ],
+      "file_name": "unyt-3.0.3-py3-none-any.whl",
+      "imports": [
+        "unyt"
+      ],
+      "install_dir": "site",
+      "name": "unyt",
+      "package_type": "package",
+      "sha256": "2d66e96ca928743de94f880b36122e5164616ded4fb1feb6e6b1e2c272fa6f79",
+      "unvendored_tests": true,
+      "version": "3.0.3"
+    },
+    "unyt-tests": {
+      "depends": [
+        "unyt"
+      ],
+      "file_name": "unyt-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "unyt-tests",
+      "package_type": "package",
+      "sha256": "2546fc0f1f734c76c1ed65ef894126b1fae20fecf5d811200c15e8645415541d",
+      "unvendored_tests": false,
+      "version": "3.0.3"
+    },
+    "urllib3": {
+      "depends": [],
+      "file_name": "urllib3-2.3.0-py3-none-any.whl",
+      "imports": [
+        "urllib3"
+      ],
+      "install_dir": "site",
+      "name": "urllib3",
+      "package_type": "package",
+      "sha256": "2b347fd6e69835a1c53f8c2263aca2efb493d5d1d85563b3f2a7499ff7b3944f",
+      "unvendored_tests": false,
+      "version": "2.3.0"
+    },
+    "vega-datasets": {
+      "depends": [
+        "pandas"
+      ],
+      "file_name": "vega_datasets-0.9.0-py3-none-any.whl",
+      "imports": [
+        "vega_datasets"
+      ],
+      "install_dir": "site",
+      "name": "vega-datasets",
+      "package_type": "package",
+      "sha256": "c2031bcf493df9094eeec393dfda992933daf804c4f0117add037991baa8ebf1",
+      "unvendored_tests": true,
+      "version": "0.9.0"
+    },
+    "vega-datasets-tests": {
+      "depends": [
+        "vega-datasets"
+      ],
+      "file_name": "vega-datasets-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "vega-datasets-tests",
+      "package_type": "package",
+      "sha256": "10ce4f10db8360b4d3a7cd23fd1d1feef161f8edff4d9e7d3721600a69afc9a4",
+      "unvendored_tests": false,
+      "version": "0.9.0"
+    },
+    "wcwidth": {
+      "depends": [],
+      "file_name": "wcwidth-0.2.13-py2.py3-none-any.whl",
+      "imports": [
+        "wcwidth"
+      ],
+      "install_dir": "site",
+      "name": "wcwidth",
+      "package_type": "package",
+      "sha256": "db9afdada79bb146dd4681fcb7c065dc1a3bc5c32f750542e695e1aa1fe3a956",
+      "unvendored_tests": false,
+      "version": "0.2.13"
+    },
+    "webencodings": {
+      "depends": [],
+      "file_name": "webencodings-0.5.1-py2.py3-none-any.whl",
+      "imports": [
+        "webencodings"
+      ],
+      "install_dir": "site",
+      "name": "webencodings",
+      "package_type": "package",
+      "sha256": "cbc9dcbcc91190df72990e2f5d5effc2f3aaf2dc09f23a7f073cfdb2adc08c58",
+      "unvendored_tests": false,
+      "version": "0.5.1"
+    },
+    "wordcloud": {
+      "depends": [
+        "matplotlib"
+      ],
+      "file_name": "wordcloud-1.9.4-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "wordcloud"
+      ],
+      "install_dir": "site",
+      "name": "wordcloud",
+      "package_type": "package",
+      "sha256": "e67706f11c85cd8ef767eddd806952e5cc8cd88469f531f8e11d433d24dd6904",
+      "unvendored_tests": false,
+      "version": "1.9.4"
+    },
+    "wrapt": {
+      "depends": [],
+      "file_name": "wrapt-1.17.2-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "wrapt"
+      ],
+      "install_dir": "site",
+      "name": "wrapt",
+      "package_type": "package",
+      "sha256": "749ad6578f49a76218f7b9a081d22610752a8f76cbb845dc604c364bcdf8d828",
+      "unvendored_tests": false,
+      "version": "1.17.2"
+    },
+    "xarray": {
+      "depends": [
+        "numpy",
+        "packaging",
+        "pandas"
+      ],
+      "file_name": "xarray-2025.1.2-py3-none-any.whl",
+      "imports": [
+        "xarray"
+      ],
+      "install_dir": "site",
+      "name": "xarray",
+      "package_type": "package",
+      "sha256": "02a4f88148fcfb864a8261197662906763b7b087f347cee12144ed5779dde482",
+      "unvendored_tests": true,
+      "version": "2025.1.2"
+    },
+    "xarray-tests": {
+      "depends": [
+        "xarray"
+      ],
+      "file_name": "xarray-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "xarray-tests",
+      "package_type": "package",
+      "sha256": "71890d21b7637e9ad6931160e0aace010866e25a75fb506e3b28d66f6ef6a579",
+      "unvendored_tests": false,
+      "version": "2025.1.2"
+    },
+    "xgboost": {
+      "depends": [
+        "numpy",
+        "scipy",
+        "setuptools"
+      ],
+      "file_name": "xgboost-2.1.4-py3-none-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "xgboost"
+      ],
+      "install_dir": "site",
+      "name": "xgboost",
+      "package_type": "package",
+      "sha256": "28de4d26a38c0df1c1674a344e0bcfda312503dc234b552dc0aac1efc2c42874",
+      "unvendored_tests": false,
+      "version": "2.1.4"
+    },
+    "xlrd": {
+      "depends": [],
+      "file_name": "xlrd-2.0.1-py2.py3-none-any.whl",
+      "imports": [
+        "xlrd"
+      ],
+      "install_dir": "site",
+      "name": "xlrd",
+      "package_type": "package",
+      "sha256": "92990ecbefdfce5123e9110c59394c8b0d4fc1fe6da8fd84b7d0a22974e8d058",
+      "unvendored_tests": false,
+      "version": "2.0.1"
+    },
+    "xxhash": {
+      "depends": [],
+      "file_name": "xxhash-3.5.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "xxhash"
+      ],
+      "install_dir": "site",
+      "name": "xxhash",
+      "package_type": "package",
+      "sha256": "984d65f4843568e03cee2190838b9c97c68731eee0193babdd3d4480fc84829d",
+      "unvendored_tests": false,
+      "version": "3.5.0"
+    },
+    "xyzservices": {
+      "depends": [],
+      "file_name": "xyzservices-2025.1.0-py3-none-any.whl",
+      "imports": [
+        "xyzservices"
+      ],
+      "install_dir": "site",
+      "name": "xyzservices",
+      "package_type": "package",
+      "sha256": "9174331356c325b80367ad54267388bfd11dd80f57f9aeac6d2e26c2a6a5d1f1",
+      "unvendored_tests": true,
+      "version": "2025.1.0"
+    },
+    "xyzservices-tests": {
+      "depends": [
+        "xyzservices"
+      ],
+      "file_name": "xyzservices-tests.tar",
+      "imports": [],
+      "install_dir": "site",
+      "name": "xyzservices-tests",
+      "package_type": "package",
+      "sha256": "e3010e0aab7eb2179a405bc97e3c0b8f247ac480ed72e22c4eab1aff308491ea",
+      "unvendored_tests": false,
+      "version": "2025.1.0"
+    },
+    "yarl": {
+      "depends": [
+        "multidict",
+        "idna",
+        "propcache"
+      ],
+      "file_name": "yarl-1.18.3-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "yarl"
+      ],
+      "install_dir": "site",
+      "name": "yarl",
+      "package_type": "package",
+      "sha256": "e2a82d7d0f11fc7a718745b38bcc6fdf59f1e8a888cfd09f9a9b0f015b694ad8",
+      "unvendored_tests": false,
+      "version": "1.18.3"
+    },
+    "yt": {
+      "depends": [
+        "ewah_bool_utils",
+        "numpy",
+        "matplotlib",
+        "sympy",
+        "setuptools",
+        "packaging",
+        "unyt",
+        "cmyt",
+        "colorspacious",
+        "tqdm",
+        "tomli",
+        "tomli-w"
+      ],
+      "file_name": "yt-4.4.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "yt"
+      ],
+      "install_dir": "site",
+      "name": "yt",
+      "package_type": "package",
+      "sha256": "76e50dafa4be8c07e57c57779c8705394c6d27311cc3859802176e5a9d5291f2",
+      "unvendored_tests": false,
+      "version": "4.4.0"
+    },
+    "zengl": {
+      "depends": [],
+      "file_name": "zengl-2.7.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "zengl",
+        "_zengl"
+      ],
+      "install_dir": "site",
+      "name": "zengl",
+      "package_type": "package",
+      "sha256": "1b5e48a8c79a7d99d7d8c080a5c9200190274f49c45241df61838afc1851e4c4",
+      "unvendored_tests": false,
+      "version": "2.7.1"
+    },
+    "zfpy": {
+      "depends": [
+        "numpy"
+      ],
+      "file_name": "zfpy-1.0.1-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "zfpy"
+      ],
+      "install_dir": "site",
+      "name": "zfpy",
+      "package_type": "package",
+      "sha256": "3a023b0d5b95eb7f38cde29f0a8b149f6471889ef8d040b460541c88ea754362",
+      "unvendored_tests": false,
+      "version": "1.0.1"
+    },
+    "zstandard": {
+      "depends": [
+        "cffi"
+      ],
+      "file_name": "zstandard-0.23.0-cp313-cp313-pyodide_2025_0_wasm32.whl",
+      "imports": [
+        "zstandard"
+      ],
+      "install_dir": "site",
+      "name": "zstandard",
+      "package_type": "package",
+      "sha256": "3146aab03772fdb30ce4b56f8993a49ce61632e3d0581c17f3212b69a977e103",
+      "unvendored_tests": false,
+      "version": "0.23.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- update docs asset pyodide lock file to v0.28.0

## Testing
- `pre-commit run --files scripts/fetch_assets.py scripts/update_pyodide.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json`
- `pytest -q` *(fails: ImportError: sentence-transformers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ff9527dac8333aeb765d69cc2374e