### PR TITLE
docs: link to CI workflow

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -3,7 +3,7 @@
 # CI Workflow
 
 The repository's main continuous integration pipeline lives in
-[`.github/workflows/ci.yml`](../.github/workflows/ci.yml). It runs only when the
+[`.github/workflows/ci.yml`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/.github/workflows/ci.yml). It runs only when the
 repository owner triggers it from the GitHub Actions UI.
 
 ## Running the workflow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,8 @@ nav:
   - Business Demo Production Guide: alpha_agi_business_v1/PRODUCTION_GUIDE.md
   - Insight Demo API: alpha_agi_insight_v1/docs/API.md
   - Insight Demo Bus TLS: alpha_agi_insight_v1/docs/bus_tls.md
+  - CI Workflow: CI_WORKFLOW.md
+  - GitHub Actions Access Notes: ADMIN_ACTIONS.md
 exclude_docs: |
   demos/TERMS_AND_CONDITIONS.md
   alpha_factory_v1/demos/**/*.md


### PR DESCRIPTION
## Summary
- update CI workflow link to the GitHub URL
- add CI workflow and admin actions pages to navigation

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_68790d6675c48333bda1ae33439a68a9