### PR TITLE
[alpha_factory] fix ts-node loader for browser tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -23,7 +23,7 @@ function run(cmd, options = {}) {
 }
 
 run(['npm', 'run', 'build']);
-run(['node', '--loader', 'ts-node/register', '--test',
+run(['node', '--import', 'ts-node/register', '--test',
   'tests/entropy.test.js',
   'tests/replay_cid.test.js',
   'tests/iframe_worker_cleanup.test.js',

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json
@@ -14,5 +14,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
+  "ts-node": {
+    "esm": true
+  },
   "include": ["src/**/*.ts", "src/**/*.js", "src/global.d.ts", "worker/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- enable ts-node's ESM loader when running Node tests
- configure ts-node to use ESM modules

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov=alpha_factory_v1 --cov-report=xml`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687722b8ac288333a2964bfaa9068381