### PR TITLE
[alpha_factory] ensure CI jobs chain correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
 
   tests:
     name: "✅ Pytest"
+    needs: [lint-type]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
@@ -212,10 +213,11 @@ jobs:
 
   windows-smoke:
     name: "Windows Smoke"
+    needs: [tests]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
@@ -255,10 +257,11 @@ jobs:
 
   docs-check:
     name: "📜 MkDocs"
+    needs: [tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'


### PR DESCRIPTION
## Summary
- enforce job dependencies in `.github/workflows/ci.yml`
- start `windows-smoke` and `docs-check` jobs with the ensure-owner action

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 75 failed, 201 passed, 33 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68751555fdcc833398fe889a5ca0bcdf