### PR TITLE
[alpha_factory] consolidate owner check

### DIFF
--- a/.github/actions/ensure-owner/action.yml
+++ b/.github/actions/ensure-owner/action.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Ensure Repository Owner
+description: Fail if the workflow is triggered by someone other than the repository owner.
+runs:
+  using: composite
+  steps:
+    - name: Check owner
+      shell: bash
+      run: |
+        if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
+          echo "Only the repository owner can run this workflow."
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -79,9 +77,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -234,9 +230,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
@@ -279,9 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -304,9 +296,7 @@ jobs:
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
     steps:
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -358,9 +348,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
@@ -455,9 +443,7 @@ jobs:
     needs: [docker]
     runs-on: ubuntu-latest
     steps:
-      - name: Verify repository owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: echo "Only the repository owner can run this workflow." && exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,7 @@ jobs:
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
     steps:
-      - name: Verify repository owner
-        if: github.actor != github.repository_owner
-        run: |
-          echo "Only the repository owner can dispatch this workflow."
-          exit 1
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Set up Python
         uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- add `ensure-owner` composite action to gate workflows
- use the new action across CI and Docs jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/docs.yml .github/actions/ensure-owner/action.yml`

------
https://chatgpt.com/codex/tasks/task_e_6874f6715e348333ba22bda76af0356d