### PR TITLE
[alpha_factory] fix mypy lint for FastAPI lifespan

### DIFF
--- a/alpha_factory_v1/core/interface/api_server.py
+++ b/alpha_factory_v1/core/interface/api_server.py
@@ -98,6 +98,7 @@ try:
     from starlette.responses import Response, PlainTextResponse
     from fastapi.staticfiles import StaticFiles
     from contextlib import asynccontextmanager
+    from collections.abc import AsyncGenerator
     from pydantic import BaseModel, ConfigDict
     import uvicorn
     from .problem_json import problem_response
@@ -251,7 +252,7 @@ if app is not None:
     app_f.state.orch_task = None
 
     @asynccontextmanager
-    async def lifespan(app_f: FastAPI):
+    async def lifespan(app_f: FastAPI) -> AsyncGenerator[None, None]:
         _log.warning(DISCLAIMER)
         if API_TOKEN == "REPLACE_ME_TOKEN":
             _log.error("API_TOKEN is set to the default 'REPLACE_ME_TOKEN'. " "Edit .env to use a strong secret.")

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -50,6 +50,7 @@ _IMPORT_ERROR: Exception | None
 try:
     from fastapi import FastAPI, HTTPException, WebSocket, Request, Depends
     from contextlib import asynccontextmanager
+    from collections.abc import AsyncGenerator
     from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
     from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
     from starlette.responses import (
@@ -83,7 +84,7 @@ if app is not None:
     app_f.state.task = None
 
     @asynccontextmanager
-    async def lifespan(_: FastAPI):
+    async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
         orch_mod = importlib.import_module("alpha_factory_v1.core.orchestrator")
         app_f.state.orchestrator = orch_mod.Orchestrator()
         app_f.state.task = asyncio.create_task(app_f.state.orchestrator.run_forever())

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -599,6 +599,7 @@ if os.getenv("OPENAI_API_KEY") and not os.getenv("NO_LLM"):
 # =============================================================================
 from fastapi import FastAPI, WebSocket  # noqa: E402
 from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 import uvicorn  # noqa: E402
 
@@ -615,7 +616,7 @@ loop_thread: Optional[threading.Thread] = None
 
 
 @asynccontextmanager
-async def lifespan(_: FastAPI):
+async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
     global orch, loop_thread
     orch = Orchestrator()
     loop_thread = threading.Thread(target=orch.loop, daemon=True)

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/meta_agentic_agi_demo_v3.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/meta_agentic_agi_demo_v3.py
@@ -499,6 +499,7 @@ def run_api(args, fm: BaseProvider, db: LineageDB) -> None:
     try:
         from fastapi import FastAPI
         from contextlib import asynccontextmanager
+        from collections.abc import AsyncGenerator
         from fastapi.responses import JSONResponse
         import uvicorn
     except ImportError:
@@ -509,7 +510,7 @@ def run_api(args, fm: BaseProvider, db: LineageDB) -> None:
     state: Dict[str, Any] = {"best": None}
 
     @asynccontextmanager
-    async def lifespan(_: FastAPI):
+    async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
         state["best"] = await evolutionary_search(
             fm,
             db,


### PR DESCRIPTION
## Summary
- annotate FastAPI `lifespan` functions with `AsyncGenerator`

## Testing
- `mypy --config-file mypy.ini`
- `pytest tests/test_ping_agent.py::TestPingAgent::test_run_cycle_publishes -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c3c3ab488333b7f6d18dd8a51306