### PR TITLE
[alpha_factory] include extra lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ env:
   NODE_LOCKFILES: |
     alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
     alpha_factory_v1/core/interface/web_client/package-lock.json
+    alpha_factory_v1/core/interface/web_client/staking/package-lock.json
+    alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package-lock.json
 
 jobs:
 


### PR DESCRIPTION
## Summary
- add missing Node lockfiles to `NODE_LOCKFILES`
- run workflow lint via pre-commit

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 27 failed, 77 passed, 31 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68751d1d68a08333be91815a672137c4