### PR TITLE
Fix CI packaging and CSP

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -222,7 +222,7 @@ async function bundle() {
         "default-src 'self'; connect-src 'self' https://api.openai.com" +
         (ipfsOrigin ? ` ${ipfsOrigin}` : "") +
         (otelOrigin ? ` ${otelOrigin}` : "") +
-        "; script-src 'self' 'wasm-unsafe-eval'";
+        "; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
     outHtml = outHtml.replace(
         /<meta[^>]*http-equiv="Content-Security-Policy"[^>]*>/,
         `<meta http-equiv="Content-Security-Policy" content="${csp}" />`,

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#0d0e2e" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval'"
+      content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
     />
     <title>α-AGI Insight – in-browser Pareto explorer</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ exclude = [
     "alpha_factory_v1/demos/meta_agentic_tree_search_v0/*",
     "alpha_factory_v1/demos/muzeromctsllmagent_v0/*",
     "alpha_factory_v1/demos/omni_factory_demo/*",
-    "alpha_factory_v1/demos/self_healing_repo/*",
     "alpha_factory_v1/demos/self_healing_repo_cli.py",
     "alpha_factory_v1/demos/solving_agi_governance/*",
     "alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/*",

--- a/requirements-demo.lock
+++ b/requirements-demo.lock
@@ -695,9 +695,9 @@ openai==1.97.0 \
     --hash=sha256:0be349569ccaa4fb54f97bb808423fd29ccaeb1246ee1be762e0c81a47bae0aa \
     --hash=sha256:a1c24d96f4609f3f7f51c9e1c2606d97cc6e334833438659cfd687e9c972c610
     # via openai-agents
-openai-agents==0.1.0 \
-    --hash=sha256:6a8ef71d3f20aecba0f01bca2e059590d1c23f5adc02d780cb5921ea8a7ca774 \
-    --hash=sha256:a697a4fdd881a7a16db8c0dcafba0f17d9e90b6236a4b79923bd043b6ae86d80
+openai-agents==0.2.2 \
+    --hash=sha256:b84c84ea29f36fc9b2d8e6a6515a147d1748fbd96ac2d3f6f7ef451fa12846db \
+    --hash=sha256:e4a4d6633a4b0b4b41fb3ac633a5d9c2b653f83c36a821f6349e2c239ab03d2e
     # via -r requirements-demo.txt
 orjson==3.11.0 \
     --hash=sha256:02dd4f0a1a2be943a104ce5f3ec092631ee3e9f0b4bb9eeee3400430bd94ddef \


### PR DESCRIPTION
## Summary
- allow inline content in Insight browser CSP
- update packaging exclusion to include self-healing demo
- bump openai-agents in demo lockfile

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js pyproject.toml requirements-demo.lock`
- `python check_env.py --auto-install`
- `pytest -m smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_687d61c9022c8333bcbf76347a28b3b6