### PR TITLE
[alpha_factory] handle browserslist failure

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -64,8 +64,15 @@ jobs:
       - name: Fetch Insight Browser assets
         run: python scripts/fetch_assets.py
       - name: Update browserslist database
+        id: browserslist
+        continue-on-error: true
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
         run: npx update-browserslist-db@latest --agree-to-terms
+      - name: Ignore stale browserslist data
+        if: steps.browserslist.outcome == 'failure'
+        run: |
+          echo "::warning::Failed to update browserslist database"
+          echo "BROWSERSLIST_IGNORE_OLD_DATA=true" >> "$GITHUB_ENV"
       - name: Verify Insight Browser assets
         run: python scripts/fetch_assets.py --verify-only
       - name: Build distribution zip

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ and npm dependencies using
 the browser `package-lock.json`, so repeat runs skip redundant downloads. It
 preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check
 passes without network hiccups.
+If the browserslist update fails, the workflow warns and sets
+`BROWSERSLIST_IGNORE_OLD_DATA=true` to continue.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- allow browserslist update to fail in Browser Size workflow
- document fallback env var in Browser Size section

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 113 failed, 174 passed, 45 skipped, 5 errors)*
- `pre-commit run --files README.md .github/workflows/size-check.yml` *(fails: interrupted due to environment)*


------
https://chatgpt.com/codex/tasks/task_e_68711293148c83338dd04f89af6d5305