### PR TITLE
[alpha_factory] drop uvloop on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,8 +267,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
-      - name: Install macOS extras
-        run: pip install appnope==0.1.4
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
@@ -327,6 +325,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
+      - name: Install macOS extras
+        run: pip install appnope==0.1.4
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'

--- a/requirements-cpu.lock
+++ b/requirements-cpu.lock
@@ -3344,7 +3344,7 @@ uvicorn[standard]==0.35.0 \
     #   google-adk
     #   gradio
     #   mcp
-uvloop==0.21.0 \
+uvloop==0.21.0 ; sys_platform != 'win32' \
     --hash=sha256:0878c2640cf341b269b7e128b1a5fed890adc4455513ca710d77d5e93aa6d6a0 \
     --hash=sha256:10d66943def5fcb6e7b37310eb6b5639fd2ccbc38df1177262b0640c3ca68c1f \
     --hash=sha256:10da8046cc4a8f12c91a1c39d1dd1585c41162a15caaef165c2174db9ef18bdc \


### PR DESCRIPTION
## Summary
- exclude `uvloop` on Windows
- tweak CI smoke jobs to install macOS extras only on macOS

## Testing
- `pre-commit run --files requirements-cpu.lock .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_687c0d7b167c8333a4d552b3e9e6bb00