### PR TITLE
[alpha_factory] Set sandbox image env in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     environment: ci-on-demand
+    env:
+      SANDBOX_IMAGE: selfheal-sandbox:latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- define `SANDBOX_IMAGE` in the CI tests job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest --cov --cov-report=xml` *(fails: 213 failed, 571 passed, 72 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6877f48fb9f88333a90dd7b9c9c90f5e