### PR TITLE
[alpha_factory] fix ci smoke installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock pytest
+          pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
       - name: Install macOS extras
         run: pip install appnope==0.1.4
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -347,7 +347,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock pytest
+          pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
## Summary
- install CPU lock dependencies on Windows and macOS smoke jobs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile`
- `pytest tests/test_ping_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf7f1e92c83339b118a2ba1c3824e