### PR TITLE
[alpha_factory] fix CI docker context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,7 @@ jobs:
         run: |
           docker build -t "$DOCKER_IMAGE:ci" \
             -f alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile \
-            .
+            alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Smoke test image
         run: |
           docker run --rm -e RUN_MODE=cli "$DOCKER_IMAGE:ci" simulate --horizon 1 --offline

--- a/DISCLAIMER_SNIPPET.md
+++ b/DISCLAIMER_SNIPPET.md
@@ -1,0 +1,1 @@
+This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.

--- a/check_env.py
+++ b/check_env.py
@@ -486,11 +486,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     missing = missing_required + missing_optional
     if missing:
         print("WARNING: Missing packages:", ", ".join(missing))
-        if auto and (wheelhouse or network_ok):
+        if auto and missing_required and (wheelhouse or network_ok):
             cmd = [sys.executable, "-m", "pip", "install", "--quiet"]
             if wheelhouse:
                 cmd += ["--no-index", "--find-links", wheelhouse]
-            packages = [PIP_NAMES.get(pkg, pkg) for pkg in missing]
+            packages = [PIP_NAMES.get(pkg, pkg) for pkg in missing_required]
             cmd += packages
             print(
                 f"Attempting automatic install (timeout {pip_timeout}s):",


### PR DESCRIPTION
## Summary
- skip optional openai_agents auto-install
- adjust docker build context
- add missing repository disclaimer

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_rate_lock.py -q`
- `pre-commit run --files check_env.py .github/workflows/ci.yml DISCLAIMER_SNIPPET.md` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687a6246892c8333be0795d00949e104