### PR TITLE
[alpha_factory] Gate web client artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,8 +494,13 @@ jobs:
         run: |
           tar -czf web-client.tar.gz -C alpha_factory_v1/core/interface/web_client/dist .
           sha256sum web-client.tar.gz > web-client.sha256
-      - uses: actions/upload-artifact@v4.6.2 # ea165f8d65b6e75b540449e92b4886f43607fa02
+      - name: Check web client artifact
         if: startsWith(github.ref, 'refs/tags/')
+        id: web-client-check
+        run: |
+          if [[ -f web-client.tar.gz ]]; then echo "found=true" >> "$GITHUB_OUTPUT"; fi
+      - uses: actions/upload-artifact@v4.6.2 # ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: startsWith(github.ref, 'refs/tags/') && steps.web-client-check.outputs.found == 'true'
         with:
           name: web-client
           path: |


### PR DESCRIPTION
## Summary
- add a check for the web-client artifact
- only upload when the artifact exists

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml --cov-fail-under=70` *(fails: 40 failed, 100 passed, 31 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68767ca779bc8333b0833c2a6d078324