### PR TITLE
[alpha_factory] add action updater script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,7 +521,7 @@ jobs:
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Login to GHCR
-        uses: docker/login-action@v3.1.0 # e92390c5fb421da1463c202d546fed0ec5c39f20
+        uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -546,7 +546,7 @@ jobs:
       - name: Prepare release assets
         run: echo "Using prebuilt web client artifact"
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2 # 72f2c25fcb47643c292f7107632f7a47c1df5cd8
+        uses: softprops/action-gh-release@v2.3.2 # 72f2c25fcb47643c292f7107632f7a47c1df5cd8
         with:
           files: web-client.tar.gz
       - name: Rollback on failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,8 @@ pre-commit run --files <paths>   # before each commit
     **CI enforces these checks.**
   - After editing `alpha_factory_v1/core/utils/a2a.proto`, run `pre-commit run --files alpha_factory_v1/core/utils/a2a.proto`
     to regenerate and verify protobuf sources.
+  - Run `python tools/update_actions.py` before committing workflow changes to
+    refresh action versions.
   - **Always run** `pre-commit run --files .github/workflows/ci.yml` after
     modifying the workflow to lint it with actionlint.
   - The configuration runs `black`, `ruff`, `flake8` and `mypy` using

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,8 @@ pre-commit run --all-files
 Use `pre-commit run --files docs/demos/<page>.md` to catch missing preview
 images. Each page under `docs/demos/` must start with a preview image using
 `![preview](...)`.
-Run `pre-commit` on any workflow edits to ensure action versions are pinned and
-the YAML passes `actionlint`:
+Run `python tools/update_actions.py` before committing workflow changes to pull
+the latest action tags. Then run `pre-commit` so the YAML passes `actionlint`:
 
 ```bash
 pre-commit run --files .github/workflows/ci.yml

--- a/tools/update_actions.py
+++ b/tools/update_actions.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# See docs/DISCLAIMER_SNIPPET.md
+"""Update GitHub Actions in the CI workflow.
+
+This script queries the GitHub API for the latest tag of each action used in
+``.github/workflows/ci.yml`` and rewrites the file so ``uses:`` lines point to
+that tag along with the corresponding commit SHA in a comment.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import requests
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
+
+PATTERN = re.compile(r"^(\s*-?\s*uses:\s*)([^@ ]+)@([^ ]+)(\s*#\s*[0-9a-fA-F]+)?\s*$")
+
+
+def fetch_latest(owner_repo: str) -> tuple[str, str] | None:
+    """Return the newest tag name and commit sha for a GitHub action."""
+    url = f"https://api.github.com/repos/{owner_repo}/tags"
+    try:
+        resp = requests.get(url, timeout=60)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        sys.stderr.write(f"Failed to fetch {url}: {exc}\n")
+        return None
+    tags = resp.json()
+    if not tags:
+        return None
+    tag = tags[0]
+    return tag["name"], tag["commit"]["sha"]
+
+
+def update() -> bool:
+    lines = WORKFLOW.read_text().splitlines()
+    changed = False
+    for i, line in enumerate(lines):
+        m = PATTERN.match(line)
+        if not m:
+            continue
+        prefix, action, current, comment = m.groups()
+        if action.startswith("./"):
+            continue
+        latest = fetch_latest(action)
+        if not latest:
+            continue
+        tag, sha = latest
+        new_comment = f" # {sha}"
+        if current == tag and comment == new_comment:
+            continue
+        lines[i] = f"{prefix}{action}@{tag}{new_comment}"
+        changed = True
+    if changed:
+        WORKFLOW.write_text("\n".join(lines) + "\n")
+    return changed
+
+
+def main() -> None:
+    if update():
+        print("Workflow updated.")
+    else:
+        print("Workflow already up to date.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/update_actions.py` to fetch latest tags
- refresh workflow with latest action versions
- document running updater in CONTRIBUTING and AGENTS guides

## Testing
- `pre-commit run --files tools/update_actions.py AGENTS.md CONTRIBUTING.md .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 204 failed, 553 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6875c7eb923c833385d703f2b8f3efb6