### PR TITLE
[alpha_factory] update SRI generation

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -73,8 +73,8 @@ injectManifest({{
     for match in re.finditer(r"<script[^>]*>(.*?)</script>", text, flags=re.DOTALL):
         if "navigator.serviceWorker" in match.group(1):
             snippet = match.group(1).strip()
-            reg_hash = hashlib.sha256(snippet.encode()).digest()
-            sri = "sha256-" + base64.b64encode(reg_hash).decode()
+            reg_hash = hashlib.sha384(snippet.encode()).digest()
+            sri = "sha384-" + base64.b64encode(reg_hash).decode()
             break
     if sri:
         text = re.sub(


### PR DESCRIPTION
## Summary
- switch inline script hashing to SHA-384

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py`
- `pytest --maxfail=1` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687e3bd28d18833391631557b14ffcf3