### PR TITLE
[alpha_factory] remove docker PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,8 +573,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # This job builds and pushes the image. It no longer creates the
-    # Pyodide update pull request.
+    # This job builds and pushes the image.
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- trim outdated comment from Docker job so only docs-build handles Pyodide update PRs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest` *(fails: 212 failed, 572 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6877da1ac7fc8333b1bfa9e8d050e5ba