### PR TITLE
[alpha_factory] use lock file for pip caching

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: 'requirements.lock'
 
       # Docker requires lowercase repository names. Convert the repository
       # owner to lowercase so image tags remain valid even when the GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
         uses: actions/cache@v4.0.2 # 0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
@@ -89,6 +90,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -188,6 +190,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -227,6 +230,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
+          cache-dependency-path: 'requirements.lock'
       - name: Install docs requirements
         run: |
           python -m pip install --upgrade pip
@@ -249,6 +253,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
+          cache-dependency-path: 'requirements.lock'
       - uses: actions/setup-node@v4.0.2 # 60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.github/workflows/nightly-transfer.yml
+++ b/.github/workflows/nightly-transfer.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: 'requirements.lock'
 
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- cache lock file across CI workflows

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 55 failed, 82 passed, 31 skipped, 8 errors)*
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/build-and-test.yml .github/workflows/docs.yml .github/workflows/bench.yml .github/workflows/deploy-kind.yml .github/workflows/loadtest.yml .github/workflows/nightly-transfer.yml .github/workflows/security.yml .github/workflows/smoke.yml`

------
https://chatgpt.com/codex/tasks/task_e_6873f1e2b3148333a5ce59c8aca6ae8d