### PR TITLE
[alpha_factory] resilient agents imports

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -51,9 +51,12 @@ except ImportError:  # pragma: no cover
     A2ASocket = None  # type: ignore
 
 try:  # optional dependency
-    from openai_agents import OpenAIAgent, Tool
-except ImportError as exc:  # pragma: no cover - missing package
-    raise ImportError("openai_agents package is required. Install with `pip install openai-agents`") from exc
+    import openai_agents as _oa
+    from openai_agents import Agent as OpenAIAgent, Tool
+    if not hasattr(_oa, "OpenAIAgent"):
+        raise AttributeError
+except Exception:  # pragma: no cover - missing package
+    from .openai_agents_bridge import OpenAIAgent, Tool
 try:
     from alpha_factory_v1.backend import adk_bridge
 except Exception:  # pragma: no cover - optional dependency

--- a/stubs/openai_agents/__init__.py
+++ b/stubs/openai_agents/__init__.py
@@ -31,3 +31,5 @@ def Tool(*_args, **_kwargs):
         return func
 
     return decorator
+
+function_tool = Tool

--- a/tests/test_external_integrations.py
+++ b/tests/test_external_integrations.py
@@ -20,7 +20,8 @@ def test_build_llm_missing_api_key(monkeypatch):
         def __init__(self, *a, base_url=None, **kw):
             captured["base_url"] = base_url
 
-    monkeypatch.setattr(oa, "OpenAIAgent", DummyAgent)
+    monkeypatch.setattr(oa, "OpenAIAgent", DummyAgent, raising=False)
+    monkeypatch.setattr(oa, "Agent", DummyAgent, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "")
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://testserver")
 


### PR DESCRIPTION
## Summary
- handle missing OpenAIAgent gracefully
- sync openai_agents stub
- skip auto install when openai-agents API missing
- update integration test monkeypatch

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py stubs/openai_agents/__init__.py check_env.py tests/test_external_integrations.py` *(fails: Interrupted)*
- `pytest --cov --cov-report=xml` *(fails: 95 failed, 303 passed, 59 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a3fc9ddc0833386333461c972657f