### PR TITLE
[alpha_factory] collect coverage artifacts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 # Checks
 - [ ] I ran `pre-commit run --files <paths>`
 - [ ] I ran `python check_env.py --auto-install`
-- [ ] I ran `pytest -q` and documented any failures below
+- [ ] I ran `pytest --cov --cov-report=xml` and documented any failures below
 
 # Testing
 Describe the outcome of the checks and tests here.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,8 +53,16 @@ jobs:
 
       - name: Run pytest inside container
         run: |
-          docker run --rm ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} \
-            bash -c "python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse \"$WHEELHOUSE\"} && pytest -q"
+          docker run --rm \
+            -v "$PWD":/repo -w /repo \
+            ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} \
+            bash -c "python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse \"$WHEELHOUSE\"} && pytest --cov --cov-report=xml:/repo/coverage.xml --cov-fail-under=80"
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -52,7 +52,15 @@ jobs:
         run: pre-commit run --all-files
       - name: Run smoke tests
         if: matrix.python-version == '3.11'
-        run: pytest tests/test_ping_agent.py tests/test_af_requests.py -q
+        run: |
+          pytest tests/test_ping_agent.py tests/test_af_requests.py \
+            --cov --cov-report=xml --cov-fail-under=80
+      - name: Upload coverage
+        if: matrix.python-version == '3.11'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-${{ matrix.python-version }}
+          path: coverage.xml
       - name: Run 2-year simulation
         run: |
           python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli simulate \

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/
 .pytest_cache/
 
 site/
+
+# Coverage files
+coverage.xml
+.coverage*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,9 +133,9 @@ Follow these steps when installing without internet access:
   missing packages before running `pytest`.
   Install `requirements-demo.txt` as well when running tests that depend on
   heavy extras such as `numpy` and `torch`.
-- Run a quick smoke check first to verify the install:
-  `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
-  - Execute `pytest -q` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes.
+ - Run a quick smoke check first to verify the install:
+   `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`
+   - Execute `pytest --cov --cov-report=xml` (or `python -m alpha_factory_v1.scripts.run_tests`) and ensure the entire suite passes.
   If failures remain, document them in the PR description.
 - When running tests directly from the repository without installation, set `PYTHONPATH`
   as described in [`tests/README.md`](tests/README.md): `export PYTHONPATH=$(pwd)`.
@@ -316,9 +316,9 @@ install dependencies without internet access.
 - Keep commits focused and descriptive. Use meaningful commit messages.
 - Ensure `git status` shows a clean working tree before committing.
 - Remove stray build artifacts with `git clean -fd` if needed.
- - Run `python scripts/check_python_deps.py` followed by
-    `python check_env.py --auto-install` (use `--wheelhouse <path>` when offline)
-    and `pytest -q` before committing. Document any remaining test failures in
+   - Run `python scripts/check_python_deps.py` followed by
+      `python check_env.py --auto-install` (use `--wheelhouse <path>` when offline)
+      and `pytest --cov --cov-report=xml` before committing. Document any remaining test failures in
     the PR description.
 - See [tests/README.md](tests/README.md) for details on running the suite locally,
   including setting `PYTHONPATH` or installing in editable mode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ The environment check installs any missing packages from PyPI (or from your
 wheelhouse when offline). Once it succeeds, execute the tests:
 
 ```bash
-pytest -q
+pytest --cov --cov-report=xml
 ```
 
 ## Pre-commit Hooks

--- a/docs/OFFLINE_SETUP.md
+++ b/docs/OFFLINE_SETUP.md
@@ -69,7 +69,7 @@ python scripts/check_python_deps.py
 python check_env.py --auto-install --wheelhouse "$WHEELHOUSE"
 ```
 
-Run `pytest -q` once the check succeeds.
+Run `pytest --cov --cov-report=xml` once the check succeeds.
 
 See the [tests README](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/tests/README.md#offline-install) and [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md#offline-setup) for the full instructions.
 

--- a/docs/POLICY_RUNBOOK.md
+++ b/docs/POLICY_RUNBOOK.md
@@ -28,7 +28,7 @@ Rego policies live under `policies/`. After editing any `.rego` file, run:
 ```bash
 pre-commit run --files policies/<file>.rego alpha_factory_v1/core/utils/opa_policy.py
 python check_env.py --auto-install
-pytest -q
+pytest --cov --cov-report=xml
 ```
 
 The hooks ensure pattern updates load correctly and unit tests exercise the new
@@ -66,7 +66,7 @@ retagging a fixed commit as `stable`.
 ## Promotion Checklist for Self‑Modifying Code
 
 1. `pre-commit run --all-files`
-2. `python check_env.py --auto-install` and `pytest -q`
+2. `python check_env.py --auto-install` and `pytest --cov --cov-report=xml`
 3. Confirm sandbox limits are set in `.env` or the deployment manifest
 4. Obtain approval from two maintainers
 5. Update `docs/CHANGELOG.md` and create a signed tag

--- a/docs/demos/alpha_agi_business_v1.md
+++ b/docs/demos/alpha_agi_business_v1.md
@@ -484,7 +484,7 @@ Run the standard checks from this folder before committing:
 ```bash
 python ../../check_env.py --auto-install   # verify optional packages
 pre-commit run --files <paths>             # format only the staged files
-pytest -q ../../../tests                   # execute the root test suite
+pytest --cov --cov-report=xml ../../../tests  # execute the root test suite
 ```
 
 [View README on GitHub](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_business_v1/README.md)

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -579,7 +579,7 @@ the `alpha_factory_v1` package. Either install the project or export
 ```bash
 export PYTHONPATH=$(pwd)  # if running from the repo root without installation
 python check_env.py --auto-install  # verify optional packages
-pytest -q          # unit + integration suite
+pytest --cov --cov-report=xml       # unit + integration suite
 pytest -m e2e      # full 5-year forecast smoke-test
 ```
 
@@ -606,7 +606,7 @@ installs the required packages from the local cache:
 
 ```bash
 WHEELHOUSE=/media/wheels python check_env.py --auto-install
-WHEELHOUSE=/media/wheels pytest -q
+WHEELHOUSE=/media/wheels pytest --cov --cov-report=xml
 ```
 
 `playwright` and other heavy packages must exist in the wheelhouse for tests to

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -124,7 +124,7 @@ Offline test workflow (https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/mai
   ```
 - **Run** the unit tests with the wheelhouse available:
   ```bash
-  WHEELHOUSE=$WHEELHOUSE pytest -q
+  WHEELHOUSE=$WHEELHOUSE pytest --cov --cov-report=xml
   ```
 
 
@@ -378,6 +378,6 @@ Apache 2.0. By using this repo you agree to cite **Montreal.AI Alpha‑Factory*
 
 ---
 
-**Contributor checklist** — run `pre-commit`, `python ../../../check_env.py --auto-install`, and `pytest -q` before submitting any changes. See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md) for the full contributor guide.
+**Contributor checklist** — run `pre-commit`, `python ../../../check_env.py --auto-install`, and `pytest --cov --cov-report=xml` before submitting any changes. See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md) for the full contributor guide.
 
 [View README on GitHub](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/era_of_experience/README.md)

--- a/docs/demos/omni_factory_demo.md
+++ b/docs/demos/omni_factory_demo.md
@@ -204,7 +204,7 @@ pip install -r requirements.txt  # install dependencies
 python check_env.py              # confirm optional extras available
 # If packages are reported missing, install them:
 pip install -r requirements.txt  # or requirements-colab.lock in Colab
-pytest -q                        # optional quick self-test
+pytest --cov --cov-report=xml    # optional quick self-test
 python -m alpha_factory_v1.demos.omni_factory_demo --metrics-port 9137
 python alpha_factory_v1/demos/omni_factory_demo/omni_dashboard.py
 ```


### PR DESCRIPTION
## Summary
- run coverage in build-and-test and smoke workflows
- store coverage.xml artifact
- update contributor docs and PR template for `pytest --cov`
- ignore coverage files

## Testing
- `pre-commit run --files .github/pull_request_template.md .github/workflows/build-and-test.yml .github/workflows/smoke.yml .gitignore AGENTS.md CONTRIBUTING.md docs/OFFLINE_SETUP.md docs/POLICY_RUNBOOK.md docs/demos/alpha_agi_business_v1.md docs/demos/alpha_agi_insight_v1.md docs/demos/era_of_experience.md docs/demos/omni_factory_demo.md`
- `pytest --cov --cov-report=xml` *(fails: 116 failed, 215 passed, 57 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68714697ac948333ae34dc68219bbf88