### PR TITLE
Fix non_network fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
 def non_network(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable outbound networking for the duration of a test."""
 
-    def _blocked(*_a: Any, **_k: Any) -> None:
+    def _blocked(*_a: Any, **_kw: Any) -> None:
         raise OSError("network disabled")
 
     monkeypatch.setattr(socket.socket, "connect", _blocked)


### PR DESCRIPTION
## Summary
- define `non_network` fixture with `_kw` arg

## Testing
- `pre-commit run --files tests/conftest.py`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_687efb97c96883338584af8198165792