### PR TITLE
fix: update CSP hash replacement

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -79,8 +79,8 @@ export async function generateServiceWorker(outDir, manifest, version) {
     inlineHash = 'sha384-' + createHash('sha384').update(snippet).digest('base64');
   }
   indexText = indexText.replace(
-    /(script-src 'self' 'wasm-unsafe-eval')[^;]*/,
-    (_, p1) => `${p1}${inlineHash ? ` '${inlineHash}'` : ''}`
+    /(script-src 'self' 'wasm-unsafe-eval')(?:\s+'(?:unsafe-inline|sha384-[^']+)')?/,
+    (_, p1) => (inlineHash ? `${p1} '${inlineHash}'` : p1)
   );
   await fs.writeFile(indexPath, indexText);
   let swText = swData.toString('utf8');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -78,7 +78,7 @@ injectManifest({{
             break
     if inline_sri:
         text = re.sub(
-            r"(script-src 'self' 'wasm-unsafe-eval')(?: 'unsafe-inline'|'sha384-[^']+')?",
+            r"(script-src 'self' 'wasm-unsafe-eval')(?:\s+'(?:unsafe-inline|sha384-[^']+)')?",
             rf"\1 '{inline_sri}'",
             text,
         )

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -9,8 +9,9 @@ from typing import Any
 from urllib.parse import urlparse
 import base64
 
-BUILD_DIR = Path(__file__).resolve().parent / "build"
-sys.path.insert(0, str(BUILD_DIR))
+BASE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(BASE_DIR))
+sys.path.insert(0, str(BASE_DIR / "build"))
 from build.common import check_gzip_size, sha384, generate_service_worker  # noqa: E402
 
 

--- a/scripts/verify_insight_offline.py
+++ b/scripts/verify_insight_offline.py
@@ -45,6 +45,8 @@ def _attempt() -> bool:
 
             page.on("console", on_console)
             page.on("pageerror", on_page_error)
+            context.on("console", on_console)
+            context.on("pageerror", on_page_error)
             page.goto(URL)
             page.wait_for_function("navigator.serviceWorker.ready", timeout=TIMEOUT_MS)
             page.wait_for_selector("body", timeout=TIMEOUT_MS)


### PR DESCRIPTION
## Summary
- ensure build script replaces any CSP hash
- update manual build path handling
- log browser console errors from context

## Testing
- `npm run build` *(fails: ENOTEMPTY rename)*
- `bash scripts/build_gallery_site.sh` *(fails: Preflight checks failed)*
- `python scripts/verify_insight_offline.py` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_687e847654c883339aa812d21417d386