### PR TITLE
[alpha_factory] fix tests loading proto stubs

### DIFF
--- a/alpha_factory_v1/common/utils/messaging.py
+++ b/alpha_factory_v1/common/utils/messaging.py
@@ -27,7 +27,12 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
 
     Envelope: TypeAlias = pb.Envelope
 else:  # pragma: no cover - runtime fallback
-    Envelope: TypeAlias = Any
+    try:
+        from alpha_factory_v1.core.utils import a2a_pb2 as pb
+
+        Envelope: TypeAlias = pb.Envelope  # type: ignore
+    except Exception:  # pragma: no cover - optional proto
+        Envelope: TypeAlias = Any
 
 
 class EnvelopeLike(Protocol):

--- a/check_env.py
+++ b/check_env.py
@@ -464,7 +464,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 missing_optional.append(pkg)
             else:
                 missing_required.append(pkg)
-        elif pkg == "openai_agents":
+        elif pkg in {"openai_agents", "agents"}:
             openai_agents_found = True
     missing = missing_required + missing_optional
     if missing:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -7,7 +7,7 @@ import importlib
 import pytest
 
 # Stub generated proto dependency if missing
-_stub_path = "alpha_factory_v1.common.utils.a2a_pb2"
+_stub_path = "alpha_factory_v1.core.utils.a2a_pb2"
 if _stub_path not in sys.modules:
     stub = types.ModuleType("a2a_pb2")
 


### PR DESCRIPTION
## Summary
- register proto stubs from core for adapter tests
- expose Envelope alias when protobuf module is present
- detect `agents` package during environment checks

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_adapters.py -q`
- `pytest tests/test_logging.py -q`
- `pytest tests/test_check_env_openai_agents_version.py::TestCheckEnvOpenAIAgentsVersion::test_missing_version_fails -q`
- `pytest --cov --cov-report=xml -q` *(fails: 35 failed, 100 passed, 31 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68748eadd3a083338d4d52040a8b16fc