### PR TITLE
ci: build sandbox earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,13 +429,13 @@ jobs:
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build sandbox image
+        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - name: Build sandbox image
-        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - name: Compute asset cache key
         id: asset-key-docs-build
         run: |
@@ -503,13 +503,13 @@ jobs:
       SANDBOX_IMAGE: selfheal-sandbox:latest
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build sandbox image
+        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - name: Build sandbox image
-        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,12 +38,6 @@ jobs:
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-precommit-
-      - name: Install Ruff
-        run: pip install ruff
-      - name: Install docs dependencies
-        run: pip install -r requirements-docs.txt
-      - name: Install project dependencies
-        run: python check_env.py --auto-install
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache sandbox layers
@@ -65,6 +59,12 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Install Ruff
+        run: pip install ruff
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+      - name: Install project dependencies
+        run: python check_env.py --auto-install
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
## Summary
- build the sandbox image before other docs jobs
- keep SANDBOX_IMAGE consistent across CI jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/docs.yml`
- `python check_env.py --auto-install`
- `SANDBOX_IMAGE=selfheal-sandbox:latest python alpha_factory_v1/scripts/preflight.py` *(fails: docker missing)*
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687867445038833388eb6fb8c72ecf37