### PR TITLE
[alpha_factory] Clarify CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # 🌐 Alpha-AGI Insight CI — GitHub Actions Workflow
 #
 # Validates the demo with lint, type checks, unit tests and Docker build.
-# Automatically runs on pushes and pull requests.
+# Runs only via manual dispatch.
 # Tagged releases deploy a Docker image with rollback on failure.
 name: "🚀 CI"
 


### PR DESCRIPTION
## Summary
- document that the CI workflow only runs on manual dispatch

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 267 failed, 511 passed, 71 skipped, 18 errors)*
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_687274175d1483338801e67fa47c1116