### PR TITLE
Fix CI job dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
 
   windows-smoke:
     name: "Windows Smoke"
-    needs: [owner-check, tests]
+    needs: [tests]
     if: always()
     runs-on: windows-latest
     environment: ci-on-demand
@@ -345,7 +345,7 @@ jobs:
 
   macos-smoke:
     name: "macOS Smoke"
-    needs: [owner-check, tests]
+    needs: [tests]
     if: always()
     runs-on: macos-latest
     environment: ci-on-demand
@@ -417,7 +417,7 @@ jobs:
 
   docs-check:
     name: "📜 MkDocs"
-    needs: [owner-check, tests]
+    needs: [tests]
     if: always()
     runs-on: ubuntu-latest
     env:
@@ -487,7 +487,7 @@ jobs:
 
   docs-build:
     name: "📚 Docs Build"
-    needs: [owner-check, tests]
+    needs: [tests]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -573,7 +573,7 @@ jobs:
 
   docker:
     name: "🐳 Docker build"
-    needs: [owner-check, tests]
+    needs: [tests]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -727,7 +727,7 @@ jobs:
   deploy:
     name: "📦 Deploy"
     if: startsWith(github.ref, 'refs/tags/') && always()
-    needs: [owner-check, docker]
+    needs: [docker]
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:


### PR DESCRIPTION
## Summary
- simplify job dependencies so later jobs just depend on test results

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_agent_manager_consumer.py tests/test_agent_experience_entrypoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687829a3b1e0833393a0a99bc654cfef