### PR TITLE
[alpha_factory] adjust uvicorn extras

### DIFF
--- a/alpha_factory_v1/requirements-core.txt
+++ b/alpha_factory_v1/requirements-core.txt
@@ -5,11 +5,12 @@
 
 # Core web runtimes
 fastapi>=0.111,<1.0
-uvicorn[standard]~=0.34
+uvicorn~=0.34
 flask~=3.0
 gunicorn~=21.2
 orjson~=3.9
 websockets~=15.0
+uvloop~=0.21 ; (sys_platform != "win32" and sys_platform != "darwin")
 
 # Utilities / config / governance
 python-dotenv~=1.0

--- a/requirements-cpu.lock
+++ b/requirements-cpu.lock
@@ -3681,9 +3681,8 @@ urllib3==2.5.0 \
     #   qdrant-client
     #   requests
     #   types-requests
-uvicorn==0.35.0 \
-    --hash=sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a \
-    --hash=sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01
+uvicorn==0.34.3 \
+    --hash=sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a
     # via
     #   -r alpha_factory_v1/requirements-core.txt
     #   google-adk

--- a/requirements-demo-cpu.lock
+++ b/requirements-demo-cpu.lock
@@ -1501,9 +1501,8 @@ urllib3==2.5.0 \
     # via
     #   requests
     #   types-requests
-uvicorn==0.35.0 \
-    --hash=sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a \
-    --hash=sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01
+uvicorn==0.34.3 \
+    --hash=sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a
     # via
     #   gradio
     #   mcp


### PR DESCRIPTION
## Summary
- avoid installing `uvloop` on Windows and macOS
- update CPU lock files to match

## Testing
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 105 failed, 305 passed, 59 skipped, 1 xfailed, 19 warnings, 5 errors)*
- `pre-commit run --files alpha_factory_v1/requirements-core.txt requirements-cpu.lock requirements-demo-cpu.lock`


------
https://chatgpt.com/codex/tasks/task_e_687c3d9f9f4883339fa3a23ae53608ed