### PR TITLE
Improve Build & Test restrictions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,9 @@ env:
 
 jobs:
   build-test:
-    if: github.actor == github.repository_owner
+    # Ensure this job only runs from the manual "Run workflow" button
+    # and only when triggered by the repository owner.
+    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ refreshing the cache.
 The [🐳 Build & Test](.github/workflows/build-and-test.yml) job runs linting,
 tests and container builds. Open **Actions → 🐳 Build & Test** and click
 **Run workflow** to start the pipeline. Only the repository owner can run this
-workflow. The job checks `github.actor == github.repository_owner` before
-executing.
+workflow. The job requires a manual dispatch and verifies both
+`github.event_name == 'workflow_dispatch'` and
+`github.actor == github.repository_owner` before executing.
 
 Docker image tags must use all lowercase characters. The workflow's
 "Prepare lowercase image name" step sets `REPO_OWNER_LC` to the lowercased


### PR DESCRIPTION
## Summary
- restrict Build & Test workflow to manual dispatch by repository owner
- document manual-only restriction in README

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml README.md`
- `python check_env.py --auto-install`
- `pytest -k 'nomatch'`

------
https://chatgpt.com/codex/tasks/task_e_6871c67397d883339e75b7c5f4ba1a77