### PR TITLE
fix: clarify Node lockfile paths in CI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,14 @@ requirements.lock` succeeds across Python versions. The Windows smoke job now
 builds the Insight browser before running tests, ensuring the service worker is
 present for the cache version check. See
 [CI_WORKFLOW.md](docs/CI_WORKFLOW.md) for a detailed job overview.
-All Node.js steps pin the same lockfiles via
-`cache-dependency-path` so `actions/setup-node` caches npm packages correctly
-and avoids "Dependencies lock file is not found" warnings.
+All Node.js steps pin the same lockfiles via `cache-dependency-path` so
+`actions/setup-node` caches npm packages correctly and avoids "Dependencies lock
+file is not found" warnings. The paths are:
+
+```
+alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+alpha_factory_v1/core/interface/web_client/package-lock.json
+```
 
 To publish a release, create a Git tag and run the same workflow on that
 tag. The Docker job pushes the `agi-insight-demo` image to GitHub Container

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -30,6 +30,12 @@ GitHub Release.
 Caching for Python and Node dependencies is enabled. The project stores
 `package-lock.json` files under the demo and web client folders rather than at
 the repository root. Each `setup-node` step lists these paths explicitly via
-`cache-dependency-path`.
-If the workflow ever reports missing lock files, double‑check those paths
-in `.github/workflows/ci.yml` and adjust them if new packages are added.
+`cache-dependency-path`:
+
+```
+alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+alpha_factory_v1/core/interface/web_client/package-lock.json
+```
+
+If the workflow ever reports missing lock files, double‑check these paths
+in `.github/workflows/ci.yml` and adjust them whenever new packages are added.


### PR DESCRIPTION
## Summary
- document the npm `cache-dependency-path` entries in CI docs
- list Node lockfile paths in README so maintainers know where they live

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_68740c1511608333bbc166b19c60e978