### PR TITLE
[alpha_factory] switch demo deps install to lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
-          pip install -r requirements-demo.txt
+          pip install -r requirements-demo.lock
           pip install pytest pytest-cov pytest-benchmark mutmut
       - name: Verify environment
         run: |


### PR DESCRIPTION
## Summary
- use `requirements-demo.lock` for CI installs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 137 failed, 291 passed, 59 skipped, 23 warnings, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68746f1fa75c833392836611f22c4b77