### PR TITLE
[alpha_factory] Fix CI workflow and stabilize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
+          architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Install dependencies
@@ -529,7 +530,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Compute repo_owner_lower
-        run: echo "repo_owner_lower=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          repo_owner_lower=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
@@ -636,7 +639,9 @@ jobs:
         run: |
           docker run --rm -e RUN_MODE=cli "$DOCKER_IMAGE:ci" simulate --horizon 1 --offline
       - name: Compute repo_owner_lower
-        run: echo "repo_owner_lower=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          repo_owner_lower=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_ENV"
       - name: Login to GHCR
         uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
@@ -665,7 +670,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Compute repo_owner_lower
-        run: echo "repo_owner_lower=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          repo_owner_lower=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_ENV"
       - name: Login to GHCR
         uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
         with:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py
@@ -18,10 +18,14 @@ from .research_agent import ResearchAgent
 from .adk_summariser_agent import ADKSummariserAgent
 from .chaos_agent import ChaosAgent
 
+# Re-export the base_agent module for convenience in tests
+from alpha_factory_v1.core.agents import base_agent
+
 __all__ = [
     "ADKAdapter",
     "MCPAdapter",
     "ResearchAgent",
     "ADKSummariserAgent",
     "ChaosAgent",
+    "base_agent",
 ]

--- a/tests/test_aiga_service.py
+++ b/tests/test_aiga_service.py
@@ -9,6 +9,8 @@ import sys
 import types
 
 import pytest
+
+pytest.importorskip("gymnasium", reason="gymnasium required for environment")
 from fastapi.testclient import TestClient
 
 


### PR DESCRIPTION
## Summary
- add `architecture: x64` for Python on macOS
- compute repo owner correctly in Docker job
- export `base_agent` for tests
- hash all inline scripts for CSP
- skip aiga service tests when gymnasium missing

## Testing
- `pre-commit run --files .github/workflows/ci.yml alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js alpha_factory_v1/demos/alpha_agi_insight_v1/src/agents/__init__.py tests/test_aiga_service.py -v`
- `pytest tests/test_adk_agent.py::test_adk_summariser_runs tests/test_aiga_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee8f7d0c48333964d9d07d749f582