### PR TITLE
Fix CSP inline script handling

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js
@@ -80,7 +80,7 @@ export async function generateServiceWorker(outDir, manifest, version) {
   }
   indexText = indexText.replace(
     /(script-src 'self' 'wasm-unsafe-eval')(?:\s+'(?:unsafe-inline|sha384-[^']+)')?/,
-    (_, p1) => (inlineHash ? `${p1} '${inlineHash}'` : p1)
+    (_, p1) => (inlineHash ? `${p1} 'unsafe-inline' '${inlineHash}'` : `${p1} 'unsafe-inline'`)
   );
   await fs.writeFile(indexPath, indexText);
   let swText = swData.toString('utf8');

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py
@@ -79,7 +79,7 @@ injectManifest({{
     if inline_sri:
         text = re.sub(
             r"(script-src 'self' 'wasm-unsafe-eval')(?:\s+'(?:unsafe-inline|sha384-[^']+)')?",
-            rf"\1 '{inline_sri}'",
+            rf"\1 'unsafe-inline' '{inline_sri}'",
             text,
         )
     else:

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -37,7 +37,7 @@
     </div>
     <div id="legend" role="region" aria-label="Legend"></div>
     <div id="depth-legend" role="region" aria-label="Depth Legend"></div>
-    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;"> <a href="../DISCLAIMER_SNIPPET.md">See docs/DISCLAIMER_SNIPPET.md</a> 
+    <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;">
       This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
     </footer>
     <script>
@@ -90,5 +90,6 @@
     </script>
     <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
+<p><a href="../index.html">⬅️ Back to Gallery</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep `unsafe-inline` when injecting SRI hashes for Insight browser
- rebuild Insight docs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js`
- `./scripts/build_insight_docs.sh` *(fails: `mkdocs: command not found`)*
- `playwright install chromium`
- `python scripts/verify_insight_offline.py` *(fails: timeout waiting for service worker)*

------
https://chatgpt.com/codex/tasks/task_e_687ea5907f98833397e5bf5cc286cfbc