### PR TITLE
[alpha_factory] clarify CI asset caching

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -64,6 +64,10 @@ fails. The workflow automatically reruns `scripts/update_pyodide.py` to refresh
 the expected hashes, fetches the assets again and then reruns
 `python scripts/fetch_assets.py --verify-only` so CI keeps running even if the
 mirrored files change.
+To avoid re-downloading these large files for every job, the workflow computes
+a cache key from the verified hashes and restores any matching archive across
+jobs and operating systems. This ensures reproducible builds and significantly
+reduces network traffic.
 
 Before submitting changes to the workflow run:
 


### PR DESCRIPTION
## Summary
- document that the CI shares downloaded Pyodide assets via a cache

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 212 failed, 570 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68784c7d4c7c83339070000ebdd4a0f5