### PR TITLE
Fix Node cache paths

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,7 +52,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+          cache-dependency-path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+            alpha_factory_v1/core/interface/web_client/package-lock.json
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          cache-dependency-path: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+          cache-dependency-path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+            alpha_factory_v1/core/interface/web_client/package-lock.json
       - name: Install pre-commit
         run: pip install pre-commit==4.2.0
         env:


### PR DESCRIPTION
## Summary
- cache Node dependencies properly in build-and-test and size-check workflows

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml .github/workflows/size-check.yml .github/workflows/ci.yml .github/workflows/docs.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_6873f7562e188333badc4c4205818047