### PR TITLE
[alpha_factory] document a11y threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ name: "🚀 CI"
 
 on:
   workflow_dispatch:
+    inputs:
+      a11y-threshold:
+        description: "Minimum Axe accessibility score"
+        required: false
+        default: "90"
 
 permissions:
   contents: read
@@ -27,6 +32,7 @@ env:
     alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/package-lock.json
   PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
   HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
+  A11Y_THRESHOLD: ${{ inputs.a11y-threshold }}
 
 jobs:
 
@@ -598,8 +604,8 @@ jobs:
         run: |
           npx --yes @axe-core/cli alpha_factory_v1/core/interface/web_client/dist/index.html --score > axe.json
           score=$(jq '.score' axe.json)
-          echo "a11y score: $score"
-          if [ "$score" -lt 90 ]; then
+          echo "a11y score: $score (threshold $A11Y_THRESHOLD)"
+          if [ "$score" -lt "$A11Y_THRESHOLD" ]; then
             cat axe.json
             exit 1
           fi

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -35,6 +35,9 @@ previous `latest` image so production always points at a working build.
   Ensure this image exists locally before building the docs.
 - **🐳 Docker build** – builds and tests the demo image.
 - **📦 Deploy** – pushes the image and release assets on tags.
+- **♿ Accessibility audit** – runs `@axe-core/cli` on the built web client. The
+  pipeline fails if the score is below the `a11y-threshold` input (default 90).
+  Keep this threshold at least 90 to maintain baseline accessibility.
 
 Caching for Python and Node dependencies is enabled. The project stores
 `package-lock.json` files under the demo and web client folders rather than at


### PR DESCRIPTION
## Summary
- document accessibility policy in CI docs
- expose a11y score threshold as a CI input

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/CI_WORKFLOW.md`
- `pytest --cov --cov-report=xml` *(fails: 33 failed, 108 passed, 31 skipped, 1 xfailed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68787183c6b083339855dd077891b1c5