### PR TITLE
Restrict mypy check to src in manual CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Ruff lint
         run: ruff check alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Mypy type-check
-        run: mypy alpha_factory_v1/demos/alpha_agi_insight_v1 --strict
+        # Use configuration defaults to restrict analysis to the src package
+        run: mypy --config-file mypy.ini
 
   tests:
     if: ${{ github.actor == github.repository_owner }}


### PR DESCRIPTION
## Summary
- ensure manual CI uses mypy configuration so tests are excluded

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml --cov-fail-under=70` *(failed: many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6872a93c9e388333b684f6aaabee7884