### PR TITLE
[alpha_factory] Fix CI dependency conflicts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,8 @@ alpha_factory_v1/demos/*
 !alpha_factory_v1/demos/alpha_agi_business_3_v1/**
 !alpha_factory_v1/demos/alpha_agi_insight_v1/
 !alpha_factory_v1/demos/alpha_agi_insight_v1/**
+!alpha_factory_v1/demos/self_healing_repo/
+!alpha_factory_v1/demos/self_healing_repo/**
 !alpha_factory_v1/__init__.py
 !alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
 !requirements-demo.txt

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in
@@ -1,7 +1,7 @@
 # α‑AGI Insight demo dependencies
 # Fully pinned runtime packages for reproducible installs
 streamlit>=1.46
-fastapi==0.115.9
+fastapi==0.116.1
 uvicorn[standard]==0.34.2
 flask==3.1.0
 gunicorn==21.2.0

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -699,9 +699,9 @@ faiss-cpu==1.11.0 \
     --hash=sha256:c4a3d35993e614847f3221c6931529c0bac637a00eff0d55293e1db5cb98c85f \
     --hash=sha256:d09d6b474c22caa0657f627be1b83d14d75ed0a29b6c06facfe9b7c9efa4ed38
     # via -r alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
-fastapi==0.115.9 \
-    --hash=sha256:4a439d7923e4de796bcc88b64e9754340fcd1574673cbd865ba8a99fe0d28c56 \
-    --hash=sha256:9d7da3b196c5eed049bc769f9475cd55509a112fbe031c0ef2f53768ae68d13f
+fastapi==0.116.1 \
+    --hash=sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565 \
+    --hash=sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143
     # via
     #   -r alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
     #   chromadb

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt
@@ -1,7 +1,7 @@
 # α‑AGI Insight demo dependencies
 # Fully pinned runtime packages for reproducible installs
 streamlit==1.46.0
-fastapi==0.115.9
+fastapi==0.116.1
 uvicorn[standard]==0.34.2
 flask==3.1.0
 gunicorn==21.2.0

--- a/alpha_factory_v1/demos/era_of_experience/requirements.lock
+++ b/alpha_factory_v1/demos/era_of_experience/requirements.lock
@@ -588,9 +588,9 @@ farama-notifications==0.0.4 \
     --hash=sha256:13fceff2d14314cf80703c8266462ebf3733c7d165336eee998fc58e545efd18 \
     --hash=sha256:14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae
     # via gymnasium
-fastapi==0.115.12 \
-    --hash=sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681 \
-    --hash=sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d
+fastapi==0.116.1 \
+    --hash=sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565 \
+    --hash=sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143
     # via
     #   -r alpha_factory_v1/demos/era_of_experience/../../requirements-core.txt
     #   google-adk

--- a/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock
+++ b/alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock
@@ -583,9 +583,9 @@ farama-notifications==0.0.4 \
     --hash=sha256:13fceff2d14314cf80703c8266462ebf3733c7d165336eee998fc58e545efd18 \
     --hash=sha256:14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae
     # via gymnasium
-fastapi==0.115.12 \
-    --hash=sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681 \
-    --hash=sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d
+fastapi==0.116.1 \
+    --hash=sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565 \
+    --hash=sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143
     # via
     #   -r /workspace/AGI-Alpha-Agent-v0/alpha_factory_v1/requirements-core.txt
     #   google-adk

--- a/alpha_factory_v1/requirements-colab.lock
+++ b/alpha_factory_v1/requirements-colab.lock
@@ -69,7 +69,7 @@ distro==1.9.0
     #   openai
 executing==2.2.0
     # via stack-data
-fastapi==0.115.13
+fastapi==0.116.1
     # via -r alpha_factory_v1/requirements-colab.txt
 filelock==3.18.0
     # via


### PR DESCRIPTION
## Summary
- upgrade FastAPI in demo lock files
- include self-healing repo in Docker context

## Testing
- `pre-commit run --files .dockerignore alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.in alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.txt alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock alpha_factory_v1/demos/era_of_experience/requirements.lock alpha_factory_v1/demos/meta_agentic_tree_search_v0/requirements.lock alpha_factory_v1/requirements-colab.lock`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --demo macro_sentinel`
- `pytest -m smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_687d48781b2c8333a7b0fa48d28c120f