### PR TITLE
[alpha_factory] update Dockerfile path

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -15,8 +15,8 @@ RUN node --version
 WORKDIR /app
 
 # Install Python dependencies for the demo
-COPY requirements.lock /tmp/requirements.lock
-RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock
+COPY alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock /tmp/requirements.lock
+RUN pip install --no-cache-dir --require-hashes -r /tmp/requirements.lock && rm /tmp/requirements.lock
 
 # Copy the project source
 COPY . /app


### PR DESCRIPTION
## Summary
- point Insight demo Dockerfile at the demo lock file

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: many tests failing)*
- `docker build -t agi-insight-demo:ci -f alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile .` *(fails: cannot connect to Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_687b1cc3cb44833388abdb9dfda9677b