### PR TITLE
[alpha_factory] enable independent matrix jobs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     steps:


### PR DESCRIPTION
## Summary
- allow matrix jobs to run in parallel by setting `fail-fast: false`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: unrecognized arguments)*
- `pre-commit run --files .github/workflows/build-and-test.yml`


------
https://chatgpt.com/codex/tasks/task_e_6871a7d3114c8333bfd6c97cb82167d9