### PR TITLE
[alpha_factory] fix docker path and cypress wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
           working-directory: alpha_factory_v1/core/interface/web_client
           start: npm run dev
           wait-on: http://localhost:5173
+          wait-on-timeout: 120
           command: npm run percy:cypress
       - name: Cypress E2E tests
         if: env.PERCY_TOKEN == ''
@@ -220,6 +221,7 @@ jobs:
           working-directory: alpha_factory_v1/core/interface/web_client
           start: npm run dev
           wait-on: http://localhost:5173
+          wait-on-timeout: 120
           command: npx cypress run
       - name: Install proto compiler
         run: pip install grpcio-tools

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -15,7 +15,7 @@ RUN node --version
 WORKDIR /app
 
 # Install Python dependencies for the demo
-COPY ../requirements.lock /tmp/requirements.lock
+COPY requirements.lock /tmp/requirements.lock
 RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock
 
 # Copy the project source


### PR DESCRIPTION
## Summary
- fix docker build path for requirements.lock
- extend Cypress wait time for dev server

## Testing
- `pre-commit run --files .github/workflows/ci.yml alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError: API...)*

------
https://chatgpt.com/codex/tasks/task_e_687af3676bbc8333868b5b47503a78f9