### PR TITLE
Fix build workflow and dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,6 +76,12 @@ jobs:
         run: |
           docker build --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
             -t ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
+      - name: Compute Python tag
+        shell: bash
+        run: |
+          tag=py${{ matrix.python-version }}
+          tag=${tag//./}
+          echo "PY_TAG=$tag" >> "$GITHUB_ENV"
 
       - name: Run pytest inside container
         run: |
@@ -91,17 +97,18 @@ jobs:
           path: coverage.xml
 
       - name: Login to GHCR
-        if: matrix.python-version == '3.12'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image
-        if: matrix.python-version == '3.12'
+      - name: Tag and push image
         run: |
+          docker tag ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:${{ github.sha }} \
+            ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:$PY_TAG
           docker push ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:${{ github.sha }}
+          docker push ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:$PY_TAG
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.1
@@ -109,21 +116,20 @@ jobs:
           cosign-release: 'v2.2.4'
 
       - name: Sign image
-        if: matrix.python-version == '3.12'
         run: |
           cosign sign --yes ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:${{ github.sha }}
+          cosign sign --yes ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:$PY_TAG
 
       - name: Verify signature
-        if: matrix.python-version == '3.12'
         run: |
           cosign verify ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:${{ github.sha }}
+          cosign verify ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:$PY_TAG
 
-      - name: Tag latest image
+      - name: Tag and push latest image
         if: matrix.python-version == '3.12'
         run: |
           docker tag ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:${{ github.sha }} \
             ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:latest
-
-      - name: Push latest tag
-        if: matrix.python-version == '3.12'
-        run: docker push ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:latest
+          docker push ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:latest
+          cosign sign --yes ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:latest
+          cosign verify ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:latest

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
@@ -1,6 +1,6 @@
 # α‑AGI Insight demo dependencies
 # Fully pinned runtime packages for reproducible installs
-streamlit==1.35.0
+streamlit==1.46.0
 fastapi==0.115.9
 uvicorn[standard]==0.34.2
 flask==3.1.0
@@ -43,7 +43,7 @@ networkx==3.4.2
 noaa-sdk==0.1.21
 llama-cpp-python==0.3.8
 ctransformers==0.2.27
-blake3==0.3.3
+blake3==1.0.5
 grpcio==1.71.0
 grpcio-tools==1.62.1
 plotly==5.21.0


### PR DESCRIPTION
## Summary
- update workflow to tag and sign Docker images for both Python versions
- push Python-version tags and latest for 3.12
- bump Streamlit and blake3 versions in the Insight demo requirements

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt`
- `python check_env.py --auto-install`
- `pytest tests/test_agent_aiga_entrypoint.py::TestAgentAIGAEntry::test_entrypoint_compiles -q`


------
https://chatgpt.com/codex/tasks/task_e_6871d0bf563c8333ae86d1d6f1a714c5