### PR TITLE
Fix docs exclusions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,23 +3,19 @@ site_url: https://montrealai.github.io/AGI-Alpha-Agent-v0/
 repo_url: https://github.com/MontrealAI/AGI-Alpha-Agent-v0
 docs_dir: docs
 exclude:
-  - docs/alpha_agi_insight_v1/assets/**
-  - docs/meta_agentic_agi/assets/**
-  - docs/meta_agentic_agi_v2/assets/**
-  - docs/meta_agentic_agi_v3/assets/**
+  - '**/assets/**'
+  - '**/wasm_llm/**'
+  - '**/assets/README.md'
+  - '**/wasm_llm/README.md'
 plugins:
   - search
   - exclude:
       glob:
         - alpha_factory_v1/demos/**/*.md
-        - docs/**/assets/**
-        - docs/**/wasm_llm/**
-        - docs/**/assets/README.md
-        - docs/**/wasm_llm/README.md
-        - 'alpha_agi_insight_v1/assets/**'
-        - 'meta_agentic_agi/assets/**'
-        - 'meta_agentic_agi_v2/assets/**'
-        - 'meta_agentic_agi_v3/assets/**'
+        - '**/assets/**'
+        - '**/wasm_llm/**'
+        - '**/assets/README.md'
+        - '**/wasm_llm/README.md'
 theme:
   name: material
 extra_css:


### PR DESCRIPTION
## Summary
- exclude asset directories from MkDocs builds

## Testing
- `pre-commit run --files mkdocs.yml .percy.yml scripts/axe_score.py`


------
https://chatgpt.com/codex/tasks/task_e_6879caef39bc83339e69373e79099976