### PR TITLE
[alpha_factory] fix mkdocs asset exclusions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ plugins:
   - exclude:
       glob:
         - alpha_factory_v1/demos/**/*.md
+        - alpha_factory_v1/demos/**/assets/**
 theme:
   name: material
 extra_css:


### PR DESCRIPTION
## Summary
- ignore asset README files in mkdocs

## Testing
- `mkdocs build --strict`
- `pre-commit run --files mkdocs.yml`

------
https://chatgpt.com/codex/tasks/task_e_687986e6aa8483339a707f0452440939