### PR TITLE
[alpha_factory] improve ci docs

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -67,6 +67,8 @@ pre-commit run --files .github/workflows/ci.yml
 
 This lints the YAML and pins action versions so the pipeline stays reproducible.
 
+The workflow uploads benchmark and coverage artifacts only when the files exist. This avoids noisy "file not found" warnings on failed runs.
+
 ## Avoid skipped jobs
 
 The workflow starts with a dedicated `owner-check` job that runs the


### PR DESCRIPTION
## Summary
- document artifact upload conditions in CI docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --maxfail=1 -q` *(fails: Agent.__init__ missing required argument)*
- `pre-commit run --files .github/workflows/ci.yml` *(fails: network while installing hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6876b45e12288333b39690f0287c5d2b