### PR TITLE
[alpha_factory] enforce pre-commit diff check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
       - name: Fail on uncommitted changes
         run: |
           git --no-pager diff
-          git diff --quiet
+          if ! git diff --quiet; then
+            echo "::error::Uncommitted changes detected. Run pre-commit locally."
+            exit 1
+          fi
       - name: Ruff lint
         run: ruff check alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Mypy type-check


### PR DESCRIPTION
## Summary
- fail lint-type job when pre-commit modifies files

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68786b92e5b08333a839419c1b9fef0d