### PR TITLE
[alpha_factory] normalize repo owner for docker

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,6 +38,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
+      - name: Compute repo_owner_lower
+        run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -67,13 +70,13 @@ jobs:
       - name: Build Docker image
         run: |
           docker build --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
-            -t ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
+            -t ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
 
       - name: Run pytest inside container
         run: |
           docker run --rm \
             -v "$PWD":/repo -w /repo \
-            ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} \
+            ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} \
             bash -c "python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse \"$WHEELHOUSE\"} && pytest --cov --cov-report=xml:/repo/coverage.xml --cov-fail-under=80"
 
       - name: Upload coverage
@@ -91,7 +94,7 @@ jobs:
 
       - name: Push image
         run: |
-          docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+          docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.1
@@ -100,16 +103,16 @@ jobs:
 
       - name: Sign image
         run: |
-          cosign sign --yes ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+          cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Verify signature
         run: |
-          cosign verify ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+          cosign verify ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Tag latest image
         run: |
-          docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} \
-            ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} \
+            ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
 
       - name: Push latest tag
-        run: docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
+        run: docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,8 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
+      - name: Compute repo_owner_lower
+        run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -320,6 +322,8 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
+      - name: Compute repo_owner_lower
+        run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -327,17 +331,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull previous image
-        run: docker pull ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest || true
+        run: docker pull ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest || true
       - name: Tag previous
-        run: docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:previous || true
+        run: docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous || true
       - name: Push previous tag
-        run: docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:previous || true
+        run: docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous || true
       - name: Push new image
         run: |
-          docker tag $DOCKER_IMAGE:ci ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.ref_name }}
-          docker tag $DOCKER_IMAGE:ci ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
-          docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.ref_name }}
-          docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
+          docker tag $DOCKER_IMAGE:ci ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}
+          docker tag $DOCKER_IMAGE:ci ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
+          docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}
+          docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -358,6 +362,6 @@ jobs:
         if: failure()
         run: |
           echo "Rolling back to previous image"
-          docker pull ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:previous || exit 0
-          docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:previous ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
-          docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:latest
+          docker pull ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous || exit 0
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
+          docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,6 +34,9 @@ jobs:
           python-version: '3.11'
           cache: pip
 
+      - name: Compute repo_owner_lower
+        run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:
@@ -60,7 +63,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
+          docker build -t ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
 
       - name: Generate Python SBOM
         run: cyclonedx-py -r requirements.lock -o sbom-python.json
@@ -71,7 +74,7 @@ jobs:
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@v0.20.0
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+          image-ref: ghcr.io/${{ env.repo_owner_lower }}/$DOCKER_IMAGE:${{ github.sha }}
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
@@ -84,7 +87,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image
-        run: docker push ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+        run: docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.1
@@ -92,15 +95,15 @@ jobs:
           cosign-release: 'v2.2.4'
 
       - name: Sign container
-        run: cosign sign --yes ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+        run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Verify signature
-        run: cosign verify ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+        run: cosign verify ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Generate provenance
         run: |
-          cosign generate --type slsaprovenance ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} > provenance.json
-          cosign attest --yes --predicate provenance.json --type slsaprovenance ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }}
+          cosign generate --type slsaprovenance ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} > provenance.json
+          cosign attest --yes --predicate provenance.json --type slsaprovenance ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -110,8 +113,8 @@ jobs:
 
       - name: Push image to Docker Hub
         run: |
-          docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} $DOCKERHUB_REPO:${{ github.ref_name }}
-          docker tag ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE:${{ github.sha }} $DOCKERHUB_REPO:latest
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} $DOCKERHUB_REPO:${{ github.ref_name }}
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} $DOCKERHUB_REPO:latest
           docker push $DOCKERHUB_REPO:${{ github.ref_name }}
           docker push $DOCKERHUB_REPO:latest
 


### PR DESCRIPTION
## Summary
- compute `repo_owner_lower` in build-and-test, security and CI workflows
- use the lowercase repo owner when building and pushing container images

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(failed: 63 failed, 79 passed, 31 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/build-and-test.yml .github/workflows/ci.yml .github/workflows/security.yml`


------
https://chatgpt.com/codex/tasks/task_e_68717dbe015083338ddf4e3204a97a84