### PR TITLE
docs: clarify owner check

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -10,9 +10,10 @@ repository owner triggers it from the GitHub Actions UI.
 
 1. Navigate to **Actions → 🚀 CI**.
 2. Choose the branch or tag in the drop‑down and click **Run workflow**.
-3. Ensure you are the repository owner; each job begins by verifying that
-   `github.actor` matches `github.repository_owner` and exits early for
-   non‑owners.
+3. Ensure you are the repository owner. The workflow starts with an
+   `owner-check` job using the `ensure-owner` composite action. If the
+   trigger user does not match `github.repository_owner` the pipeline exits
+   immediately.
 
 When invoked on a tagged commit the pipeline also builds and publishes a Docker
 image to GHCR and uploads the prebuilt web client bundle to the corresponding


### PR DESCRIPTION
## Summary
- clarify that the CI pipeline checks owner once via ensure-owner step

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md`


------
https://chatgpt.com/codex/tasks/task_e_68764698d9ec8333b8b80b6df5a2d2e5