### PR TITLE
[alpha_factory] update create-pull-request action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
           fi
       - name: Create Pyodide update PR
         if: steps.pyodide-diff-docs.outputs.changed == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: peter-evans/create-pull-request@v6.1.0 # c5a7806660adbe173f04e3e038b0ccdcd758773c
+        uses: peter-evans/create-pull-request@v7.0.8 # 271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update Pyodide asset hashes"
@@ -423,7 +423,7 @@ jobs:
           fi
       - name: Create Pyodide update PR
         if: steps.pyodide-diff-docker.outputs.changed == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: peter-evans/create-pull-request@v6.1.0 # c5a7806660adbe173f04e3e038b0ccdcd758773c
+        uses: peter-evans/create-pull-request@v7.0.8 # 271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update Pyodide asset hashes"


### PR DESCRIPTION
## Summary
- bump peter-evans/create-pull-request to v7.0.8 in CI workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 37 failed, 100 passed, 31 skipped, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68753da67e24833388a3725d6b0130c5