### PR TITLE
[alpha_factory] fix size-check workflow indentation

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -46,11 +46,11 @@ jobs:
         id: asset-key
         run: |
           key=$(python - <<'PY'
-          import hashlib, json, scripts.fetch_assets as fa
-          env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
-          data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
-          print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
-          PY
+import hashlib, json, scripts.fetch_assets as fa
+env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
+data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
+print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
+PY
           )
           echo "key=$key" >> "$GITHUB_OUTPUT"
       - name: Cache Pyodide and GPT-2 assets


### PR DESCRIPTION
## Summary
- fix indentation for the python heredoc in `.github/workflows/size-check.yml`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 198 failed, 369 passed, 61 skipped, 7 errors)*
- `pre-commit run --files .github/workflows/size-check.yml`


------
https://chatgpt.com/codex/tasks/task_e_687096c53a28833391fa09cb296e13a4