### PR TITLE
[alpha_factory] Update size-check limits

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -81,7 +81,9 @@ jobs:
         run: |
           size=$(stat -c%s alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/insight_browser.zip)
           echo "insight_browser.zip size: $size bytes"
-          if [ "$size" -gt $((3 * 1024 * 1024)) ]; then
-            echo "Archive exceeds 3 MiB" >&2
+          if [ "$size" -gt $((750 * 1024 * 1024)) ]; then
+            echo "::error::Archive exceeds 750 MiB" >&2
             exit 1
+          elif [ "$size" -gt $((500 * 1024 * 1024)) ]; then
+            echo "::warning::Archive exceeds 500 MiB" >&2
           fi


### PR DESCRIPTION
## Summary
- enforce 500 MiB soft and 750 MiB hard limits for the browser zip
- keep manual dispatch token requirement intact

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files .github/workflows/size-check.yml`


------
https://chatgpt.com/codex/tasks/task_e_68712ac7101883339ce93ad2ec361494