### PR TITLE
Fix asset cache keys for cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,8 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docs-build.outputs.key }}
-          restore-keys: assets-
+          key: assets-${{ steps.asset-key-docs-build.outputs.key }}-${{ runner.os }}
+          restore-keys: assets-${{ runner.os }}-
       - name: Compute asset cache key
         id: asset-key-docker
         run: |
@@ -168,8 +168,8 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docker.outputs.key }}
-          restore-keys: assets-
+          key: assets-${{ steps.asset-key-docker.outputs.key }}-${{ runner.os }}
+          restore-keys: assets-${{ runner.os }}-
       - name: Fetch insight browser assets
         run: |
           set -e
@@ -323,8 +323,8 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docker.outputs.key }}
-          restore-keys: assets-
+          key: assets-${{ steps.asset-key-docker.outputs.key }}-${{ runner.os }}
+          restore-keys: assets-${{ runner.os }}-
       - name: Build web assets
         shell: bash
         run: |
@@ -395,8 +395,8 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docker.outputs.key }}
-          restore-keys: assets-
+          key: assets-${{ steps.asset-key-docker.outputs.key }}-${{ runner.os }}
+          restore-keys: assets-${{ runner.os }}-
       - name: Build web assets
         shell: bash
         run: |
@@ -455,8 +455,8 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docs-build.outputs.key }}
-          restore-keys: assets-
+          key: assets-${{ steps.asset-key-docs-build.outputs.key }}-${{ runner.os }}
+          restore-keys: assets-${{ runner.os }}-
       - name: Fetch insight browser assets
         run: |
           set -e
@@ -630,8 +630,8 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docker.outputs.key }}
-          restore-keys: assets-
+          key: assets-${{ steps.asset-key-docker.outputs.key }}-${{ runner.os }}
+          restore-keys: assets-${{ runner.os }}-
       - name: Fetch insight browser assets
         run: |
           set -e


### PR DESCRIPTION
## Summary
- isolate asset caches per OS in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(failed: KeyboardInterrupt)*
- `pytest -k "" -q` *(failed: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687814b628d88333b1bb0b684c7c837f