### PR TITLE
docs: explain CI trigger requires owner

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -10,9 +10,11 @@ repository owner triggers it from the GitHub Actions UI.
 
 1. Navigate to **Actions → 🚀 CI**.
 2. Choose the branch or tag in the drop‑down and click **Run workflow**.
-3. Only the repository owner can trigger this button. The workflow starts with
-   an `owner-check` job using the `ensure-owner` composite action. If the actor
-   does not match `github.repository_owner` the pipeline exits immediately.
+3. Only the repository owner can trigger this button. The workflow begins with
+   a **Verify owner** job that runs the `ensure-owner` composite action. If the
+   actor does not match `github.repository_owner` the pipeline exits
+   immediately. Contributors will see a skipped run unless the repository owner
+   clicks **Run workflow**.
 4. Confirm **Python&nbsp;3.11 or 3.12** and **Node.js&nbsp;20** are installed.
 5. Run `pre-commit run --all-files` so the hooks pass before pushing.
 


### PR DESCRIPTION
## Summary
- clarify that only the repository owner can run `🚀 CI`
- mention the **Verify owner** job and why collaborator attempts may be skipped

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687e6d61e6d88333a46d65d90caba400