### PR TITLE
[alpha_factory] ensure owner check first in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,10 +20,16 @@ env:
   DOCKER_IMAGE: alpha-factory
 
 jobs:
+  owner-check:
+    name: "Verify owner"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/ensure-owner
+
   build-test:
-    # Ensure this job only runs from the manual "Run workflow" button
-    # and only when triggered by the repository owner.
-    if: github.event_name == 'workflow_dispatch' 
+    needs: owner-check
+    # The workflow itself is dispatched manually so no additional
+    # event check is required here.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,46 +524,59 @@ jobs:
           docker run --rm -e RUN_MODE=cli "$DOCKER_IMAGE:ci" simulate --horizon 1 --offline
 
   deploy:
-    if: startsWith(github.ref, 'refs/tags/')
     name: "📦 Deploy"
     needs: [docker]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
+      - name: Check tag
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: echo "Deployment runs only on tags" && exit 0
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Compute repo_owner_lower
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Login to GHCR
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull previous image
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: docker pull "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest" || true
       - name: Tag previous
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: docker tag "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous" || true
       - name: Push previous tag
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous" || true
       - name: Push new image
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           docker tag "$DOCKER_IMAGE:ci" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}"
           docker tag "$DOCKER_IMAGE:ci" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest"
           docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}"
           docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest"
       - uses: actions/download-artifact@v4.3.0 # d3f86a106a0bac45b974a628896c90dbdf5c8093
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           name: web-client
       - name: Verify web client artifact
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: sha256sum -c web-client.sha256
       - name: Prepare release assets
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: echo "Using prebuilt web client artifact"
       - name: Upload release assets
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v2.3.2 # 72f2c25fcb47643c292f7107632f7a47c1df5cd8
         with:
           files: web-client.tar.gz
       - name: Rollback on failure
-        if: failure()
+        if: ${{ failure() && startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo "Rolling back to previous image"
           docker pull "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous"

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -10,10 +10,9 @@ repository owner triggers it from the GitHub Actions UI.
 
 1. Navigate to **Actions → 🚀 CI**.
 2. Choose the branch or tag in the drop‑down and click **Run workflow**.
-3. Ensure you are the repository owner. The workflow starts with an
-   `owner-check` job using the `ensure-owner` composite action. If the
-   trigger user does not match `github.repository_owner` the pipeline exits
-   immediately.
+3. Only the repository owner can trigger this button. The workflow starts with
+   an `owner-check` job using the `ensure-owner` composite action. If the actor
+   does not match `github.repository_owner` the pipeline exits immediately.
 
 When invoked on a tagged commit the pipeline also builds and publishes a Docker
 image to GHCR and uploads the prebuilt web client bundle to the corresponding


### PR DESCRIPTION
## Summary
- run ensure-owner first in Build & Test and CI workflows
- gate deploy steps on tags without skipping job
- clarify CI docs about the Run workflow button

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/build-and-test.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 39 failed, 100 passed, 31 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68767f58cf048333b1ea84ccb43746df