### PR TITLE
[alpha_factory] refine manual build workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,13 @@ You can manually trigger the CI run from the GitHub UI:
 
 The pipeline validates linting, type checks, tests and the Docker build.
 
+### Build & Test Workflow
+Repository owners may also launch the general build and unit test pipeline:
+
+1. Open **Actions → 🐳 Build & Test**.
+2. Click **Run workflow**. This job only executes when triggered by the
+   repository owner.
+
 ### Deploy to Kind
 The **Deploy — Kind** workflow provisions a local kind cluster, builds the Insight demo image, installs the Helm chart with default values, applies Terraform from `infrastructure/terraform` using the local backend and waits for pods to become ready. Repository settings mark this workflow as **required**.
 


### PR DESCRIPTION
## Summary
- restrict `build-and-test.yml` to repository owner and use lowercase image names
- update docs about manual Build & Test workflow

## Testing
- `pre-commit run --files AGENTS.md`
- `python check_env.py --auto-install`
- `pytest tests/test_preflight.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871990064088333b8cc7dd050adedbd