### PR TITLE
ci: ensure deploy always runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,7 +716,7 @@ jobs:
 
   deploy:
     name: "📦 Deploy"
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && always()
     needs: [owner-check, docker]
     runs-on: ubuntu-latest
     environment: ci-on-demand


### PR DESCRIPTION
## Summary
- make the deploy job run even if earlier jobs fail

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6877e002fa508333b8bcc07358b0cd72