### PR TITLE
[alpha_factory] Update Docker images to Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
-FROM python:3.11.8-slim@sha256:90f8795536170fd08236d2ceb74fe7065dbf74f738d8b84bfbf263656654dc9b
+FROM python:3.12-slim@sha256:4600f71648e110b005bf7bca92dbb335e549e6b27f2e83fceee5e11b3e1a4d01
 
 # install build tools and npm for the React UI
 RUN apt-get update && \

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim@sha256:4600f71648e110b005bf7bca92dbb335e549e6b27f2e83fceee5e11b3e1a4d01
 
 # install system deps
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential postgresql-client && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- use `python:3.12-slim` for the demo Dockerfile
- sync infrastructure Dockerfile with the same pinned digest

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 33 failed, 5 errors)*
- `pre-commit run --files Dockerfile infrastructure/Dockerfile` *(failed to install hooks)*

------
https://chatgpt.com/codex/tasks/task_e_687d9d6d6e14833399731349f0ce1e47