### PR TITLE
Ensure git available for GitPython

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg build-essential git \
         rustc cargo postgresql-client patch && \
+    git --version && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
@@ -45,6 +46,10 @@ COPY alpha_factory_v1/demos/self_healing_repo_cli.py alpha_factory_v1/demos/self
 RUN npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client \
     && npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client run build \
     && rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+
+# git executable path for GitPython
+ENV GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git
+ENV PATH="/usr/bin:$PATH"
 
 # run as non-root user for demos
 RUN useradd --uid 1001 --create-home appuser \

--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -47,7 +47,9 @@ LABEL org.opencontainers.image.title="Alpha-Factory Runtime" \
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git \
+    PATH="/usr/bin:$PATH"
 
 #############################
 # 2) System packages         #
@@ -66,6 +68,7 @@ RUN apt-get update && \
         postgresql-client \
         patch \  # required by the self-healing demo
         curl ca-certificates && \
+    git --version && \
     rm -rf /var/lib/apt/lists/*
 
 #############################

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -4,8 +4,9 @@ FROM python:3.11.13-slim
 # Install build tools for optional native extensions
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg build-essential && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+        curl ca-certificates gnupg build-essential git && \
+    git --version && \
+        curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
@@ -34,6 +35,8 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 USER afuser
 
 ENV PYTHONUNBUFFERED=1
+ENV GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git
+ENV PATH="/usr/bin:$PATH"
 EXPOSE 8000 8501 6006
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["web"]

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Alpha-Factory Insight demo entrypoint
 set -Eeuo pipefail
+export PATH="/usr/bin:$PATH"
+export GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git
 
 export PYTHONUNBUFFERED=1
 MODE="${RUN_MODE:-web}"

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -2,7 +2,13 @@
 # Minimal runtime image for the quickstart script
 FROM python:3.11.13-slim
 
+# confirm git availability
+RUN apt-get update && apt-get install -y --no-install-recommends git && git --version && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+
+ENV GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git
+ENV PATH="/usr/bin:$PATH"
 
 # Install Alpha-Factory with default extras
 COPY requirements.lock /tmp/requirements.lock

--- a/infrastructure/docker-entrypoint.sh
+++ b/infrastructure/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
+export PATH="/usr/bin:$PATH"
+export GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git
 MODE=${RUN_MODE:-web}
 if [ "$MODE" = "api" ]; then
   exec python -m alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server


### PR DESCRIPTION
## Summary
- verify git is installed during image builds
- expose GIT_PYTHON_GIT_EXECUTABLE in Dockerfiles
- add /usr/bin to PATH in entrypoints

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --hook-stage manual --verbose --files Dockerfile alpha_factory_v1/Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/docker-entrypoint.sh docker/quickstart/Dockerfile infrastructure/docker-entrypoint.sh`
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed1507f408333901a986f9c860ef8