### PR TITLE
Fix CI pip version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             ${{ runner.os }}-precommit-py${{ matrix.python-version }}-
       - name: Install lint tools
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<25"
           pip install ruff mypy
       - name: Install pre-commit
         run: pip install pre-commit==4.2.0
@@ -125,7 +125,7 @@ jobs:
           cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<25"
           pip install -r requirements.lock -r requirements-dev.lock -r requirements-demo.lock pytest pytest-cov pytest-benchmark mutmut
       - name: Verify environment
         run: |
@@ -286,7 +286,7 @@ jobs:
           cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<25"
           pip install -r requirements.lock -r requirements-dev.lock -r requirements-demo.lock pytest
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -344,7 +344,7 @@ jobs:
           cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<25"
           pip install -r requirements.lock -r requirements-dev.lock -r requirements-demo.lock pytest
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -406,7 +406,7 @@ jobs:
           cache-dependency-path: 'requirements.lock'
       - name: Install docs requirements
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<25"
           pip install -r requirements-docs.lock
       - name: Install base dependencies
         run: python check_env.py --auto-install
@@ -475,7 +475,9 @@ jobs:
       - name: Install base dependencies
         run: python check_env.py --auto-install
       - name: Install docs requirements
-        run: pip install -r requirements-docs.lock
+        run: |
+          python -m pip install --upgrade "pip<25"
+          pip install -r requirements-docs.lock
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Install web client dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # upgrade pip to avoid outdated versions
-RUN python -m pip install --upgrade pip setuptools wheel
+RUN python -m pip install --upgrade "pip<25" setuptools wheel
 
 # Verify Node installation is >=20 (NodeSource script sets up latest LTS)
 RUN node --version


### PR DESCRIPTION
## Summary
- pin pip<25 in workflow jobs to avoid hash failures
- pin pip<25 when building Docker image

## Testing
- `pre-commit run --files Dockerfile .github/workflows/ci.yml`
- `pytest -m smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8d1304a483338fab8254470d899d