### PR TITLE
Restrict build workflow to repo owner

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,17 +16,13 @@ env:
 
 jobs:
   build-test:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - name: Ensure repository owner
-        if: github.actor != github.repository_owner
-        run: |
-          echo "This workflow can only be run by the repository owner." >&2
-          exit 1
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,8 +353,8 @@ The pipeline validates linting, type checks, tests and the Docker build.
 Repository owners may also launch the general build and unit test pipeline:
 
 1. Open **Actions → 🐳 Build & Test**.
-2. Click **Run workflow**. This job only executes when triggered by the
-   repository owner.
+2. Click **Run workflow**. The job executes only when `github.actor` matches
+   `github.repository_owner`.
    Docker repository and image names must be lowercase. The workflow
    automatically lowercases `${{ github.repository_owner }}` to satisfy this
    requirement.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ refreshing the cache.
 The [🐳 Build & Test](.github/workflows/build-and-test.yml) job runs linting,
 tests and container builds. Open **Actions → 🐳 Build & Test** and click
 **Run workflow** to start the pipeline. Only the repository owner can run this
-workflow.
+workflow. The job checks `github.actor == github.repository_owner` before
+executing.
 
 Docker image tags must use all lowercase characters. The workflow automatically
 converts the repository owner to lowercase so tags like `ghcr.io/montrealai` are


### PR DESCRIPTION
## Summary
- restrict build-test job to the repository owner
- document the new owner check

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml README.md AGENTS.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871affdf35c83338a049bda26945ba6