### PR TITLE
[alpha_factory] Update Percy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
     environment: ci-on-demand
     env:
       SANDBOX_IMAGE: selfheal-sandbox:latest
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -198,10 +199,15 @@ jobs:
       - name: Type check insight browser
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run typecheck
       - name: Cypress E2E tests with Percy
+        if: env.PERCY_TOKEN != ''
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_TOKEN_E2E: ${{ secrets.PERCY_TOKEN }}
-        run: npm --prefix alpha_factory_v1/core/interface/web_client run percy:cypress
+        uses: cypress-io/github-action@v5
+        with:
+          start: npm run dev --prefix alpha_factory_v1/core/interface/web_client
+          wait-on: http://localhost:5173
+          command: npm --prefix alpha_factory_v1/core/interface/web_client run percy:cypress
       - name: Install proto compiler
         run: pip install grpcio-tools
       - name: Verify protobuf

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,6 +1,6 @@
 version: 2
 snapshot:
   widths: [375, 768, 1280]
-  minimum_height: 800
+  minHeight: 800
 failure:
   diff_threshold: 0.1


### PR DESCRIPTION
## Summary
- run Cypress with `cypress-io/github-action@v5`
- switch Percy config to `minHeight`
- skip E2E tests if no Percy token

## Testing
- `npm ci --prefix alpha_factory_v1/core/interface/web_client`
- `pre-commit run --files .github/workflows/ci.yml .percy.yml alpha_factory_v1/core/interface/web_client/package-lock.json`

------
https://chatgpt.com/codex/tasks/task_e_687984959118833398ef80067fb6786b