### PR TITLE
[alpha_factory] skip service worker reload on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,8 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
       - name: Run insight browser tests
+        env:
+          CI: 'true'
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Install web dependencies
         run: npm ci --prefix alpha_factory_v1/core/interface/web_client
@@ -583,6 +585,8 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
       - name: Run insight browser tests
+        env:
+          CI: 'true'
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 test
       - name: Type check insight browser
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
@@ -23,7 +23,10 @@ function startServer(dir) {
   });
 }
 
-test('service worker update reloads page', {skip: !!process.env.CI}, async () => {
+if (process.env.CI) {
+  test.skip('service worker update reloads page', () => {});
+} else {
+  test('service worker update reloads page', async () => {
   let browser;
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const dist = path.resolve(__dirname, '../dist');
@@ -62,4 +65,5 @@ test('service worker update reloads page', {skip: !!process.env.CI}, async () =>
     server.close();
     await fs.writeFile(swPath, original);
   }
-});
+  });
+}


### PR DESCRIPTION
## Summary
- skip service worker update test when `CI` is set
- set `CI: 'true'` for Insight demo tests in `ci.yml`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 33 failed, 108 passed, 31 skipped, 5 errors)*
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878f6e474fc83339932aa65a60d979c