### PR TITLE
docs: add lock update script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,17 @@ pre-commit run --files .github/workflows/ci.yml
 
 Regenerate the lock files whenever you modify `requirements*.txt`:
 
+Run `scripts/update_root_lock_files.sh` to regenerate all lock files in a single
+pass. The helper calls `pip-compile` for each requirements file so that shared
+dependencies like `aiohttp` resolve to the same versions across the project:
+
 ```bash
-pip-compile --upgrade --allow-unsafe --generate-hashes \
-  --output-file requirements.lock requirements.txt
+./scripts/update_root_lock_files.sh
 ```
+
+The script writes `requirements.lock`, `requirements-dev.lock`,
+`requirements-docs.lock`, `requirements-demo.lock`, `requirements-cpu.lock` and
+`requirements-demo-cpu.lock`.
 
 ### Pre-commit in Air-Gapped Setups
 

--- a/scripts/update_root_lock_files.sh
+++ b/scripts/update_root_lock_files.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Regenerate top-level lock files in one pass.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if command -v pip-compile >/dev/null; then
+    PIP_COMPILE=pip-compile
+else
+    PIP_COMPILE="python -m piptools compile"
+fi
+
+opts=(--upgrade --allow-unsafe --generate-hashes)
+
+$PIP_COMPILE "${opts[@]}" requirements.txt -o requirements.lock
+$PIP_COMPILE "${opts[@]}" requirements-dev.txt -o requirements-dev.lock
+$PIP_COMPILE "${opts[@]}" requirements-docs.txt -o requirements-docs.lock
+$PIP_COMPILE "${opts[@]}" requirements-demo.txt -o requirements-demo.lock
+$PIP_COMPILE "${opts[@]}" --index-url=https://pypi.org/simple \
+    requirements-demo.txt requirements-dev.txt requirements.txt \
+    -o requirements-cpu.new
+mv requirements-cpu.new requirements-cpu.lock
+$PIP_COMPILE "${opts[@]}" --index-url=https://pypi.org/simple \
+    requirements-demo.txt -o requirements-demo-cpu.new
+mv requirements-demo-cpu.new requirements-demo-cpu.lock


### PR DESCRIPTION
## Summary
- add a helper script that regenerates all root lock files
- document lock update process in the contributing guide

## Testing
- ❌ `pre-commit run --files scripts/update_root_lock_files.sh CONTRIBUTING.md` *(failed to run: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687c395128d083339e041e2f8fb593d0