### PR TITLE
[alpha_factory] Update Node lockfile docs

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -41,6 +41,8 @@ passes the same list via `cache-dependency-path`:
 ```
 alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
 alpha_factory_v1/core/interface/web_client/package-lock.json
+alpha_factory_v1/core/interface/web_client/staking/package-lock.json
+alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package-lock.json
 ```
 
 After `npm ci` the workflow updates the Browserslist database with


### PR DESCRIPTION
## Summary
- list all NODE_LOCKFILES paths in CI docs

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 137 failed, 344 passed, 62 skipped, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c1d66ac4833392f48073e86b6432