### PR TITLE
[alpha_factory] update lint-type npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Clean insight browser node_modules
         run: |
           rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+          npm cache verify
           npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Run pre-commit checks
         run: pre-commit run --all-files


### PR DESCRIPTION
## Summary
- delete `node_modules` before running `npm ci` and verify npm cache

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_687c458c394483338c053856500ac1f7