### PR TITLE
[alpha_factory] improve docker job gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,16 +708,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push image
+        if: ${{ needs.tests.result == 'success' }}
         run: |
           docker tag "$DOCKER_IMAGE:ci" "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
           docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
       - name: Install cosign
+        if: ${{ needs.tests.result == 'success' }}
         uses: sigstore/cosign-installer@v3.9.1 # 398d4b0eeef1380460a10c8013a76f728fb906ac
         with:
           cosign-release: 'v2.2.4'
       - name: Sign image
+        if: ${{ needs.tests.result == 'success' }}
         run: cosign sign --yes "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
       - name: Verify image signature
+        if: ${{ needs.tests.result == 'success' }}
         run: cosign verify "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
 
   deploy:


### PR DESCRIPTION
## Summary
- gate docker image push and signing on successful tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 27 failed, 91 passed, 31 skipped, 1 xfailed, 8 warnings, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687824f68d108333ae325695cf3f5455