### PR TITLE
Fix Docker build by pinning insight dependencies

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -1774,7 +1774,7 @@ noaa-sdk==0.1.21 \
     --hash=sha256:b07ca0b911b584b166e7d433b5814d10083ce52a7f9e3e92d98a3a6bf8a27f18 \
     --hash=sha256:bb1308140cc5f6a5d82132e13cc54c8a8d94a2264607e7c95471ab186f059d7c
     # via -r alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
-numpy>=2.3,<2.4 \
+numpy==2.3.1 \
     --hash=sha256:0255732338c4fdd00996c0421884ea8a3651eea555c3a56b84892b66f696eb70 \
     --hash=sha256:02f226baeefa68f7d579e213d0f3493496397d8f1cff5e2b222af274c86a552a \
     --hash=sha256:059b51b658f4414fff78c6d7b1b4e18283ab5fa56d270ff212d5ba0c561846f4 \
@@ -2168,7 +2168,7 @@ packaging==25.0 \
     #   pytest
     #   streamlit
     #   transformers
-pandas>=2.3,<2.4 \
+pandas==2.3.1 \
     --hash=sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a \
     --hash=sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d \
     --hash=sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5 \

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
@@ -26,8 +26,8 @@ protobuf==4.25.3
 sentence-transformers==4.1.0
 faiss-cpu==1.11.0
 chromadb==1.0.7
-numpy==2.2.5
-pandas==2.2.3
+numpy==2.3.1
+pandas==2.3.1
 scipy==1.15.2
 ortools==9.9.3963
 transformers==4.51.3


### PR DESCRIPTION
## Summary
- pin `numpy` and `pandas` in the Insight demo lock file
- update Insight demo requirements

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt` *(failed: KeyboardInterrupt)*
- `pytest -k "test" -q` *(failed: ModuleNotFoundError: No module named 'adk')*

------
https://chatgpt.com/codex/tasks/task_e_687b752555f88333b9049aa0c2cf3274