### PR TITLE
Update CI docs to use inline owner check

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,9 @@ linting, type checks, unit tests and a Docker build. Open **Actions → 🚀 CI 
 Insight Demo**, select the branch or tag to test in the drop‑down and click
 **Run workflow** to dispatch the pipeline. This
 workflow has no automatic triggers; only the repository owner can launch it
-manually from the GitHub UI. An initial *owner-check* job prints a notice and
-exits successfully when someone else dispatches the workflow. All subsequent
-stages include the same condition so non‑owner runs finish quickly without
-executing the heavy jobs. When the owner launches the workflow every job runs.
+manually from the GitHub UI. Each job begins by verifying the actor matches the
+repository owner, so non‑owners exit immediately before running the heavy
+steps. When the owner launches the workflow every job runs.
 Dependency hashes are fully locked, including `setuptools`, so `pip install -r
 requirements.lock` succeeds across Python versions. The Windows smoke job now
 builds the Insight browser before running tests, ensuring the service worker is
@@ -170,8 +169,8 @@ the previous `latest` tag to avoid shipping a broken image.
 The [🐳 Build & Test](.github/workflows/build-and-test.yml) job runs linting,
 tests and container builds. Open **Actions → 🐳 Build & Test** and click
 **Run workflow** to start the pipeline. Only the repository owner can run this
-workflow. A small *owner-check* step at the start of the workflow exits early if
-someone else triggers it, keeping the rest of the jobs from being skipped.
+workflow. Each job verifies the actor first and exits immediately for
+non‑owners, keeping the rest of the jobs from being skipped.
 
 Docker image tags must use all lowercase characters. The workflow's
 "Prepare lowercase image name" step sets `REPO_OWNER_LC` to the lowercased

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -10,8 +10,9 @@ repository owner triggers it from the GitHub Actions UI.
 
 1. Navigate to **Actions → 🚀 CI**.
 2. Choose the branch or tag in the drop‑down and click **Run workflow**.
-3. Ensure you are the repository owner; non‑owners exit immediately after the
-   initial *owner-check* job.
+3. Ensure you are the repository owner; each job begins by verifying that
+   `github.actor` matches `github.repository_owner` and exits early for
+   non‑owners.
 
 When invoked on a tagged commit the pipeline also builds and publishes a Docker
 image to GHCR and uploads the prebuilt web client bundle to the corresponding
@@ -61,9 +62,11 @@ This lints the YAML and pins action versions so the pipeline stays reproducible.
 
 ## Avoid skipped jobs
 
-Each job declares its dependencies via the `needs:` field. When the workflow runs
-the *owner-check* job completes first. All other jobs start in parallel as soon
-as their prerequisites succeed. A failure in linting or tests deliberately stops
-the Docker build and deploy stages. If a job unexpectedly shows as skipped, first
-check whether one of its dependencies failed earlier in the run. With the lock
-file paths fixed, all jobs should execute when tests pass.
+Each job declares its dependencies via the `needs:` field and begins with an
+owner verification step. Jobs exit immediately when `github.actor` does not
+match `github.repository_owner`, so there is no separate *owner-check* stage.
+Once prerequisites succeed the remaining jobs run in parallel. A failure in
+linting or tests deliberately stops the Docker build and deploy stages. If a
+job unexpectedly shows as skipped, first check whether one of its dependencies
+failed earlier in the run. With the lock file paths fixed, all jobs should
+execute when tests pass.


### PR DESCRIPTION
## Summary
- update README to describe inline owner checks
- clarify CI workflow docs and remove references to standalone job

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md README.md alpha_factory_v1.egg-info/PKG-INFO`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 188 failed, 379 passed, 62 skipped, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874609e5cf083338b444cdf694cbdb2