### PR TITLE
fix: update CI and asset hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
@@ -80,8 +80,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
@@ -219,8 +219,8 @@ jobs:
     runs-on: windows-latest
     environment: ci-on-demand
     steps:
-      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
@@ -264,8 +264,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
-      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -291,8 +291,8 @@ jobs:
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
     steps:
-      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
       - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -363,8 +363,8 @@ jobs:
       pull-requests: write
     environment: ci-on-demand
     steps:
-      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -475,8 +475,8 @@ jobs:
     needs: [docker]
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Login to GHCR

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -42,7 +42,7 @@
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",
     "lib/workbox-sw.js": "sha384-/j5bxz2M6SWcn4kruDXVGz6kda+w6URjOoHS6d3lcJYM0iFuMkvwxQonG8IsK0Ec",
     "pyodide-lock.json": "sha384-2t7FpZqshEP49Av2AHAvKgiBBKi4lIjL2MqLocHFbE+bqa7/KYAhcqVPtO37bir1",
-    "pyodide.asm.wasm": "sha384-nmltu7flheCw5NzKFX44e8BEt8XM61Av/mLIbzbS4aOf2COxsQxE2u75buNoSrVg",
+    "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
     "pyodide.js": "sha384-aD6ek5pFVnSSMGK0qubk9ZJdMYGjPs8F6jdJaDJiyZbTcH9jLWR4LJNJ7yY430qI",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421"
   }

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -61,7 +61,7 @@ ASSETS = {
 CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",  # noqa: E501
     "lib/workbox-sw.js": "sha384-/j5bxz2M6SWcn4kruDXVGz6kda+w6URjOoHS6d3lcJYM0iFuMkvwxQonG8IsK0Ec",  # noqa: E501
-    "pyodide.asm.wasm": "sha384-nmltu7flheCw5NzKFX44e8BEt8XM61Av/mLIbzbS4aOf2COxsQxE2u75buNoSrVg",
+    "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
     "pyodide.js": "sha384-aD6ek5pFVnSSMGK0qubk9ZJdMYGjPs8F6jdJaDJiyZbTcH9jLWR4LJNJ7yY430qI",
     "pyodide-lock.json": "sha384-2t7FpZqshEP49Av2AHAvKgiBBKi4lIjL2MqLocHFbE+bqa7/KYAhcqVPtO37bir1",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",


### PR DESCRIPTION
## Summary
- update pyodide.asm.wasm checksum
- adjust ensure-owner ordering in CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml scripts/fetch_assets.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml --cov-fail-under=70` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68754de6a9dc833382820aaf1db1cc96