### PR TITLE
Fix openai_agents fallback check

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -551,8 +551,9 @@ def main(argv: Optional[List[str]] = None) -> int:
                 mod = None
         mod_spec = getattr(mod, "__spec__", None)
         if allow_basic:
-            if mod_spec and getattr(mod_spec, "loader", None) and not check_openai_agents_version():
-                return 1
+            if mod_spec is not None and getattr(mod_spec, "loader", None):
+                if not check_openai_agents_version():
+                    return 1
         else:
             if mod_spec is None or getattr(mod_spec, "loader", None) is None:
                 print("WARNING: openai_agents package lacks __spec__ metadata")

--- a/stubs/openai_agents/__init__.py
+++ b/stubs/openai_agents/__init__.py
@@ -5,9 +5,7 @@ Provides basic classes so demos import without the real SDK."""
 
 import importlib.machinery
 
-__spec__ = importlib.machinery.ModuleSpec(
-    __name__, importlib.machinery.BuiltinImporter
-)
+__spec__ = importlib.machinery.ModuleSpec(__name__, importlib.machinery.BuiltinImporter)
 
 __version__ = "0.0.0"
 


### PR DESCRIPTION
## Summary
- guard openai_agents version check when running with --allow-basic-fallback

## Testing
- `pre-commit run --files check_env.py`
- `python check_env.py --auto-install`

------
https://chatgpt.com/codex/tasks/task_e_687aa44809448333becf10d4dd2966bc