### PR TITLE
fix: ignore asset README files

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,8 @@ plugins:
       glob:
         - alpha_factory_v1/demos/**/*.md
         - alpha_factory_v1/demos/**/assets/**
-        - '**/assets/**'
+        - '**/wasm_llm/README.md'
+        - '**/assets/README.md'
 theme:
   name: material
 extra_css:


### PR DESCRIPTION
## Summary
- ignore README files in asset folders during docs build

## Testing
- `pre-commit run --files mkdocs.yml`
- `pytest tests/test_llm_client_utils.py::test_summarize_error_returns_first_line -q`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_68799ba554048333a69b2b3de05a41af