### PR TITLE
[alpha_factory] compute a11y score in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,8 +636,8 @@ jobs:
             web-client.tar.gz.sig
       - name: Accessibility audit
         run: |
-          npx --yes @axe-core/cli alpha_factory_v1/core/interface/web_client/dist/index.html --score > axe.json
-          score=$(jq '.score' axe.json)
+          npx --yes @axe-core/cli alpha_factory_v1/core/interface/web_client/dist/index.html --format=json > axe.json
+          score=$(python scripts/axe_score.py axe.json)
           echo "a11y score: $score (threshold $A11Y_THRESHOLD)"
           if [ "$score" -lt "$A11Y_THRESHOLD" ]; then
             cat axe.json

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -35,8 +35,9 @@ previous `latest` image so production always points at a working build.
   Ensure this image exists locally before building the docs.
 - **🐳 Docker build** – builds and tests the demo image.
 - **📦 Deploy** – pushes the image and release assets on tags.
-- **♿ Accessibility audit** – runs `@axe-core/cli` on the built web client. The
-  pipeline fails if the score is below the `a11y-threshold` input (default 90).
+- **♿ Accessibility audit** – runs `@axe-core/cli --format=json` on the built web client
+  and calculates a score via `scripts/axe_score.py`. The pipeline fails if the
+  score is below the `a11y-threshold` input (default 90).
   Keep this threshold at least 90 to maintain baseline accessibility.
 
 Caching for Python and Node dependencies is enabled. The project stores

--- a/scripts/axe_score.py
+++ b/scripts/axe_score.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Compute an accessibility score from Axe JSON output."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+WEIGHTS = {
+    "minor": 1,
+    "moderate": 5,
+    "serious": 10,
+    "critical": 20,
+}
+
+
+def compute_score(data: dict) -> int:
+    """Return a simplified Axe score (0-100)."""
+    total = 0
+    for violation in data.get("violations", []):
+        impact = violation.get("impact", "minor")
+        total += WEIGHTS.get(impact, 1)
+    score = max(0, 100 - total)
+    return score
+
+
+def main(path: str) -> int:
+    data = json.loads(Path(path).read_text())
+    score = compute_score(data)
+    print(score)
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit(f"Usage: {sys.argv[0]} <axe.json>")
+    raise SystemExit(main(sys.argv[1]))


### PR DESCRIPTION
## Summary
- parse axe json output in CI
- add helper script to compute accessibility score
- describe the new process in CI docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: ModuleNotFoundError and others)*
- `pre-commit run --files scripts/axe_score.py .github/workflows/ci.yml docs/CI_WORKFLOW.md`

------
https://chatgpt.com/codex/tasks/task_e_68790ed97f9c8333b3a78ac91001dffb