### PR TITLE
[alpha_factory] expand CI Python matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
         uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: .cache/pre-commit
-          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ runner.os }}-precommit-py${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-precommit-
+            ${{ runner.os }}-precommit-py${{ matrix.python-version }}-
       - name: Install lint tools
         run: |
           python -m pip install --upgrade pip
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
@@ -147,8 +147,9 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docs-build.outputs.key }}-${{ runner.os }}
-          restore-keys: assets-${{ runner.os }}-
+          key: assets-${{ steps.asset-key-docs-build.outputs.key }}-${{ runner.os }}-py${{ matrix.python-version }}
+          restore-keys: |
+            assets-${{ runner.os }}-py${{ matrix.python-version }}-
       - id: asset-key-docker
         uses: ./.github/actions/generate-asset-key
       - name: Restore Insight asset cache
@@ -157,8 +158,9 @@ jobs:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docker.outputs.key }}-${{ runner.os }}
-          restore-keys: assets-${{ runner.os }}-
+          key: assets-${{ steps.asset-key-docker.outputs.key }}-${{ runner.os }}-py${{ matrix.python-version }}
+          restore-keys: |
+            assets-${{ runner.os }}-py${{ matrix.python-version }}-
       - name: Fetch insight browser assets
         run: |
           set -e


### PR DESCRIPTION
## Summary
- test Python 3.10 in CI
- isolate caches by Python version

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 35 failed, 5 errors)*
- `pre-commit run --files .github/workflows/ci.yml` *(failed to finish due to KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687933c603488333ac780a24c414c055