### PR TITLE
[alpha_factory] Fix size-check workflow indentation

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -46,11 +46,11 @@ jobs:
         id: asset-key
         run: |
           key=$(python - <<'PY'
-import hashlib, json, scripts.fetch_assets as fa
-env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
-data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
-print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
-PY
+          import hashlib, json, scripts.fetch_assets as fa
+          env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
+          data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
+          print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
+          PY
           )
           echo "key=$key" >> "$GITHUB_OUTPUT"
       - name: Cache Pyodide and GPT-2 assets


### PR DESCRIPTION
## Summary
- ensure heredoc indentation is consistent in `.github/workflows/size-check.yml`

## Testing
- `pre-commit run --files .github/workflows/size-check.yml`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68704a2b9d988333b0998302316fc2a4