### PR TITLE
[alpha_factory] finalize manual CI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ manually from the GitHub UI. An initial *owner-check* step exits immediately if
 anyone else dispatches the job, ensuring the pipeline fails fast rather than
 skipping stages. This guarantees that when the owner runs the workflow every
 job executes.
+Dependency hashes are fully locked, including `setuptools`, so `pip install -r
+requirements.lock` succeeds across Python versions. The Windows smoke job now
+builds the Insight browser before running tests, ensuring the service worker is
+present for the cache version check.
 
 ### Build & Test Workflow
 


### PR DESCRIPTION
## Summary
- clarify that `setuptools` is pinned so pip install passes
- note Windows smoke job builds the Insight browser assets

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 60 failed, 82 passed, 31 skipped)*
- `pre-commit run --files README.md`

------
https://chatgpt.com/codex/tasks/task_e_6873a02371848333ae84bab7c7717bc8