### PR TITLE
[alpha_factory] include tree search demo in docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,8 @@ requests/tests/
 
 # Restrict build context for demo images
 alpha_factory_v1/demos/*
+!alpha_factory_v1/demos/meta_agentic_tree_search_v0/
+!alpha_factory_v1/demos/meta_agentic_tree_search_v0/**
 !alpha_factory_v1/demos/__init__.py
 !alpha_factory_v1/demos/alpha_agi_business_3_v1/
 !alpha_factory_v1/demos/alpha_agi_business_3_v1/**
@@ -33,8 +35,6 @@ alpha_factory_v1/demos/*
 !alpha_factory_v1/demos/alpha_agi_insight_v1/**
 !alpha_factory_v1/demos/self_healing_repo/
 !alpha_factory_v1/demos/self_healing_repo/**
-!alpha_factory_v1/demos/meta_agentic_tree_search_v0/
-!alpha_factory_v1/demos/meta_agentic_tree_search_v0/**
 !alpha_factory_v1/__init__.py
 !alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
 !requirements-demo.txt

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -38,7 +38,7 @@
     <div id="legend" role="region" aria-label="Legend"></div>
     <div id="depth-legend" role="region" aria-label="Depth Legend"></div>
     <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;">
-      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+ <a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
     </footer>
     <script>
       const SW_URL = 'service-worker.js';


### PR DESCRIPTION
## Summary
- unignore meta_agentic_tree_search_v0 demo in `.dockerignore`
- add disclaimer link to Insight demo HTML

## Testing
- `pre-commit run --files .dockerignore docs/alpha_agi_insight_v1/index.html`

------
https://chatgpt.com/codex/tasks/task_e_687e38f16fd483338b1b00ea37c702a8