### PR TITLE
fix: use docs lock file in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
       - name: Install docs requirements
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-docs.txt
+          pip install -r requirements-docs.lock
       - name: Install base dependencies
         run: python check_env.py --auto-install
       - id: asset-key-docs-build
@@ -475,7 +475,7 @@ jobs:
       - name: Install base dependencies
         run: python check_env.py --auto-install
       - name: Install docs requirements
-        run: pip install -r requirements-docs.txt
+        run: pip install -r requirements-docs.lock
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Install web client dependencies


### PR DESCRIPTION
## Summary
- install docs dependencies from requirements-docs.lock rather than the .txt file so docs build uses pinned versions

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -m smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_687b87d865c08333a4da60301374745c