### PR TITLE
[alpha_factory] make demo helpers robust

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py
@@ -82,8 +82,12 @@ class Orchestrator:
             "price_dislocation": random.gauss(0, 0.05),
         }
 
-    def post_alpha_job(self, bundle_id: str, delta_g: float) -> None:
+    def post_alpha_job(self, bundle_id: str | None, delta_g: float | None) -> None:
         """Broadcast a new job for agents when ``delta_g`` is favourable."""
+
+        if bundle_id is None or delta_g is None:
+            log.info("[Orchestrator] Ignoring job with missing data")
+            return
 
         log.info(
             "[Orchestrator] Posting alpha job for bundle %s with ΔG=%.6f",
@@ -164,8 +168,11 @@ class Model:
         log.info("[Model] New weights committed (Gödel-proof verified)")
 
 
-async def _close_adk_client(client: Any) -> None:
+async def _close_adk_client(client: Any | None) -> None:
     """Attempt to gracefully close an ADK client."""
+
+    if client is None:
+        return
 
     closer = getattr(client, "close", None)
     if closer is not None:


### PR DESCRIPTION
## Summary
- guard `Orchestrator.post_alpha_job` against missing data
- ignore `None` in `_close_adk_client`
- verify alpha business demo tests under Python 3.11 and 3.12

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_3_v1/alpha_agi_business_3_v1.py`
- `pytest tests/test_alpha_agi_business_3_v1.py -q` (Python 3.12)
- `pytest tests/test_alpha_agi_business_3_v1.py -q` (Python 3.11)

------
https://chatgpt.com/codex/tasks/task_e_687ef0a70ac483339a7e448849f67805