### PR TITLE
[alpha_factory] pin browserslist update version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,10 @@ jobs:
         run: python scripts/fetch_assets.py --verify-only
       - name: Install update-browserslist-db (Insight demo)
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
-        run: npm install --no-save update-browserslist-db
+        run: npm install --no-save update-browserslist-db@1.1.3
       - name: Update browserslist database (Insight demo)
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
-        run: npm exec update-browserslist-db -- --update-db --yes
+        run: npm exec update-browserslist-db@1.1.3 -- --update-db --yes
       - name: Audit insight browser dependencies
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 audit --production --audit-level=high
       - name: Run insight browser tests
@@ -167,10 +167,10 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
       - name: Install update-browserslist-db (Web client)
         working-directory: alpha_factory_v1/core/interface/web_client
-        run: npm install --no-save update-browserslist-db
+        run: npm install --no-save update-browserslist-db@1.1.3
       - name: Update browserslist database (Web client)
         working-directory: alpha_factory_v1/core/interface/web_client
-        run: npm exec update-browserslist-db -- --update-db --yes
+        run: npm exec update-browserslist-db@1.1.3 -- --update-db --yes
       - name: Audit web dependencies
         run: npm --prefix alpha_factory_v1/core/interface/web_client audit --production --audit-level=high
       - name: Type check insight browser
@@ -298,8 +298,8 @@ jobs:
           set -e
           npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
           (cd alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 && \
-            npm install --no-save update-browserslist-db && \
-            npm exec update-browserslist-db -- --update-db --yes)
+            npm install --no-save update-browserslist-db@1.1.3 && \
+            npm exec update-browserslist-db@1.1.3 -- --update-db --yes)
           npm run --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 fetch-assets || (
             echo "Detected asset hash change, updating..." &&
             python scripts/update_pyodide.py 0.28.0 &&
@@ -368,16 +368,16 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
       - name: Install update-browserslist-db (Insight demo)
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
-        run: npm install --no-save update-browserslist-db
+        run: npm install --no-save update-browserslist-db@1.1.3
       - name: Update browserslist database (Insight demo)
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
-        run: npm exec update-browserslist-db -- --update-db --yes
+        run: npm exec update-browserslist-db@1.1.3 -- --update-db --yes
       - name: Install update-browserslist-db (Web client)
         working-directory: alpha_factory_v1/core/interface/web_client
-        run: npm install --no-save update-browserslist-db
+        run: npm install --no-save update-browserslist-db@1.1.3
       - name: Update browserslist database (Web client)
         working-directory: alpha_factory_v1/core/interface/web_client
-        run: npm exec update-browserslist-db -- --update-db --yes
+        run: npm exec update-browserslist-db@1.1.3 -- --update-db --yes
       - name: Build gallery site
         run: ./scripts/build_gallery_site.sh
       - name: Verify downloaded assets
@@ -442,18 +442,18 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Install update-browserslist-db (Insight demo)
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
-        run: npm install --no-save update-browserslist-db
+        run: npm install --no-save update-browserslist-db@1.1.3
       - name: Update browserslist database (Insight demo)
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
-        run: npm exec update-browserslist-db -- --update-db --yes
+        run: npm exec update-browserslist-db@1.1.3 -- --update-db --yes
       - name: Install web client dependencies
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
       - name: Install update-browserslist-db (Web client)
         working-directory: alpha_factory_v1/core/interface/web_client
-        run: npm install --no-save update-browserslist-db
+        run: npm install --no-save update-browserslist-db@1.1.3
       - name: Update browserslist database (Web client)
         working-directory: alpha_factory_v1/core/interface/web_client
-        run: npm exec update-browserslist-db -- --update-db --yes
+        run: npm exec update-browserslist-db@1.1.3 -- --update-db --yes
       - name: Compute asset cache key
         id: asset-key-docker
         run: |

--- a/README.md
+++ b/README.md
@@ -130,9 +130,13 @@ preinstalls `numpy`, `pandas`, `pytest` and `PyYAML` so the environment check
 passes without network hiccups. During the run it also updates the
 `browserslist` cache inside
 `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` **and**
-`alpha_factory_v1/core/interface/web_client` to ensure the generated assets
-target the latest browsers. When running offline or if the update fails, set
+`alpha_factory_v1/core/interface/web_client` using
+`update-browserslist-db@1.1.3` to ensure the generated assets target the latest
+browsers. When running offline or if the update fails, set
 `BROWSERSLIST_IGNORE_OLD_DATA=true` to continue without refreshing the cache.
+Update the version in `.github/workflows/ci.yml` and rerun
+`npx update-browserslist-db@1.1.3 --update-db --yes` whenever dependencies
+change.
 
 ### CI Workflow
 

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -46,9 +46,10 @@ alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package-loc
 ```
 
 After `npm ci` the workflow updates the Browserslist database with
-`npx update-browserslist-db@latest --update-db --yes` to silence the
+`npx update-browserslist-db@1.1.3 --update-db --yes` to silence the
 "caniuse-lite is outdated" warning. Run the same command locally when
-dependencies change so the CI logs stay clean.
+dependencies change. Bump the version in `.github/workflows/ci.yml` and this
+documentation whenever a newer release is required so CI stays reproducible.
 
 If the workflow ever reports missing lock files, double‑check these paths
 in `.github/workflows/ci.yml` and adjust them whenever new packages are added.


### PR DESCRIPTION
## Summary
- pin `update-browserslist-db` to 1.1.3 in CI workflow
- document how to update browserslist database in README and CI docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 137 failed, 344 passed, 62 skipped, 21 warnings, 6 errors)*
- `pre-commit run --files .github/workflows/ci.yml docs/CI_WORKFLOW.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_6876e843c47c8333a3b8e91ea661c221