### PR TITLE
[alpha_factory] CI robustness tweak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
           SERVER_PID=$!
           sleep 2
           python scripts/verify_insight_offline.py
-          kill $SERVER_PID
+          kill "$SERVER_PID"
 
   docker:
     if: ${{ github.actor == github.repository_owner }}


### PR DESCRIPTION
## Summary
- quote `SERVER_PID` when stopping local server in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --maxfail=1 -q` *(fails: test_adk_generate_text_flow)*

------
https://chatgpt.com/codex/tasks/task_e_6872c461b1c08333ad13b87ea079aac1