### PR TITLE
docs: note actions permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ tests and container builds. Open **Actions → 🐳 Build & Test** and click
 **Run workflow** to start the pipeline. Only the repository owner can run this
 workflow. Each job verifies the actor first and exits immediately for
 non‑owners, keeping the rest of the jobs from being skipped.
+See [ADMIN_ACTIONS.md](docs/ADMIN_ACTIONS.md) for details on the manual
+workflow restrictions and protected environments.
 
 Docker image tags must use all lowercase characters. The workflow's
 "Prepare lowercase image name" step sets `REPO_OWNER_LC` to the lowercased

--- a/docs/ADMIN_ACTIONS.md
+++ b/docs/ADMIN_ACTIONS.md
@@ -1,0 +1,11 @@
+[See docs/DISCLAIMER_SNIPPET.md](DISCLAIMER_SNIPPET.md)
+
+# GitHub Actions Access Notes
+
+This repository restricts manual workflows to the repository owner or designated administrators.
+
+- Each workflow uses the custom **Ensure Repository Owner** action which exits if `github.actor` does not match `github.repository_owner`.
+- The main CI pipeline specifies the `ci-on-demand` environment. Configure this environment under **Settings → Environments** to require administrator approval before jobs run.
+- Manual jobs appear in the **Actions** tab with a **Run workflow** button but will fail immediately for unauthorized users.
+
+Only trusted maintainers should have permission to approve the protected environment or dispatch these workflows.


### PR DESCRIPTION
## Summary
- mention admin-only workflows in the README
- document the 'Ensure Repository Owner' guard and environment protections

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files README.md docs/ADMIN_ACTIONS.md`

------
https://chatgpt.com/codex/tasks/task_e_68751f55a8dc833387ead3731e39c865