### PR TITLE
[alpha_factory] Update zip size assertion

### DIFF
--- a/tests/test_distribution_zip.py
+++ b/tests/test_distribution_zip.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 BROWSER_DIR = Path("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1")
+MAX_ZIP_BYTES = 500 * 1024 * 1024
 
 
 @pytest.mark.skipif(not shutil.which("npm"), reason="npm not available")
@@ -26,7 +27,7 @@ def test_distribution_zip(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert zip_path.exists(), "insight_browser.zip missing"
-    assert zip_path.stat().st_size <= 500 * 1024 * 1024, "zip size exceeds 500 MiB"
+    assert zip_path.stat().st_size <= MAX_ZIP_BYTES, "zip size exceeds 500 MiB"
     with zipfile.ZipFile(zip_path) as zf:
         names = zf.namelist()
     expected = {


### PR DESCRIPTION
## Summary
- clarify the max archive size used in the browser distribution test

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_distribution_zip.py::test_distribution_zip -q` *(fails: Missing dependency `esbuild`)*
- `pre-commit run --files tests/test_distribution_zip.py` *(fails during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68712f6eaca08333bd7aa7d99e88e823