### PR TITLE
[alpha_factory] Clarify CI workflow permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ generated assets target the latest browsers. When running offline or if the
 update fails, set `BROWSERSLIST_IGNORE_OLD_DATA=true` to continue without
 refreshing the cache.
 
+### CI Workflow
+
+The [🚀 CI](.github/workflows/ci.yml) job verifies the Insight demo with
+linting, type checks, unit tests and a Docker build. Open **Actions → 🚀 CI —
+Insight Demo** and click **Run workflow** to dispatch the pipeline. Only the
+repository owner can trigger the job directly. Others must provide the
+`run_token` that matches the `DISPATCH_TOKEN` secret when clicking the button.
+
 ### Build & Test Workflow
 
 The [🐳 Build & Test](.github/workflows/build-and-test.yml) job runs linting,


### PR DESCRIPTION
## Summary
- document that only repo owners can directly run the `ci.yml` workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: tests failing)*
- `pre-commit run --files README.md`


------
https://chatgpt.com/codex/tasks/task_e_687280f88e248333b09f006cf665de25