### PR TITLE
[alpha_factory] build web client before docker build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,6 +83,11 @@ jobs:
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
 
+      - name: Build web client
+        run: |
+          make build_web
+          test -f alpha_factory_v1/core/interface/web_client/dist/index.html
+
       - name: Build Docker image
         run: |
           docker build --build-arg "PYTHON_VERSION=${{ matrix.python-version }}" \


### PR DESCRIPTION
## Summary
- ensure web client is built before Docker image
- check the dist index exists prior to building

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 34 failed, 108 passed, 31 skipped, 1 xfailed, 7 warnings, 5 errors)*
- `pre-commit run --files .github/workflows/build-and-test.yml` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687c47d32d6c83339f03df0679531bc9