### PR TITLE
fix: hash inline scripts for CSP

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -222,6 +222,12 @@ async function bundle() {
         "default-src 'self'; connect-src 'self' https://api.openai.com" +
         (ipfsOrigin ? ` ${ipfsOrigin}` : "") +
         (otelOrigin ? ` ${otelOrigin}` : "");
+    const envScript = injectEnv(process.env);
+    const envHash =
+        'sha384-' +
+        createHash('sha384')
+            .update(envScript.replace(/^<script>|<\/script>$/g, ''))
+            .digest('base64');
     const csp =
         `${cspBase}; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' ${envHash}; style-src 'self' 'unsafe-inline'`;
     outHtml = outHtml.replace(
@@ -235,12 +241,6 @@ async function bundle() {
             path.join(OUT_DIR, "insight_browser_quickstart.pdf"),
         );
     }
-    const envScript = injectEnv(process.env);
-    const envHash =
-        'sha384-' +
-        createHash('sha384')
-            .update(envScript.replace(/^<script>|<\/script>$/g, ''))
-            .digest('base64');
 
     const checksums = manifest.checksums || {};
 

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -88,7 +88,7 @@
         });
       }
     </script>
-  <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
+    <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>


### PR DESCRIPTION
## Summary
- hash all inline script blocks in build helpers
- update Insight demo CSP

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.js alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/common.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js docs/alpha_agi_insight_v1/index.html`
- `python scripts/verify_insight_offline.py` *(fails: Refused to execute inline script)*

------
https://chatgpt.com/codex/tasks/task_e_687f0cb922c483339649c3ff2fd6e248