### PR TITLE
[alpha_factory] fix Browser Size workflow

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -46,11 +46,11 @@ jobs:
         id: asset-key
         run: |
           key=$(python - <<'PY'
-          import hashlib, json, scripts.fetch_assets as fa
-          env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
-          data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
-          print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
-          PY
+import hashlib, json, scripts.fetch_assets as fa
+env_data = json.dumps({'PYODIDE_BASE_URL': fa.PYODIDE_BASE_URL, 'HF_GPT2_BASE_URL': fa.HF_GPT2_BASE_URL})
+data = json.dumps(fa.CHECKSUMS, sort_keys=True) + env_data
+print('sha256-' + hashlib.sha256(data.encode()).hexdigest())
+PY
           )
           echo "key=$key" >> "$GITHUB_OUTPUT"
       - name: Cache Pyodide and GPT-2 assets

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ deployment.
 ### Browser Size Workflow
 
 The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
-Insight archive stays below 3 MiB. Trigger it from the GitHub Actions tab. If you
-are not the repository owner, provide the `run_token` that matches the
-`DISPATCH_TOKEN` secret. The workflow caches pip and npm dependencies using
+Insight archive stays below 3 MiB. Open **Actions → 📦 Browser Size** and click
+**Run workflow** to start the check. If you are not the repository owner, provide
+the `run_token` that matches the `DISPATCH_TOKEN` secret. The workflow caches pip
+and npm dependencies using
 `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and
 the browser `package-lock.json`, so repeat runs skip redundant downloads. It
 preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check


### PR DESCRIPTION
## Summary
- ensure the Browser Size workflow's Python script isn't indented
- clarify how to run the manual workflow

## Testing
- `pre-commit run --files .github/workflows/size-check.yml README.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6870f94581748333bff2d003f3f73e29