### PR TITLE
[alpha_factory] update archive API paths

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/archive.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/archive.cy.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 describe('archive page', () => {
   it('renders diff when selecting an agent', () => {
-    cy.intercept('GET', '**/archive', [
+    cy.intercept('GET', '**/api/archive*', [
       { hash: 'abc', parent: null, score: 1 },
     ]).as('list');
-    cy.intercept('GET', '**/archive/abc/diff', 'diff').as('diff');
-    cy.intercept('GET', '**/archive/abc/timeline', []).as('timeline');
+    cy.intercept('GET', '**/api/archive/abc/diff', 'diff').as('diff');
+    cy.intercept('GET', '**/api/archive/abc/timeline', []).as('timeline');
     cy.visit('/archive');
     cy.get('.agent-row button', { timeout: 10000 });
     cy.get('.agent-row button').first().click();
@@ -14,11 +14,11 @@ describe('archive page', () => {
   });
 
   it('shows backlink to parent', () => {
-    cy.intercept('GET', '**/archive', [
+    cy.intercept('GET', '**/api/archive*', [
       { hash: 'abc', parent: 'def', score: 1 },
     ]).as('list');
-    cy.intercept('GET', '**/archive/abc/diff', 'diff').as('diff');
-    cy.intercept('GET', '**/archive/abc/timeline', []).as('timeline');
+    cy.intercept('GET', '**/api/archive/abc/diff', 'diff').as('diff');
+    cy.intercept('GET', '**/api/archive/abc/timeline', []).as('timeline');
     cy.visit('/archive');
     cy.get('.agent-row button', { timeout: 10000 });
     cy.get('.agent-row button').first().click();

--- a/alpha_factory_v1/core/interface/web_client/src/pages/Archive.tsx
+++ b/alpha_factory_v1/core/interface/web_client/src/pages/Archive.tsx
@@ -13,7 +13,7 @@ interface TimelinePoint {
   ts: number;
 }
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+const API_BASE = `${(import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '')}/api`;
 
 export default function Archive() {
   const { t } = useI18n();


### PR DESCRIPTION
## Summary
- adjust `Archive.tsx` API base to include `/api`
- update Cypress specs for new `/api/archive` routes

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 33 failed, 5 errors)*
- `pre-commit run --files alpha_factory_v1/core/interface/web_client/src/pages/Archive.tsx alpha_factory_v1/core/interface/web_client/cypress/e2e/archive.cy.ts` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_687baf9c8b94833393eace1a46bf5ce4