### PR TITLE
[alpha_factory] docs: clarify Browser Size workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ deployment.
 
 The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
 Insight archive stays below 3 MiB. Open **Actions → 📦 Browser Size** and click
-**Run workflow** to start the check. If you are not the repository owner, provide
-the `run_token` that matches the `DISPATCH_TOKEN` secret. The workflow caches pip
+**Run workflow** to start the check. Repository owners can leave `run_token`
+blank. Others must provide the `run_token` that matches the `DISPATCH_TOKEN`
+secret. The workflow caches pip
 and npm dependencies using
 `actions/setup-python` and `actions/setup-node`, keyed by `requirements.lock` and
 the browser `package-lock.json`, so repeat runs skip redundant downloads. It


### PR DESCRIPTION
## Summary
- clarify when the `run_token` is needed for the manual Browser Size check

## Testing
- `pre-commit run --files README.md .github/workflows/size-check.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6870fc6c42c88333aa6e8152feebc91c