### PR TITLE
fix: stabilize docs workflow and browser test

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
@@ -23,8 +23,7 @@ function startServer(dir) {
   });
 }
 
-test('service worker update reloads page', async (t) => {
-  if (process.env.CI) t.skip('flaky in CI');
+test('service worker update reloads page', {skip: !!process.env.CI}, async () => {
   let browser;
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const dist = path.resolve(__dirname, '../dist');

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,6 +2,7 @@ mkdocs==1.6.1
 mkdocs-material==9.6.15
 openai-agents==0.0.17
 google-adk==1.5.0
+requests
 
 playwright
 


### PR DESCRIPTION
## Summary
- skip flaky service worker update test in CI properly
- ensure docs workflow installs `requests`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js requirements-docs.txt`
- `pytest -m smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ed508b348333be3b17a434724d08