### PR TITLE
[alpha_factory] chore: add macOS smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,76 @@ jobs:
       - name: Run smoke tests
         run: pytest -m smoke -q
 
+  macos-smoke:
+    name: "macOS Smoke"
+    needs: [owner-check, tests]
+    runs-on: macos-latest
+    environment: ci-on-demand
+    steps:
+      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: 'requirements.lock'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.lock
+          pip install -r requirements-dev.lock
+          pip install pytest
+      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: ${{ env.NODE_LOCKFILES }}
+      - name: Verify environment
+        run: |
+          python scripts/check_python_deps.py
+          python check_env.py --auto-install
+      - name: Compute asset cache key
+        id: asset-key-docker
+        run: |
+          key=$(python - <<'EOF'
+          import hashlib, os
+          import scripts.fetch_assets as fa
+          env_data = f"{os.getenv('PYODIDE_BASE_URL','')}:{os.getenv('HF_GPT2_BASE_URL','')}"
+          data = (
+              fa.CHECKSUMS["pyodide.asm.wasm"]
+              + fa.CHECKSUMS["pyodide.js"]
+              + fa.CHECKSUMS["pyodide-lock.json"]
+              + fa.CHECKSUMS["pytorch_model.bin"]
+              + env_data
+          )
+          print(hashlib.sha256(data.encode()).hexdigest())
+          EOF
+          )
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+      - name: Cache Insight assets
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
+          key: assets-${{ steps.asset-key-docker.outputs.key }}
+          restore-keys: assets-
+      - name: Build web assets
+        run: |
+          set -e
+          npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+          (cd alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 && \
+            npm install --no-save update-browserslist-db@1.1.3 && \
+            npm exec update-browserslist-db@1.1.3 -- --update-db --yes)
+          npm run --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 fetch-assets || (
+            echo "Detected asset hash change, updating..." &&
+            python scripts/update_pyodide.py 0.28.0 &&
+            npm run --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 fetch-assets
+          )
+          python scripts/fetch_assets.py --verify-only
+          npm run --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 build
+      - name: Run smoke tests
+        run: pytest -m smoke -q
+
   docs-check:
     name: "📜 MkDocs"
     needs: [owner-check, tests]


### PR DESCRIPTION
## Summary
- add macOS smoke test job to CI pipeline

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py -q --cov=alpha_factory_v1 --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_6876fe650bd88333b308690a94e0f6fb