### PR TITLE
Update CI deploy job environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,6 +474,7 @@ jobs:
     name: "📦 Deploy"
     needs: [docker]
     runs-on: ubuntu-latest
+    environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: ./.github/actions/ensure-owner


### PR DESCRIPTION
## Summary
- enforce `ci-on-demand` environment for the deploy job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/fetch_assets.py --verify-only`
- `pytest -k smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_68756dbbdf308333a491b63b9bc99da9