### PR TITLE
[alpha_factory] add ci-on-demand env to smoke workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
     name: "Windows Smoke"
     needs: [tests]
     runs-on: windows-latest
+    environment: ci-on-demand
     steps:
       - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -261,6 +262,7 @@ jobs:
     name: "📜 MkDocs"
     needs: [tests]
     runs-on: ubuntu-latest
+    environment: ci-on-demand
     steps:
       - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- set `environment: ci-on-demand` for `windows-smoke` and `docs-check` jobs in CI workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68752dce1d70833386ec0f55cae5f7eb