### PR TITLE
[alpha_factory] enhance lint job checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
         run: pre-commit run --all-files
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
+      - name: Fail on uncommitted changes
+        run: |
+          git --no-pager diff
+          git diff --quiet
       - name: Ruff lint
         run: ruff check alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Mypy type-check


### PR DESCRIPTION
## Summary
- fail if pre-commit modifies files

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_agent_manager_consumer.py::test_manager_starts_and_stops_bus_consumer -q`


------
https://chatgpt.com/codex/tasks/task_e_68783dcd008c8333a751c09b42ee9a70