### PR TITLE
[alpha_factory] streamline npm caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,16 +192,11 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
           pip install pytest
-      - name: Cache npm
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: windows-npm-${{ hashFiles('alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json') }}
-          restore-keys: |
-            windows-npm-
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
       - name: Verify environment
         run: |
           python scripts/check_python_deps.py


### PR DESCRIPTION
## Summary
- use `setup-node` caching in Windows smoke job

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(failed: KeyboardInterrupt)*
- `pre-commit run --files .github/workflows/ci.yml` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6873dd73c27c833397fec901347c0cdd