### PR TITLE
[alpha_factory] Bump Percy CLI to 1.31.0

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/package-lock.json
+++ b/alpha_factory_v1/core/interface/web_client/package-lock.json
@@ -19,7 +19,7 @@
         "vue": "^3.3.4"
       },
       "devDependencies": {
-        "@percy/cli": "^1.30.11",
+        "@percy/cli": "^1.31.0",
         "@percy/cypress": "^3.1.0",
         "@playwright/test": "^1.39.0",
         "@types/react": "^18.2.0",
@@ -2543,21 +2543,21 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.30.11.tgz",
-      "integrity": "sha512-+UX5w5m3CT7g6OrcYL6WTOTL81dYOG14RxgAuvu8i+6ua2smSN2VfMF8ibHsD+BE/CkHXyqymvosyedWcsVZJw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.0.tgz",
+      "integrity": "sha512-Ftztj3PLvdMnBylyXIsfEKbHsKRRMpKuk4pFi4MizCFrbM3O6D8raHmff6GaVkE95tMnkF+7gX0BlPzjnbzG8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-app": "1.30.11",
-        "@percy/cli-build": "1.30.11",
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-config": "1.30.11",
-        "@percy/cli-exec": "1.30.11",
-        "@percy/cli-snapshot": "1.30.11",
-        "@percy/cli-upload": "1.30.11",
-        "@percy/client": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/cli-app": "1.31.0",
+        "@percy/cli-build": "1.31.0",
+        "@percy/cli-command": "1.31.0",
+        "@percy/cli-config": "1.31.0",
+        "@percy/cli-exec": "1.31.0",
+        "@percy/cli-snapshot": "1.31.0",
+        "@percy/cli-upload": "1.31.0",
+        "@percy/client": "1.31.0",
+        "@percy/logger": "1.31.0"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -2567,42 +2567,42 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.30.11.tgz",
-      "integrity": "sha512-Iq3QGaDsKWEKIIRQzq09OxuwSFhV2JtGT9poZ9RvDaFrKcy3e3VkHWNH/jcxSv0IPNB6EptEfoG8XVY93OKA8Q==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.0.tgz",
+      "integrity": "sha512-NU4zSDNXbwL/AG58eFT5YPd8McZSY2vTV1MEnKNTixiSAM+KXX5oZ4ehrRV3bod+jIOsgl3x7WZJOwW9n+T1mQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-exec": "1.30.11"
+        "@percy/cli-command": "1.31.0",
+        "@percy/cli-exec": "1.31.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.30.11.tgz",
-      "integrity": "sha512-o0qyiW+F3xX+X/pnKgSgK4Dvc1PKqWHvceanWOw0t1F8Qdq5n/rYOHwkpYKV+jOE4vEH1tpdcRo8YsXq9C+0ug==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.0.tgz",
+      "integrity": "sha512-p+ml01nFlcHayQwNHrwC+DALUuSmz4I8839AoTAgnxqswEHwqPK9VR0Dtk1h+u8buviZ1meCtSETZLxClOYC5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.30.11.tgz",
-      "integrity": "sha512-UIkk3IGI5Tazhy6Kho+M04oG9ZFfpyqDuCFGHYNm5ZUPgZcGK0BUrEd9/JmjLPA9AIMSlFn2PGzWSzNDT1+ThQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.0.tgz",
+      "integrity": "sha512-6NfDQLFV/56bI0RwVqe9rWvJ5IXrln84ZIPwT5NPsMYlLsu90hiS1360KcYllBTziZQUpBDT/uIpGxl+mFO/gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/core": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/config": "1.31.0",
+        "@percy/core": "1.31.0",
+        "@percy/logger": "1.31.0"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -2612,27 +2612,27 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.30.11.tgz",
-      "integrity": "sha512-R42o/XI1x44vUe4BYlpNrKioc+8PxrC554GcnKmgSWENRnT8e1dZKl3jb5ppKd0qUPBnqDEJCGvpzAVVeiTNuQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.0.tgz",
+      "integrity": "sha512-VjUvrlIvo46Vtdm7wfgOyLFHvY2QISUO8utQXfQZYXhPWN31laURKpQrSMkAkhpjlJ47/QNmRYvjjg5swRy7cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.30.11.tgz",
-      "integrity": "sha512-UqRx7NaGTtuWhr/Ucq4PCKnJ5V6dTgi5hDZdSWwBhpqHmhdKGD3JFZVCC9xXAO84M7n6VbWOnIDpv+AVe/XWeg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.0.tgz",
+      "integrity": "sha512-GI8YRYTGwM1WnFHVlQap9Lw+w7PzgryTay61R4yD7HcZInotehaSoGgQMB4jqMBlLYqVABaqsA2ZHaOmLMaeVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/cli-command": "1.31.0",
+        "@percy/logger": "1.31.0",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -2641,13 +2641,13 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.30.11.tgz",
-      "integrity": "sha512-wc5quGBLghO3vWO4r0lnqL8DxJYPo13oNlbyeCZFWPiCBtxW/AQyTtzBdS//murcM0aP1Yb2vbkLp1eH742vVQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.0.tgz",
+      "integrity": "sha512-HNpNLgX9ZaYU6DUR9ekH5al8SJ+sVKG5kqvnR2k/61+aEzcCrTFDXY5sJcby69mRNVy5mdVRqLKmDxc+sHdI+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.0",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -2655,13 +2655,13 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.30.11.tgz",
-      "integrity": "sha512-97zu5KcNcx6A3hrwCHMdi97Wsvd2qg/QkH86FWtnsDzOxLQUuWiDqyuxNnYuBr02dsOwEvwVxeJl0maCsfPNJw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.0.tgz",
+      "integrity": "sha512-dTnE4i2T1IQeAPLMkiFjWqfuaC4p3U/gJTjCU5xFpVAGs8Sw4WECXc7kZ1pe6o4IYUuGoM7bdqnVyLaUHbxp8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.0",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -2670,14 +2670,14 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.30.11.tgz",
-      "integrity": "sha512-1QJK26ZU40GoeqGgMt3cbRdJy2hhb3N9ReSzlYzEiNaSQQ5ZZcL3SXt3IDUtrR6WsoMvT7Kk+6R0yK/JDa8/LA==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.0.tgz",
+      "integrity": "sha512-ACC2zSLOr+c/huLXYFFTrcF2B0c9EIK4gWg1yacIHeaI8ulkX+34UHeCwkWjDM4tcN5cANQ0y+EQv+QuCcWcYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/env": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/env": "1.31.0",
+        "@percy/logger": "1.31.0",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       },
@@ -2686,13 +2686,13 @@
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.30.11.tgz",
-      "integrity": "sha512-DZo4pXz6EHIJIH2Y+lzyjVu2bY8hiS2zBNxtXKmxAEB6EoNGlObFDN29ce7xhb/5Rb3/smqk8bDHU45biZKEVQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.0.tgz",
+      "integrity": "sha512-PPsITaULaxYLyraSEZs1x9VKDhWunh0JfX/LSKh48BFE1ABWOxIUrqWP9KmCV2XelNAiLEm2ErkCMeS0vjTBxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.30.11",
+        "@percy/logger": "1.31.0",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -2702,19 +2702,19 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.30.11.tgz",
-      "integrity": "sha512-1GSnvQZQ/uzQ4Jp0eZMrUEn+wKyMBE1yi3djZp24zwy5PEGJgm01Wsq409SMwE+J8JGJjCOhshxtfH5UmL7txw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.0.tgz",
+      "integrity": "sha512-7grj0KMnWeHAQkT7EGOIztEwnQJ2U0Ejvd+Agz0UoWYMXtPnn4QapSeVjqVAr7s7y4PtDVT9kwZ55Kzuq+hzTg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/client": "1.30.11",
-        "@percy/config": "1.30.11",
-        "@percy/dom": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/monitoring": "1.30.11",
-        "@percy/webdriver-utils": "1.30.11",
+        "@percy/client": "1.31.0",
+        "@percy/config": "1.31.0",
+        "@percy/dom": "1.31.0",
+        "@percy/logger": "1.31.0",
+        "@percy/monitoring": "1.31.0",
+        "@percy/webdriver-utils": "1.31.0",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -2745,29 +2745,29 @@
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.30.11.tgz",
-      "integrity": "sha512-g5/28YhKzgU8UWpWHBX1/RXaOjqnoCPl597dTG0s5gJrEuj7teWvkkRMcDhWE4YVfJMT+zXIaxdR0IECaw57iw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.0.tgz",
+      "integrity": "sha512-eEzzYQGVTZoq0ENrDX9Ih1G3JSYaqLpci++bb1J9kgulkSLXVi0JE8cKftcajo/8QrTrSs9OQCJa2+M1X2te8Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@percy/env": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.30.11.tgz",
-      "integrity": "sha512-dOn+yDHvw85SyDkYoJZsceB+/kby+ESqQ2weC6SyM0T5nJQiLVxdgaetJ76DNNW9TmzJMlGPIo1/2BGB9bDe7Q==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.0.tgz",
+      "integrity": "sha512-KRKYhDLlMwyLvKQNw1bx8XeXArLig6WyuCTIdwQkLwh4fZllEmSqPDnCUSk0Cu5rpcq0ItVOcZ4vy0R3KcmLBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.30.11"
+        "@percy/logger": "1.31.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.30.11.tgz",
-      "integrity": "sha512-w1hVsHHpISGNvohmvbRR2oK3RIIGBNhKe04sHo684NK1185B9HrKfPTo/EttRf1hw8cFKlEVCP5Nq+d+ykbCxQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.0.tgz",
+      "integrity": "sha512-OZHybJzTFFeG44uh02SXHCVbMpyE4KnGHr2rFG1T6/RLfmy0WPBOYz2yvCKDPKjuTkYBd4zBacTgokK0onAoJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2775,15 +2775,15 @@
       }
     },
     "node_modules/@percy/monitoring": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.30.11.tgz",
-      "integrity": "sha512-xsUE2ZPdpBJT73P6FlruAgPd/VgzVfmo6gcqiY4UbUeDHtXKIZ7tgYjhYivfeTxI12G03HFQMxRxR0HFiwUrTw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.0.tgz",
+      "integrity": "sha512-myysetAc2Kz0LsLy1JGHHB7DCsiodeW1u/b71M7kiwWYBWw840hiBEgoUDvJkgJ2Tig3oLoyI4aTqyvTExNu+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/sdk-utils": "1.30.11",
+        "@percy/config": "1.31.0",
+        "@percy/logger": "1.31.0",
+        "@percy/sdk-utils": "1.31.0",
         "systeminformation": "^5.25.11"
       },
       "engines": {
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/@percy/monitoring/node_modules/@percy/sdk-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.30.11.tgz",
-      "integrity": "sha512-EuJB8R+ZS7Q/LpdiCoXM+MIGuBVDtvH0vIYQRK6abu0QlD11ra30eN4beD3zTOIe15CgOawzGFLs3cv1noX5fg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.0.tgz",
+      "integrity": "sha512-hlzEq75BmQUwzu9oOVNWCRmT8l1PZ/KTDdBF01swArevffOV4cF4QtOQAA+jpDT4SIur66X9AmciLnMLmLzYkA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2811,23 +2811,23 @@
       }
     },
     "node_modules/@percy/webdriver-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.30.11.tgz",
-      "integrity": "sha512-djIShfhPVms/TE0GLLtM6qY/yz5OSL6ZQS95FqGq1akC/Ti+MXuBF8dws14B4w6CzZiw4gHaVe4IvBrq/y2TJQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.0.tgz",
+      "integrity": "sha512-e7k/rpkd9mhZWbUdgMU9wSj5exWWAmSLnVVLPPXn//SujSvt0koDkvCkXNMbE3aOSNC7yB48w3LE4hh0TK5slQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/sdk-utils": "1.30.11"
+        "@percy/config": "1.31.0",
+        "@percy/sdk-utils": "1.31.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/webdriver-utils/node_modules/@percy/sdk-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.30.11.tgz",
-      "integrity": "sha512-EuJB8R+ZS7Q/LpdiCoXM+MIGuBVDtvH0vIYQRK6abu0QlD11ra30eN4beD3zTOIe15CgOawzGFLs3cv1noX5fg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.0.tgz",
+      "integrity": "sha512-hlzEq75BmQUwzu9oOVNWCRmT8l1PZ/KTDdBF01swArevffOV4cF4QtOQAA+jpDT4SIur66X9AmciLnMLmLzYkA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3711,9 +3711,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6512,9 +6512,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9893,9 +9893,9 @@
       "license": "MIT"
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.6.tgz",
+      "integrity": "sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10285,9 +10285,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.1.tgz",
-      "integrity": "sha512-FgkVpT6GgATtNvADgtEzDxI/SVaBisfnQ4fmgQZhCJ4335noTgt9q6O81ioHwzs9HgnJaaFSdHSEMIkneZ55iA==",
+      "version": "5.27.7",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
+      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -11626,9 +11626,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/alpha_factory_v1/core/interface/web_client/package.json
+++ b/alpha_factory_v1/core/interface/web_client/package.json
@@ -24,7 +24,7 @@
     "vue": "^3.3.4"
   },
   "devDependencies": {
-    "@percy/cli": "^1.30.11",
+    "@percy/cli": "^1.31.0",
     "@percy/cypress": "^3.1.0",
     "@playwright/test": "^1.39.0",
     "@types/react": "^18.2.0",


### PR DESCRIPTION
## Summary
- update `@percy/cli` to `^1.31.0`
- refresh lock file via `npm install`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68790638e2508333a5c7b9b95e23e6bb