### PR TITLE
[alpha_factory] Add concurrency to build workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOCKER_IMAGE: alpha-factory
 


### PR DESCRIPTION
## Summary
- add concurrency block to prevent duplicate pushes

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 60 failed, 79 passed, 31 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/build-and-test.yml` *(failed to complete due to environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_6871aae0105c8333aa7298992f375161