### PR TITLE
fix: document lowercase tags in build workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,9 @@ Repository owners may also launch the general build and unit test pipeline:
 1. Open **Actions → 🐳 Build & Test**.
 2. Click **Run workflow**. This job only executes when triggered by the
    repository owner.
+   Docker repository and image names must be lowercase. The workflow
+   automatically lowercases `${{ github.repository_owner }}` to satisfy this
+   requirement.
 
 ### Deploy to Kind
 The **Deploy — Kind** workflow provisions a local kind cluster, builds the Insight demo image, installs the Helm chart with default values, applies Terraform from `infrastructure/terraform` using the local backend and waits for pods to become ready. Repository settings mark this workflow as **required**.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ tests and container builds. Open **Actions → 🐳 Build & Test** and click
 **Run workflow** to start the pipeline. Only the repository owner can run this
 workflow.
 
+Docker image tags must use all lowercase characters. The workflow automatically
+converts the repository owner to lowercase so tags like `ghcr.io/montrealai` are
+valid.
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify in docs that docker tags use lowercase repo names

## Testing
- `pre-commit run --files README.md AGENTS.md .github/workflows/build-and-test.yml`

------
https://chatgpt.com/codex/tasks/task_e_6871add40f988333a72417409e67208f