### PR TITLE
fix: enable SPA history fallback

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/vite.config.ts
+++ b/alpha_factory_v1/core/interface/web_client/vite.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   plugins: [react(), vue()],
   root: '.',
   envPrefix: 'VITE_',
+  appType: 'spa',
+  server: {
+    historyApiFallback: true,
+  },
   build: {
     outDir: 'dist',
     rollupOptions: {


### PR DESCRIPTION
## Summary
- configure Vite dev server with `historyApiFallback` for SPA routing

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/core/interface/web_client/vite.config.ts` *(failed: KeyboardInterrupt while initializing semgrep)*
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_687b9c9dd4008333b39fbb9242a2d5fd