### PR TITLE
Adjust workflow owner checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,7 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ensure-owner
 
   build-test:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
       # scripts/fetch_assets.py for details.
       # HF_GPT2_BASE_URL overrides the default Hugging Face mirror.
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ensure-owner
       - uses: actions/checkout@v4.1.5 # 44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Set up Python


### PR DESCRIPTION
## Summary
- checkout repo earlier in docs workflow
- checkout repo before verify owner in build-and-test workflow

## Testing
- `pre-commit run --files .github/workflows/docs.yml .github/workflows/build-and-test.yml`
- `python tools/update_actions.py`

------
https://chatgpt.com/codex/tasks/task_e_687692eb600883339664beb0e65c0c27