### PR TITLE
test: ensure config tests import pytest

### DIFF
--- a/tests/test_world_model_config.py
+++ b/tests/test_world_model_config.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import importlib
 import sys
 
+import pytest
+
 
 def test_bool_env_override(monkeypatch, non_network: None) -> None:
     """ALPHA_ASI_LOG_JSON=false should disable JSON logging."""


### PR DESCRIPTION
## Summary
- verify `tests/conftest.py` is loaded and fixture `non_network` is available
- import `pytest` in `tests/test_world_model_config.py` so the fixture works

## Testing
- `python check_env.py --auto-install`
- `pytest --fixtures | grep -n non_network`
- `pytest tests/test_world_model_config.py::test_bool_env_override -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687fcd25185483338cfab84e9c4a764a