### PR TITLE
[alpha_factory] Include core requirements in Dockerfile

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -6,8 +6,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 WORKDIR /app
 
 # install Python dependencies
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+# copy both requirement files so relative includes resolve during build
+COPY requirements.txt alpha_factory_v1/requirements-core.txt /tmp/
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt /tmp/requirements-core.txt
 
 # copy project source
 COPY . /app


### PR DESCRIPTION
## Summary
- ensure `alpha_factory_v1/requirements-core.txt` is available during Docker build

## Testing
- `pre-commit run --files infrastructure/Dockerfile`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`
- `pytest --cov --cov-report=xml` *(fails: 220 failed, 17 errors)*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0e8ca0508333a553b4313840f9b4