### PR TITLE
[alpha_factory] document docker tag convention

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,6 +32,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
+      # Docker requires lowercase repository names. Convert the repository
+      # owner to lowercase so image tags remain valid even when the GitHub
+      # organization uses capital letters.
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
- document why repository owner is lowercased in build-and-test workflow

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 73 failed, 94 passed, 32 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68719d5aaf2c8333b2a62cd95d4f47b8