### PR TITLE
[alpha_factory] refactor gpu flag test

### DIFF
--- a/tests/gpu_flag.test.js
+++ b/tests/gpu_flag.test.js
@@ -1,27 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
-/* eslint-env jest */
-
-import { mutate } from '../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts';
-
-jest.mock('../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts', () => ({
-  mutate: jest.fn(() => [])
-}));
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as mutateMod from '../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/src/evolve/mutate.ts';
 
 function makeMsg(gen) {
   return { pop: [], rngState: 1, mutations: [], popSize: 1, critic: 'none', gen };
 }
 
 test('worker updates gpu flag before mutate calls', async () => {
-  const selfObj = { navigator: {}, postMessage: jest.fn() };
+  const selfObj = { navigator: {}, postMessage() {} };
+  mock.method(selfObj, 'postMessage', () => {});
   global.self = selfObj;
+  const mutateSpy = mock.method(mutateMod, 'mutate', () => []);
+
   await import('../alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/worker/evolver.ts');
   const handler = selfObj.onmessage;
 
   handler({ data: { type: 'gpu', available: true } });
   await handler({ data: makeMsg(1) });
-  expect(mutate.mock.calls[0][6]).toBe(true);
+  assert.equal(mutateSpy.mock.calls[0].arguments[6], true);
 
   handler({ data: { type: 'gpu', available: false } });
   await handler({ data: makeMsg(2) });
-  expect(mutate.mock.calls[1][6]).toBe(false);
+  assert.equal(mutateSpy.mock.calls[1].arguments[6], false);
+
+  mock.restoreAll();
 });


### PR DESCRIPTION
## Summary
- refactor GPU worker test to use Node's experimental mock API
- drop Jest references and switch to node:test

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files tests/gpu_flag.test.js`
- `node --loader ts-node/esm --test tests/gpu_flag.test.js` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68771f68e0108333beb825e7d83a2181