### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: "Verify owner"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
 
   lint-type:
@@ -53,24 +53,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11.12"]
     steps:
       # checkout required for local composite actions
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: 'requirements.lock'
 
-      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: ${{ env.NODE_LOCKFILES }}
 
       - name: Cache pre-commit
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: .cache/pre-commit
           key: ${{ runner.os }}-precommit-py${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -117,10 +117,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11.12", "3.12.10"]
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -136,7 +136,7 @@ jobs:
       - name: Build sandbox image
         run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       # Install Node.js and cache dependencies using both lockfiles
-      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -144,7 +144,7 @@ jobs:
       - id: asset-key-docs-build
         uses: ./.github/actions/generate-asset-key
       - name: Restore Insight asset cache
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
@@ -155,7 +155,7 @@ jobs:
       - id: asset-key-docker
         uses: ./.github/actions/generate-asset-key
       - name: Restore Insight asset cache
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
@@ -263,17 +263,17 @@ jobs:
     runs-on: windows-latest
     environment: ci-on-demand
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.11'
+          python-version: '3.11.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
-      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -285,7 +285,7 @@ jobs:
       - id: asset-key-docker
         uses: ./.github/actions/generate-asset-key
       - name: Cache Insight assets
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
@@ -321,10 +321,10 @@ jobs:
     environment: ci-on-demand
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.11'
+          python-version: '3.11.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
@@ -333,7 +333,7 @@ jobs:
           pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
       - name: Install macOS extras
         run: pip install appnope==0.1.4
-      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -345,7 +345,7 @@ jobs:
       - id: asset-key-docker
         uses: ./.github/actions/generate-asset-key
       - name: Cache Insight assets
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
@@ -384,12 +384,12 @@ jobs:
       PWA_TIMEOUT_MS: '120000'
     environment: ci-on-demand
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Build sandbox image
         run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
-      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.12.10'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Install docs requirements
@@ -402,14 +402,14 @@ jobs:
       - id: asset-key-docs-build
         uses: ./.github/actions/generate-asset-key
       - name: Restore Insight asset cache
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
           key: assets-${{ steps.asset-key-docs-build.outputs.key }}-${{ runner.os }}
           restore-keys: assets-${{ runner.os }}-
-      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -450,15 +450,15 @@ jobs:
       SANDBOX_IMAGE: selfheal-sandbox:latest
       PWA_TIMEOUT_MS: '120000'
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Build sandbox image
         run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
-      - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.12.10'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -527,10 +527,10 @@ jobs:
     # This job builds and pushes the image.
     environment: ci-on-demand
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-      - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@v4 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -548,7 +548,7 @@ jobs:
       - id: asset-key-docker
         uses: ./.github/actions/generate-asset-key
       - name: Cache Insight assets
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@v4 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
@@ -663,7 +663,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ci-on-demand
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Compute repo_owner_lower
         run: echo "repo_owner_lower=$(echo \"${{ github.repository_owner }}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Login to GHCR


### PR DESCRIPTION
## Summary
- bump GitHub Actions in `ci.yml` to v4/v5 tags
- test matrix now uses Python 3.11.12 and 3.12.10

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `act -j lint-type -n` *(fails: couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_687e6a3c23dc833385826674c7712f40