### PR TITLE
Fix dispatch auth for size check

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -2,6 +2,10 @@ name: "📦 Browser Size"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_token:
+        description: 'Authorization token for maintainers'
+        required: false
 
 permissions:
   contents: read
@@ -10,11 +14,13 @@ jobs:
   build-and-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure repository owner
+      - name: Check dispatch token
         if: github.actor != github.repository_owner
         run: |
-          echo "Unauthorized"
-          exit 1
+          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
+            echo "Unauthorized"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,13 @@ deployment.
 ### Browser Size Workflow
 
 The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
-Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab. The workflow verifies that the actor is the repository owner before running. The workflow caches pip and npm dependencies using `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and the browser `package-lock.json`, so repeat runs skip redundant downloads. It preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check passes without network hiccups.
+Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab. If you
+are not the repository owner, provide the `run_token` that matches the
+`DISPATCH_TOKEN` secret. The workflow caches pip and npm dependencies using
+`actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and
+the browser `package-lock.json`, so repeat runs skip redundant downloads. It
+preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check
+passes without network hiccups.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- restrict size-check workflow with run_token
- document dispatch token requirement in README

## Testing
- `pre-commit run --files .github/workflows/size-check.yml README.md`
- `pytest tests/test_assets_replaced.py tests/test_integrity.py -q` *(fails: integrity mismatch and missing build artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68702e4e0ac08333a44beabd6282ff30