### PR TITLE
Fix failing tests and CSP hash

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -218,11 +218,12 @@ async function bundle() {
         '<script type="module" src="insight.bundle.js" crossorigin="anonymous"></script>';
     const sriTag = `<script type="module" src="insight.bundle.js" integrity="${appSri}" crossorigin="anonymous"></script>`;
     let outHtml = html.replace(scriptTag, sriTag);
-    const csp =
+    const cspBase =
         "default-src 'self'; connect-src 'self' https://api.openai.com" +
         (ipfsOrigin ? ` ${ipfsOrigin}` : "") +
-        (otelOrigin ? ` ${otelOrigin}` : "") +
-        "; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
+        (otelOrigin ? ` ${otelOrigin}` : "");
+    const csp =
+        `${cspBase}; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' ${envHash}; style-src 'self' 'unsafe-inline'`;
     outHtml = outHtml.replace(
         /<meta[^>]*http-equiv="Content-Security-Policy"[^>]*>/,
         `<meta http-equiv="Content-Security-Policy" content="${csp}" />`,
@@ -235,6 +236,11 @@ async function bundle() {
         );
     }
     const envScript = injectEnv(process.env);
+    const envHash =
+        'sha384-' +
+        createHash('sha384')
+            .update(envScript.replace(/^<script>|<\/script>$/g, ''))
+            .digest('base64');
 
     const checksums = manifest.checksums || {};
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -8,9 +8,12 @@ subclasses :class:`~alpha_factory_v1.core.agents.base_agent.BaseAgent` and coope
 
 from .adk_adapter import ADKAdapter
 from .mcp_adapter import MCPAdapter
-from alpha_factory_v1.core.agents import base_agent as base_agent
 
-BaseAgent = base_agent.BaseAgent
+# Importing BaseAgent from the core package during module import triggers a
+# circular dependency because ``base_agent`` itself loads this package.  The
+# individual agents directly import :class:`~alpha_factory_v1.core.agents.base_agent.BaseAgent`,
+# so re-exporting here is unnecessary.  Avoid the early import to prevent a
+# partially initialised module during start-up.
 from .research_agent import ResearchAgent
 from .adk_summariser_agent import ADKSummariserAgent
 from .chaos_agent import ChaosAgent


### PR DESCRIPTION
## Summary
- prevent circular import by removing BaseAgent re-export
- fix A2A business demo tests and CLI
- patch Insight build to hash env injection script

## Testing
- `pre-commit run --files tests/test_alpha_agi_business_3_v1.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py`
- `pytest tests/test_alpha_agi_business_3_v1.py::test_cli_entrypoint tests/test_alpha_agi_business_3_v1.py::test_main_stops_a2a -q`


------
https://chatgpt.com/codex/tasks/task_e_687ee3c8117483339da691a06d8017c2