### PR TITLE
[alpha_factory] fix: point setup-node to lock files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+          cache-dependency-path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+            alpha_factory_v1/core/interface/web_client/package-lock.json
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Audit insight browser dependencies


### PR DESCRIPTION
## Summary
- update `actions/setup-node` step in ci.yml

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 70 failed, 95 passed, 31 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml` *(fails: environment initialization interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6873d256d68c833380207dc2a275cf90