### PR TITLE
[alpha_factory] skip agents version check when __spec__ missing

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -207,6 +207,13 @@ def check_openai_agents_version(min_version: str = MIN_OPENAI_AGENTS_VERSION) ->
             return True
 
     mod = importlib.import_module(module_name)
+    mod_spec = getattr(mod, "__spec__", None)
+    if mod_spec is None:
+        banner(
+            f"{module_name} missing __spec__; skipping version check",
+            "YELLOW",
+        )
+        return True
     if not hasattr(mod, "__version__"):
         banner(
             f"{module_name} missing __version__; >={min_version} required",

--- a/check_env.py
+++ b/check_env.py
@@ -550,12 +550,13 @@ def main(argv: Optional[List[str]] = None) -> int:
             except Exception:
                 mod = None
         mod_spec = getattr(mod, "__spec__", None)
-        if allow_basic:
-            if mod_spec is not None and getattr(mod_spec, "loader", None):
-                if not check_openai_agents_version():
-                    return 1
+        if mod_spec is None:
+            print("WARNING: openai_agents package lacks __spec__ metadata; skipping version check")
+        elif allow_basic:
+            if getattr(mod_spec, "loader", None) and not check_openai_agents_version():
+                return 1
         else:
-            if mod_spec is None or getattr(mod_spec, "loader", None) is None:
+            if getattr(mod_spec, "loader", None) is None:
                 print("WARNING: openai_agents package lacks __spec__ metadata")
             elif not check_openai_agents_version():
                 return 1

--- a/tests/test_check_env_openai_agents_version.py
+++ b/tests/test_check_env_openai_agents_version.py
@@ -86,6 +86,38 @@ class TestCheckEnvOpenAIAgentsVersion(unittest.TestCase):
         ):
             self.assertEqual(check_env.main(["--allow-basic-fallback"]), 0)
 
+    def test_missing_spec_skips_check_without_flag(self) -> None:
+        fake_mod = types.SimpleNamespace(
+            __version__="0.0.17",
+            __spec__=None,
+            OpenAIAgent=object,
+        )
+
+        def _fake_import(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == "openai_agents":
+                return fake_mod
+            return importlib.import_module(name, *args, **kwargs)
+
+        def _fake_find_spec(name: str, *args: Any, **kwargs: Any) -> object:
+            if name == "openai_agents":
+                return object()
+            if name == "agents":
+                return None
+            return importlib.util.find_spec(name, *args, **kwargs)
+
+        def _raise() -> bool:
+            raise AssertionError("check_openai_agents_version should not run")
+
+        with (
+            mock.patch("importlib.import_module", side_effect=_fake_import),
+            mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
+            mock.patch.object(check_env, "REQUIRED", []),
+            mock.patch.object(check_env, "OPTIONAL", ["openai_agents"]),
+            mock.patch.object(check_env, "warn_missing_core", lambda: []),
+            mock.patch.object(check_env, "check_openai_agents_version", _raise),
+        ):
+            self.assertEqual(check_env.main([]), 0)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     unittest.main()


### PR DESCRIPTION
## Summary
- skip openai_agents version validation when module lacks `__spec__`
- warn and continue instead of erroring
- test fallback logic in preflight and check_env

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 48 failed, 123 passed, 32 skipped, 1 xfailed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ad1c7829c83339554aa26cd1f2d2e