### PR TITLE
fix: stabilize browser tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json
@@ -28,6 +28,7 @@
         "serve": "^14.2.4",
         "tailwindcss": "^3.4.0",
         "ts-node": "^10.9.1",
+        "tsx": "^4.20.3",
         "typescript": "^5.3.0",
         "workbox-build": "^7.3.0"
       },
@@ -6981,6 +6982,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -9964,6 +9978,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -11204,6 +11228,26 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -37,6 +37,7 @@
     "serve": "^14.2.4",
     "tailwindcss": "^3.4.0",
     "ts-node": "^10.9.1",
+    "tsx": "^4.20.3",
     "typescript": "^5.3.0",
     "workbox-build": "^7.3.0"
   },

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs
@@ -23,7 +23,7 @@ function run(cmd, options = {}) {
 }
 
 run(['npm', 'run', 'build']);
-run(['node', '--loader', 'ts-node/esm', '--test',
+run(['npx', 'tsx', '--test',
   'tests/entropy.test.js',
   'tests/iframe_worker_cleanup.test.js',
   'tests/locale_parity.test.js',


### PR DESCRIPTION
## Summary
- use `tsx` to run TypeScript browser tests
- add `tsx` dev dependency
- install Playwright browsers for all engines before running tests

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package-lock.json alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/run.mjs .github/workflows/ci.yml`
- `python check_env.py --auto-install`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError API)*

------
https://chatgpt.com/codex/tasks/task_e_6877a5fbb0c8833396c21a6493d6b2fb