### PR TITLE
[alpha_factory] fix quoting in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}" -f Dockerfile .
+          docker build -t ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} -f Dockerfile .
 
       - name: Generate Python SBOM
         run: cyclonedx-py -r requirements.lock -o sbom-python.json
@@ -88,7 +88,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image
-        run: docker push "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
+        run: docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
@@ -96,15 +96,15 @@ jobs:
           cosign-release: 'v2.2.4'
 
       - name: Sign container
-        run: cosign sign --yes "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
+        run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Verify signature
-        run: cosign verify "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
+        run: cosign verify ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Generate provenance
         run: |
-          cosign generate --type slsaprovenance "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}" > provenance.json
-          cosign attest --yes --predicate provenance.json --type slsaprovenance "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}"
+          cosign generate --type slsaprovenance ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} > provenance.json
+          cosign attest --yes --predicate provenance.json --type slsaprovenance ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
@@ -114,8 +114,8 @@ jobs:
 
       - name: Push image to Docker Hub
         run: |
-          docker tag "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}" "$DOCKERHUB_REPO:${{ github.ref_name }}"
-          docker tag "ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}" "$DOCKERHUB_REPO:latest"
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} "$DOCKERHUB_REPO:${{ github.ref_name }}"
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} "$DOCKERHUB_REPO:latest"
           docker push "$DOCKERHUB_REPO:${{ github.ref_name }}"
           docker push "$DOCKERHUB_REPO:latest"
 


### PR DESCRIPTION
## Summary
- remove quotes around `$repo_owner_lower` references in `security.yml`
- confirm `pre-commit`, `check_env.py` and tests pass
- attempted a dry-run of the CI workflow via `act` but it failed due to missing Docker in the environment

## Testing
- `pre-commit run --files .github/workflows/security.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`
- `act -j docker --workflows .github/workflows/ci.yml --dryrun` *(fails: no Docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_687f9925132c8333a818715c9dbfb3fc