### PR TITLE
ci: push latest image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,3 +105,11 @@ jobs:
       - name: Verify signature
         run: |
           cosign verify ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+
+      - name: Tag latest image
+        run: |
+          docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} \
+            ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
+
+      - name: Push latest tag
+        run: docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Alternatively, run the pre-built image directly:
 docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 ```
 
+Replace `latest` with a commit SHA to run that exact build:
+
+```bash
+docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:<commit>
+```
+
 Set `OPENAI_API_KEY` and other required secrets in your environment or `.env`
 before launching the container. The orchestrator prints the
 [project disclaimer](docs/DISCLAIMER_SNIPPET.md) when it starts.
@@ -1097,6 +1103,9 @@ pip install -r requirements.lock
 
 # Deploy instantly with Docker (prebuilt image)
 docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
+
+# Pull a specific build by commit SHA
+docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:<commit>
 
 # The `alpha-factory` CLI also works when the package is installed:
 # A short warning is printed before startup.


### PR DESCRIPTION
## Summary
- push `latest` tag after build and test
- document how to pull an image for a specific commit

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/build-and-test.yml README.md` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68715a7999f08333bd137eb624a503d5