### PR TITLE
fix: harmonize lock files and improve CI stability

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -334,7 +334,7 @@ ccxt==4.4.78 \
     --hash=sha256:622c8edf5aec5bca032a0e313ecf94d6e802f8fa366edee8378a22176876a048 \
     --hash=sha256:c6f6093abdda68d3c87a8435955b1b9088d87f10342a07489ef387f325108ed0
     # via -r alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
-certifi==2025.7.9 \
+certifi==2025.7.14 \
     --hash=sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079 \
     --hash=sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39
     # via

--- a/alpha_factory_v1/demos/era_of_experience/requirements.lock
+++ b/alpha_factory_v1/demos/era_of_experience/requirements.lock
@@ -243,7 +243,7 @@ ccxt==4.4.91 \
     --hash=sha256:454efd9637cbf0aab852db1a3d2c294b68b9a46ac6da9365b615623a0bfa1bb2 \
     --hash=sha256:812c4a98875a87bdcd86cab25f84ccd1bb96c1d4fb3227ecda75e305b881df2b
     # via -r alpha_factory_v1/demos/era_of_experience/../../requirements.txt
-certifi==2025.4.26 \
+certifi==2025.7.14 \
     --hash=sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6 \
     --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3
     # via
@@ -450,7 +450,7 @@ coloredlogs==15.0.1 \
     --hash=sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934 \
     --hash=sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0
     # via onnxruntime
-cryptography==45.0.3 \
+cryptography==45.0.5 \
     --hash=sha256:00094838ecc7c6594171e8c8a9166124c1197b074cfca23645cee573910d76bc \
     --hash=sha256:050ce5209d5072472971e6efbfc8ec5a8f9a841de5a4db0ebd9c2e392cb81972 \
     --hash=sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b \

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock
@@ -238,7 +238,7 @@ ccxt==4.4.90 \
     --hash=sha256:399489dbbf1caea2152e171ddf10b08dbd8fb7d488651402e3596b39bf186943 \
     --hash=sha256:f1cc6c7eaa820cdf6b05fa5416b419d44900c89f9cc20915b41d38a9a7fb10dd
     # via -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements.txt
-certifi==2025.4.26 \
+certifi==2025.7.14 \
     --hash=sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6 \
     --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3
     # via
@@ -445,7 +445,7 @@ coloredlogs==15.0.1 \
     --hash=sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934 \
     --hash=sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0
     # via onnxruntime
-cryptography==45.0.3 \
+cryptography==45.0.5 \
     --hash=sha256:00094838ecc7c6594171e8c8a9166124c1197b074cfca23645cee573910d76bc \
     --hash=sha256:050ce5209d5072472971e6efbfc8ec5a8f9a841de5a4db0ebd9c2e392cb81972 \
     --hash=sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b \

--- a/alpha_factory_v1/requirements.lock
+++ b/alpha_factory_v1/requirements.lock
@@ -411,24 +411,24 @@ numpy==2.3.1
     #   streamlit
     #   transformers
     #   yfinance
-nvidia-cublas-cu12==12.6.4.1
+nvidia-cublas-cu12==12.6.4.1 ; platform_system == "Linux"
     # via
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.6.80
+nvidia-cuda-cupti-cu12==12.6.80 ; platform_system == "Linux"
     # via torch
-nvidia-cuda-nvrtc-cu12==12.6.77
+nvidia-cuda-nvrtc-cu12==12.6.77 ; platform_system == "Linux"
     # via torch
-nvidia-cuda-runtime-cu12==12.6.77
+nvidia-cuda-runtime-cu12==12.6.77 ; platform_system == "Linux"
     # via torch
-nvidia-cudnn-cu12==9.5.1.17
+nvidia-cudnn-cu12==9.5.1.17 ; platform_system == "Linux"
     # via torch
-nvidia-cufft-cu12==11.3.0.4
+nvidia-cufft-cu12==11.3.0.4 ; platform_system == "Linux"
     # via torch
-nvidia-cufile-cu12==1.11.1.6
+nvidia-cufile-cu12==1.11.1.6 ; platform_system == "Linux"
     # via torch
-nvidia-curand-cu12==10.3.7.77
+nvidia-curand-cu12==10.3.7.77 ; platform_system == "Linux"
     # via torch
 nvidia-cusolver-cu12==11.7.1.2
     # via torch

--- a/infrastructure/evolution_worker.Dockerfile
+++ b/infrastructure/evolution_worker.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+COPY requirements.lock /tmp/requirements.lock
+RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock
 COPY alpha_factory_v1/demos/alpha_agi_insight_v1 /app/alpha_factory_v1/demos/alpha_agi_insight_v1
 EXPOSE 8000
 CMD ["uvicorn", "alpha_factory_v1.demos.alpha_agi_insight_v1.src.evolution_worker:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/requirements-cpu.lock
+++ b/requirements-cpu.lock
@@ -3512,7 +3512,7 @@ tomlkit==0.13.3 \
     --hash=sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1 \
     --hash=sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0
     # via gradio
-torch==2.7.1 
+torch==2.7.1 \
     --hash=sha256:a1684793e352f03fa14f78857e55d65de4ada8405ded1da2bf4f452179c4b779 
     --hash=sha256:8f8b3cfc53010a4b4a3c7ecb88c212e9decc4f5eeb6af75c3c803937d2d60947 
     --hash=sha256:7b977eccbc85ae2bd19d6998de7b1f1f4bd3c04eaffd3015deb7934389783399 

--- a/scripts/verify_insight_offline.py
+++ b/scripts/verify_insight_offline.py
@@ -13,7 +13,7 @@ import time
 URL = "http://localhost:8000/alpha_agi_insight_v1/"
 
 # Allow the timeout to be overridden via PWA_TIMEOUT_MS for slow CI runners
-TIMEOUT_MS = int(os.environ.get("PWA_TIMEOUT_MS", "90000"))
+TIMEOUT_MS = int(os.environ.get("PWA_TIMEOUT_MS", "120000"))
 
 
 def _print_console(logs: list[str]) -> None:


### PR DESCRIPTION
## Summary
- align demo requirement locks with main versions
- mark GPU-only wheels as Linux-only
- fix torch line in CPU lock
- extend PWA offline timeout
- install from lock file in evolution worker Docker build

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock alpha_factory_v1/demos/era_of_experience/requirements.lock alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock alpha_factory_v1/requirements.lock infrastructure/evolution_worker.Dockerfile requirements-cpu.lock scripts/verify_insight_offline.py`

------
https://chatgpt.com/codex/tasks/task_e_687d2604c86c83339982dec78af6abd8