### PR TITLE
[alpha_factory] clarify CI job behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,4 +179,6 @@ pre-commit run --files .github/workflows/ci.yml
 
 The job runs only when `github.actor` equals `github.repository_owner`, so other
 contributors cannot execute it unless the owner grants them explicit
-permissions or dispatches the workflow on their behalf.
+permissions or dispatches the workflow on their behalf. Downstream jobs use
+`if: always()` so Windows and macOS smoke tests, docs and Docker steps still run
+whenever the owner triggers the workflow even if earlier stages fail.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ workflow has no automatic triggers; only the repository owner can launch it
 manually from the GitHub UI. Each job begins by verifying the actor matches the
 repository owner, so non‑owners exit immediately before running the heavy
 steps. When the owner launches the workflow every job runs.
+Jobs following the main test stage include `if: always()` so the Windows and
+macOS smoke tests, documentation build and Docker jobs execute even when the
+lint or unit tests fail. This behavior helps confirm that cross‑platform builds
+and docs generation succeed while debugging failures.
 Dependency hashes are fully locked, including `setuptools`, so `pip install -r
 requirements.lock` succeeds across Python versions. The Windows smoke job now
 builds the Insight browser before running tests, ensuring the service worker is


### PR DESCRIPTION
## Summary
- note that CI jobs with `if: always()` run despite earlier failures

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --all-files` *(fails: ENOENT in npm install)*
- `pytest` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68800f517dc48333b0d2606e6da06f87