### PR TITLE
[alpha_factory] enable spa fallback

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/vite.config.ts
+++ b/alpha_factory_v1/core/interface/web_client/vite.config.ts
@@ -9,7 +9,16 @@ export default defineConfig({
   envPrefix: 'VITE_',
   appType: 'spa',
   server: {
-    historyApiFallback: true,
+    historyApiFallback: {
+      index: '/index.html',
+      disableDotRule: true,
+    },
+  },
+  preview: {
+    historyApiFallback: {
+      index: '/index.html',
+      disableDotRule: true,
+    },
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- configure Vite dev/preview servers to always serve `index.html`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest` *(fails: 217 failed, 571 passed, 72 skipped)*
- `pre-commit run --files alpha_factory_v1/core/interface/web_client/vite.config.ts`
- `npm run test:cypress` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bdcd219bc8333a353d27ad943de19