### PR TITLE
Fix docs timeout and Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,7 @@ jobs:
     env:
       FETCH_ASSETS_ATTEMPTS: '5'
       SANDBOX_IMAGE: selfheal-sandbox:latest
+      PWA_TIMEOUT_MS: '120000'
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Build sandbox image

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /app
 
 # install Python dependencies using the pinned lock file
 COPY requirements.lock /tmp/requirements.lock
-RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock
+COPY alpha_factory_v1/requirements-core.txt /tmp/requirements-core.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock \
+    && rm /tmp/requirements-core.txt
 
 # copy project source
 COPY . /app


### PR DESCRIPTION
## Summary
- ensure docs build waits longer for PWA
- copy requirements-core.txt in Dockerfile so Docker build succeeds

## Testing
- `pre-commit run --files .github/workflows/ci.yml infrastructure/Dockerfile`
- `pytest -k smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2e2686148333b152b3439889203e