### PR TITLE
[alpha_factory] update cache and setup actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,14 @@ jobs:
         python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - uses: actions/setup-python@v5.1.0 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
+      - uses: actions/setup-python@v5 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
-        uses: actions/cache@v4.0.2 # 0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@v4 # 0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: .cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -89,7 +89,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - uses: actions/setup-python@v5.1.0 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
+      - uses: actions/setup-python@v5 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -108,7 +108,7 @@ jobs:
       - name: Build sandbox image
         run: docker build -t selfheal-sandbox:latest -f sandbox.Dockerfile .
       # Install Node.js and cache dependencies using both lockfiles
-      - uses: actions/setup-node@v4.0.2 # 60edb5dd545a775178f52524783378180af0d1f8
+      - uses: actions/setup-node@v4 # 60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -188,7 +188,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - uses: actions/setup-python@v5.1.0 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
+      - uses: actions/setup-python@v5 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '3.11'
           cache: pip
@@ -199,7 +199,7 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
           pip install pytest
-      - uses: actions/setup-node@v4.0.2 # 60edb5dd545a775178f52524783378180af0d1f8
+      - uses: actions/setup-node@v4 # 60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - uses: actions/setup-python@v5.1.0 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
+      - uses: actions/setup-python@v5 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '3.12'
           cache: pip
@@ -249,12 +249,12 @@ jobs:
       FETCH_ASSETS_ATTEMPTS: '5'
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - uses: actions/setup-python@v5.1.0 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
+      - uses: actions/setup-python@v5 # 82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - uses: actions/setup-node@v4.0.2 # 60edb5dd545a775178f52524783378180af0d1f8
+      - uses: actions/setup-node@v4 # 60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -298,7 +298,7 @@ jobs:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-      - uses: actions/setup-node@v4.0.2 # 60edb5dd545a775178f52524783378180af0d1f8
+      - uses: actions/setup-node@v4 # 60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
## Summary
- switch to major versions for `actions/cache`
- bump to `@v5` for `actions/setup-python`
- bump to `@v4` for `actions/setup-node`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_687429bbf07883338419c094901cea56