### PR TITLE
Ensure business demo resets global socket

### DIFF
--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import hashlib
 import json
-from typing import Any
+from typing import Any, Iterator
 from unittest import mock
 import pytest
 from pathlib import Path
@@ -17,6 +17,14 @@ ROOT = Path(__file__).resolve().parents[1]
 STUB_DIR = ROOT / "tests" / "resources"
 
 MODULE = "alpha_factory_v1.demos.alpha_agi_business_3_v1.alpha_agi_business_3_v1"
+
+
+@pytest.fixture(autouse=True)
+def _reset_demo_globals() -> Iterator[None]:
+    """Reset global state altered by the demo."""
+    yield
+    if MODULE in sys.modules:
+        sys.modules[MODULE]._A2A = None
 
 
 def test_adk_client_import(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- reset `_A2A` after each business demo test to avoid cross-test pollution

## Testing
- `pre-commit run --files tests/test_alpha_agi_business_3_v1.py`
- `pytest tests/test_alpha_agi_business_3_v1.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcecb551c833397aa957bd0285228