### PR TITLE
[alpha_factory] fix docs build config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ plugins:
         - alpha_factory_v1/demos/**/assets/**
         - '**/wasm_llm/README.md'
         - '**/assets/README.md'
+        - '**/assets/**'
+        - '**/wasm_llm/**'
 theme:
   name: material
 extra_css:


### PR DESCRIPTION
## Summary
- exclude asset folders from docs site build

## Testing
- `pre-commit run --files mkdocs.yml scripts/axe_score.py`
- `pytest -m smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_6879a0c3e2908333b7b739aa0ee988a1