### PR TITLE
fix: match Insight CSP hash

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -76,7 +76,7 @@ export async function generateServiceWorker(outDir, manifest, version) {
   const scriptMatch = /<script[^>]*>([\s\S]*?navigator\.serviceWorker[\s\S]*?)<\/script>/.exec(indexText);
   if (scriptMatch) {
     const snippet = scriptMatch[1].trim();
-    inlineHash = 'sha256-' + createHash('sha256').update(snippet).digest('base64');
+    inlineHash = 'sha384-' + createHash('sha384').update(snippet).digest('base64');
   }
   indexText = indexText.replace(
     /(script-src 'self' 'wasm-unsafe-eval')[^;]*/,

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -69,17 +69,17 @@ injectManifest({{
     text = index_path.read_text()
     text = text.replace(".register('sw.js')", ".register('service-worker.js')")
     text = text.replace("__SW_HASH__", sw_hash)
-    sri = None
+    inline_sri = None
     for match in re.finditer(r"<script[^>]*>(.*?)</script>", text, flags=re.DOTALL):
         if "navigator.serviceWorker" in match.group(1):
             snippet = match.group(1).strip()
             reg_hash = hashlib.sha384(snippet.encode()).digest()
-            sri = "sha384-" + base64.b64encode(reg_hash).decode()
+            inline_sri = "sha384-" + base64.b64encode(reg_hash).decode()
             break
-    if sri:
+    if inline_sri:
         text = re.sub(
             r"(script-src 'self' 'wasm-unsafe-eval')[^;]*",
-            rf"\1 '{sri}'",
+            rf"\1 '{inline_sri}'",
             text,
         )
     else:

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0d0e2e" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval' 'sha256-jeuMdmtcbxXdgSP1Tcx4Q57IAjlyvnuzDA9jSjZyzPw='; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval' 'sha384-8A5krj4onYofBH4cDYWKBARy59wh5+SyOiZefJxzQYl20s2A65jvYdFlniK1X+v+'; style-src 'self' 'unsafe-inline'" />
     <title>α-AGI Insight – in-browser Pareto explorer</title>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="assets/manifest.json" />


### PR DESCRIPTION
## Summary
- compute SHA-384 for service worker registration in build scripts
- embed the digest in the generated Insight docs CSP

## Testing
- `pre-commit run --hook-stage manual --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py docs/alpha_agi_insight_v1/index.html`
- `python scripts/verify_insight_offline.py` *(fails: BrowserType.launch error)*

------
https://chatgpt.com/codex/tasks/task_e_687e4db792488333a6fcdf5b70f1d24d