### PR TITLE
[alpha_factory] sync Dockerfiles docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,12 @@ wheelhouse when offline). Once it succeeds, execute the tests:
 pytest --cov --cov-report=xml
 ```
 
+### Dockerfiles
+
+When modifying build dependencies or system packages in the project
+`Dockerfile`, update `alpha_factory_v1/Dockerfile` as well so both images
+remain consistent.
+
 ## Pre-commit Hooks
 
 Run `./codex/setup.sh` to install project dependencies. The script also

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+# When changing build dependencies here, mirror the updates in
+# alpha_factory_v1/Dockerfile to keep both images consistent.
 ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION}-slim
 


### PR DESCRIPTION
## Summary
- reference alpha_factory_v1/Dockerfile in root Dockerfile
- document that build changes must be mirrored in both Dockerfiles

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 56 failed, 79 passed, 31 skipped, 56 warnings, 5 errors)*
- `pre-commit run --files Dockerfile CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_687284b6893883338a06744a1d406da8