### PR TITLE
ci: centralize node lockfile paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ concurrency:
 
 env:
   DOCKER_IMAGE: agi-insight-demo
+  NODE_LOCKFILES: |
+    alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+    alpha_factory_v1/core/interface/web_client/package-lock.json
 
 jobs:
   owner-check:
@@ -109,9 +112,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          cache-dependency-path: |
-            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
-            alpha_factory_v1/core/interface/web_client/package-lock.json
+          cache-dependency-path: ${{ env.NODE_LOCKFILES }}
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Audit insight browser dependencies
@@ -202,9 +203,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          cache-dependency-path: |
-            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
-            alpha_factory_v1/core/interface/web_client/package-lock.json
+          cache-dependency-path: ${{ env.NODE_LOCKFILES }}
       - name: Verify environment
         run: |
           python scripts/check_python_deps.py
@@ -259,9 +258,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          cache-dependency-path: |
-            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
-            alpha_factory_v1/core/interface/web_client/package-lock.json
+          cache-dependency-path: ${{ env.NODE_LOCKFILES }}
       - name: Install base dependencies
         run: python check_env.py --auto-install
       - name: Install docs requirements
@@ -305,9 +302,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          cache-dependency-path: |
-            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
-            alpha_factory_v1/core/interface/web_client/package-lock.json
+          cache-dependency-path: ${{ env.NODE_LOCKFILES }}
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Audit insight browser dependencies

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ to reference
 `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json`
 and `alpha_factory_v1/core/interface/web_client/package-lock.json` so repeat runs
 skip redundant downloads and avoid the “Dependencies lock file is not found”
-warning. `ci.yml` applies the same paths for the tests, docs-build and Docker
-jobs. It
+warning. `ci.yml` stores these paths in the `NODE_LOCKFILES` environment
+variable so every `setup-node` step uses the same list. It
+applies the same paths for the tests, docs-build and Docker jobs. It
 preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check
 passes without network hiccups. During the run it also updates the
 `browserslist` cache inside

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -33,9 +33,9 @@ previous `latest` image so production always points at a working build.
 
 Caching for Python and Node dependencies is enabled. The project stores
 `package-lock.json` files under the demo and web client folders rather than at
- the repository root. Each `setup-node` step, including the test matrix,
- lists these paths explicitly via
-`cache-dependency-path`:
+ the repository root. The workflow defines these paths once in the
+`NODE_LOCKFILES` environment variable so each `setup-node` step
+passes the same list via `cache-dependency-path`:
 
 ```
 alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json


### PR DESCRIPTION
## Summary
- reference Node lockfiles via `NODE_LOCKFILES` env var
- document the new variable in the README and CI workflow guide

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md docs/CI_WORKFLOW.md`

------
https://chatgpt.com/codex/tasks/task_e_6874244b6d288333baba65059ecf241c