### PR TITLE
[alpha_factory] Add CI docs verifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,12 @@ repos:
         entry: python scripts/verify_html_disclaimer.py
         language: python
         pass_filenames: false
+      - id: verify-ci-docs
+        name: Verify CI docs match ci.yml
+        entry: python tools/verify_ci_docs.py
+        language: python
+        additional_dependencies: [PyYAML]
+        pass_filenames: false
       - id: py-compile
         name: Validate Python syntax with py_compile
         entry: python -m py_compile

--- a/tools/verify_ci_docs.py
+++ b/tools/verify_ci_docs.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify that CI docs match the workflow configuration."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import List
+
+import yaml
+
+
+def extract_lockfiles(ci_yaml: pathlib.Path) -> List[str]:
+    """Return NODE_LOCKFILES from the workflow file."""
+    data = yaml.safe_load(ci_yaml.read_text())
+    env = data.get("env", {})
+    lockfiles_str = env.get("NODE_LOCKFILES", "")
+    return [line.strip() for line in str(lockfiles_str).splitlines() if line.strip()]
+
+
+def owner_check_defined(ci_yaml: pathlib.Path) -> bool:
+    """Return True if the workflow defines an owner-check job."""
+    data = yaml.safe_load(ci_yaml.read_text())
+    return "owner-check" in data.get("jobs", {})
+
+
+def verify_docs(lockfiles: List[str], docs_text: str, has_owner_job: bool) -> List[str]:
+    """Return a list of mismatches between docs and workflow."""
+    errors: List[str] = []
+    for path in lockfiles:
+        if path not in docs_text:
+            errors.append(f"Lockfile path missing from docs: {path}")
+
+    if has_owner_job and "owner-check" not in docs_text:
+        errors.append("Docs missing description of 'owner-check' job")
+    if not has_owner_job:
+        errors.append("Workflow missing required 'owner-check' job")
+    return errors
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    ci_path = repo_root / ".github" / "workflows" / "ci.yml"
+    docs_path = repo_root / "docs" / "CI_WORKFLOW.md"
+
+    lockfiles = extract_lockfiles(ci_path)
+    has_owner = owner_check_defined(ci_path)
+    docs_text = docs_path.read_text()
+
+    errors = verify_docs(lockfiles, docs_text, has_owner)
+    if errors:
+        print("CI docs verification failed:\n" + "\n".join(f"- {e}" for e in errors))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- ensure docs/CI_WORKFLOW.md matches `.github/workflows/ci.yml`
- run the check via pre-commit

## Testing
- `pre-commit run --files tools/verify_ci_docs.py .pre-commit-config.yaml`
- `python scripts/check_python_deps.py && python check_env.py --auto-install && pytest tests/test_ping_agent.py tests/test_af_requests.py`


------
https://chatgpt.com/codex/tasks/task_e_6875c588d540833395faacb207b5c5f2