### PR TITLE
Fix flaky service worker test in CI

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js
@@ -23,9 +23,10 @@ function startServer(dir) {
   });
 }
 
-const skip = !!process.env.CI;
-
-test('service worker update reloads page', { skip }, async () => {
+if (process.env.CI) {
+  test.skip('service worker update reloads page', () => {});
+} else {
+  test('service worker update reloads page', async () => {
   let browser;
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const dist = path.resolve(__dirname, '../dist');
@@ -65,3 +66,4 @@ test('service worker update reloads page', { skip }, async () => {
   await fs.writeFile(swPath, original);
   }
   });
+}


### PR DESCRIPTION
## Summary
- skip `service worker update reloads page` when running under CI

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_sw_update.js`
- `python check_env.py --auto-install`

------
https://chatgpt.com/codex/tasks/task_e_687cde4f38488333a1efa94cc1b7c9f8