### PR TITLE
[alpha_factory] clarify CI owner check docs

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -67,10 +67,10 @@ This lints the YAML and pins action versions so the pipeline stays reproducible.
 
 ## Avoid skipped jobs
 
-Each job declares its dependencies via the `needs:` field and begins with an
-owner verification step. Jobs exit immediately when `github.actor` does not
-match `github.repository_owner`, so there is no separate *owner-check* stage.
-Once prerequisites succeed the remaining jobs run in parallel. A failure in
+The workflow starts with a dedicated `owner-check` job that runs the
+`ensure-owner` composite action. All other jobs declare `needs: owner-check`
+so they wait for that verification instead of performing owner checks
+themselves. Once prerequisites succeed the remaining jobs run in parallel. A failure in
 linting or tests deliberately stops the Docker build and deploy stages. If a
 job unexpectedly shows as skipped, first check whether one of its dependencies
 failed earlier in the run. With the lock file paths fixed, all jobs should


### PR DESCRIPTION
## Summary
- document `owner-check` job
- clarify that other CI jobs depend on it

## Testing
- `pytest tests/test_ping_agent.py`
- `pre-commit run --files docs/CI_WORKFLOW.md`


------
https://chatgpt.com/codex/tasks/task_e_6875be4bc51c8333ae6ee6b45d06ab8c