### PR TITLE
[alpha_factory] build sandbox for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           python scripts/check_python_deps.py
           python check_env.py --auto-install --demo macro_sentinel
       - name: Build sandbox image
-        run: docker build -t selfheal-sandbox:latest -f sandbox.Dockerfile .
+        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       # Install Node.js and cache dependencies using both lockfiles
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -499,7 +499,7 @@ jobs:
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Build sandbox image
-        run: docker build -t selfheal-sandbox:latest -f sandbox.Dockerfile .
+        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -28,7 +28,11 @@ previous `latest` image so production always points at a working build.
 - **✅ Pytest** – unit tests and front‑end checks.
 - **Windows Smoke** – lightweight sanity tests on Windows.
 - **📜 MkDocs** – basic documentation build.
-- **📚 Docs Build** – full docs site verification.
+- **📚 Docs Build** – full docs site verification. The job runs
+  `scripts/build_gallery_site.sh` which executes `preflight.py`. This
+  script requires `/usr/bin/patch` inside the sandbox container, so the
+  workflow builds `sandbox.Dockerfile` and sets `SANDBOX_IMAGE=selfheal-sandbox:latest`.
+  Ensure this image exists locally before building the docs.
 - **🐳 Docker build** – builds and tests the demo image.
 - **📦 Deploy** – pushes the image and release assets on tags.
 


### PR DESCRIPTION
## Summary
- build sandbox.Dockerfile in docs-build as well as tests
- explain the sandbox image requirement in docs/CI_WORKFLOW.md

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/CI_WORKFLOW.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 13 failed, 68 passed, 31 skipped, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877ef7d695483339f91f040fa33c40c