### PR TITLE
docs: emphasize workflow lint step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,9 +290,8 @@ pre-commit run --files <paths>   # before each commit
     **CI enforces these checks.**
   - After editing `alpha_factory_v1/core/utils/a2a.proto`, run `pre-commit run --files alpha_factory_v1/core/utils/a2a.proto`
     to regenerate and verify protobuf sources.
-  - After modifying `.github/workflows/ci.yml`, run
-    `pre-commit run --files .github/workflows/ci.yml` to lint the workflow
-    with actionlint.
+  - **Always run** `pre-commit run --files .github/workflows/ci.yml` after
+    modifying the workflow to lint it with actionlint.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using
     `mypy.ini`.
   - Semgrep scans Python files with the official `p/python` ruleset to enforce

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,11 @@ repository owner must trigger it manually from the GitHub Actions page:
 1. Open **Actions → 🚀 CI — Insight Demo**.
 2. Click **Run workflow** to start the pipeline.
 
+Remember to lint workflow edits:
+```bash
+pre-commit run --files .github/workflows/ci.yml
+```
+
 The job runs only when `github.actor` equals `github.repository_owner`, so other
 contributors cannot execute it unless the owner grants them explicit
 permissions or dispatches the workflow on their behalf.


### PR DESCRIPTION
## Summary
- highlight lint step for workflow changes in AGENTS.md
- remind contributors to run pre-commit for `.github/workflows/ci.yml` in CONTRIBUTING.md

## Testing
- `pre-commit run --files AGENTS.md CONTRIBUTING.md`


------
https://chatgpt.com/codex/tasks/task_e_68754b6a2748833385f67e9ebe6e2fbc