### PR TITLE
Fix docs build exclusion

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ plugins:
       glob:
         - alpha_factory_v1/demos/**/*.md
         - '**/wasm_llm/**'
+        - '**/assets/**'
         - '**/assets/README.md'
         - '**/wasm_llm/README.md'
 theme:


### PR DESCRIPTION
## Summary
- exclude asset folders from MkDocs site

## Testing
- `pre-commit run --files mkdocs.yml .github/workflows/ci.yml scripts/axe_score.py`


------
https://chatgpt.com/codex/tasks/task_e_6879d0ec5e088333942285d4ff4ce1a5