### PR TITLE
fix: ensure wasm assets are fetched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Audit insight browser dependencies
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 audit --production --audit-level=high
+      - name: Fetch insight browser assets
+        env:
+          PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
+          HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
+        run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
       - name: Run insight browser tests
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Install web dependencies


### PR DESCRIPTION
## Summary
- run `npm run fetch-assets` before building the Insight browser so Pyodide files are present

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_687439cc2b9c8333935704fc0674f8ca