### PR TITLE
Fix CI owner check and Pyodide hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
 
   lint-type:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json
@@ -42,8 +42,8 @@
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",
     "lib/workbox-sw.js": "sha384-/j5bxz2M6SWcn4kruDXVGz6kda+w6URjOoHS6d3lcJYM0iFuMkvwxQonG8IsK0Ec",
     "pyodide-lock.json": "sha384-2t7FpZqshEP49Av2AHAvKgiBBKi4lIjL2MqLocHFbE+bqa7/KYAhcqVPtO37bir1",
-    "pyodide.asm.wasm": "sha384-nmltu7flheCw5NzKFX44e8BEt8XM61Av/mLIbzbS4aOf2COxsQxE2u75buNoSrVg",
-    "pyodide.js": "sha384-aD6ek5pFVnSSMGK0qubk9ZJdMYGjPs8F6jdJaDJiyZbTcH9jLWR4LJNJ7yY430qI",
+    "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
+    "pyodide.js": "sha384-OwNlf3TkEgnIUkrwes9m8B7eZZVNgqMrQ+enUYidg4jAFdc0Fl1W9BU9exXYQtjG",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421"
   }
 }

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -61,8 +61,8 @@ ASSETS = {
 CHECKSUMS = {
     "lib/bundle.esm.min.js": "sha384-qri3JZdkai966TTOV3Cl4xxA97q+qXCgKrd49pOn7DPuYN74wOEd6CIJ9HnqEROD",  # noqa: E501
     "lib/workbox-sw.js": "sha384-/j5bxz2M6SWcn4kruDXVGz6kda+w6URjOoHS6d3lcJYM0iFuMkvwxQonG8IsK0Ec",  # noqa: E501
-    "pyodide.asm.wasm": "sha384-nmltu7flheCw5NzKFX44e8BEt8XM61Av/mLIbzbS4aOf2COxsQxE2u75buNoSrVg",
-    "pyodide.js": "sha384-aD6ek5pFVnSSMGK0qubk9ZJdMYGjPs8F6jdJaDJiyZbTcH9jLWR4LJNJ7yY430qI",
+    "pyodide.asm.wasm": "sha384-kdvSehcoFMjX55sjg+o5JHaLhOx3HMkaLOwwMFmwH+bmmtvfeJ7zFEMWaqV9+wqo",
+    "pyodide.js": "sha384-OwNlf3TkEgnIUkrwes9m8B7eZZVNgqMrQ+enUYidg4jAFdc0Fl1W9BU9exXYQtjG",
     "pyodide-lock.json": "sha384-2t7FpZqshEP49Av2AHAvKgiBBKi4lIjL2MqLocHFbE+bqa7/KYAhcqVPtO37bir1",
     "pytorch_model.bin": "sha256-7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",
 }


### PR DESCRIPTION
## Summary
- checkout repo before ensure-owner action
- refresh Pyodide checksums in fetch_assets and manifest

## Testing
- `pre-commit run --files .github/workflows/ci.yml scripts/fetch_assets.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build_assets.json`
- `python scripts/fetch_assets.py --verify-only` *(fails: missing wasm_llm assets)*

------
https://chatgpt.com/codex/tasks/task_e_6876525f6c608333bf6610343b83efa4