### PR TITLE
[alpha_factory] Fix evolution_worker lifespan typing

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py
@@ -14,7 +14,8 @@ import shutil
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
+from collections.abc import AsyncGenerator
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from contextlib import asynccontextmanager
@@ -53,7 +54,7 @@ class MutationResponse(BaseModel):  # type: ignore[misc]
 
 
 @asynccontextmanager
-async def lifespan(_: FastAPI):
+async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
     STORAGE_PATH.mkdir(parents=True, exist_ok=True)
     yield
 


### PR DESCRIPTION
## Summary
- import AsyncGenerator in `evolution_worker`
- annotate `lifespan` with `AsyncGenerator`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/src/evolution_worker.py`
- `mypy --config-file mypy.ini`


------
https://chatgpt.com/codex/tasks/task_e_6873b3e46bd8833399076107077b861e