### PR TITLE
ci: clean node modules before lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
         run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
+      - name: Clean insight browser node_modules
+        run: |
+          rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+          npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Run pre-commit checks
         run: pre-commit run --all-files
         env:


### PR DESCRIPTION
## Summary
- remove old node modules during lint-type job
- npm clean install so the workflow starts fresh

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_687ae40f56308333a666c20bd55e9cee