### PR TITLE
[alpha_factory] Deploy push rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,6 @@ jobs:
       - name: Push previous tag
         run: docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous" || true
       - name: Push new image
-        continue-on-error: true
         run: |
           docker tag "$DOCKER_IMAGE:ci" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}"
           docker tag "$DOCKER_IMAGE:ci" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest"
@@ -350,6 +349,7 @@ jobs:
         if: failure()
         run: |
           echo "Rolling back to previous image"
-          docker pull "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous" || exit 0
+          docker pull "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous"
           docker tag "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest"
           docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest"
+          echo "Rollback succeeded"


### PR DESCRIPTION
## Summary
- trigger rollback by removing `continue-on-error` from push step
- log successful rollback in CI

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 132 failed, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml` *(failed to initialize)

------
https://chatgpt.com/codex/tasks/task_e_6872e36ab9d48333a765b5924f951c72