### PR TITLE
[alpha_factory] remove duplicate fetch step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,14 +169,6 @@ jobs:
           )
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
-      - name: Fetch insight browser assets
-        run: |
-          set -e
-          npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets || (
-            echo "Detected asset hash change, updating..." &&
-            python scripts/update_pyodide.py 0.28.0 &&
-            npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
-          )
       - name: Verify insight assets
         run: |
           python scripts/fetch_assets.py --verify-only || (


### PR DESCRIPTION
## Summary
- remove the extra 'Fetch insight browser assets' step from the tests job

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --maxfail=1 -q` *(fails: test_openai_agents_stub_call)*
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_6879314a8808833385943e6ce67c8f67