### PR TITLE
Fix Docker build context paths

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -12,7 +12,8 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 # copy project source
 COPY . /app
 # copy pre-built React bundle if available
-COPY src/interface/web_client/dist/ /app/src/interface/web_client/dist/
+COPY alpha_factory_v1/core/interface/web_client/dist/ \
+     /app/alpha_factory_v1/core/interface/web_client/dist/
 
 # add non-root user
 RUN adduser --disabled-password --gecos '' afuser && chown -R afuser /app


### PR DESCRIPTION
## Summary
- copy the prebuilt React bundle from the correct web client directory in the infrastructure Dockerfile

## Testing
- `pytest -k 'nothing'`
- `pre-commit run --files infrastructure/Dockerfile` *(failed: shellcheck_py build error)*

------
https://chatgpt.com/codex/tasks/task_e_687b083a82148333a2d657c2ff1c0d15