### PR TITLE
[alpha_factory] Update browser size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ deployment.
 ### Browser Size Workflow
 
 The [📦 Browser Size](.github/workflows/size-check.yml) job ensures the
-Insight archive stays below 3 MiB. Open **Actions → 📦 Browser Size** and click
+Insight archive stays under 500 MiB (with a 750 MiB hard cap). Open **Actions → 📦 Browser Size** and click
 **Run workflow** to start the check. Repository owners can leave `run_token`
 blank. Others must provide the `run_token` that matches the `DISPATCH_TOKEN`
 secret. The workflow caches pip and npm dependencies using

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -293,7 +293,7 @@ Run `node tests/run.mjs --offline` to confirm the build works without network ac
 ## Distribution
 Run `npm run build:dist` to generate `insight_browser.zip` in this directory.
 The archive bundles the production build along with the service worker and
-assets. It stays under **3&nbsp;MiB** so the entire demo can be shared easily.
+assets. it stays under **500&nbsp;MiB** (the hard cap is 750&nbsp;MiB) so the entire demo can be shared easily.
 Extract the zip and open `index.html` directly—no additional dependencies are
 required. New users can review
 [dist/insight_browser_quickstart.pdf](dist/insight_browser_quickstart.pdf) after
@@ -302,7 +302,7 @@ extraction for a brief walkthrough.
 A dedicated GitHub Actions workflow
 [`size-check.yml`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/.github/workflows/size-check.yml) rebuilds the
 archive when triggered manually and fails if `insight_browser.zip` grows beyond
-**3&nbsp;MiB**.
+**500&nbsp;MiB**.
 
 ## Locale Support
 The interface automatically loads French, Spanish or Chinese translations based

--- a/tests/test_distribution_zip.py
+++ b/tests/test_distribution_zip.py
@@ -26,7 +26,7 @@ def test_distribution_zip(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert zip_path.exists(), "insight_browser.zip missing"
-    assert zip_path.stat().st_size <= 3 * 1024 * 1024, "zip size exceeds 3 MiB"
+    assert zip_path.stat().st_size <= 500 * 1024 * 1024, "zip size exceeds 500 MiB"
     with zipfile.ZipFile(zip_path) as zf:
         names = zf.namelist()
     expected = {


### PR DESCRIPTION
## Summary
- raise insight browser size thresholds to 500MiB soft with a 750MiB hard cap
- adjust docs and index accordingly
- update the distribution zip test

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 64 failed, 79 passed, 31 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68712c8601508333839cdeb142bf05a7