### PR TITLE
Fix CSP hash in docs

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0d0e2e" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval' 'sha384-8A5krj4onYofBH4cDYWKBARy59wh5+SyOiZefJxzQYl20s2A65jvYdFlniK1X+v+'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval' 'sha384-egqa7Y7D6n2ypX+nsPLHMkoeXHfr2Hspg0E565xR8l+cRu78dXHzRuisNB1qMmVv'; style-src 'self' 'unsafe-inline'" />
     <title>α-AGI Insight – in-browser Pareto explorer</title>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="assets/manifest.json" />
@@ -37,12 +37,12 @@
     </div>
     <div id="legend" role="region" aria-label="Legend"></div>
     <div id="depth-legend" role="region" aria-label="Depth Legend"></div>
-    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;">
- <a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a> This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
+    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;"> <a href="../DISCLAIMER_SNIPPET.md">See docs/DISCLAIMER_SNIPPET.md</a> 
+      This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
     </footer>
     <script>
       const SW_URL = 'service-worker.js';
-      const SW_HASH = 'sha384-kOliY3N8vCbHaZnKpSaYVwOoQSmlUb50kQIsEYqQtVjkB4d0KTS5u2lDs8jtX5VE';
+      const SW_HASH = 'sha384-ITQvGaSQBg4EGhxnB0OuTBcb9mYff22hfLOPenTASEQMJ4eKhFZb/TJbdttP4tRh';
       // Replaced with the SHA-384 digest of service-worker.js during
       // `npm run build` (or `python manual_build.py`)
       if ('serviceWorker' in navigator) {
@@ -90,6 +90,5 @@
     </script>
     <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
-<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild Insight docs so the service worker script hash matches the CSP

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/index.html`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_687e58123ad8833398b16cbd22380a0b