### PR TITLE
[alpha_factory] restrict CI to repository owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
-            echo "This workflow may only be run by the repository owner."
-            exit 1
-          fi
+      - if: ${{ github.actor != github.repository_owner }}
+        run: |
+          echo "Skipping because ${{ github.actor }} is not the repository owner."
+          exit 0
 
   lint-type:
+    if: ${{ github.actor == github.repository_owner }}
     needs: owner-check
     name: "🧹 Ruff + 🏷️ Mypy"
     runs-on: ubuntu-latest
@@ -74,6 +74,7 @@ jobs:
         run: mypy --config-file mypy.ini
 
   tests:
+    if: ${{ github.actor == github.repository_owner }}
     needs: owner-check
     name: "✅ Pytest"
     runs-on: ubuntu-latest
@@ -177,6 +178,7 @@ jobs:
           path: coverage.xml
 
   windows-smoke:
+    if: ${{ github.actor == github.repository_owner }}
     name: "Windows Smoke"
     needs: owner-check
     runs-on: windows-latest
@@ -213,6 +215,7 @@ jobs:
         run: pytest -m smoke -q
 
   docs-check:
+    if: ${{ github.actor == github.repository_owner }}
     name: "📜 MkDocs"
     needs: owner-check
     runs-on: ubuntu-latest
@@ -230,6 +233,7 @@ jobs:
         run: mkdocs build --strict
 
   docs-build:
+    if: ${{ github.actor == github.repository_owner }}
     name: "📚 Docs Build"
     needs: [owner-check, tests]
     runs-on: ubuntu-latest
@@ -280,6 +284,7 @@ jobs:
           kill "$SERVER_PID"
 
   docker:
+    if: ${{ github.actor == github.repository_owner }}
     name: "🐳 Docker build"
     needs: [owner-check, tests]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- only run CI jobs when the actor matches the repository owner
- gracefully skip the workflow for non-owners

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: collected 835 items, multiple test failures)*
- `pre-commit run --files .github/workflows/ci.yml` *(fails to initialize semgrep)*

------
https://chatgpt.com/codex/tasks/task_e_6873e73b01dc8333892923c3e15b581b