### PR TITLE
Fix fastapi conflicts and package install

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -14,6 +14,8 @@ RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements
 
 # copy project source
 COPY . /app
+# install project in editable mode
+RUN pip install --no-cache-dir -e /app
 # copy pre-built React bundle if available
 COPY alpha_factory_v1/core/interface/web_client/dist/ \
      /app/alpha_factory_v1/core/interface/web_client/dist/

--- a/requirements-demo.lock
+++ b/requirements-demo.lock
@@ -697,9 +697,8 @@ openai==1.97.0 \
     --hash=sha256:0be349569ccaa4fb54f97bb808423fd29ccaeb1246ee1be762e0c81a47bae0aa \
     --hash=sha256:a1c24d96f4609f3f7f51c9e1c2606d97cc6e334833438659cfd687e9c972c610
     # via openai-agents
-openai-agents==0.2.2 \
-    --hash=sha256:8a40971db5113be8f1a5842f30cd9f5ebec29848124f64f95820b6d52096241c \
-    --hash=sha256:cff8a2556c8e69e05aff3ab9eb40ceff05494c60297a682964dbc8e5309a3686
+openai-agents==0.0.17 \
+    --hash=sha256:924e0be145b42fb8984e35ab9d14e4948a2251c3b122a02ca989b223e4d39c27
     # via -r requirements-demo.txt
 orjson==3.11.0 \
     --hash=sha256:02dd4f0a1a2be943a104ce5f3ec092631ee3e9f0b4bb9eeee3400430bd94ddef \

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -4,6 +4,6 @@ torch>=2.2
 gymnasium[classic-control]>=0.29
 gradio>=5.38.0
 filelock>=3.13
-openai-agents>=0.0.17
+openai-agents>=0.0.17,<0.2
 tqdm~=4.67
 


### PR DESCRIPTION
## Summary
- pin openai-agents below 0.2 to avoid FastAPI version conflict
- update demo lock file
- install project in Docker image so demos load correctly

## Testing
- `pre-commit run --files requirements-demo.txt requirements-demo.lock infrastructure/Dockerfile`
- `python check_env.py --auto-install`

------
https://chatgpt.com/codex/tasks/task_e_687d4d7e19bc83338dbaf79e1cb6b51b