### PR TITLE
[alpha_factory] CI owner check and artifact fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,16 @@ env:
 
 jobs:
 
+  owner-check:
+    name: "Verify owner"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
+
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy"
+    needs: owner-check
     runs-on: ubuntu-latest
     environment: ci-on-demand        # ⇦ optional: add reviewers in repo Settings → Environments
     strategy:
@@ -41,11 +49,6 @@ jobs:
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Verify owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: |
-          echo "Only the repository owner can run this workflow."
-          exit 1
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
@@ -79,7 +82,7 @@ jobs:
 
   tests:
     name: "✅ Pytest"
-    needs: [lint-type]
+    needs: [owner-check, lint-type]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     strategy:
@@ -88,11 +91,6 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Verify owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: |
-          echo "Only the repository owner can run this workflow."
-          exit 1
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
@@ -235,16 +233,11 @@ jobs:
 
   windows-smoke:
     name: "Windows Smoke"
-    needs: [tests]
+    needs: [owner-check, tests]
     runs-on: windows-latest
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Verify owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: |
-          echo "Only the repository owner can run this workflow."
-          exit 1
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
@@ -309,16 +302,11 @@ jobs:
 
   docs-check:
     name: "📜 MkDocs"
-    needs: [tests]
+    needs: [owner-check, tests]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Verify owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: |
-          echo "Only the repository owner can run this workflow."
-          exit 1
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -340,7 +328,7 @@ jobs:
 
   docs-build:
     name: "📚 Docs Build"
-    needs: [tests]
+    needs: [owner-check, tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -350,11 +338,6 @@ jobs:
       FETCH_ASSETS_ATTEMPTS: '5'
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Verify owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: |
-          echo "Only the repository owner can run this workflow."
-          exit 1
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -422,7 +405,7 @@ jobs:
 
   docker:
     name: "🐳 Docker build"
-    needs: [tests]
+    needs: [owner-check, tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -430,11 +413,6 @@ jobs:
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Verify owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: |
-          echo "Only the repository owner can run this workflow."
-          exit 1
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -550,16 +528,11 @@ jobs:
   deploy:
     name: "📦 Deploy"
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [docker]
+    needs: [owner-check, docker]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Verify owner
-        if: ${{ github.actor != github.repository_owner }}
-        run: |
-          echo "Only the repository owner can run this workflow."
-          exit 1
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Login to GHCR


### PR DESCRIPTION
## Summary
- add dedicated `owner-check` job and remove per-job owner steps
- avoid job skips by having each job depend on `owner-check`
- guard artifact uploads so missing files don't warn

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_base_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c51544dc83339a40af49f1f05d90