### PR TITLE
fix: improve offline check stability

### DIFF
--- a/scripts/verify_insight_offline.py
+++ b/scripts/verify_insight_offline.py
@@ -5,33 +5,56 @@
 from __future__ import annotations
 
 import sys
-from playwright.sync_api import sync_playwright, Error as PlaywrightError
+from playwright.sync_api import Error as PlaywrightError, sync_playwright
+import time
 
 
 URL = "http://localhost:8000/alpha_agi_insight_v1/"
 
+TIMEOUT_MS = 90_000
 
-def main() -> int:
+
+def _print_console(logs: list[str]) -> None:
+    if logs:
+        print("--- Browser console logs ---", file=sys.stderr)
+        for line in logs:
+            print(line, file=sys.stderr)
+
+
+def _attempt() -> bool:
+    logs: list[str] = []
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             context = browser.new_context()
             page = context.new_page()
+            page.on("console", lambda msg: logs.append(f"[{msg.type}] {msg.text}"))
             page.goto(URL)
-            page.wait_for_function("navigator.serviceWorker.ready")
-            page.wait_for_selector("body")
+            page.wait_for_function("navigator.serviceWorker.ready", timeout=TIMEOUT_MS)
+            page.wait_for_selector("body", timeout=TIMEOUT_MS)
             context.set_offline(True)
             page.reload()
-            page.wait_for_selector("body")
-            page.wait_for_selector("#tree-container .node", timeout=15000)
+            page.wait_for_selector("body", timeout=TIMEOUT_MS)
+            page.wait_for_selector("#tree-container .node", timeout=TIMEOUT_MS)
             browser.close()
-        return 0
+        return True
     except PlaywrightError as exc:
         print(f"Playwright error: {exc}", file=sys.stderr)
-        return 1
     except Exception as exc:  # noqa: BLE001
         print(f"Offline check failed: {exc}", file=sys.stderr)
-        return 1
+
+    _print_console(logs)
+    return False
+
+
+def main() -> int:
+    for attempt in range(2):
+        if _attempt():
+            return 0
+        if attempt == 0:
+            print("Retrying offline check...", file=sys.stderr)
+            time.sleep(2)
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- increase wait timeouts in `verify_insight_offline.py`
- retry once and dump console logs on failure

## Testing
- `pre-commit run --hook-stage manual --files scripts/verify_insight_offline.py`
- `mkdocs build --strict`
- `python scripts/verify_insight_offline.py` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_687d0824489483339e4a106dabef571b