### PR TITLE
docs: clarify CI dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
       - name: Pack release assets
         run: tar -czf web-client.tar.gz -C alpha_factory_v1/core/interface/web_client/dist .
       - name: Upload release assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: web-client.tar.gz
       - name: Rollback on failure

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ refreshing the cache.
 The [🚀 CI](.github/workflows/ci.yml) job verifies the Insight demo with
 linting, type checks, unit tests and a Docker build. Open **Actions → 🚀 CI —
 Insight Demo** and click **Run workflow** to dispatch the pipeline. Only the
-repository owner can trigger the job directly. Others must provide the
-`run_token` that matches the `DISPATCH_TOKEN` secret when clicking the button.
+repository owner can trigger the job directly.
 
 ### Build & Test Workflow
 


### PR DESCRIPTION
## Summary
- remove obsolete run_token reference from README
- update release action in the CI workflow

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68728e437aac8333ad0b5d3f63cf91e4