### PR TITLE
Inline repository owner check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,8 @@ env:
     alpha_factory_v1/core/interface/web_client/package-lock.json
 
 jobs:
-  owner-check:
-    name: "Verify repository owner"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
 
   lint-type:
-    needs: owner-check
     name: "🧹 Ruff + 🏷️ Mypy"
     runs-on: ubuntu-latest
     environment: ci-on-demand        # ⇦ optional: add reviewers in repo Settings → Environments
@@ -43,6 +35,9 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
+      - name: Verify repository owner
+        if: ${{ github.actor != github.repository_owner }}
+        run: echo "Only the repository owner can run this workflow." && exit 1
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -76,7 +71,6 @@ jobs:
         run: mypy --config-file mypy.ini
 
   tests:
-    needs: owner-check
     name: "✅ Pytest"
     runs-on: ubuntu-latest
     environment: ci-on-demand
@@ -85,6 +79,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
+      - name: Verify repository owner
+        if: ${{ github.actor != github.repository_owner }}
+        run: echo "Only the repository owner can run this workflow." && exit 1
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -256,10 +253,12 @@ jobs:
 
   windows-smoke:
     name: "Windows Smoke"
-    needs: owner-check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - name: Verify repository owner
+        if: ${{ github.actor != github.repository_owner }}
+        run: echo "Only the repository owner can run this workflow." && exit 1
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
@@ -299,10 +298,12 @@ jobs:
 
   docs-check:
     name: "📜 MkDocs"
-    needs: owner-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - name: Verify repository owner
+        if: ${{ github.actor != github.repository_owner }}
+        run: echo "Only the repository owner can run this workflow." && exit 1
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -317,13 +318,16 @@ jobs:
 
   docs-build:
     name: "📚 Docs Build"
-    needs: [owner-check, tests]
+    needs: [tests]
     runs-on: ubuntu-latest
     env:
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
     steps:
+      - name: Verify repository owner
+        if: ${{ github.actor != github.repository_owner }}
+        run: echo "Only the repository owner can run this workflow." && exit 1
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -371,10 +375,13 @@ jobs:
 
   docker:
     name: "🐳 Docker build"
-    needs: [owner-check, tests]
+    needs: [tests]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
+      - name: Verify repository owner
+        if: ${{ github.actor != github.repository_owner }}
+        run: echo "Only the repository owner can run this workflow." && exit 1
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
@@ -466,9 +473,12 @@ jobs:
   deploy:
     if: startsWith(github.ref, 'refs/tags/')
     name: "📦 Deploy"
-    needs: [owner-check, docker]
+    needs: [docker]
     runs-on: ubuntu-latest
     steps:
+      - name: Verify repository owner
+        if: ${{ github.actor != github.repository_owner }}
+        run: echo "Only the repository owner can run this workflow." && exit 1
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- simplify CI workflow by removing the dedicated `owner-check` job
- add an owner verification step to each job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68745802ee448333ab1dd3c2c27c8796