### PR TITLE
[alpha_factory] manual build workflow improvements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,6 +93,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image
+        if: matrix.python-version == '3.12'
         run: |
           docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
@@ -102,17 +103,21 @@ jobs:
           cosign-release: 'v2.2.4'
 
       - name: Sign image
+        if: matrix.python-version == '3.12'
         run: |
           cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Verify signature
+        if: matrix.python-version == '3.12'
         run: |
           cosign verify ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Tag latest image
+        if: matrix.python-version == '3.12'
         run: |
           docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} \
             ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
 
       - name: Push latest tag
+        if: matrix.python-version == '3.12'
         run: docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ generated assets target the latest browsers. When running offline or if the
 update fails, set `BROWSERSLIST_IGNORE_OLD_DATA=true` to continue without
 refreshing the cache.
 
+### Build & Test Workflow
+
+The [🐳 Build & Test](.github/workflows/build-and-test.yml) job runs linting,
+tests and container builds. Open **Actions → 🐳 Build & Test** and click
+**Run workflow** to start the pipeline. Repository owners may leave `run_token`
+blank, while collaborators must supply the dispatch token stored in the
+`DISPATCH_TOKEN` secret.
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary
- restrict push/sign steps to Python 3.12 to avoid tag clashes
- document how to run the Build & Test workflow

## Checks
- `pre-commit run --files .github/workflows/build-and-test.yml README.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 267 failed, 511 passed, 71 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6871832226708333a565bcb521ebdaac