### PR TITLE
[alpha_factory] include web client dist in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,3 +35,4 @@ alpha_factory_v1/demos/*
 !alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
 !requirements-demo.txt
 !alpha_factory_v1/core/interface/web_client/dist/
+!alpha_factory_v1/core/interface/web_client/dist/**


### PR DESCRIPTION
## Summary
- ensure `alpha_factory_v1/core/interface/web_client/dist` contents are copied during Docker builds

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -k 'this_test_does_not_exist' --maxfail=1 --cov --cov-report=xml` *(fails: KeyboardInterrupt)*
- `pre-commit run --files .dockerignore` *(fails: Interrupted)*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c368953c88333be9c6cace777258e