### PR TITLE
[alpha_factory] fix Node test loader

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -23,7 +23,7 @@ function run(cmd, options = {}) {
 }
 
 run(['npm', 'run', 'build']);
-run(['node', '--import', 'ts-node/register', '--test',
+run(['node', '--loader', 'ts-node/esm', '--test',
   'tests/entropy.test.js',
   'tests/replay_cid.test.js',
   'tests/iframe_worker_cleanup.test.js',


### PR DESCRIPTION
## Summary
- use `ts-node/esm` loader for browser tests in run.mjs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError: API...)*

------
https://chatgpt.com/codex/tasks/task_e_6877914bce98833385d4b272fa184d88