### PR TITLE
[alpha_factory] update cosign verification

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,12 +94,14 @@ jobs:
           docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v3.9.1
         with:
           cosign-release: 'v2.2.4'
 
       - name: Sign image
-        env:
-          COSIGN_EXPERIMENTAL: "1"
         run: |
           cosign sign --yes ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+
+      - name: Verify signature
+        run: |
+          cosign verify ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -87,18 +87,17 @@ jobs:
         run: docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v3.9.1
         with:
           cosign-release: 'v2.2.4'
 
       - name: Sign container
-        env:
-          COSIGN_EXPERIMENTAL: "1"
         run: cosign sign --yes ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
 
+      - name: Verify signature
+        run: cosign verify ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+
       - name: Generate provenance
-        env:
-          COSIGN_EXPERIMENTAL: "1"
         run: |
           cosign generate --type slsaprovenance ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} > provenance.json
           cosign attest --yes --predicate provenance.json --type slsaprovenance ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}


### PR DESCRIPTION
## Summary
- update cosign-installer to v3.9.1
- drop deprecated `COSIGN_EXPERIMENTAL`
- verify signatures after signing

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 55 failed, 75 passed, 31 skipped)*
- `pre-commit run --files .github/workflows/build-and-test.yml .github/workflows/security.yml`

------
https://chatgpt.com/codex/tasks/task_e_6871548520a4833390a4549e29c63565