### PR TITLE
[alpha_factory] drop unused PYTHON_VERSION_MATRIX

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,6 @@ permissions:
   packages: write
 
 env:
-  PYTHON_VERSION_MATRIX: "3.11,3.12"
   DOCKER_IMAGE: alpha-factory
 
 jobs:


### PR DESCRIPTION
## Summary
- remove unused `PYTHON_VERSION_MATRIX` env var from Build & Test workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 48 failed, 56 passed)*
- `pre-commit run --files .github/workflows/build-and-test.yml`


------
https://chatgpt.com/codex/tasks/task_e_6871a5c7f33083338ef3787cfc2f89e2