### PR TITLE
[alpha_factory] restrict CUDA wheels to Linux

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -1848,7 +1848,7 @@ numpy==2.3.1 \
     #   streamlit
     #   transformers
     #   yfinance
-nvidia-cublas-cu12==12.6.4.1 \
+nvidia-cublas-cu12==12.6.4.1 ; platform_system == "Linux" \
     --hash=sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb \
     --hash=sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668 \
     --hash=sha256:9e4fa264f4d8a4eb0cdbd34beadc029f453b3bafae02401e999cf3d5a5af75f8
@@ -1856,56 +1856,56 @@ nvidia-cublas-cu12==12.6.4.1 \
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.6.80 \
+nvidia-cuda-cupti-cu12==12.6.80 ; platform_system == "Linux" \
     --hash=sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc \
     --hash=sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4 \
     --hash=sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132 \
     --hash=sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73 \
     --hash=sha256:bbe6ae76e83ce5251b56e8c8e61a964f757175682bbad058b170b136266ab00a
     # via torch
-nvidia-cuda-nvrtc-cu12==12.6.77 \
+nvidia-cuda-nvrtc-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53 \
     --hash=sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13 \
     --hash=sha256:f7007dbd914c56bd80ea31bc43e8e149da38f68158f423ba845fc3292684e45a
     # via torch
-nvidia-cuda-runtime-cu12==12.6.77 \
+nvidia-cuda-runtime-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd \
     --hash=sha256:86c58044c824bf3c173c49a2dbc7a6c8b53cb4e4dca50068be0bf64e9dab3f7f \
     --hash=sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8 \
     --hash=sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7 \
     --hash=sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e
     # via torch
-nvidia-cudnn-cu12==9.5.1.17 \
+nvidia-cudnn-cu12==9.5.1.17 ; platform_system == "Linux" \
     --hash=sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2 \
     --hash=sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def \
     --hash=sha256:d7af0f8a4f3b4b9dbb3122f2ef553b45694ed9c384d5a75bab197b8eefb79ab8
     # via torch
-nvidia-cufft-cu12==11.3.0.4 \
+nvidia-cufft-cu12==11.3.0.4 ; platform_system == "Linux" \
     --hash=sha256:6048ebddfb90d09d2707efb1fd78d4e3a77cb3ae4dc60e19aab6be0ece2ae464 \
     --hash=sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca \
     --hash=sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb \
     --hash=sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5 \
     --hash=sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6
     # via torch
-nvidia-cufile-cu12==1.11.1.6 \
+nvidia-cufile-cu12==1.11.1.6 ; platform_system == "Linux" \
     --hash=sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db \
     --hash=sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159
     # via torch
-nvidia-curand-cu12==10.3.7.77 \
+nvidia-curand-cu12==10.3.7.77 ; platform_system == "Linux" \
     --hash=sha256:6d6d935ffba0f3d439b7cd968192ff068fafd9018dbf1b85b37261b13cfc9905 \
     --hash=sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8 \
     --hash=sha256:7b2ed8e95595c3591d984ea3603dd66fe6ce6812b886d59049988a712ed06b6e \
     --hash=sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117 \
     --hash=sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf
     # via torch
-nvidia-cusolver-cu12==11.7.1.2 \
+nvidia-cusolver-cu12==11.7.1.2 ; platform_system == "Linux" \
     --hash=sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0 \
     --hash=sha256:6813f9d8073f555444a8705f3ab0296d3e1cb37a16d694c5fc8b862a0d8706d7 \
     --hash=sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6 \
     --hash=sha256:dbbe4fc38ec1289c7e5230e16248365e375c3673c9c8bac5796e2e20db07f56e \
     --hash=sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c
     # via torch
-nvidia-cusparse-cu12==12.5.4.2 \
+nvidia-cusparse-cu12==12.5.4.2 ; platform_system == "Linux" \
     --hash=sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f \
     --hash=sha256:4acb8c08855a26d737398cba8fb6f8f5045d93f82612b4cfd84645a2332ccf20 \
     --hash=sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73 \
@@ -1914,16 +1914,16 @@ nvidia-cusparse-cu12==12.5.4.2 \
     # via
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cusparselt-cu12==0.6.3 \
+nvidia-cusparselt-cu12==0.6.3 ; platform_system == "Linux" \
     --hash=sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7 \
     --hash=sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1 \
     --hash=sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46
     # via torch
-nvidia-nccl-cu12==2.26.2 \
+nvidia-nccl-cu12==2.26.2 ; platform_system == "Linux" \
     --hash=sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522 \
     --hash=sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6
     # via torch
-nvidia-nvjitlink-cu12==12.6.85 \
+nvidia-nvjitlink-cu12==12.6.85 ; platform_system == "Linux" \
     --hash=sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41 \
     --hash=sha256:e61120e52ed675747825cdd16febc6a0730537451d867ee58bee3853b1b13d1c \
     --hash=sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a
@@ -1932,7 +1932,7 @@ nvidia-nvjitlink-cu12==12.6.85 \
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
     #   torch
-nvidia-nvtx-cu12==12.6.77 \
+nvidia-nvtx-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:2fb11a4af04a5e6c84073e6404d26588a34afd35379f0855a99797897efa75c0 \
     --hash=sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1 \
     --hash=sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059 \

--- a/alpha_factory_v1/demos/era_of_experience/requirements.lock
+++ b/alpha_factory_v1/demos/era_of_experience/requirements.lock
@@ -1769,7 +1769,7 @@ numpy>=2.3,<2.4 \
     #   streamlit
     #   transformers
     #   yfinance
-nvidia-cublas-cu12==12.6.4.1 \
+nvidia-cublas-cu12==12.6.4.1 ; platform_system == "Linux" \
     --hash=sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb \
     --hash=sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668 \
     --hash=sha256:9e4fa264f4d8a4eb0cdbd34beadc029f453b3bafae02401e999cf3d5a5af75f8
@@ -1777,56 +1777,56 @@ nvidia-cublas-cu12==12.6.4.1 \
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.6.80 \
+nvidia-cuda-cupti-cu12==12.6.80 ; platform_system == "Linux" \
     --hash=sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc \
     --hash=sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4 \
     --hash=sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132 \
     --hash=sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73 \
     --hash=sha256:bbe6ae76e83ce5251b56e8c8e61a964f757175682bbad058b170b136266ab00a
     # via torch
-nvidia-cuda-nvrtc-cu12==12.6.77 \
+nvidia-cuda-nvrtc-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53 \
     --hash=sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13 \
     --hash=sha256:f7007dbd914c56bd80ea31bc43e8e149da38f68158f423ba845fc3292684e45a
     # via torch
-nvidia-cuda-runtime-cu12==12.6.77 \
+nvidia-cuda-runtime-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd \
     --hash=sha256:86c58044c824bf3c173c49a2dbc7a6c8b53cb4e4dca50068be0bf64e9dab3f7f \
     --hash=sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8 \
     --hash=sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7 \
     --hash=sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e
     # via torch
-nvidia-cudnn-cu12==9.5.1.17 \
+nvidia-cudnn-cu12==9.5.1.17 ; platform_system == "Linux" \
     --hash=sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2 \
     --hash=sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def \
     --hash=sha256:d7af0f8a4f3b4b9dbb3122f2ef553b45694ed9c384d5a75bab197b8eefb79ab8
     # via torch
-nvidia-cufft-cu12==11.3.0.4 \
+nvidia-cufft-cu12==11.3.0.4 ; platform_system == "Linux" \
     --hash=sha256:6048ebddfb90d09d2707efb1fd78d4e3a77cb3ae4dc60e19aab6be0ece2ae464 \
     --hash=sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca \
     --hash=sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb \
     --hash=sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5 \
     --hash=sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6
     # via torch
-nvidia-cufile-cu12==1.11.1.6 \
+nvidia-cufile-cu12==1.11.1.6 ; platform_system == "Linux" \
     --hash=sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db \
     --hash=sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159
     # via torch
-nvidia-curand-cu12==10.3.7.77 \
+nvidia-curand-cu12==10.3.7.77 ; platform_system == "Linux" \
     --hash=sha256:6d6d935ffba0f3d439b7cd968192ff068fafd9018dbf1b85b37261b13cfc9905 \
     --hash=sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8 \
     --hash=sha256:7b2ed8e95595c3591d984ea3603dd66fe6ce6812b886d59049988a712ed06b6e \
     --hash=sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117 \
     --hash=sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf
     # via torch
-nvidia-cusolver-cu12==11.7.1.2 \
+nvidia-cusolver-cu12==11.7.1.2 ; platform_system == "Linux" \
     --hash=sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0 \
     --hash=sha256:6813f9d8073f555444a8705f3ab0296d3e1cb37a16d694c5fc8b862a0d8706d7 \
     --hash=sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6 \
     --hash=sha256:dbbe4fc38ec1289c7e5230e16248365e375c3673c9c8bac5796e2e20db07f56e \
     --hash=sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c
     # via torch
-nvidia-cusparse-cu12==12.5.4.2 \
+nvidia-cusparse-cu12==12.5.4.2 ; platform_system == "Linux" \
     --hash=sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f \
     --hash=sha256:4acb8c08855a26d737398cba8fb6f8f5045d93f82612b4cfd84645a2332ccf20 \
     --hash=sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73 \
@@ -1835,16 +1835,16 @@ nvidia-cusparse-cu12==12.5.4.2 \
     # via
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cusparselt-cu12==0.6.3 \
+nvidia-cusparselt-cu12==0.6.3 ; platform_system == "Linux" \
     --hash=sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7 \
     --hash=sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1 \
     --hash=sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46
     # via torch
-nvidia-nccl-cu12==2.26.2 \
+nvidia-nccl-cu12==2.26.2 ; platform_system == "Linux" \
     --hash=sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522 \
     --hash=sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6
     # via torch
-nvidia-nvjitlink-cu12==12.6.85 \
+nvidia-nvjitlink-cu12==12.6.85 ; platform_system == "Linux" \
     --hash=sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41 \
     --hash=sha256:e61120e52ed675747825cdd16febc6a0730537451d867ee58bee3853b1b13d1c \
     --hash=sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a
@@ -1853,7 +1853,7 @@ nvidia-nvjitlink-cu12==12.6.85 \
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
     #   torch
-nvidia-nvtx-cu12==12.6.77 \
+nvidia-nvtx-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:2fb11a4af04a5e6c84073e6404d26588a34afd35379f0855a99797897efa75c0 \
     --hash=sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1 \
     --hash=sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059 \

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock
@@ -1742,57 +1742,57 @@ numpy>=2.3,<2.4 \
     #   streamlit
     #   transformers
     #   yfinance
-nvidia-cublas-cu12==12.1.3.1 \
+nvidia-cublas-cu12==12.1.3.1 ; platform_system == "Linux" \
     --hash=sha256:2b964d60e8cf11b5e1073d179d85fa340c120e99b3067558f3cf98dd69d02906 \
     --hash=sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728
     # via
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.1.105 \
+nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == "Linux" \
     --hash=sha256:bea8236d13a0ac7190bd2919c3e8e6ce1e402104276e6f9694479e48bb0eb2a4 \
     --hash=sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e
     # via torch
-nvidia-cuda-nvrtc-cu12==12.1.105 \
+nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == "Linux" \
     --hash=sha256:0a98a522d9ff138b96c010a65e145dc1b4850e9ecb75a0172371793752fd46ed \
     --hash=sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2
     # via torch
-nvidia-cuda-runtime-cu12==12.1.105 \
+nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == "Linux" \
     --hash=sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40 \
     --hash=sha256:dfb46ef84d73fababab44cf03e3b83f80700d27ca300e537f85f636fac474344
     # via torch
-nvidia-cudnn-cu12==8.9.2.26 \
+nvidia-cudnn-cu12==8.9.2.26 ; platform_system == "Linux" \
     --hash=sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9
     # via torch
-nvidia-cufft-cu12==11.0.2.54 \
+nvidia-cufft-cu12==11.0.2.54 ; platform_system == "Linux" \
     --hash=sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56 \
     --hash=sha256:d9ac353f78ff89951da4af698f80870b1534ed69993f10a4cf1d96f21357e253
     # via torch
-nvidia-curand-cu12==10.3.2.106 \
+nvidia-curand-cu12==10.3.2.106 ; platform_system == "Linux" \
     --hash=sha256:75b6b0c574c0037839121317e17fd01f8a69fd2ef8e25853d826fec30bdba74a \
     --hash=sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0
     # via torch
-nvidia-cusolver-cu12==11.4.5.107 \
+nvidia-cusolver-cu12==11.4.5.107 ; platform_system == "Linux" \
     --hash=sha256:74e0c3a24c78612192a74fcd90dd117f1cf21dea4822e66d89e8ea80e3cd2da5 \
     --hash=sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd
     # via torch
-nvidia-cusparse-cu12==12.1.0.106 \
+nvidia-cusparse-cu12==12.1.0.106 ; platform_system == "Linux" \
     --hash=sha256:b798237e81b9719373e8fae8d4f091b70a0cf09d9d85c95a557e11df2d8e9a5a \
     --hash=sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c
     # via
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-nccl-cu12==2.19.3 \
+nvidia-nccl-cu12==2.19.3 ; platform_system == "Linux" \
     --hash=sha256:a9734707a2c96443331c1e48c717024aa6678a0e2a4cb66b2c364d18cee6b48d
     # via torch
-nvidia-nvjitlink-cu12==12.9.86 \
+nvidia-nvjitlink-cu12==12.9.86 ; platform_system == "Linux" \
     --hash=sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca \
     --hash=sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db \
     --hash=sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
-nvidia-nvtx-cu12==12.1.105 \
+nvidia-nvtx-cu12==12.1.105 ; platform_system == "Linux" \
     --hash=sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82 \
     --hash=sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5
     # via torch

--- a/requirements-demo.lock
+++ b/requirements-demo.lock
@@ -459,7 +459,7 @@ numpy==2.3.1 \
     #   gradio
     #   gymnasium
     #   pandas
-nvidia-cublas-cu12==12.6.4.1 \
+nvidia-cublas-cu12==12.6.4.1 ; platform_system == "Linux" \
     --hash=sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb \
     --hash=sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668 \
     --hash=sha256:9e4fa264f4d8a4eb0cdbd34beadc029f453b3bafae02401e999cf3d5a5af75f8
@@ -467,56 +467,56 @@ nvidia-cublas-cu12==12.6.4.1 \
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.6.80 \
+nvidia-cuda-cupti-cu12==12.6.80 ; platform_system == "Linux" \
     --hash=sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc \
     --hash=sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4 \
     --hash=sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132 \
     --hash=sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73 \
     --hash=sha256:bbe6ae76e83ce5251b56e8c8e61a964f757175682bbad058b170b136266ab00a
     # via torch
-nvidia-cuda-nvrtc-cu12==12.6.77 \
+nvidia-cuda-nvrtc-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53 \
     --hash=sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13 \
     --hash=sha256:f7007dbd914c56bd80ea31bc43e8e149da38f68158f423ba845fc3292684e45a
     # via torch
-nvidia-cuda-runtime-cu12==12.6.77 \
+nvidia-cuda-runtime-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd \
     --hash=sha256:86c58044c824bf3c173c49a2dbc7a6c8b53cb4e4dca50068be0bf64e9dab3f7f \
     --hash=sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8 \
     --hash=sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7 \
     --hash=sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e
     # via torch
-nvidia-cudnn-cu12==9.5.1.17 \
+nvidia-cudnn-cu12==9.5.1.17 ; platform_system == "Linux" \
     --hash=sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2 \
     --hash=sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def \
     --hash=sha256:d7af0f8a4f3b4b9dbb3122f2ef553b45694ed9c384d5a75bab197b8eefb79ab8
     # via torch
-nvidia-cufft-cu12==11.3.0.4 \
+nvidia-cufft-cu12==11.3.0.4 ; platform_system == "Linux" \
     --hash=sha256:6048ebddfb90d09d2707efb1fd78d4e3a77cb3ae4dc60e19aab6be0ece2ae464 \
     --hash=sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca \
     --hash=sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb \
     --hash=sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5 \
     --hash=sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6
     # via torch
-nvidia-cufile-cu12==1.11.1.6 \
+nvidia-cufile-cu12==1.11.1.6 ; platform_system == "Linux" \
     --hash=sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db \
     --hash=sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159
     # via torch
-nvidia-curand-cu12==10.3.7.77 \
+nvidia-curand-cu12==10.3.7.77 ; platform_system == "Linux" \
     --hash=sha256:6d6d935ffba0f3d439b7cd968192ff068fafd9018dbf1b85b37261b13cfc9905 \
     --hash=sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8 \
     --hash=sha256:7b2ed8e95595c3591d984ea3603dd66fe6ce6812b886d59049988a712ed06b6e \
     --hash=sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117 \
     --hash=sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf
     # via torch
-nvidia-cusolver-cu12==11.7.1.2 \
+nvidia-cusolver-cu12==11.7.1.2 ; platform_system == "Linux" \
     --hash=sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0 \
     --hash=sha256:6813f9d8073f555444a8705f3ab0296d3e1cb37a16d694c5fc8b862a0d8706d7 \
     --hash=sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6 \
     --hash=sha256:dbbe4fc38ec1289c7e5230e16248365e375c3673c9c8bac5796e2e20db07f56e \
     --hash=sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c
     # via torch
-nvidia-cusparse-cu12==12.5.4.2 \
+nvidia-cusparse-cu12==12.5.4.2 ; platform_system == "Linux" \
     --hash=sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f \
     --hash=sha256:4acb8c08855a26d737398cba8fb6f8f5045d93f82612b4cfd84645a2332ccf20 \
     --hash=sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73 \
@@ -525,16 +525,16 @@ nvidia-cusparse-cu12==12.5.4.2 \
     # via
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cusparselt-cu12==0.6.3 \
+nvidia-cusparselt-cu12==0.6.3 ; platform_system == "Linux" \
     --hash=sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7 \
     --hash=sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1 \
     --hash=sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46
     # via torch
-nvidia-nccl-cu12==2.26.2 \
+nvidia-nccl-cu12==2.26.2 ; platform_system == "Linux" \
     --hash=sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522 \
     --hash=sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6
     # via torch
-nvidia-nvjitlink-cu12==12.6.85 \
+nvidia-nvjitlink-cu12==12.6.85 ; platform_system == "Linux" \
     --hash=sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41 \
     --hash=sha256:e61120e52ed675747825cdd16febc6a0730537451d867ee58bee3853b1b13d1c \
     --hash=sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a
@@ -543,7 +543,7 @@ nvidia-nvjitlink-cu12==12.6.85 \
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
     #   torch
-nvidia-nvtx-cu12==12.6.77 \
+nvidia-nvtx-cu12==12.6.77 ; platform_system == "Linux" \
     --hash=sha256:2fb11a4af04a5e6c84073e6404d26588a34afd35379f0855a99797897efa75c0 \
     --hash=sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1 \
     --hash=sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059 \


### PR DESCRIPTION
## Summary
- add platform markers so CUDA wheels only install on Linux

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_adk_gateway_startup.py::test_openai_agents_stub_call -q` *(fails: `Agent.__init__() missing 1 required positional argument: 'name'`)*

------
https://chatgpt.com/codex/tasks/task_e_687d145c81808333b60789c992f1d83f