### PR TITLE
[alpha_factory] update CI Python matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -326,6 +326,7 @@ jobs:
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
+          architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- test against Python 3.11 and 3.12 in lint job
- explicitly use x64 architecture on macOS smoke job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: FileNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f03836a108333af32b6a187dbf055