### PR TITLE
fix size-check workflow indentation

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -46,11 +46,11 @@ jobs:
         id: asset-key
         run: |
           key=$(python - <<'PY'
-          import hashlib, json, scripts.fetch_assets as fa
-          env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
-          data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
-          print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
-          PY
+import hashlib, json, scripts.fetch_assets as fa
+env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
+data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
+print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
+PY
           )
           echo "key=$key" >> "$GITHUB_OUTPUT"
       - name: Cache Pyodide and GPT-2 assets


### PR DESCRIPTION
## Summary
- fix indentation in inline Python so the `size-check` workflow runs cleanly

## Testing
- `pre-commit run --files .github/workflows/size-check.yml`


------
https://chatgpt.com/codex/tasks/task_e_687061b7714c8333abea97b082301745