### PR TITLE
[alpha_factory] add missing type hints

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_codegen_safety.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_codegen_safety.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 
+import pytest
+
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import codegen_agent
 from alpha_factory_v1.common.utils import config, messaging
 from alpha_factory_v1.common.utils.logging import Ledger
@@ -32,7 +34,7 @@ class DummyLedger:
         pass
 
 
-def test_skip_unsafe_execution(monkeypatch) -> None:
+def test_skip_unsafe_execution(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = config.Settings(bus_port=0)
     bus = DummyBus(cfg)
     ledger = DummyLedger()

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_local_validator.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_local_validator.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Iterator
 
 import asyncio
 import pytest
@@ -47,7 +48,7 @@ def _wait_rpc(url: str, timeout: int = 30) -> bool:
 
 
 @pytest.fixture(scope="module")
-def validator() -> str:
+def validator() -> Iterator[str]:
     port = _free_port()
     cid = (
         subprocess.check_output(

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_verify.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_verify.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+import pytest
+
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src import orchestrator
 from alpha_factory_v1.common.utils import config, messaging
 
 
-def test_verify_ledger_slashes(tmp_path, monkeypatch) -> None:
+def test_verify_ledger_slashes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     settings = config.Settings(bus_port=0, ledger_path=str(tmp_path / "ledger.db"))
     monkeypatch.setattr(orchestrator.Orchestrator, "_init_agents", lambda self: [])
     orch = orchestrator.Orchestrator(settings)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_self_improver.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_self_improver.py
@@ -9,11 +9,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 from alpha_factory_v1.demos.alpha_agi_insight_v1.src import self_improver
 
-
 git = pytest.importorskip("git")
+from git import Repo
 
 
-def _init_repo(path: Path) -> git.Repo:
+def _init_repo(path: Path) -> Repo:
     repo = git.Repo.init(path)
     (path / "metric.txt").write_text("1\n")
     repo.git.add("metric.txt")


### PR DESCRIPTION
## Summary
- add missing iterator annotations to fixtures
- annotate parameters and return types
- import Repo from Git for tests

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_adapters.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_codegen_safety.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_verify.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_ledger_local_validator.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/test_self_improver.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install` *(fails: pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68729828e124833390de1b71dc4ab323