### PR TITLE
[alpha_factory] clarify CI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ refreshing the cache.
 
 The [🚀 CI](.github/workflows/ci.yml) job verifies the Insight demo with
 linting, type checks, unit tests and a Docker build. Open **Actions → 🚀 CI —
-Insight Demo** and click **Run workflow** to dispatch the pipeline. This
+Insight Demo**, select the branch or tag to test in the drop‑down and click
+**Run workflow** to dispatch the pipeline. This
 workflow has no automatic triggers; only the repository owner can launch it
 manually from the GitHub UI. An initial *owner-check* job prints a notice and
 exits successfully when someone else dispatches the workflow. All subsequent


### PR DESCRIPTION
## Summary
- document selecting branch or tag when running CI manually

## Testing
- `pre-commit run --files README.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_benchmark.py -q --cov --cov-report=xml --cov-fail-under=70` *(fails: Required test coverage of 70% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6873f9c2e41883339538e05240fa10ef