### PR TITLE
[alpha_factory] pin setuptools via allow-unsafe

### DIFF
--- a/scripts/offline_prepare.sh
+++ b/scripts/offline_prepare.sh
@@ -31,7 +31,7 @@ else
   PIP_COMPILE="python -m piptools compile"
 fi
 
-opts=(--generate-hashes --quiet)
+opts=(--generate-hashes --quiet --allow-unsafe)
 if [[ -n "${WHEELHOUSE:-}" ]]; then
   opts+=(--no-index --find-links "$WHEELHOUSE")
 fi

--- a/scripts/verify_alpha_requirements_lock.py
+++ b/scripts/verify_alpha_requirements_lock.py
@@ -24,7 +24,7 @@ def main() -> int:
         else:
             cmd = [sys.executable, "-m", "piptools", "compile"]
         wheelhouse = os.getenv("WHEELHOUSE")
-        cmd += ["--generate-hashes", "--quiet"]
+        cmd += ["--generate-hashes", "--quiet", "--allow-unsafe"]
         if wheelhouse:
             cmd += ["--no-index", "--find-links", wheelhouse]
         cmd += [str(req_txt), "-o", str(out_path)]


### PR DESCRIPTION
## Summary
- use `--allow-unsafe` when compiling offline lock files
- update lock verification script accordingly

## Testing
- `pre-commit run --all-files` *(fails: line too long)*
- `pytest` *(fails: 17 failed, 76 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687ff4cfe61083339120410d3edfc949