### PR TITLE
[alpha_factory] wait for controls panel

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
@@ -36,7 +36,7 @@ test('service worker update reloads page', async () => {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(url);
-    await page.waitForSelector('#controls');
+    await page.waitForSelector('#controls', { state: 'attached' });
     await page.waitForFunction('navigator.serviceWorker.ready');
     const initial = await page.evaluate(() => navigator.serviceWorker.controller?.scriptURL);
 


### PR DESCRIPTION
## Summary
- fix Playwright test by waiting for the `#controls` element to be attached

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js` *(fails: initializing environment for semgrep)*
- `npm test` *(fails: checksum mismatch for `pyodide.js` in build step)*

------
https://chatgpt.com/codex/tasks/task_e_68787596520c83339b0626385c221927