### PR TITLE
ci: pin pre-commit version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,7 +40,7 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,7 +56,7 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
 
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff mypy
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-precommit-
 
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Update browserslist database
         run: npx update-browserslist-db@latest --agree-to-terms
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -40,7 +40,7 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -40,7 +40,7 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
           python -m pip install --upgrade pip cyclonedx-bom
           npm install -g @cyclonedx/bom
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -41,7 +41,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Install required Python packages

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -54,7 +54,7 @@ jobs:
           fi
       - name: Install pre-commit
         if: matrix.python-version == '3.11'
-        run: pip install pre-commit
+        run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Run pre-commit checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 2a1c67e0b2f81df602ec1f6e7aeb030b9709dc7c
     hooks:
       - id: black
         exclude: alpha_factory_v1/backend/agent_factory.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: 1bd02b3569e3ac5cc66552b1336a96a8880d1bae
     hooks:
       - id: ruff
         exclude: alpha_factory_v1/backend/agent_factory.py
       - id: ruff-format
         exclude: alpha_factory_v1/backend/agent_factory.py
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7d37d9032d0d161634be4554273c30efd4dea0b3
     hooks:
       - id: flake8
   - repo: https://github.com/semgrep/semgrep
-    rev: v1.61.0
+    rev: 0bacb757cb8aaef5ac6603fe129a42ad78d99956
     hooks:
       - id: semgrep
         args: ["--config", "semgrep.yml"]
         types: [python]
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.1
+    rev: d0a0a0d7aa4e87ed0c7a31b5fcee1c20697718ff
     hooks:
       - id: shellcheck
   - repo: local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,12 @@ Please report security vulnerabilities as described in our [Security Policy](SEC
   `nvm use` before installing Node dependencies.
 - Keep `package-lock.json` under version control so `npm ci` reproduces the same
   dependency tree.
+- The project expects `pre-commit` **4.2.0**. CI installs the same version with
+  `pip install pre-commit==4.2.0`.
 - Run `python alpha_factory_v1/scripts/preflight.py` to validate these tools.
  - Run `./codex/setup.sh` to install project dependencies and set up the git
-   hooks. The script attempts to install `pre-commit` automatically. If
-   `pre-commit` isn't found, run `pip install pre-commit` and re-run the script.
+  hooks. The script attempts to install `pre-commit` automatically. If
+  `pre-commit` isn't found, run `pip install pre-commit==4.2.0` and re-run the script.
 - The first `pre-commit run` may take several minutes as it builds tool environments.
 - Install `pytest` and `prometheus_client` using
   `python check_env.py --auto-install` or `pip install pytest prometheus_client`.
@@ -386,7 +388,7 @@ issues locally before dispatching the workflow.
   consider bundling `numpy`, `pyyaml` and `pandas` so the smoke tests run without
   contacting PyPI.
 - If `pre-commit` reports "command not found", install it manually with
-  `pip install pre-commit` and run `pre-commit install` once.
+  `pip install pre-commit==4.2.0` and run `pre-commit install` once.
 - To reinstall the hooks, run `pip install -U pre-commit` and then
   `pre-commit install` again.
 


### PR DESCRIPTION
## Summary
- lock pre-commit hooks to specific commit hashes
- pin pre-commit 4.2.0 in CI workflows
- document expected pre-commit version in the contributor guide

## Testing
- `pre-commit run --files .github/workflows/bench.yml .github/workflows/build-and-test.yml .github/workflows/ci.yml .github/workflows/deploy-kind.yml .github/workflows/docs.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/security.yml .github/workflows/size-check.yml .github/workflows/smoke.yml .pre-commit-config.yaml AGENTS.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68716006252c8333b22485ccbba9ee0b