### PR TITLE
Fix docs link

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -3,7 +3,7 @@
 # CI Workflow
 
 The repository's main continuous integration pipeline lives in
-[`.github/workflows/ci.yml`](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/.github/workflows/ci.yml). It runs only when the
+[CI workflow file](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/.github/workflows/ci.yml). It runs only when the
 repository owner triggers it from the GitHub Actions UI.
 
 ## Running the workflow


### PR DESCRIPTION
## Summary
- fix link to ci.yml in docs

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md`

------
https://chatgpt.com/codex/tasks/task_e_6879220016d4833393d092125fc9a774