### PR TITLE
[alpha_factory] fix lint cache

### DIFF
--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -8,6 +8,7 @@ CHECK_FILE="$BROWSER_DIR/node_modules/.package_lock_checksum"
 
 # Always reinstall dependencies for a clean tree
 rm -rf "$BROWSER_DIR/node_modules"
+npm --prefix "$BROWSER_DIR" cache clean --force >/dev/null
 npm --prefix "$BROWSER_DIR" ci >/dev/null
 sha256sum "$LOCK_FILE" | awk '{print $1}' > "$CHECK_FILE"
 cd "$BROWSER_DIR"


### PR DESCRIPTION
## Summary
- clear npm cache before running ESLint to avoid leftover node modules

## Testing
- `pre-commit run --files scripts/run_eslint.sh`
- `python check_env.py --auto-install`
- `pytest -k "not slow" tests/test_benchmark.py` *(fails: RuntimeError: API)*

------
https://chatgpt.com/codex/tasks/task_e_687af75e8b7483339d66b26403094eba