### PR TITLE
Improve CI stability for docs and browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-docs.lock
+          pip install requests
       - name: Install base dependencies
         run: python check_env.py --auto-install
       - id: asset-key-docs-build

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
@@ -23,10 +23,9 @@ function startServer(dir) {
   });
 }
 
-if (process.env.CI) {
-  test.skip('service worker update reloads page', () => {});
-} else {
-  test('service worker update reloads page', async () => {
+const skip = !!process.env.CI;
+
+test('service worker update reloads page', { skip }, async () => {
   let browser;
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const dist = path.resolve(__dirname, '../dist');
@@ -63,7 +62,6 @@ if (process.env.CI) {
   } finally {
     if (browser) await browser.close();
     server.close();
-    await fs.writeFile(swPath, original);
+  await fs.writeFile(swPath, original);
   }
   });
-}


### PR DESCRIPTION
## Summary
- skip service worker update test automatically in CI
- ensure docs job installs `requests`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_687c7552810c8333a8f91bc1faa1af18