### PR TITLE
[alpha_factory] disable matrix fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ci-on-demand        # ⇦ optional: add reviewers in repo Settings → Environments
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
@@ -72,11 +73,12 @@ jobs:
         run: mypy --config-file mypy.ini
 
   tests:
-    needs: [owner-check, lint-type]
+    needs: owner-check
     name: "✅ Pytest"
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
@@ -170,7 +172,7 @@ jobs:
 
   windows-smoke:
     name: "Windows Smoke"
-    needs: [owner-check, lint-type]
+    needs: owner-check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -211,7 +213,7 @@ jobs:
 
   docs-check:
     name: "📜 MkDocs"
-    needs: [owner-check, lint-type]
+    needs: owner-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- update CI lint and tests strategies to keep jobs running
- depend on owner-check for tests, Windows smoke and docs check

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError: API...)*

------
https://chatgpt.com/codex/tasks/task_e_6873b8035a188333b4fba7e916aa6e3e