### PR TITLE
ci: install playwright before verifying demo pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,8 @@ jobs:
           fi
       - name: Install Playwright browsers
         run: python -m playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
+      - name: Install Playwright browsers (Node)
+        run: npx playwright install
       - name: Verify demo pages
         run: python scripts/verify_demo_pages.py
       - name: Verify Insight PWA offline


### PR DESCRIPTION
## Summary
- install Playwright browsers with `npx` right before docs verification

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687c344572048333a7ec24f867b64863