### PR TITLE
fix: update Insight CSP SRI replacement

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -78,7 +78,7 @@ injectManifest({{
             break
     if inline_sri:
         text = re.sub(
-            r"(script-src 'self' 'wasm-unsafe-eval')[^;]*",
+            r"(script-src 'self' 'wasm-unsafe-eval')(?: 'unsafe-inline'|'sha384-[^']+')?",
             rf"\1 '{inline_sri}'",
             text,
         )

--- a/scripts/verify_insight_offline.py
+++ b/scripts/verify_insight_offline.py
@@ -36,12 +36,12 @@ def _attempt() -> bool:
             def on_console(msg: object) -> None:
                 entry = f"[{msg.type}] {msg.text}"
                 logs.append(entry)
-                print(entry, file=sys.stderr)
+                print(entry, file=sys.stderr, flush=True)
 
             def on_page_error(exc: Exception) -> None:
                 err = str(exc)
                 page_errors.append(err)
-                print(err, file=sys.stderr)
+                print(err, file=sys.stderr, flush=True)
 
             page.on("console", on_console)
             page.on("pageerror", on_page_error)


### PR DESCRIPTION
## Summary
- ensure CSP script-src replaces any existing inline hash when building the Insight browser
- flush console and page error logs immediately during offline verification

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py scripts/verify_insight_offline.py`
- `bash scripts/build_gallery_site.sh` *(fails: Preflight checks failed)*
- `python scripts/verify_insight_offline.py` *(fails: Playwright browser missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e75610dec8333a1fd9fa0ba2ea553