### PR TITLE
fix: ensure container build installs rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM python:${PYTHON_VERSION}-slim
 # install build tools and npm for the React UI
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg build-essential postgresql-client patch && \
+        curl ca-certificates gnupg build-essential \
+        rustc cargo postgresql-client patch && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add `rustc` and `cargo` packages in Dockerfile so Rust-based wheels build
- Build & Test workflow uses manual dispatch and tags each Python variant

## Testing
- `pre-commit run --files Dockerfile .github/workflows/build-and-test.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68723cea9cb88333ae153c2df1250fa1