### PR TITLE
[alpha_factory] use workbox CDN

### DIFF
--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -56,7 +56,7 @@ ASSETS = {
     # Web3.Storage bundle
     "lib/bundle.esm.min.js": "https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js",  # noqa: E501
     # Workbox runtime
-    "lib/workbox-sw.js": "sha384-R7RXlLLrbRAy0JWTwv62SHZwpjwwc7C0wjnLGa5bRxm6YCl5zw87IRvhlleSM5zd",
+    "lib/workbox-sw.js": "https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js",
 }
 
 CHECKSUMS = {


### PR DESCRIPTION
## Summary
- fetch `workbox-sw.js` from the official CDN

## Testing
- `pre-commit run --files scripts/fetch_assets.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68790777a2908333a70bae6386ca6f3b