### PR TITLE
[alpha_factory] docs-build handles pyodide updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create Pyodide update PR
+        # docs-build is the only job that should open this pull request
         if: steps.pyodide-diff-docs.outputs.changed == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: peter-evans/create-pull-request@v7.0.8 # 271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
@@ -572,6 +573,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    # This job builds and pushes the image. It no longer creates the
+    # Pyodide update pull request.
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- stop mentioning the docker job for updating Pyodide hashes
- clarify that only the docs-build job creates the PR

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(failed: connection refused)*
- `pre-commit run --files .github/workflows/ci.yml` *(failed: environment setup interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6877c9ea10e48333b06fd67dfefdf13e