### PR TITLE
[alpha_factory] docs: emphasize full pre-commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ This repository is a conceptual research prototype. References to "AGI" and "sup
 
 # Checks
 - [ ] I ran `pre-commit run --files <paths>`
+- [ ] I ran `pre-commit run --all-files`
 - [ ] I ran `python check_env.py --auto-install`
 - [ ] I ran `pytest --cov --cov-report=xml` and documented any failures below
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ pre-commit install
 python check_env.py --auto-install  # add --wheelhouse <dir> when offline
 pre-commit run --all-files
 ```
+Run `pre-commit run --all-files` again before opening a pull request to ensure
+repository-wide checks pass.
 Use `pre-commit run --files docs/demos/<page>.md` to catch missing preview
 images. Each page under `docs/demos/` must start with a preview image using
 `![preview](...)`.


### PR DESCRIPTION
## Summary
- remind contributors to run `pre-commit run --all-files`
- note this requirement in the PR template

## Testing
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 35 failed, 108 passed, 31 skipped, 5 errors)*
- `pre-commit run --files CONTRIBUTING.md .github/pull_request_template.md`

------
https://chatgpt.com/codex/tasks/task_e_687a9323f57483339889f0effd23b2b3