### PR TITLE
Remove checkout from owner-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
 
   lint-type:


### PR DESCRIPTION
## Summary
- tweak CI workflow so owner-check just runs the ensure-owner action

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_687673628934833381a2b838ec245680