### PR TITLE
[alpha_factory] handle missing openai_agents spec

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -541,8 +541,18 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if openai_agents_found and not openai_agents_attr_ok:
         print("WARNING: openai_agents package lacks required API; skipping auto-install")
-    elif openai_agents_found and not check_openai_agents_version():
-        return 1
+    elif openai_agents_found:
+        try:
+            mod = importlib.import_module("openai_agents")
+        except Exception:
+            try:
+                mod = importlib.import_module("agents")
+            except Exception:
+                mod = None
+        if allow_basic and getattr(mod, "__spec__", None) is None:
+            pass
+        elif not check_openai_agents_version():
+            return 1
 
     if demo == "macro_sentinel" and not os.getenv("ETHERSCAN_API_KEY"):
         print("WARNING: ETHERSCAN_API_KEY is unset; Etherscan collector disabled")

--- a/stubs/openai_agents/__init__.py
+++ b/stubs/openai_agents/__init__.py
@@ -3,6 +3,10 @@
 
 Provides basic classes so demos import without the real SDK."""
 
+import importlib.machinery
+
+__spec__ = importlib.machinery.ModuleSpec(__name__, None)
+
 __version__ = "0.0.0"
 
 


### PR DESCRIPTION
## Summary
- set a dummy `__spec__` on the openai_agents stub to avoid monkeypatch crashes
- skip openai_agents version check when its `__spec__` is missing and `--allow-basic-fallback` is used

## Testing
- `pre-commit run --files stubs/openai_agents/__init__.py check_env.py`
- `pytest -q` *(fails: DummyAgent takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687a734223248333a597b550c8bd9d8b