### PR TITLE
[alpha_factory] stabilize manual CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,12 @@ jobs:
           python scripts/check_python_deps.py
           python check_env.py --auto-install
       - name: Build web assets
+        env:
+          PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
+          HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
         run: |
           npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+          npm run --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 fetch-assets
           npm run --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 build
       - name: Run smoke tests
         run: pytest -m smoke -q


### PR DESCRIPTION
## Summary
- build insight browser assets on Windows jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --maxfail=1 --cov --cov-report=xml` *(fails: test_adk_generate_text_flow)*

------
https://chatgpt.com/codex/tasks/task_e_687384c88220833393ed6d6534154c29