### PR TITLE
[alpha_factory] switch jest-style tests to esm

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-const { Archive } = require('../src/archive.ts');
-const { set } = require('../src/utils/keyval.ts');
+import { Archive } from '../src/archive.ts';
+import { set } from '../src/utils/keyval.ts';
+import * as keyval from '../src/utils/keyval.ts';
+import { chat } from '../src/utils/llm.ts';
 
 beforeEach(async () => {
   indexedDB.deleteDatabase('jest');
@@ -112,7 +114,7 @@ test('prune ranks by score and novelty', async () => {
 jest.mock('../src/utils/llm.ts', () => ({
   chat: jest.fn(() => Promise.resolve('5')),
 }));
-const { chat } = require('../src/utils/llm.ts');
+
 
 test('add calls chat when api key set and stores impact score', async () => {
   global.localStorage = { getItem: () => 'k' };
@@ -125,7 +127,6 @@ test('add calls chat when api key set and stores impact score', async () => {
 });
 
 test('prune logs warning when deletion fails', async () => {
-  const keyval = require('../src/utils/keyval.ts');
   const origDel = keyval.del;
   keyval.del = jest.fn(() => { throw new DOMException('fail'); });
   const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/cluster.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/cluster.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { detectColdZone } = require('../src/utils/cluster.ts');
+import { detectColdZone } from '../src/utils/cluster.ts';
 
 test('detect coldest cell', () => {
   const pts = [

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/consilience.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/consilience.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { consilience, scoreGenome, LogicCritic, FeasibilityCritic, JudgmentDB } = require('../src/wasm/critics.ts');
+import { consilience, scoreGenome, LogicCritic, FeasibilityCritic, JudgmentDB } from '../src/wasm/critics.ts';
 
 beforeEach(() => {
   indexedDB.deleteDatabase('jest');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/evaluator_genome.test.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-const { mutateEvaluator } = require('../src/evaluator_genome.ts');
-const { lcg } = require('../src/utils/rng.ts');
+import { mutateEvaluator } from '../src/evaluator_genome.ts';
+import { lcg } from '../src/utils/rng.ts';
 
 test('mutateEvaluator changes weights and prompt', () => {
   const rand = lcg(1);

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/gpu_flag.test.js
@@ -3,7 +3,7 @@ jest.mock('../src/evolve/mutate.ts', () => ({
   mutate: jest.fn(() => [])
 }));
 
-const { mutate } = require('../src/evolve/mutate.ts');
+import { mutate } from '../src/evolve/mutate.ts';
 
 function makeMsg(gen) {
   return { pop: [], rngState: 1, mutations: [], popSize: 1, critic: 'none', gen };

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/i18n_fallback.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/i18n_fallback.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { initI18n, t } = require('../src/ui/i18n.ts');
+import { initI18n, t } from '../src/ui/i18n.ts';
 
 beforeEach(() => {
   global.fetch = jest.fn(() => Promise.reject(new Error('fail')));

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/keyval.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/keyval.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { createStore, set, get } = require('../src/utils/keyval.ts');
+import { createStore, set, get } from '../src/utils/keyval.ts';
 
 beforeEach(() => {
   indexedDB.deleteDatabase('jest');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/limits.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/limits.test.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-const { initControls } = require('../src/ui/ControlsPanel.ts');
-const { parseHash } = require('../src/config/params.ts');
+import { initControls } from '../src/ui/ControlsPanel.ts';
+import { parseHash } from '../src/config/params.ts';
 
 test('values above max are clamped', () => {
   document.body.innerHTML = '<div id="controls"></div>';

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/locale_parity.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/locale_parity.test.js
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const en = require('../src/i18n/en.json');
+import en from '../src/i18n/en.json' assert { type: 'json' };
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const dir = path.join(__dirname, '../src/i18n');
 
 test('all locale files share the same keys', () => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/meme_usage.test.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-const { Simulator } = require('../src/simulator.ts');
-const { mineMemes, saveMemes, loadMemes } = require('@insight-src/memeplex.ts');
+import { Simulator } from '../src/simulator.ts';
+import { mineMemes, saveMemes, loadMemes } from '@insight-src/memeplex.ts';
 
 beforeEach(() => {
   indexedDB.deleteDatabase('memeplex');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/mutate_scaling.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/mutate_scaling.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { mutate } = require('../src/evolve/mutate.ts');
+import { mutate } from '../src/evolve/mutate.ts';
 
 function fixed(v) {
   return () => v;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/power_panel_update.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/power_panel_update.test.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-const simulator = require('../src/simulator.ts');
-const { initSimulatorPanel } = require('../src/ui/SimulatorPanel.ts');
+import simulator from '../src/simulator.ts';
+import { initSimulatorPanel } from '../src/ui/SimulatorPanel.ts';
 
 jest.mock('@insight-src/replay.ts', () => ({
   ReplayDB: class {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/replaydb.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { ReplayDB } = require('../src/replay.ts');
+import { ReplayDB } from '../src/replay.ts';
 
 beforeEach(() => {
   indexedDB.deleteDatabase('jest');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/simulator.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { Simulator } = require('../src/simulator.ts');
+import { Simulator } from '../src/simulator.ts';
 
 jest.setTimeout(10000);
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/taxonomy.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/taxonomy.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-const { mineTaxonomy, saveTaxonomy, loadTaxonomy, proposeSectorNodes } = require('../../src/taxonomy.ts');
+import { mineTaxonomy, saveTaxonomy, loadTaxonomy, proposeSectorNodes } from '../../src/taxonomy.ts';
 
 jest.mock('../../src/utils/llm.ts', () => ({
   chat: async () => 'Yes',

--- a/tests/gpu_flag.test.js
+++ b/tests/gpu_flag.test.js
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-/* globals require */
-const path = require('path');
+/* eslint-env jest */
+
+import { mutate } from '../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts';
 
 jest.mock('../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts', () => ({
   mutate: jest.fn(() => [])
 }));
-
-const { mutate } = require('../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts');
 
 function makeMsg(gen) {
   return { pop: [], rngState: 1, mutations: [], popSize: 1, critic: 'none', gen };


### PR DESCRIPTION
## Summary
- use ES module syntax in browser-related tests
- use native `node:` imports for built-ins

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --maxfail=1 -q` *(fails: openai_agents stub call)*

------
https://chatgpt.com/codex/tasks/task_e_68771a98cecc83339cd7d60cc42057f9