### PR TITLE
[alpha_factory] chore: pin action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,16 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner
-      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: 'requirements.lock'
 
       - name: Cache pre-commit
-        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: .cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -80,9 +80,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner
-      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -101,7 +101,7 @@ jobs:
       - name: Build sandbox image
         run: docker build -t selfheal-sandbox:latest -f sandbox.Dockerfile .
       # Install Node.js and cache dependencies using both lockfiles
-      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -127,7 +127,7 @@ jobs:
           )
           echo "key=$key" >> "$GITHUB_OUTPUT"
       - name: Cache Insight assets
-        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
@@ -187,7 +187,7 @@ jobs:
           cat tests/benchmarks/latest.json
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4 # ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v4.3.2 # 1746f4ab65b179e0ea60a494b83293b640dd5bba
         with:
           name: benchmark-results
           path: tests/benchmarks/latest.json
@@ -208,7 +208,7 @@ jobs:
           path: bench.txt
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4 # ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v4.3.2 # 1746f4ab65b179e0ea60a494b83293b640dd5bba
         with:
           name: coverage-xml
           path: coverage.xml
@@ -219,9 +219,9 @@ jobs:
     runs-on: windows-latest
     environment: ci-on-demand
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner
-      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
           cache: pip
@@ -232,7 +232,7 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.txt
           pip install pytest
-      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -264,9 +264,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner
-      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: pip
@@ -291,14 +291,14 @@ jobs:
       HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
       FETCH_ASSETS_ATTEMPTS: '5'
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner
-      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -363,11 +363,11 @@ jobs:
       pull-requests: write
     environment: ci-on-demand
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -395,7 +395,7 @@ jobs:
           )
           echo "key=$key" >> "$GITHUB_OUTPUT"
       - name: Cache Insight assets
-        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
@@ -445,7 +445,7 @@ jobs:
         run: |
           tar -czf web-client.tar.gz -C alpha_factory_v1/core/interface/web_client/dist .
           sha256sum web-client.tar.gz > web-client.sha256
-      - uses: actions/upload-artifact@v4 # ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@v4.3.2 # 1746f4ab65b179e0ea60a494b83293b640dd5bba
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: web-client
@@ -475,12 +475,12 @@ jobs:
     needs: [docker]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Login to GHCR
-        uses: docker/login-action@v3 # 74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@v3.1.0 # e92390c5fb421da1463c202d546fed0ec5c39f20
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -497,7 +497,7 @@ jobs:
           docker tag "$DOCKER_IMAGE:ci" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest"
           docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}"
           docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest"
-      - uses: actions/download-artifact@v4 # d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/download-artifact@v4.1.7 # 65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           name: web-client
       - name: Verify web client artifact


### PR DESCRIPTION
## Summary
- pin GitHub Actions in CI to patch versions

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError: API...)*

------
https://chatgpt.com/codex/tasks/task_e_687550d413808333a296443bf476c743