### PR TITLE
[alpha_factory] fix offline csp hash

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0d0e2e" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval' 'sha384-zjLdlW2fSuFcsxgjoklKIZEMTmz3zTlINKYlRiDXoix+iWemjTuu1AOmY2eY0sQV'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; script-src 'self' 'wasm-unsafe-eval' 'sha384-egqa7Y7D6n2ypX+nsPLHMkoeXHfr2Hspg0E565xR8l+cRu78dXHzRuisNB1qMmVv'; style-src 'self' 'unsafe-inline'" />
     <title>α-AGI Insight – in-browser Pareto explorer</title>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="assets/manifest.json" />

--- a/scripts/verify_insight_offline.py
+++ b/scripts/verify_insight_offline.py
@@ -32,8 +32,19 @@ def _attempt() -> bool:
             browser = p.chromium.launch(args=["--disable-web-security"])
             context = browser.new_context()
             page = context.new_page()
-            page.on("console", lambda msg: logs.append(f"[{msg.type}] {msg.text}"))
-            page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+
+            def on_console(msg: object) -> None:
+                entry = f"[{msg.type}] {msg.text}"
+                logs.append(entry)
+                print(entry, file=sys.stderr)
+
+            def on_page_error(exc: Exception) -> None:
+                err = str(exc)
+                page_errors.append(err)
+                print(err, file=sys.stderr)
+
+            page.on("console", on_console)
+            page.on("pageerror", on_page_error)
             page.goto(URL)
             page.wait_for_function("navigator.serviceWorker.ready", timeout=TIMEOUT_MS)
             page.wait_for_selector("body", timeout=TIMEOUT_MS)


### PR DESCRIPTION
## Summary
- update CSP hash for Insight demo
- print browser console errors immediately in the PWA offline check script

## Testing
- `ruff check scripts/verify_insight_offline.py`
- `python -m py_compile scripts/verify_insight_offline.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687e657c6408833380f8a19eede2ab6e