### PR TITLE
Scope API under /api

### DIFF
--- a/alpha_factory_v1/backend/trace_ws.py
+++ b/alpha_factory_v1/backend/trace_ws.py
@@ -144,7 +144,7 @@ hub = TraceHub()
 # --------------------------------------------------------------------- #
 # FastAPI / Starlette integration                                       #
 # --------------------------------------------------------------------- #
-def attach(app) -> None:  # noqa: D401
+def attach(app, prefix: str = "") -> None:  # noqa: D401
     """
     Dynamically mount the ``/ws/trace`` WebSocket endpoint on *app*.
 
@@ -163,7 +163,7 @@ def attach(app) -> None:  # noqa: D401
     # Import the CSRF token buffer exposed by backend.__init__
     _api_buffer: dict[str, float] = import_module("backend")._api_buffer  # type: ignore[attr-defined]
 
-    router = APIRouter()
+    router = APIRouter(prefix=prefix)
 
     @router.websocket("/ws/trace")
     async def _trace_ws(websocket: WebSocket):

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/adaptive.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/adaptive.cy.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 describe('adaptive toggle', () => {
   it('toggles body attribute', () => {
-    cy.intercept('GET', '**/lineage', [
+    cy.intercept('GET', '**/api/lineage', [
       { id: 1, pass_rate: 1 },
       { id: 2, parent: 1, pass_rate: 1 },
     ]).as('lineage');
-    cy.intercept('GET', '**/memes', {}).as('memes');
+    cy.intercept('GET', '**/api/memes', {}).as('memes');
     cy.visit('/');
     cy.get('#adaptive', { timeout: 10000 }).check();
     cy.get('body').should('have.attr', 'data-adaptive', 'true');

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/dashboard.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/dashboard.cy.ts
@@ -4,12 +4,12 @@ describe('dashboard', () => {
     cy.on('window:before:load', (win) => {
       cy.spy(win.console, 'error').as('consoleError');
     });
-    cy.intercept('GET', '**/lineage', [
+    cy.intercept('GET', '**/api/lineage', [
       { id: 1, pass_rate: 1 },
       { id: 2, parent: 1, pass_rate: 1 },
       { id: 3, parent: 1, pass_rate: 1 },
     ]).as('lineage');
-    cy.intercept('GET', '**/memes', {}).as('memes');
+    cy.intercept('GET', '**/api/memes', {}).as('memes');
     cy.visit('/');
     cy.get('#lineage-tree', { timeout: 10000 });
     cy.get('#lineage-tree g.slice').should('have.length.gte', 3);
@@ -17,12 +17,12 @@ describe('dashboard', () => {
   });
 
   it('shows annotation on hover', () => {
-    cy.intercept('GET', '**/lineage', [
+    cy.intercept('GET', '**/api/lineage', [
       { id: 1, pass_rate: 1 },
       { id: 2, parent: 1, pass_rate: 1 },
       { id: 3, parent: 1, pass_rate: 1 },
     ]).as('lineage');
-    cy.intercept('GET', '**/memes', {}).as('memes');
+    cy.intercept('GET', '**/api/memes', {}).as('memes');
     cy.visit('/');
     cy.get('#lineage-tree', { timeout: 10000 });
     cy.get('#lineage-tree g.slice').first().trigger('mouseover');

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/debate.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/debate.cy.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 describe('debate arena', () => {
   it('runs debate and updates ranking', () => {
-    cy.intercept('GET', '**/lineage', [
+    cy.intercept('GET', '**/api/lineage', [
       { id: 1, pass_rate: 1 },
       { id: 2, parent: 1, pass_rate: 1 },
     ]).as('lineage');
-    cy.intercept('GET', '**/memes', {}).as('memes');
+    cy.intercept('GET', '**/api/memes', {}).as('memes');
     cy.visit('/');
     cy.get('#start-debate', { timeout: 10000 });
     cy.get('#start-debate').click();

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/responsive.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/responsive.cy.ts
@@ -9,11 +9,11 @@ describe('responsive dashboard', () => {
   viewports.forEach(([w, h]) => {
     it(`renders at ${w}x${h}`, () => {
       cy.viewport(w, h);
-      cy.intercept('GET', '**/lineage', [
+      cy.intercept('GET', '**/api/lineage', [
         { id: 1, pass_rate: 1 },
         { id: 2, parent: 1, pass_rate: 1 },
       ]).as('lineage');
-      cy.intercept('GET', '**/memes', {}).as('memes');
+      cy.intercept('GET', '**/api/memes', {}).as('memes');
       cy.visit('/');
       cy.get('#lineage-tree', { timeout: 10000 });
       cy.get('#lineage-tree').should('be.visible');
@@ -21,11 +21,11 @@ describe('responsive dashboard', () => {
   });
 
   it('loads while offline after first visit', () => {
-    cy.intercept('GET', '**/lineage', [
+    cy.intercept('GET', '**/api/lineage', [
       { id: 1, pass_rate: 1 },
       { id: 2, parent: 1, pass_rate: 1 },
     ]).as('lineage');
-    cy.intercept('GET', '**/memes', {}).as('memes');
+    cy.intercept('GET', '**/api/memes', {}).as('memes');
     cy.visit('/');
     cy.get('#lineage-tree', { timeout: 10000 });
     cy.intercept('GET', '**/*', { forceNetworkError: true }).as('offline');
@@ -34,11 +34,11 @@ describe('responsive dashboard', () => {
   });
 
   it('copies share link', () => {
-    cy.intercept('GET', '**/lineage', [
+    cy.intercept('GET', '**/api/lineage', [
       { id: 1, pass_rate: 1 },
       { id: 2, parent: 1, pass_rate: 1 },
     ]).as('lineage');
-    cy.intercept('GET', '**/memes', {}).as('memes');
+    cy.intercept('GET', '**/api/memes', {}).as('memes');
     cy.visit('/');
     cy.get('button[type="submit"]', { timeout: 10000 });
     cy.window().then((win) => {

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/stake.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/stake.cy.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 describe('staking flow', () => {
   it('stakes tokens and retrieves proof', () => {
-    cy.intercept('POST', '/stake', { statusCode: 200 }).as('stake');
-    cy.intercept('POST', '/dispatch', { statusCode: 200 }).as('dispatch');
-    cy.intercept('GET', /\/proof\/.+/, { cid: 'Qm123', proof: 'proof' }).as('proof');
+    cy.intercept('POST', '/api/stake', { statusCode: 200 }).as('stake');
+    cy.intercept('POST', '/api/dispatch', { statusCode: 200 }).as('dispatch');
+    cy.intercept('GET', /\/api\/proof\/.+/, { cid: 'Qm123', proof: 'proof' }).as('proof');
     cy.visit('/staking/index.html');
     cy.get('input').type('1');
     cy.contains('Stake').click();

--- a/alpha_factory_v1/core/interface/web_client/cypress/e2e/taxonomy.cy.ts
+++ b/alpha_factory_v1/core/interface/web_client/cypress/e2e/taxonomy.cy.ts
@@ -2,11 +2,11 @@
 
 describe('taxonomy persistence', () => {
   it('restores taxonomy tree after reload', () => {
-    cy.intercept('GET', '**/lineage', [
+    cy.intercept('GET', '**/api/lineage', [
       { id: 1, pass_rate: 1 },
       { id: 2, parent: 1, pass_rate: 1 },
     ]).as('lineage');
-    cy.intercept('GET', '**/memes', {}).as('memes');
+    cy.intercept('GET', '**/api/memes', {}).as('memes');
     cy.visit('/', {
       onBeforeLoad(win) {
         const req = win.indexedDB.open('sectorTaxonomy', 1);

--- a/alpha_factory_v1/core/interface/web_client/dist/app.js
+++ b/alpha_factory_v1/core/interface/web_client/dist/app.js
@@ -8,7 +8,7 @@
     const [data, setData] = useState([]);
     const [population, setPopulation] = useState([]);
     const [runs, setRuns] = useState([]);
-    const API_BASE = (window.API_BASE_URL || '').replace(/\/$/, '');
+    const API_BASE = (window.API_BASE_URL || '/api').replace(/\/$/, '');
     const TOKEN = window.API_TOKEN || '';
 
     async function fetchLatest(){

--- a/alpha_factory_v1/core/interface/web_client/index.md
+++ b/alpha_factory_v1/core/interface/web_client/index.md
@@ -21,8 +21,8 @@ npm run build      # build production assets in `dist/`
 The build step uses Workbox to generate `service-worker.js` and precache the
 site's assets so the demo can load offline.
 
-Set `VITE_API_BASE_URL` to change the API path prefix and `VITE_API_TOKEN` to
-embed the API bearer token at build time:
+`VITE_API_BASE_URL` defaults to `/api`. Override it and `VITE_API_TOKEN` to embed
+the API bearer token at build time:
 
 ```bash
 # prepend '/api' to all requests and embed a token

--- a/alpha_factory_v1/core/interface/web_client/pages/Archive.vue
+++ b/alpha_factory_v1/core/interface/web_client/pages/Archive.vue
@@ -39,7 +39,7 @@ import { ref, onMounted } from 'vue';
 interface Agent { hash: string; parent: string | null; score: number; }
 interface TimelinePoint { tool: string; ts: number; }
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '/api').replace(/\/$/, '');
 
 const agents = ref<Agent[]>([]);
 const diff = ref('');

--- a/alpha_factory_v1/core/interface/web_client/src/App.tsx
+++ b/alpha_factory_v1/core/interface/web_client/src/App.tsx
@@ -40,7 +40,7 @@ export default function App() {
   const [data, setData] = useState<ForecastPoint[]>([]);
   const [population, setPopulation] = useState<PopulationMember[]>([]);
   const [runs, setRuns] = useState<string[]>([]);
-  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '/api').replace(/\/$/, '');
   const TOKEN = import.meta.env.VITE_API_TOKEN ?? '';
 
   useEffect(() => {

--- a/alpha_factory_v1/core/interface/web_client/src/pages/Archive.tsx
+++ b/alpha_factory_v1/core/interface/web_client/src/pages/Archive.tsx
@@ -13,7 +13,7 @@ interface TimelinePoint {
   ts: number;
 }
 
-const API_BASE = `${(import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '')}/api`;
+const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '/api').replace(/\/$/, '');
 
 export default function Archive() {
   const { t } = useI18n();

--- a/alpha_factory_v1/core/interface/web_client/src/pages/Dashboard.tsx
+++ b/alpha_factory_v1/core/interface/web_client/src/pages/Dashboard.tsx
@@ -41,7 +41,7 @@ export default function Dashboard() {
   const buffer = useRef<ForecastPoint[]>([]);
   const flushRef = useRef<number | null>(null);
 
-  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '/api').replace(/\/$/, '');
   const TOKEN = import.meta.env.VITE_API_TOKEN ?? '';
   const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
 

--- a/alpha_factory_v1/core/interface/web_client/staking/src/App.tsx
+++ b/alpha_factory_v1/core/interface/web_client/staking/src/App.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { ethers } from 'ethers';
 
 const ABI = ["function stake() payable"];
-const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '/api').replace(/\/$/, '');
 const CONTRACT_ADDRESS = import.meta.env.VITE_CONTRACT_ADDRESS ?? '';
 
 export default function App() {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js
@@ -4,7 +4,7 @@
   function App() {
     const [timeline, setTimeline] = useState([]);
     const [sectors, setSectors] = useState([]);
-    const API_BASE = '';
+    const API_BASE = '/api';
     const TOKEN = '';
     const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
     useEffect(() => {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx
@@ -23,7 +23,7 @@ function App() {
   const [runId, setRunId] = useState<string | null>(null);
   const [timeline, setTimeline] = useState<ProgressMsg[]>([]);
   const [sectors, setSectors] = useState<string[]>([]);
-  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+  const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '/api').replace(/\/$/, '');
   const TOKEN = import.meta.env.VITE_API_TOKEN ?? '';
   const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
 

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -22,12 +22,12 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 USER afuser
 
 ENV PYTHONUNBUFFERED=1
-ARG VITE_API_BASE_URL=/
+ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 
 # verify the API server is responsive
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD \
-  curl -fsS http://localhost:8000/runs || exit 1
+  curl -fsS http://localhost:8000/api/runs || exit 1
 
 EXPOSE 8000 8501 6006
 ENTRYPOINT ["entrypoint.sh"]

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       AWS_REGION: ${AWS_REGION:-}
       OPENAI_API_KEY_SECRET_ID: ${OPENAI_API_KEY_SECRET_ID:-}
       AGI_INSIGHT_OFFLINE: ${AGI_INSIGHT_OFFLINE:-0} # set 1 for local models
-      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-/}
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-/api}
     ports:
       - "8501:8501"                           # host:container dashboard port
     depends_on:


### PR DESCRIPTION
## Summary
- mount FastAPI router under `/api`
- update WebSocket attach helper for prefix
- default the web client API base path to `/api`
- set `/api` in Docker compose and Dockerfile
- update Cypress intercepts for new API prefix

## Testing
- `pre-commit run --files alpha_factory_v1/backend/__init__.py alpha_factory_v1/backend/trace_ws.py alpha_factory_v1/core/interface/web_client/cypress/e2e/adaptive.cy.ts alpha_factory_v1/core/interface/web_client/cypress/e2e/dashboard.cy.ts alpha_factory_v1/core/interface/web_client/cypress/e2e/debate.cy.ts alpha_factory_v1/core/interface/web_client/cypress/e2e/responsive.cy.ts alpha_factory_v1/core/interface/web_client/cypress/e2e/stake.cy.ts alpha_factory_v1/core/interface/web_client/cypress/e2e/taxonomy.cy.ts alpha_factory_v1/core/interface/web_client/dist/app.js alpha_factory_v1/core/interface/web_client/index.md alpha_factory_v1/core/interface/web_client/pages/Archive.vue alpha_factory_v1/core/interface/web_client/src/App.tsx alpha_factory_v1/core/interface/web_client/src/pages/Archive.tsx alpha_factory_v1/core/interface/web_client/src/pages/Dashboard.tsx alpha_factory_v1/core/interface/web_client/staking/src/App.tsx alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/dist/app.js alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/src/main.tsx infrastructure/Dockerfile infrastructure/docker-compose.yml`
- `pytest -q` *(fails: AttributeError and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_687bbef862b8833396fccec47787cea3