### PR TITLE
[alpha_factory] fix docker owner step name

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,8 @@ jobs:
       # Docker requires lowercase repository names. Convert the repository
       # owner to lowercase so image tags remain valid even when the GitHub
       # organization uses capital letters.
-      - name: Compute REPO_OWNER_LC
+      - name: Prepare lowercase image name
+        id: prepare
         shell: bash
         run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ tests and container builds. Open **Actions → 🐳 Build & Test** and click
 workflow. The job checks `github.actor == github.repository_owner` before
 executing.
 
-Docker image tags must use all lowercase characters. The workflow automatically
-sets `REPO_OWNER_LC` to the lowercased repository owner so tags like
-`ghcr.io/montrealai` are valid.
+Docker image tags must use all lowercase characters. The workflow's
+"Prepare lowercase image name" step sets `REPO_OWNER_LC` to the lowercased
+repository owner so tags like `ghcr.io/montrealai` are valid.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- clarify README for lowercase docker repo owner step
- rename step in build-and-test workflow

## Checks
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files .github/workflows/build-and-test.yml README.md`


------
https://chatgpt.com/codex/tasks/task_e_6871c2d655a883338ac50e7c02d50067