### PR TITLE
[alpha_factory] allow unsafe install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN python -m pip install --upgrade pip
 # Install demo-specific Python dependencies
 COPY alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock /tmp/requirements-demo.lock
 RUN if [ -f /tmp/requirements-demo.lock ]; then \
-      pip install --no-cache-dir -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock; \
+      pip install --no-cache-dir --allow-unsafe -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock; \
     else \
       echo "Missing demo requirements" && exit 1; \
     fi


### PR DESCRIPTION
## Summary
- add `--allow-unsafe` option when installing demo requirements
- run `pre-commit` on Dockerfile
- attempted to rebuild Docker image

## Testing
- `pre-commit run --files Dockerfile`
- `docker build -t testbuild -f Dockerfile .` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687facd4a2d48333856015d034cc2197