### PR TITLE
[alpha_factory] ensure CI artifacts always upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
           pytest tests/test_benchmark.py -q
           cat tests/benchmarks/latest.json
       - name: Upload benchmark results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
@@ -169,6 +170,7 @@ jobs:
           header: benchmark
           path: bench.txt
       - name: Upload coverage
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml


### PR DESCRIPTION
## Summary
- always upload benchmark results and coverage in CI

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml --cov-fail-under=70` *(fails: 55 failed, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml` *(aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5d614188333b9a3ac7e54a58e3c