### PR TITLE
Fix owner check in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,8 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure repository owner
-        run: |
-          if [ "$GITHUB_ACTOR" != "$GITHUB_REPOSITORY_OWNER" ]; then
-            echo "Only the repository owner can run this workflow."
-            exit 1
-          fi
+      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/ensure-owner
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy"


### PR DESCRIPTION
## Summary
- use the reusable `ensure-owner` action for the CI owner check

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_6876deae41f88333b629e6ffb2223fe9