### PR TITLE
Fix CI demo dependency conflicts and PWA integrity

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -106,6 +106,6 @@
         });
       }
     </script>
-    <script type="module" src="insight.bundle.js" crossorigin="anonymous"></script>
+    <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/alpha_factory_v1/demos/self_healing_repo/__init__.py
+++ b/alpha_factory_v1/demos/self_healing_repo/__init__.py
@@ -1,2 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Self-healing demo package."""
+
+from importlib import import_module
+
+# Expose patching utilities at package level
+patcher_core = import_module(".patcher_core", __name__)
+
+__all__ = ["patcher_core"]

--- a/requirements-demo.lock
+++ b/requirements-demo.lock
@@ -695,9 +695,10 @@ openai==1.97.0 \
     --hash=sha256:0be349569ccaa4fb54f97bb808423fd29ccaeb1246ee1be762e0c81a47bae0aa \
     --hash=sha256:a1c24d96f4609f3f7f51c9e1c2606d97cc6e334833438659cfd687e9c972c610
     # via openai-agents
-openai-agents==0.2.2 \
-    --hash=sha256:b84c84ea29f36fc9b2d8e6a6515a147d1748fbd96ac2d3f6f7ef451fa12846db \
-    --hash=sha256:e4a4d6633a4b0b4b41fb3ac633a5d9c2b653f83c36a821f6349e2c239ab03d2e
+openai-agents==0.0.17 \
+    --hash=sha256:924e0be145b42fb8984e35ab9d14e4948a2251c3b122a02ca989b223e4d39c27
+    --hash=sha256:44f9c8e80b461c64cfdcf55d162ca8bb0594f4b2ada48daf1be34a8d4cd0759f 
+
     # via -r requirements-demo.txt
 orjson==3.11.0 \
     --hash=sha256:02dd4f0a1a2be943a104ce5f3ec092631ee3e9f0b4bb9eeee3400430bd94ddef \


### PR DESCRIPTION
## Summary
- pin `openai-agents` in `requirements-demo.lock` to 0.0.17
- update Insight browser script tag with correct SRI
- expose `patcher_core` from `self_healing_repo`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html alpha_factory_v1/demos/self_healing_repo/__init__.py requirements-demo.lock`
- `pytest -m smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_687d71a0b4e48333ada2b8b5bf63ed09