### PR TITLE
Fix docs-check dependency order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,12 +398,12 @@ jobs:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - name: Install base dependencies
-        run: python check_env.py --auto-install
       - name: Install docs requirements
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-docs.txt
+      - name: Install base dependencies
+        run: python check_env.py --auto-install
       - id: asset-key-docs-build
         uses: ./.github/actions/generate-asset-key
       - name: Restore Insight asset cache


### PR DESCRIPTION
## Summary
- install docs requirements before running the generate-asset-key action

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -m smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_6878f9ca5a408333914ec6537293c7bb