### PR TITLE
[alpha_factory] Remove unused workflow variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION_MATRIX: "3.11,3.12"
   DOCKER_IMAGE: agi-insight-demo
 
 jobs:


### PR DESCRIPTION
## Summary
- remove unused PYTHON_VERSION_MATRIX from CI workflow
- run pre-commit on the workflow file

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68729fe11ac8833392471b910a0fd448