### PR TITLE
[alpha_factory] require owner for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,18 @@ env:
   DOCKER_IMAGE: agi-insight-demo
 
 jobs:
+  owner-check:
+    name: "Verify owner"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
+            echo "This workflow may only be run by the repository owner."
+            exit 1
+          fi
+
   lint-type:
+    needs: owner-check
     name: "🧹 Ruff + 🏷️ Mypy"
     runs-on: ubuntu-latest
     environment: ci-on-demand        # ⇦ optional: add reviewers in repo Settings → Environments
@@ -61,8 +72,8 @@ jobs:
         run: mypy --config-file mypy.ini
 
   tests:
+    needs: [owner-check, lint-type]
     name: "✅ Pytest"
-    needs: lint-type
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
@@ -159,7 +170,7 @@ jobs:
 
   windows-smoke:
     name: "Windows Smoke"
-    needs: lint-type
+    needs: [owner-check, lint-type]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -196,7 +207,7 @@ jobs:
 
   docs-check:
     name: "📜 MkDocs"
-    needs: lint-type
+    needs: [owner-check, lint-type]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -213,7 +224,7 @@ jobs:
 
   docs-build:
     name: "📚 Docs Build"
-    needs: tests
+    needs: [owner-check, tests]
     runs-on: ubuntu-latest
     env:
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
@@ -263,7 +274,7 @@ jobs:
 
   docker:
     name: "🐳 Docker build"
-    needs: tests
+    needs: [owner-check, tests]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
@@ -305,7 +316,7 @@ jobs:
   deploy:
     if: github.actor == github.repository_owner && startsWith(github.ref, 'refs/tags/')
     name: "📦 Deploy"
-    needs: docker
+    needs: [owner-check, docker]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- ensure the workflow checks the actor is the repo owner
- run all jobs after a successful owner check

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py && python check_env.py --auto-install`
- `pytest --cov=alpha_factory_v1 --cov-report=xml -m smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_6872edc4a7688333a0777a7de22cedcd