### PR TITLE
Update docker build context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,7 +640,7 @@ jobs:
       - name: Build image
         run: |
           docker build -t "$DOCKER_IMAGE:ci" \
-            -f alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile \
+            -f infrastructure/Dockerfile \
             alpha_factory_v1/demos/alpha_agi_insight_v1
       - name: Smoke test image
         run: |

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/.dockerignore
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/.dockerignore
@@ -1,0 +1,25 @@
+# Ignore temporary files and dev artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.pyc
+*.pytest_cache/
+*.coverage
+*.egg-info/
+build/
+dist/
+.eggs/
+*.log
+*.tmp
+*.swp
+.cache/
+.git/
+.gitignore
+Dockerfile*
+.dockerignore
+.env
+*.env
+*.md
+insight_browser_v1/node_modules/
+!requirements.lock


### PR DESCRIPTION
## Summary
- set context for insight image build to the demo folder
- add .dockerignore for the demo so requirements.lock is included

## Testing
- `pre-commit run --files .github/workflows/ci.yml alpha_factory_v1/demos/alpha_agi_insight_v1/.dockerignore`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: test_openai_agents_stub_call, test_import_without_openaiagent, test_agent_registration_and_heartbeat, ...)*

------
https://chatgpt.com/codex/tasks/task_e_687bd9aad96c8333ac3701d5e0b3451b