### PR TITLE
Improve coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse "$WHEELHOUSE"}
-          pytest --cov --cov-report=xml --cov-fail-under=70
+          pytest --cov --cov-report=xml --cov-fail-under=80
       - name: Mutation tests
         run: |
           mutmut run --paths-to-mutate alpha_factory_v1/demos/alpha_agi_insight_v1/src --runner "pytest -q"

--- a/tests/test_agent_runner_utils.py
+++ b/tests/test_agent_runner_utils.py
@@ -1,0 +1,36 @@
+import os
+import asyncio
+from alpha_factory_v1.backend.agent_runner import _env_float, maybe_await, utc_now
+
+
+def test_env_float_valid(monkeypatch):
+    monkeypatch.setenv("AF_TEST", "1.5")
+    assert _env_float("AF_TEST", 2.0) == 1.5
+
+
+def test_env_float_invalid(monkeypatch):
+    monkeypatch.setenv("AF_TEST", "bad")
+    assert _env_float("AF_TEST", 3.0) == 3.0
+
+
+async def _async_fn(x):
+    await asyncio.sleep(0)
+    return x * 2
+
+
+def _sync_fn(x):
+    return x + 1
+
+
+def test_maybe_await_async():
+    result = asyncio.run(maybe_await(_async_fn, 5))
+    assert result == 10
+
+
+def test_maybe_await_sync():
+    result = asyncio.run(maybe_await(_sync_fn, 5))
+    assert result == 6
+
+
+def test_utc_now_timezone():
+    assert utc_now().endswith("+00:00")

--- a/tests/test_portfolio_basic.py
+++ b/tests/test_portfolio_basic.py
@@ -1,0 +1,30 @@
+import os
+import json
+import tempfile
+import asyncio
+from unittest import mock
+from alpha_factory_v1.backend import portfolio
+
+
+def test_portfolio_record_and_history():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "book.jsonl")
+        p = portfolio.Portfolio(portfolio.Path(path))
+        with mock.patch.object(portfolio.Portfolio, "_broadcast", lambda *a, **k: None):
+            p.record_fill("BTC", 1.0, 100.0, "BUY")
+            p.record_fill("BTC", 0.5, 110.0, "SELL")
+            asyncio.run(p.arecord_fill("BTC", 0.5, 120.0, "BUY"))
+        assert p.position("BTC") == 1.0
+        assert p.book()["BTC"] == 1.0
+        hist = list(p.history())
+        assert len(hist) == 3
+        assert hist[0].symbol == "BTC"
+        assert hist[1].side == "SELL"
+        # ensure persisted json
+        with open(path) as fh:
+            lines = fh.read().splitlines()
+        assert len(lines) == 3
+        rec = json.loads(lines[0])
+        assert rec["symbol"] == "BTC"
+        p.clear()
+        assert p.book() == {}

--- a/tests/test_trace_hub.py
+++ b/tests/test_trace_hub.py
@@ -1,0 +1,35 @@
+import asyncio
+import json
+from unittest import mock
+from alpha_factory_v1.backend.trace_ws import TraceHub, TraceEvent
+
+
+async def _run_broadcast():
+    hub = TraceHub()
+    q = await hub.subscribe()
+    with mock.patch("alpha_factory_v1.backend.trace_ws.asyncio.create_task", asyncio.ensure_future):
+        await hub.broadcast({"label": "hi", "type": "tool_call"})
+        await asyncio.sleep(0)
+    payload = await asyncio.wait_for(q.get(), timeout=1)
+    await hub.unsubscribe(q)
+    return json.loads(payload.decode())
+
+
+def test_tracehub_broadcast():
+    event = asyncio.run(_run_broadcast())
+    assert event["label"] == "hi"
+    assert event["type"] == "tool_call"
+
+
+async def _run_unsubscribe():
+    hub = TraceHub()
+    q = await hub.subscribe()
+    await hub.unsubscribe(q)
+    with mock.patch("alpha_factory_v1.backend.trace_ws.asyncio.create_task", asyncio.ensure_future):
+        await hub.broadcast(TraceEvent(label="bye"))
+        await asyncio.sleep(0.1)
+    assert q.empty()
+
+
+def test_unsubscribe_stops_delivery():
+    asyncio.run(_run_unsubscribe())


### PR DESCRIPTION
## Summary
- add unit tests for helper functions
- test TraceHub broadcast paths
- cover Portfolio operations
- enforce 80% coverage in CI

## Testing
- `pytest tests/test_agent_runner_utils.py tests/test_trace_hub.py tests/test_portfolio_basic.py tests/test_trace_token_expiry.py tests/test_finance_utils.py tests/test_portfolio_no_lock.py --cov=alpha_factory_v1.backend.portfolio --cov-report=xml --cov-fail-under=80 -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f2a397108333a25cfbb64cf9dec4