### PR TITLE
[alpha_factory] include self_healing_repo in package list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ packages = [
     "af_requests",
     "alpha_factory_v1.demos.meta_agentic_tree_search_v0",
     "alpha_factory_v1.demos.meta_agentic_tree_search_v0.mats",
+    "alpha_factory_v1.demos.self_healing_repo",
 ]
 include-package-data = true
 


### PR DESCRIPTION
## Summary
- add `alpha_factory_v1.demos.self_healing_repo` to setuptools packages

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml -m 'not e2e'` *(fails: 215 failed, 568 passed)*
- `pre-commit run --files pyproject.toml`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_687d4284a4848333ae173950aa6d7e01