### PR TITLE
docs: clarify CI workflow permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,3 +92,16 @@ that `github.actor` matches `github.repository_owner` before building the site.
 The job runs `scripts/edge_human_knowledge_pages_sprint.sh` to rebuild the site
 and then uses the [Lychee](https://github.com/lycheeverse/lychee) checker to
 verify all internal links. If any links fail validation, the workflow aborts.
+
+### 🚀 CI Workflow
+
+The **🚀 CI** workflow verifies linting, type checks, unit tests and the Docker
+build. It does **not** run automatically from pull requests. Instead, the
+repository owner must trigger it manually from the GitHub Actions page:
+
+1. Open **Actions → 🚀 CI — Insight Demo**.
+2. Click **Run workflow** to start the pipeline.
+
+The job runs only when `github.actor` equals `github.repository_owner`, so other
+contributors cannot execute it unless the owner grants them explicit
+permissions or dispatches the workflow on their behalf.


### PR DESCRIPTION
## Summary
- document that the CI workflow runs only when triggered manually
- explain that only the repository owner can dispatch it

## Testing
- `pre-commit run --files CONTRIBUTING.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_6872a1adee4c833381c56abe58dd33b7