### PR TITLE
[alpha_factory] update openai_agents stub

### DIFF
--- a/stubs/openai_agents/__init__.py
+++ b/stubs/openai_agents/__init__.py
@@ -5,7 +5,9 @@ Provides basic classes so demos import without the real SDK."""
 
 import importlib.machinery
 
-__spec__ = importlib.machinery.ModuleSpec(__name__, None)
+__spec__ = importlib.machinery.ModuleSpec(
+    __name__, importlib.machinery.BuiltinImporter
+)
 
 __version__ = "0.0.0"
 


### PR DESCRIPTION
## Summary
- update the `__spec__` initialization in the `openai_agents` stub so
  ModuleSpec uses `BuiltinImporter`

## Testing
- `python scripts/check_python_deps.py` *(fails: Missing packages)*
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py`
- `pre-commit run --files stubs/openai_agents/__init__.py` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687a8bb158e08333aeb12c24053d008a