### PR TITLE
[alpha_factory] Add env to docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,7 @@ jobs:
     name: "📚 Docs Build"
     needs: [tests]
     runs-on: ubuntu-latest
+    environment: ci-on-demand
     env:
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main


### PR DESCRIPTION
## Summary
- run docs build with the same `ci-on-demand` environment as other CI jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest --cov --cov-report=xml` *(fails: 55 failed, 82 passed, 31 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68747247725c8333a382ea9d57bb3057