### PR TITLE
[alpha_factory] Pin Python images with digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
-ARG PYTHON_VERSION=3.11
-FROM python:${PYTHON_VERSION}-slim
+FROM python:3.11.8-slim@sha256:90f8795536170fd08236d2ceb74fe7065dbf74f738d8b84bfbf263656654dc9b
 
 # install build tools and npm for the React UI
 RUN apt-get update && \

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -1,6 +1,5 @@
 # Demo container for α‑AGI Insight
-ARG PYTHON_VERSION=3.11
-FROM python:${PYTHON_VERSION}-slim
+FROM python:3.11.8-slim@sha256:90f8795536170fd08236d2ceb74fe7065dbf74f738d8b84bfbf263656654dc9b
 
 # Install build tools for optional native extensions
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- use exact Python base images with digests in Dockerfiles

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 16 failed, 60 passed, 31 skipped, 2 errors)*
- `pre-commit run --files Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_6876e17a47188333b4b6d9c411366e5c