### PR TITLE
[alpha_factory] use backend lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.lock
           pip install -r requirements-demo-cpu.lock
+          pip install -r alpha_factory_v1/backend/requirements-lock.txt
       - name: Verify environment
         run: |
           python scripts/check_python_deps.py
@@ -276,6 +277,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
+          pip install -r alpha_factory_v1/backend/requirements-lock.txt
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN python -m pip install --upgrade pip
 # Install demo-specific Python dependencies
 COPY alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock /tmp/requirements-demo.lock
 RUN if [ -f /tmp/requirements-demo.lock ]; then \
-      pip install --no-cache-dir --allow-unsafe -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock; \
+      pip install --no-cache-dir -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock; \
     else \
       echo "Missing demo requirements" && exit 1; \
     fi

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -9,11 +9,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # install Python dependencies using the pinned lock file
-COPY requirements.lock /tmp/requirements.lock
-COPY requirements.txt /tmp/requirements.txt
-COPY alpha_factory_v1/requirements-core.txt /tmp/requirements-core.txt
+COPY alpha_factory_v1/backend/requirements-lock.txt /tmp/requirements.lock
+COPY alpha_factory_v1/backend/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock \
-    && rm /tmp/requirements.txt /tmp/requirements-core.txt
+    && rm /tmp/requirements.txt
 
 # copy project source
 COPY . /app


### PR DESCRIPTION
## Summary
- use backend requirements lock file in `infrastructure/Dockerfile`
- install backend lock file in `ci.yml`
- drop `--allow-unsafe` in the Dockerfile

## Testing
- `pre-commit run --files Dockerfile infrastructure/Dockerfile .github/workflows/ci.yml`
- `pytest -k "" -q` *(fails: 23 failed, 110 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688023c38870833394c79ccc94c5b00c