### PR TITLE
[alpha_factory] restrict build workflow to owner

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,10 +2,6 @@ name: "🐳 Build & Test"
 
 on:
   workflow_dispatch:
-    inputs:
-      run_token:
-        description: 'Authorization token for maintainers'
-        required: false
 
 permissions:
   contents: read
@@ -22,13 +18,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - name: Check dispatch token
+      - name: Ensure repository owner
         if: github.actor != github.repository_owner
         run: |
-          if [ "${{ github.event.inputs.run_token }}" != "${{ secrets.DISPATCH_TOKEN }}" ]; then
-            echo "Unauthorized"
-            exit 1
-          fi
+          echo "This workflow can only be run by the repository owner." >&2
+          exit 1
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,8 @@ refreshing the cache.
 
 The [🐳 Build & Test](.github/workflows/build-and-test.yml) job runs linting,
 tests and container builds. Open **Actions → 🐳 Build & Test** and click
-**Run workflow** to start the pipeline. Repository owners may leave `run_token`
-blank, while collaborators must supply the dispatch token stored in the
-`DISPATCH_TOKEN` secret.
+**Run workflow** to start the pipeline. Only the repository owner can run this
+workflow.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- allow only the repo owner to trigger the 🐳 Build & Test workflow
- update docs for the manual workflow

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml README.md`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: RuntimeError and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687194454bcc8333b82ab40fbed1918d