### PR TITLE
ci: update owner-check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
 
   lint-type:


### PR DESCRIPTION
## Summary
- checkout repo during owner verification
- refresh pinned action versions

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_687687a590a08333b47e6e1cef14807a