### PR TITLE
[alpha_factory] fix eslint exclude for tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/)|
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/)|
           (build\.js$)|
-          (^tests/)|
+          (tests/)|
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/)|
           (^alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/)|
           (^alpha_factory_v1/ui/static/)|


### PR DESCRIPTION
## Summary
- tweak ESLint exclude pattern so test files are always skipped

## Testing
- `pre-commit run --files .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6878383f97188333a671f601b61a4e2a