### PR TITLE
Fix openai_agents detection

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -193,10 +193,16 @@ def check_openai_agents_version(min_version: str = MIN_OPENAI_AGENTS_VERSION) ->
     import importlib
 
     module_name = "openai_agents"
-    spec = importlib.util.find_spec(module_name)
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except ValueError:
+        spec = None
     if spec is None:
         module_name = "agents"
-        spec = importlib.util.find_spec(module_name)
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except ValueError:
+            spec = None
         if spec is None:  # not installed
             return True
 


### PR DESCRIPTION
## Summary
- avoid ValueError when openai_agents has no __spec__

## Testing
- `pre-commit run --files alpha_factory_v1/scripts/preflight.py`
- `pytest tests/test_check_env_core.py::test_check_env_allow_fallback -q`


------
https://chatgpt.com/codex/tasks/task_e_687a9e26c3908333a40793f36bc6b10e