### PR TITLE
[alpha_factory] fix: add packages permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   actions: read
   checks:  write
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- grant CI workflow permission to push packages

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6873bd9469b88333ab2b78cb52503abc