### PR TITLE
[alpha_factory] Fix Docker build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ WORKDIR /app
 # install Python dependencies
 # Install demo-specific Python dependencies
 COPY alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock /tmp/requirements-demo.lock
-RUN pip install --no-cache-dir -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock
+RUN if [ -f /tmp/requirements-demo.lock ]; then \
+      pip install --no-cache-dir -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock; \
+    else \
+      echo "Missing demo requirements" && exit 1; \
+    fi
 RUN pip install --no-cache-dir "openai_agents>=0.0.17"
 
 # copy minimal package files for the Insight demo


### PR DESCRIPTION
## Summary
- ensure the demo requirements are installed when building the root Dockerfile

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError: API...)*
- `pre-commit run --files Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_687bab8eb70083339513e7cf0264ce83