### PR TITLE
ci: cache node setup in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
           cache: pip
           cache-dependency-path: 'requirements.lock'
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: ${{ env.NODE_LOCKFILES }}
+
       - name: Cache pre-commit
         uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:


### PR DESCRIPTION
## Summary
- update lint job to install Node.js with caching before using pre-commit

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(failed: KeyboardInterrupt during environment initialization)*

------
https://chatgpt.com/codex/tasks/task_e_687900d5e2388333b4cc4e51a8c243ab