### PR TITLE
[alpha_factory] bump python images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The instructions below apply to all contributors and automated agents.
 All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 Please report security vulnerabilities as described in our [Security Policy](SECURITY.md).
 ## Prerequisites
-- Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**)
+- Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**)
 - Docker and Docker Compose (Compose ≥2.5)
 - Git
 - Node.js 20 for the web client and browser demo. A `.nvmrc` is provided, so run
@@ -46,10 +46,10 @@ docker --version
 docker compose version
 git --version
 ```
-Python must report 3.11 or 3.12 and Docker Compose must be at least 2.5.
+Python must report 3.11 or 3.13 and Docker Compose must be at least 2.5.
 
 ## Development Environment
-- Create and activate a Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**) virtual
+- Create and activate a Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**) virtual
   environment before running the setup script. On Linux or macOS:
   ```bash
   python3 -m venv .venv
@@ -260,7 +260,7 @@ template). The sample file now lists every variable with its default value.
 | `CROSS_ALPHA_MODEL` | OpenAI model for the discovery tool when `OPENAI_API_KEY` is set | `gpt-4o-mini` |
 
 ## Coding Style
-- Use Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**) and include type hints for public APIs.
+- Use Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**) and include type hints for public APIs.
 - Indent with 4 spaces and keep lines under 120 characters.
 - `.editorconfig` enforces UTF-8 encoding, LF line endings and the 120-character limit for Python and Markdown files.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
@@ -387,7 +387,7 @@ issues locally before dispatching the workflow.
 
 ### Troubleshooting
 - If the stack fails to start, verify Docker and Docker Compose are running.
-- Setup errors usually mean Python is older than 3.11. Use Python 3.11 or 3.12 (>=3.11,<3.13).
+- Setup errors usually mean Python is older than 3.11. Use Python 3.11 or 3.13 (>=3.11,<3.14).
 - When working offline, build the wheelhouse with `scripts/build_offline_wheels.sh` on a
   machine with internet access, copy the `wheels/` directory to the repository root and set
   `WHEELHOUSE=$(pwd)/wheels` before running `python check_env.py --auto-install` or the tests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
-FROM python:3.12.11-slim
+FROM python:3.13.5-slim
 
 # install build tools and npm for the React UI
 RUN apt-get update && \

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Minimal runtime image for the quickstart script
-FROM python:3.11.13-slim
+FROM python:3.13.5-slim
 
 # confirm git availability
 RUN apt-get update && apt-get install -y --no-install-recommends git && git --version && rm -rf /var/lib/apt/lists/*

--- a/sandbox.Dockerfile
+++ b/sandbox.Dockerfile
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-FROM python:3.11.13-slim
+FROM python:3.13.5-slim
 RUN apt-get update && apt-get install -y --no-install-recommends patch \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- use python 3.13.5-slim in Dockerfiles
- document Python 3.13 support in AGENTS guide

## Testing
- `pre-commit run --files Dockerfile sandbox.Dockerfile docker/quickstart/Dockerfile AGENTS.md`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: 132 failed, 358 passed, 62 skipped, 1 xfailed, 1 error)*


------
https://chatgpt.com/codex/tasks/task_e_688008174670833390e43f3a4574a603