### PR TITLE
Fix ESLint test exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/)|
           (build\.js$)|
           (^tests/)|
+          (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/)|
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/)|
           (^alpha_factory_v1/ui/static/)|
           (bundle\.esm\.min\.js$)|(insight\.bundle\.js$)


### PR DESCRIPTION
## Summary
- exclude browser tests from ESLint pre-commit hook

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest tests/test_ping_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687809c538048333873a9c0063cd12cb