### PR TITLE
Fix lint script and Dockerfile path

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -24,10 +24,6 @@ RUN npm ci --prefix src/interface/web_client \
     && npm --prefix src/interface/web_client run build \
     && rm -rf src/interface/web_client/node_modules
 
-# copy built assets
-COPY ./src/interface/web_client/dist/ \
-    /app/src/interface/web_client/dist/
-
 # Add non-root user and entrypoint
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app
 COPY ./infrastructure/docker-entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/scripts/run_eslint.sh
+++ b/scripts/run_eslint.sh
@@ -7,6 +7,7 @@ LOCK_FILE="$BROWSER_DIR/package-lock.json"
 CHECK_FILE="$BROWSER_DIR/node_modules/.package_lock_checksum"
 
 # Always reinstall dependencies for a clean tree
+chmod -R u+w "$BROWSER_DIR/node_modules" 2>/dev/null || true
 rm -rf "$BROWSER_DIR/node_modules"
 npm --prefix "$BROWSER_DIR" cache clean --force >/dev/null
 npm --prefix "$BROWSER_DIR" ci >/dev/null

--- a/stubs/openai_agents/__init__.py
+++ b/stubs/openai_agents/__init__.py
@@ -5,7 +5,7 @@ Provides basic classes so demos import without the real SDK."""
 
 import importlib.machinery
 
-__spec__ = importlib.machinery.ModuleSpec(__name__, importlib.machinery.BuiltinImporter)
+__spec__ = importlib.machinery.ModuleSpec("openai_agents", None)
 
 __version__ = "0.0.0"
 


### PR DESCRIPTION
## Summary
- handle permissions when wiping `node_modules`
- simplify Insight Dockerfile
- expose a `__spec__` object in the `openai_agents` stub

## Testing
- `pytest tests/test_agent_aiga_entrypoint.py::test_import -q` *(fails: Operation cancelled by user)*
- `pre-commit run --hook-stage manual --files alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile scripts/run_eslint.sh stubs/openai_agents/__init__.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687af9aa92f88333992e33e352a3a8d2