### PR TITLE
Ensure docs-check builds sandbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,8 @@ jobs:
     needs: [owner-check, tests]
     if: always()
     runs-on: ubuntu-latest
+    env:
+      SANDBOX_IMAGE: selfheal-sandbox:latest
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -428,6 +430,8 @@ jobs:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
+      - name: Build sandbox image
+        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - name: Compute asset cache key
         id: asset-key-docs-build
         run: |


### PR DESCRIPTION
## Summary
- build sandbox image in docs-check job
- pass SANDBOX_IMAGE to docs-check environment

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -k smoke -q`
- `./scripts/build_gallery_site.sh` *(fails: docker missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877ffc0e13483338f6f13a6b4772633