### PR TITLE
[alpha_factory] remove redundant asset fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,17 +135,6 @@ jobs:
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
           key: assets-${{ steps.asset-key-docker.outputs.key }}
           restore-keys: assets-
-      - name: Fetch insight browser assets
-        env:
-          PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
-          HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
-        run: |
-          set -e
-          npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets || (
-            echo "Detected asset hash change, updating..." &&
-            python scripts/update_pyodide.py 0.28.0 &&
-            npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
-          )
       - name: Update browserslist database
         run: npx update-browserslist-db@latest --agree-to-terms
       - name: Audit insight browser dependencies
@@ -176,17 +165,6 @@ jobs:
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
           key: assets-${{ steps.asset-key.outputs.key }}
           restore-keys: assets-
-      - name: Fetch insight browser assets
-        env:
-          PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
-          HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
-        run: |
-          set -e
-          npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets || (
-            echo "Detected asset hash change, updating..." &&
-            python scripts/update_pyodide.py 0.28.0 &&
-            npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
-          )
       - name: Run insight browser tests
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Install web dependencies


### PR DESCRIPTION
## Summary
- remove the extra `Fetch insight browser assets` step from the tests workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68746c79b1788333aee91ea4c69b1dbc