### PR TITLE
Fix CSP rewrite for Insight docs

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -88,8 +88,9 @@
         });
       }
     </script>
-    <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
+  <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
+<p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure build/common.py inserts hashes for all inline scripts
- add missing disclaimer link to Insight index

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py docs/alpha_agi_insight_v1/index.html`

------
https://chatgpt.com/codex/tasks/task_e_687ecac1f2d08333860a5d809e21638d