### PR TITLE
[alpha_factory] handle missing loader in spec

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -551,10 +551,10 @@ def main(argv: Optional[List[str]] = None) -> int:
                 mod = None
         mod_spec = getattr(mod, "__spec__", None)
         if allow_basic:
-            if mod_spec and not check_openai_agents_version():
+            if mod_spec and getattr(mod_spec, "loader", None) and not check_openai_agents_version():
                 return 1
         else:
-            if mod_spec is None:
+            if mod_spec is None or getattr(mod_spec, "loader", None) is None:
                 print("WARNING: openai_agents package lacks __spec__ metadata")
             elif not check_openai_agents_version():
                 return 1


### PR DESCRIPTION
## Summary
- handle missing loader in `openai_agents` module spec
- allow fallback when `__spec__` is `None`
- test that `--allow-basic-fallback` skips the version check when the spec is missing

## Testing
- `pre-commit run --files check_env.py tests/test_check_env_openai_agents_version.py`
- `pytest --cov --cov-report=xml` *(fails: AttributeError: 'Set...' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687a8f7148388333a575227675d0bfab