### PR TITLE
[alpha_factory] Update CI workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     environment: ci-on-demand
     env:
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
@@ -352,6 +353,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     environment: ci-on-demand
     steps:
       - uses: ./.github/actions/ensure-owner


### PR DESCRIPTION
## Summary
- allow workflow to create PRs when building docs or the Docker image

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 29 failed, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml --hook-stage manual` *(fails to finish)*

------
https://chatgpt.com/codex/tasks/task_e_68750863633083338eccb220bc022236