### PR TITLE
fix: copy demo lockfile correctly

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -15,7 +15,8 @@ RUN node --version
 WORKDIR /app
 
 # Install Python dependencies for the demo
-COPY requirements.lock /tmp/requirements.lock
+# The build context is the demo directory so copy the lock file directly
+COPY ./requirements.lock /tmp/requirements.lock
 # Installing without `--require-hashes` avoids failures when platform specific
 # wheels are pulled in by pip. The lock file still pins exact versions.
 RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock


### PR DESCRIPTION
## Summary
- copy demo lockfile from build context so Docker build works

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_687bf3970a8483338e4f43c5120b52bd