### PR TITLE
[alpha_factory] ci: grant id-token to build workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- add `id-token: write` permission to build-and-test workflow

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_6872568957248333a431991c2fd70d36