### PR TITLE
[alpha_factory] document CI manual trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ refreshing the cache.
 
 The [🚀 CI](.github/workflows/ci.yml) job verifies the Insight demo with
 linting, type checks, unit tests and a Docker build. Open **Actions → 🚀 CI —
-Insight Demo** and click **Run workflow** to dispatch the pipeline. Only the
-repository owner can trigger the job directly.
+Insight Demo** and click **Run workflow** to dispatch the pipeline. This
+workflow has no automatic triggers; only the repository owner can launch it
+manually from the GitHub UI.
 
 ### Build & Test Workflow
 


### PR DESCRIPTION
## Summary
- clarify that CI workflow only runs on manual dispatch

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -k 'smoke' -q` *(fails: FileNotFoundError: sw.js)*

------
https://chatgpt.com/codex/tasks/task_e_6872b215519c83339a0638a3122ae544