### PR TITLE
docs: fix size workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ deployment.
 ### Browser Size Workflow
 
 The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
-Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab and
-provide a valid `run_token` matching the `DISPATCH_TOKEN` secret to authorize
-the run. The workflow caches pip and npm dependencies using `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and the browser `package-lock.json`, so repeat runs skip redundant downloads. It preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check passes without network hiccups.
+Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab. The workflow verifies that the actor is the repository owner before running. The workflow caches pip and npm dependencies using `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and the browser `package-lock.json`, so repeat runs skip redundant downloads. It preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check passes without network hiccups.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- update "Browser Size Workflow" instructions to mention the current trigger
- remove outdated run_token mention

## Testing
- `pre-commit run --files README.md`

------
https://chatgpt.com/codex/tasks/task_e_687004e2e33083339b3d22bcf48871fa