### PR TITLE
[alpha_factory] restrict CI workflow to manual runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,9 +1,6 @@
 name: "🐳 Build & Test"
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
     inputs:
       run_token:


### PR DESCRIPTION
## Summary
- remove push and pull_request triggers so build-and-test runs only on dispatch

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml`
- `pytest tests/test_ping_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687173832a9c8333969962b1d2b77846