### PR TITLE
[alpha_factory] parameterize docker builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
+          docker build --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+            -t ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
 
       - name: Run pytest inside container
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-FROM python:3.11-slim
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim
 
 # install build tools and npm for the React UI
 RUN apt-get update && \

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -1,5 +1,6 @@
 # Demo container for α‑AGI Insight
-FROM python:3.11-slim
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim
 
 # Install build tools for optional native extensions
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- allow providing `PYTHON_VERSION` as Dockerfile build-arg
- build CI image with the current matrix version

## Testing
- `pre-commit run --files Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile .github/workflows/build-and-test.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 267 failed, 511 passed, 71 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6871430b18e48333a4ae2ae422eec07f