### PR TITLE
[alpha_factory] stabilize cypress tests

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/adaptive.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/adaptive.cy.ts
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 describe('adaptive toggle', () => {
   it('toggles body attribute', () => {
+    cy.intercept('GET', '**/lineage', [
+      { id: 1, pass_rate: 1 },
+      { id: 2, parent: 1, pass_rate: 1 },
+    ]).as('lineage');
+    cy.intercept('GET', '**/memes', {}).as('memes');
     cy.visit('/');
-    cy.get('#adaptive').check();
+    cy.get('#adaptive', { timeout: 10000 }).check();
     cy.get('body').should('have.attr', 'data-adaptive', 'true');
     cy.get('#adaptive').uncheck();
     cy.get('body').should('not.have.attr', 'data-adaptive');

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/archive.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/archive.cy.ts
@@ -1,14 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 describe('archive page', () => {
   it('renders diff when selecting an agent', () => {
+    cy.intercept('GET', '**/archive', [
+      { hash: 'abc', parent: null, score: 1 },
+    ]).as('list');
+    cy.intercept('GET', '**/archive/abc/diff', 'diff').as('diff');
+    cy.intercept('GET', '**/archive/abc/timeline', []).as('timeline');
     cy.visit('/archive');
+    cy.get('.agent-row button', { timeout: 10000 });
     cy.get('.agent-row button').first().click();
+    cy.get('pre.diff', { timeout: 10000 });
     cy.get('pre.diff').should('be.visible');
   });
 
   it('shows backlink to parent', () => {
+    cy.intercept('GET', '**/archive', [
+      { hash: 'abc', parent: 'def', score: 1 },
+    ]).as('list');
+    cy.intercept('GET', '**/archive/abc/diff', 'diff').as('diff');
+    cy.intercept('GET', '**/archive/abc/timeline', []).as('timeline');
     cy.visit('/archive');
+    cy.get('.agent-row button', { timeout: 10000 });
     cy.get('.agent-row button').first().click();
+    cy.get('a.parent-link', { timeout: 10000 });
     cy.get('a.parent-link').should('have.attr', 'href');
   });
 });

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/dashboard.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/dashboard.cy.ts
@@ -4,13 +4,27 @@ describe('dashboard', () => {
     cy.on('window:before:load', (win) => {
       cy.spy(win.console, 'error').as('consoleError');
     });
+    cy.intercept('GET', '**/lineage', [
+      { id: 1, pass_rate: 1 },
+      { id: 2, parent: 1, pass_rate: 1 },
+      { id: 3, parent: 1, pass_rate: 1 },
+    ]).as('lineage');
+    cy.intercept('GET', '**/memes', {}).as('memes');
     cy.visit('/');
+    cy.get('#lineage-tree', { timeout: 10000 });
     cy.get('#lineage-tree g.slice').should('have.length.gte', 3);
     cy.get('@consoleError').should('not.be.called');
   });
 
   it('shows annotation on hover', () => {
+    cy.intercept('GET', '**/lineage', [
+      { id: 1, pass_rate: 1 },
+      { id: 2, parent: 1, pass_rate: 1 },
+      { id: 3, parent: 1, pass_rate: 1 },
+    ]).as('lineage');
+    cy.intercept('GET', '**/memes', {}).as('memes');
     cy.visit('/');
+    cy.get('#lineage-tree', { timeout: 10000 });
     cy.get('#lineage-tree g.slice').first().trigger('mouseover');
     cy.get('#lineage-tree .hovertext').should('be.visible');
   });

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/debate.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/debate.cy.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 describe('debate arena', () => {
   it('runs debate and updates ranking', () => {
+    cy.intercept('GET', '**/lineage', [
+      { id: 1, pass_rate: 1 },
+      { id: 2, parent: 1, pass_rate: 1 },
+    ]).as('lineage');
+    cy.intercept('GET', '**/memes', {}).as('memes');
     cy.visit('/');
+    cy.get('#start-debate', { timeout: 10000 });
     cy.get('#start-debate').click();
     cy.get('#debate-panel li').should('have.length.at.least', 4);
     cy.get('#ranking li').should('have.length.at.least', 1);

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/responsive.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/responsive.cy.ts
@@ -9,20 +9,38 @@ describe('responsive dashboard', () => {
   viewports.forEach(([w, h]) => {
     it(`renders at ${w}x${h}`, () => {
       cy.viewport(w, h);
+      cy.intercept('GET', '**/lineage', [
+        { id: 1, pass_rate: 1 },
+        { id: 2, parent: 1, pass_rate: 1 },
+      ]).as('lineage');
+      cy.intercept('GET', '**/memes', {}).as('memes');
       cy.visit('/');
+      cy.get('#lineage-tree', { timeout: 10000 });
       cy.get('#lineage-tree').should('be.visible');
     });
   });
 
   it('loads while offline after first visit', () => {
+    cy.intercept('GET', '**/lineage', [
+      { id: 1, pass_rate: 1 },
+      { id: 2, parent: 1, pass_rate: 1 },
+    ]).as('lineage');
+    cy.intercept('GET', '**/memes', {}).as('memes');
     cy.visit('/');
+    cy.get('#lineage-tree', { timeout: 10000 });
     cy.intercept('GET', '**/*', { forceNetworkError: true }).as('offline');
     cy.reload();
     cy.get('#lineage-tree').should('be.visible');
   });
 
   it('copies share link', () => {
+    cy.intercept('GET', '**/lineage', [
+      { id: 1, pass_rate: 1 },
+      { id: 2, parent: 1, pass_rate: 1 },
+    ]).as('lineage');
+    cy.intercept('GET', '**/memes', {}).as('memes');
     cy.visit('/');
+    cy.get('button[type="submit"]', { timeout: 10000 });
     cy.window().then((win) => {
       cy.stub(win.navigator, 'clipboard', {
         writeText: cy.stub().as('copy'),

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/taxonomy.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/taxonomy.cy.ts
@@ -2,6 +2,11 @@
 
 describe('taxonomy persistence', () => {
   it('restores taxonomy tree after reload', () => {
+    cy.intercept('GET', '**/lineage', [
+      { id: 1, pass_rate: 1 },
+      { id: 2, parent: 1, pass_rate: 1 },
+    ]).as('lineage');
+    cy.intercept('GET', '**/memes', {}).as('memes');
     cy.visit('/', {
       onBeforeLoad(win) {
         const req = win.indexedDB.open('sectorTaxonomy', 1);
@@ -15,6 +20,7 @@ describe('taxonomy persistence', () => {
         };
       },
     });
+    cy.get('#taxonomy-tree', { timeout: 10000 });
     cy.get('#taxonomy-tree button').contains('foo');
     cy.reload();
     cy.get('#taxonomy-tree button').contains('foo');

--- a/alpha_factory_v1/core/interface/web_client/cypress/support/e2e.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/support/e2e.ts
@@ -1,2 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import '@percy/cypress';
+
+// Ignore service worker registration failures which cause uncaught exceptions
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('ServiceWorker')) {
+    return false;
+  }
+});
+
+// Stub the service worker to prevent network errors during tests
+beforeEach(() => {
+  cy.intercept('GET', '/service-worker.js', { body: '' }).as('sw');
+});


### PR DESCRIPTION
## Summary
- intercept service worker and ignore related errors
- stub API requests in E2E specs
- add explicit waits for dynamic elements

## Testing
- `npx cypress run` *(fails: Timed out retrying after 10000ms)*

------
https://chatgpt.com/codex/tasks/task_e_687b13bb96d08333b56f2e749ec21cb2