### PR TITLE
[alpha_factory] fix windows shell for asset caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Compute asset cache key
         id: asset-key-docker
+        shell: bash
         run: |
           key=$(python - <<'EOF'
           import hashlib, os
@@ -268,6 +269,7 @@ jobs:
           python check_env.py --auto-install
       - name: Compute asset cache key
         id: asset-key-docker
+        shell: bash
         run: |
           key=$(python - <<'EOF'
           import hashlib, os


### PR DESCRIPTION
## Summary
- ensure bash shell for Windows asset cache step

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -k smoke -q`
- *(pre-commit initialization interrupted due to install time)*

------
https://chatgpt.com/codex/tasks/task_e_687704a6dad0833389e22246704a3fca