### PR TITLE
[alpha_factory] fix eslint warnings

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/archive.test.js
@@ -127,6 +127,7 @@ test('add calls chat when api key set and stores impact score', async () => {
 });
 
 test('prune logs warning when deletion fails', async () => {
+  // eslint-disable-next-line no-import-assign
   const delSpy = jest.spyOn(keyval, 'del').mockImplementation(() => {
     throw new DOMException('fail');
   });
@@ -139,6 +140,7 @@ test('prune logs warning when deletion fails', async () => {
 
   expect(warn).toHaveBeenCalled();
 
+  // eslint-disable-next-line no-import-assign
   delSpy.mockRestore();
   warn.mockRestore();
 });


### PR DESCRIPTION
## Summary
- silence no-import-assign lint rule in archive test

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 211 failed, 571 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6878580cbff48333811210d15a960dbe