### PR TITLE
Stabilize CI docs and assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,14 @@ jobs:
           start: npm run dev
           wait-on: http://localhost:5173
           command: npm run percy:cypress
+      - name: Cypress E2E tests
+        if: env.PERCY_TOKEN == ''
+        uses: cypress-io/github-action@v6.10.1 # 6c143abc292aa835d827652c2ea025d098311070
+        with:
+          working-directory: alpha_factory_v1/core/interface/web_client
+          start: npm run dev
+          wait-on: http://localhost:5173
+          command: npx cypress run
       - name: Install proto compiler
         run: pip install grpcio-tools
       - name: Verify protobuf

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # GPT‑2 Small Weights

--- a/alpha_factory_v1/demos/meta_agentic_agi/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v2/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/ui/assets/README.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/ui/assets/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Meta‑Agentic α‑AGI UI Assets (Alpha‑Factory v1)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - Insight Demo Bus TLS: alpha_agi_insight_v1/docs/bus_tls.md
   - CI Workflow: CI_WORKFLOW.md
   - GitHub Actions Access Notes: ADMIN_ACTIONS.md
-exclude_docs: |
-  demos/TERMS_AND_CONDITIONS.md
-  alpha_factory_v1/demos/**/*.md
+  exclude_docs: |
+    demos/TERMS_AND_CONDITIONS.md
+    alpha_factory_v1/demos/**/*.md
+    **/assets/**


### PR DESCRIPTION
## Summary
- fix relative disclaimers in asset READMEs
- filter asset folders in mkdocs
- conditionally run Percy in CI and add fallback cypress step

## Testing
- `pre-commit run --files .github/workflows/ci.yml mkdocs.yml alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm/README.md alpha_factory_v1/demos/meta_agentic_agi/ui/assets/README.md alpha_factory_v1/demos/meta_agentic_agi_v2/ui/assets/README.md alpha_factory_v1/demos/meta_agentic_agi_v3/ui/assets/README.md`
- `pytest -k "missing_version_fails" tests/test_preflight_openai_agents_version.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6879a724200c8333bead7682dc7f0adc