### PR TITLE
docs: emphasize running check_env before hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,7 @@ for modules, classes and functions.
 
 ```bash
 pre-commit install
+python check_env.py --auto-install   # add --wheelhouse <dir> when offline
 pre-commit run --all-files   # run once after installation
 pre-commit run --files <paths>   # before each commit
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ Install the git hooks once and run them before each commit:
 
 ```bash
 pre-commit install
+python check_env.py --auto-install  # add --wheelhouse <dir> when offline
 pre-commit run --all-files
 ```
 Use `pre-commit run --files docs/demos/<page>.md` to catch missing preview

--- a/scripts/env_check.sh
+++ b/scripts/env_check.sh
@@ -25,4 +25,7 @@ if [[ -n "${WHEELHOUSE:-}" ]]; then
     env_opts=(--wheelhouse "$WHEELHOUSE")
 fi
 
-python check_env.py --auto-install "${env_opts[@]}"
+if ! python check_env.py --auto-install "${env_opts[@]}"; then
+    echo "Environment check failed. Run 'python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse \"$WHEELHOUSE\"}' and try again." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- document running `python check_env.py --auto-install` before invoking pre-commit
- print a clearer hint from the `env-check` hook if the environment check fails

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files AGENTS.md CONTRIBUTING.md scripts/env_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873ae26545c8333a443ca7649c2237e