### PR TITLE
Fix size-check workflow indentation

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -46,11 +46,11 @@ jobs:
         id: asset-key
         run: |
           key=$(python - <<'PY'
-import hashlib, json, scripts.fetch_assets as fa
-env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
-data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
-print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
-PY
+          import hashlib, json, scripts.fetch_assets as fa
+          env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
+          data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
+          print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
+          PY
           )
           echo "key=$key" >> "$GITHUB_OUTPUT"
       - name: Cache Pyodide and GPT-2 assets


### PR DESCRIPTION
## Summary
- fix Python heredoc indentation in browser size workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files .github/workflows/size-check.yml` *(fails: shellcheck_py wheel build error)*

------
https://chatgpt.com/codex/tasks/task_e_68705a3d07fc833387167640f85d3235