### PR TITLE
[alpha_factory] add diagnostics to server tests

### DIFF
--- a/alpha_factory_v1/core/interface/api_server.py
+++ b/alpha_factory_v1/core/interface/api_server.py
@@ -906,7 +906,11 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--host", default="0.0.0.0", help="Bind host")
     parser.add_argument("--port", type=int, default=8000, help="Bind port")
     args = parser.parse_args(argv)
-    uvicorn.run(cast(Any, app), host=args.host, port=args.port)
+    try:
+        uvicorn.run(cast(Any, app), host=args.host, port=args.port)
+    except Exception as exc:  # pragma: no cover - runtime failure
+        _log.exception("server failed: %s", exc)
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- capture server output in subprocess-based API server tests
- fail fast if api_server main exits unexpectedly

## Testing
- `pre-commit run --files alpha_factory_v1/core/interface/api_server.py tests/test_api_server_subprocess.py`
- `pytest tests/test_api_server.py tests/test_api_server_subprocess.py -q` *(fails: AttributeError: 'Settings' object has no attribute 'json_logs')*

------
https://chatgpt.com/codex/tasks/task_e_687ef3dc8f608333a4b8b784c38fcc6e