### PR TITLE
Fix Docker asset paths

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -25,12 +25,12 @@ RUN npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/we
     && rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
 
 # copy built assets
-COPY ../src/interface/web_client/dist/ \
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/ \
     /app/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/
 
 # Add non-root user and entrypoint
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app
-COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 USER afuser
 


### PR DESCRIPTION
## Summary
- fix asset copy paths in Insight Dockerfile

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile`
- `pytest -m smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_687a987c40b08333a5335e45456af289