### PR TITLE
[alpha_factory] cache pre-commit in workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,8 +41,12 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run replay harness
         run: python scripts/run_replay_bench.py
       - name: Run micro benchmarks

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,19 +32,37 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
 
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
+
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
 
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - name: Install lint tools
         run: |
           python -m pip install --upgrade pip
           pip install ruff mypy
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Ruff lint
         run: ruff check alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Mypy type-check

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -24,10 +24,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
+
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
 
       - name: Set up Kind cluster
         uses: helm/kind-action@v1.7.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - name: Install Ruff
         run: pip install ruff
       - name: Install docs dependencies
@@ -75,8 +83,12 @@ jobs:
         run: npx update-browserslist-db@latest --agree-to-terms
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Install Playwright browsers
         uses: microsoft/playwright-github-action@v1
         with:

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,8 +41,12 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Start API server
         run: |
           API_TOKEN=test-token python -m src.interface.api_server &

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,8 +41,12 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run transfer test
         run: |
           python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.cli transfer-test --models "o3-mini,llama-3" --top-n 5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -43,8 +51,12 @@ jobs:
           npm install -g @cyclonedx/bom
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -27,6 +27,14 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'requirements.lock'
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -34,12 +42,16 @@ jobs:
           cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
       - name: Install pre-commit
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Install required Python packages
         run: pip install numpy pandas pytest pyyaml
       - name: Run environment check
         run: ./scripts/env_check.sh
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Install dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Compute asset cache key

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: .cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
       - name: Prepare build tools
         run: |
           python -m pip install --upgrade pip setuptools wheel
@@ -47,9 +55,13 @@ jobs:
       - name: Install pre-commit
         if: matrix.python-version == '3.11'
         run: pip install pre-commit
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks
         if: matrix.python-version == '3.11'
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run smoke tests
         if: matrix.python-version == '3.11'
         run: |


### PR DESCRIPTION
## Summary
- run `actions/setup-python@v5` with pip caching
- cache `.cache/pre-commit` before running hooks

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/bench.yml .github/workflows/build-and-test.yml .github/workflows/ci.yml .github/workflows/deploy-kind.yml .github/workflows/docs.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/security.yml .github/workflows/size-check.yml .github/workflows/smoke.yml`
- `pytest --cov --cov-report=xml` *(fails: TypeError: Any cannot be instantiated)*

------
https://chatgpt.com/codex/tasks/task_e_68714ddeeb9c833391d88098f8a0ba09