### PR TITLE
fix CI owner check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: ./.github/actions/ensure-owner
+      - name: Ensure repository owner
+        run: |
+          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
+            echo "Only the repository owner can run this workflow."
+            exit 1
+          fi
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy"


### PR DESCRIPTION
## Summary
- inline the repository owner verification step so the CI workflow doesn't fail

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -k "" -m "" -q` *(fails: 159 failed, 415 passed, 63 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68769d2f0f8483339d9660bed4c917c7