### PR TITLE
[alpha_factory] fix node cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: |
-            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
-            alpha_factory_v1/core/interface/web_client/package-lock.json
+            ./alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+            ./alpha_factory_v1/core/interface/web_client/package-lock.json
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Audit insight browser dependencies

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -29,7 +29,8 @@ GitHub Release.
 
 Caching for Python and Node dependencies is enabled. The project stores
 `package-lock.json` files under the demo and web client folders rather than at
-the repository root. Each `setup-node` step lists these paths explicitly via
+ the repository root. Each `setup-node` step, including the test matrix,
+ lists these paths explicitly via
 `cache-dependency-path`:
 
 ```


### PR DESCRIPTION
## Summary
- reference npm lockfiles in the tests job
- clarify caching in CI docs

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/CI_WORKFLOW.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: TypeError Any cannot be instantiated)*

------
https://chatgpt.com/codex/tasks/task_e_68740f8cfb2c8333b1b079e8d6ca7ea5