### PR TITLE
[alpha_factory] refresh eslint deps

### DIFF
--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -6,11 +6,10 @@ BROWSER_DIR="$ROOT/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v
 LOCK_FILE="$BROWSER_DIR/package-lock.json"
 CHECK_FILE="$BROWSER_DIR/node_modules/.package_lock_checksum"
 
-# Only (re)install dependencies when node_modules or the checksum file is missing
-if [ ! -d "$BROWSER_DIR/node_modules" ] || [ ! -f "$CHECK_FILE" ]; then
-    npm --prefix "$BROWSER_DIR" ci >/dev/null
-    sha256sum "$LOCK_FILE" | awk '{print $1}' > "$CHECK_FILE"
-fi
+# Always reinstall dependencies for a clean tree
+rm -rf "$BROWSER_DIR/node_modules"
+npm --prefix "$BROWSER_DIR" ci >/dev/null
+sha256sum "$LOCK_FILE" | awk '{print $1}' > "$CHECK_FILE"
 cd "$BROWSER_DIR"
 args=()
 for f in "$@"; do


### PR DESCRIPTION
## Summary
- reinstall insight browser dependencies for eslint by clearing node_modules

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest` *(fails: 28 failed, 103 passed, 31 skipped, 1 xfailed, 5 errors)*
- `pre-commit run --files scripts/run_eslint.sh` *(failed to initialize due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687ac7de9aa483338e4b48b50c81a9fa