### PR TITLE
Fix CI owner check and artifact handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,12 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: ./.github/actions/ensure-owner
+      - name: Ensure repository owner
+        run: |
+          if [ "$GITHUB_ACTOR" != "$GITHUB_REPOSITORY_OWNER" ]; then
+            echo "Only the repository owner can run this workflow."
+            exit 1
+          fi
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy"


### PR DESCRIPTION
## Summary
- ensure owner verification is inline so the workflow doesn't fail to locate the composite action
- update browserslist database after installing dependencies
- upload coverage and benchmark artifacts only when files exist

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -k "" -m "" -q` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6876cbf9d69c8333aad3cf3d167a37e2