### PR TITLE
[alpha_factory] update workflow action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           PY
       - name: Comment benchmark
         if: ${{ github.event.pull_request }}
-        uses: marocchino/sticky-pull-request-comment@v2 # 52423e01640425a022ef5fd42c6fb5f633a02728
+        uses: marocchino/sticky-pull-request-comment@v2.9.3 # d2ad0de260ae8b0235ce059e63f2949ba9e05943
         with:
           header: benchmark
           path: bench.txt
@@ -330,7 +330,7 @@ jobs:
           fi
       - name: Create Pyodide update PR
         if: steps.pyodide-diff-docs.outputs.changed == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v6.1.0 # c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update Pyodide asset hashes"
@@ -423,7 +423,7 @@ jobs:
           fi
       - name: Create Pyodide update PR
         if: steps.pyodide-diff-docker.outputs.changed == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v6.1.0 # c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update Pyodide asset hashes"


### PR DESCRIPTION
## Summary
- update marocchino/sticky-pull-request-comment to v2.9.3
- pin peter-evans/create-pull-request to v6.1.0

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 42 failed, 99 passed, 31 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68753215ee588333810018c36549c55e