### PR TITLE
[alpha_factory] ensure coverage artifact uploads

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,6 +92,7 @@ jobs:
             bash -c "python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse \"$WHEELHOUSE\"} && pytest --cov --cov-report=xml:/repo/coverage.xml --cov-fail-under=80"
 
       - name: Upload coverage
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml


### PR DESCRIPTION
## Summary
- save coverage file even if earlier steps fail

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: tests/test_agents_fallback.py::test_agents_import_fallback[openai_agents] et al.)*
- `pre-commit run --files .github/workflows/build-and-test.yml`

------
https://chatgpt.com/codex/tasks/task_e_687282916d408333802148a139028b53