### PR TITLE
chore: install Playwright browsers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,8 @@ jobs:
         run: npm exec update-browserslist-db@1.1.3 -- --update-db --yes
       - name: Audit insight browser dependencies
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 audit --production --audit-level=high
+      - name: Install Playwright browsers
+        run: npx playwright install chromium webkit firefox
       - name: Run insight browser tests
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Install web dependencies
@@ -181,14 +183,6 @@ jobs:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_TOKEN_E2E: ${{ secrets.PERCY_TOKEN }}
         run: npm --prefix alpha_factory_v1/core/interface/web_client run percy:cypress
-      - name: Install Playwright browsers
-        id: install-browsers
-        run: |
-          set +e
-          if ! playwright install chromium webkit; then
-            echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
-          fi
-          set -e
       - name: Install proto compiler
         run: pip install grpcio-tools
       - name: Verify protobuf
@@ -478,12 +472,7 @@ jobs:
           branch: pyodide-update-${{ github.run_id }}
           delete-branch: true
       - name: Install Playwright browsers
-        run: |
-          set +e
-          if ! playwright install chromium webkit; then
-            echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
-          fi
-          set -e
+        run: npx playwright install chromium webkit firefox
       - name: Verify demo pages
         run: python scripts/verify_demo_pages.py
       - name: Verify Insight PWA offline
@@ -582,6 +571,8 @@ jobs:
           delete-branch: true
       - name: Audit insight browser dependencies
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 audit --production --audit-level=high
+      - name: Install Playwright browsers
+        run: npx playwright install chromium webkit firefox
       - name: Run insight browser tests
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Type check insight browser

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,7 +91,7 @@ jobs:
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium webkit firefox
       - name: Make scripts executable
         run: chmod +x ./scripts/*.sh
       - name: Compute asset cache key

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
@@ -23,6 +23,7 @@
         "jsdom": "^26.1.0",
         "multiformats": "^12.1.2",
         "onnxruntime-web": "^1.18.0",
+        "playwright": "^1.54.1",
         "regl": "^2.1.1",
         "serve": "^14.2.4",
         "tailwindcss": "^3.4.0",
@@ -9285,6 +9286,53 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -32,6 +32,7 @@
     "jsdom": "^26.1.0",
     "multiformats": "^12.1.2",
     "onnxruntime-web": "^1.18.0",
+    "playwright": "^1.54.1",
     "regl": "^2.1.1",
     "serve": "^14.2.4",
     "tailwindcss": "^3.4.0",


### PR DESCRIPTION
## Summary
- add `playwright` to `insight_browser_v1` package
- install Playwright browsers before running insight browser tests
- use the same install command in docs and docker jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/docs.yml alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687724bee7308333bb9a58529d234f3d