### PR TITLE
[alpha_factory] fix offline cache path

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/sw.js
@@ -8,12 +8,12 @@ import {CacheFirst} from 'workbox-strategies';
 // replaced during build
 const CACHE_VERSION = '__CACHE_VERSION__';
 async function init() {
-  const res = await fetch('assets/lib/workbox-sw.js');
+  const res = await fetch('lib/workbox-sw.js');
   const buf = await res.arrayBuffer();
   const digest = await crypto.subtle.digest('SHA-384', buf);
   const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
   if (`sha384-${b64}` !== WORKBOX_SW_HASH) {
-    throw new Error('assets/lib/workbox-sw.js hash mismatch');
+    throw new Error('lib/workbox-sw.js hash mismatch');
   }
   importScripts(URL.createObjectURL(new Blob([buf], {type: 'application/javascript'})));
   workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});

--- a/docs/alpha_agi_insight_v1/service-worker.js
+++ b/docs/alpha_agi_insight_v1/service-worker.js
@@ -8,12 +8,12 @@ import {CacheFirst} from 'workbox-strategies';
 // replaced during build
 const CACHE_VERSION = '0.1.0';
 async function init() {
-  const res = await fetch('assets/lib/workbox-sw.js');
+  const res = await fetch('lib/workbox-sw.js');
   const buf = await res.arrayBuffer();
   const digest = await crypto.subtle.digest('SHA-384', buf);
   const b64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
   if (`sha384-${b64}` !== WORKBOX_SW_HASH) {
-    throw new Error('assets/lib/workbox-sw.js hash mismatch');
+    throw new Error('lib/workbox-sw.js hash mismatch');
   }
   importScripts(URL.createObjectURL(new Blob([buf], {type: 'application/javascript'})));
   workbox.core.setCacheNameDetails({prefix: CACHE_VERSION});


### PR DESCRIPTION
## Summary
- correct service worker fetch path for workbox
- update built service worker accordingly

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --all-files`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_687fc3c809148333a6ea4f41e5218e02