### PR TITLE
[alpha_factory] improve asset fetch resiliency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ env:
   PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.28.0/full
   HF_GPT2_BASE_URL: https://huggingface.co/openai-community/gpt2/resolve/main
   A11Y_THRESHOLD: ${{ inputs.a11y-threshold }}
+  FETCH_ASSETS_ATTEMPTS: '5'
+  FETCH_ASSETS_BACKOFF: '2'
 
 jobs:
 
@@ -173,12 +175,16 @@ jobs:
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Verify insight assets
         run: |
-          python scripts/fetch_assets.py --verify-only || (
-            echo "Detected asset hash change, updating..." &&
-            python scripts/update_pyodide.py 0.28.0 &&
-            npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets &&
-            python scripts/fetch_assets.py --verify-only
-          )
+          set -eo pipefail
+          python scripts/fetch_assets.py --verify-only 2>&1 | tee verify.log
+          if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+            echo "::error::Initial asset verification failed" >&2
+            cat verify.log
+            python scripts/update_pyodide.py 0.28.0
+            npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
+            python scripts/fetch_assets.py --verify-only 2>&1 | tee verify.log
+          fi
+          cat verify.log
       - name: Update browserslist database (Insight demo)
         working-directory: alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
         run: npx update-browserslist-db --update-db --yes
@@ -557,12 +563,16 @@ jobs:
           )
       - name: Verify insight assets
         run: |
-          python scripts/fetch_assets.py --verify-only || (
-            echo "Detected asset hash change, updating..." &&
-            python scripts/update_pyodide.py 0.28.0 &&
-            npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets &&
-            python scripts/fetch_assets.py --verify-only
-          )
+          set -eo pipefail
+          python scripts/fetch_assets.py --verify-only 2>&1 | tee verify.log
+          if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+            echo "::error::Initial asset verification failed" >&2
+            cat verify.log
+            python scripts/update_pyodide.py 0.28.0
+            npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
+            python scripts/fetch_assets.py --verify-only 2>&1 | tee verify.log
+          fi
+          cat verify.log
       - name: Audit insight browser dependencies
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 audit --production --audit-level=high
       - name: Install Playwright browsers

--- a/README.md
+++ b/README.md
@@ -1319,6 +1319,7 @@ for instructions and example volume mounts.
 | `HF_GPT2_BASE_URL` | `https://huggingface.co/openai-community/gpt2/resolve/main` | Base URL for the GPT‑2 checkpoints. |
 | `PYODIDE_BASE_URL` | `https://cdn.jsdelivr.net/pyodide/v0.28.0/full` | Base URL for the Pyodide runtime files. |
 | `FETCH_ASSETS_ATTEMPTS` | `3` | Download retry count for `fetch_assets.py`. |
+| `FETCH_ASSETS_BACKOFF` | `1` | Base delay between retries in seconds. |
 | `OTEL_ENDPOINT` | _(empty)_ | OTLP endpoint for anonymous telemetry. |
 | `SKIP_WEBKIT_TESTS` | _(empty)_ | Skip WebKit browser tests when set. |
 | `ALPHA_FACTORY_ENABLE_ADK` | `false` | Set to `true` to start the Google ADK gateway. |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@ Downstream users should consult this section when upgrading.
 - `scripts/fetch_assets.py` now downloads the Pyodide runtime from the official
   CDN and retrieves GPT-2 weights directly from Hugging Face.
 - Added `FETCH_ASSETS_ATTEMPTS` environment variable to control download retries.
+- Added `FETCH_ASSETS_BACKOFF` environment variable to adjust retry delay.
 - The browser bundle now defaults to the official Web3 Storage CDN. IPFS
   fallback has been removed.
 - Fixed internal documentation links so MkDocs builds without warnings.


### PR DESCRIPTION
## Summary
- retry asset downloads with exponential backoff
- expose `FETCH_ASSETS_BACKOFF` env var
- adjust CI to use new retries and log verification failures

## Testing
- `pre-commit run --files scripts/fetch_assets.py README.md docs/CHANGELOG.md .github/workflows/ci.yml` *(with `SKIP=shellcheck`)*
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --maxfail=1 -q` *(fails: Agent.__init__ missing required argument)*


------
https://chatgpt.com/codex/tasks/task_e_687d180158388333a1364b45a44e443a