### PR TITLE
[alpha_factory] migrate to lifespan events

### DIFF
--- a/alpha_factory_v1/backend/memory_fabric.py
+++ b/alpha_factory_v1/backend/memory_fabric.py
@@ -54,7 +54,8 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union, Final
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union, Final, ClassVar
+from alpha_factory_v1.utils.config_common import SettingsConfigDict
 
 # ─────────────────────── dynamic soft-deps ░──────────────────
 try:
@@ -137,14 +138,15 @@ class _Settings(BaseSettings):
 
     # Memory policies
     MEM_TTL_SECONDS: int = 0  # 0 = infinite
-    MEM_MAX_PER_AGENT: PositiveInt = Field(100_000, env="MEM_MAX_PER_AGENT")
+    MEM_MAX_PER_AGENT: PositiveInt = Field(100_000, validation_alias="MEM_MAX_PER_AGENT")
 
     # Quotas / circuit breaker
     MEM_FAIL_GRACE_SEC: int = 20
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config: ClassVar[SettingsConfigDict] = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+    }
 
 
 CFG = _Settings()  # single instance

--- a/alpha_factory_v1/common/utils/config.py
+++ b/alpha_factory_v1/common/utils/config.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Optional, Dict
+from typing import Any, Optional, Dict, ClassVar
 
 from alpha_factory_v1.utils.config_common import (
     _load_dotenv,
     _prefetch_vault,
+    SettingsConfigDict,
 )
 from pydantic_settings import BaseSettings
 
@@ -70,6 +71,13 @@ class Settings(BaseSettings):  # type: ignore[misc]
         default_factory=lambda: {"default": "gpt-4o"},
         alias="AGI_ISLAND_BACKENDS",
     )
+
+    model_config: ClassVar[SettingsConfigDict] = {
+        "env_file": ".env",
+        "extra": "ignore",
+        "populate_by_name": True,
+        "env_prefix": "",
+    }
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - exercised in tests
         super().__init__(**data)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from contextlib import asynccontextmanager
 from pydantic import BaseModel
 
 from alpha_factory_v1.core.simulation import mats
@@ -51,9 +52,13 @@ class MutationResponse(BaseModel):  # type: ignore[misc]
     child: List[float]
 
 
-@app.on_event("startup")  # type: ignore[misc]
-async def _prepare() -> None:
+@asynccontextmanager
+async def lifespan(_: FastAPI):
     STORAGE_PATH.mkdir(parents=True, exist_ok=True)
+    yield
+
+
+app.router.lifespan_context = lifespan
 
 
 @app.post("/mutate", response_model=MutationResponse)  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- use `lifespan` instead of `@app.on_event`
- switch settings models to `ConfigDict`
- add JSON schema example for `SimRequest`

## Testing
- `pre-commit run --files alpha_factory_v1/backend/memory_fabric.py alpha_factory_v1/common/utils/config.py alpha_factory_v1/core/interface/api_server.py alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py alpha_factory_v1/demos/meta_agentic_agi_v3/meta_agentic_agi_demo_v3.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py`
- `pytest --maxfail=1 --cov=alpha_factory_v1 --cov-report=xml` *(fails: Any cannot be instantiated)*

------
https://chatgpt.com/codex/tasks/task_e_6872e7f3b2ec8333bd715c6d7c5a1b66