### PR TITLE
[alpha_factory] fix docs-check name emoji

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
         run: pytest -m smoke -q
 
   docs-check:
-    name: "\ud83d\udcdc MkDocs"
+    name: "📜 MkDocs"
     needs: lint-type
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- restore emoji in docs-check job

## Testing
- `yamllint .github/workflows/ci.yml | head -n 20`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68726f73941883338603ed37f3d861fe