### PR TITLE
[alpha_factory] update torch wheel reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,8 +265,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
-      - name: Install torch CPU wheel
-        run: pip install torch==2.7.1
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
@@ -324,8 +322,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
-      - name: Install torch CPU wheel
-        run: pip install torch==2.7.1
       - name: Install macOS extras
         run: pip install appnope==0.1.4
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020

--- a/requirements-cpu.lock
+++ b/requirements-cpu.lock
@@ -3532,7 +3532,7 @@ tomlkit==0.13.3 \
     --hash=sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1 \
     --hash=sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0
     # via gradio
-torch==2.7.1 \
+torch==2.7.1+cpu \
     --hash=sha256:03563603d931e70722dce0e11999d53aa80a375a3d78e6b39b9f6805ea0a8d28 \
     --hash=sha256:06eea61f859436622e78dd0cdd51dbc8f8c6d76917a9cf0555a333f9eac31ec1 \
     --hash=sha256:0da4f4dba9f65d0d203794e619fe7ca3247a55ffdcbd17ae8fb83c8b2dc9b585 \


### PR DESCRIPTION
## Summary
- pin torch==2.7.1+cpu in requirements-cpu.lock
- remove manual torch install from Windows and macOS smoke tests

## Testing
- `pre-commit run --files requirements-cpu.lock requirements-demo-cpu.lock .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 65 failed, 169 passed, 33 skipped, 1 xfailed, 14 warnings, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c42b418bc83339fe2a57410d2221e