### PR TITLE
fix duplicate d3 in Insight PWA

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -221,6 +221,7 @@ async function bundle() {
         target: "es2020",
         outfile: `${OUT_DIR}/insight.bundle.js`,
         plugins: [aliasPlugin],
+        external: ["d3"],
     });
     execSync(`npx tailwindcss -i style.css -o ${OUT_DIR}/style.css --minify`, {
         stdio: "inherit",
@@ -281,7 +282,6 @@ async function bundle() {
     }
     const bundlePath = `${OUT_DIR}/insight.bundle.js`;
     let bundleText = await fs.readFile(bundlePath, "utf8");
-    const d3Code = await fs.readFile("d3.v7.min.js", "utf8");
     let web3Code = await fs.readFile(
         path.join("lib", "bundle.esm.min.js"),
         "utf8",
@@ -303,7 +303,7 @@ async function bundle() {
         ortCode += "\nwindow.ort=ort;";
     }
     bundleText =
-        `${d3Code}\n${web3Code}\n${pyCode}\n${ortCode}\nwindow.PYODIDE_WASM_BASE64='${wasmBase64}';window.GPT2_MODEL_BASE64='${gpt2Base64}';\n` +
+        `${web3Code}\n${pyCode}\n${ortCode}\nwindow.PYODIDE_WASM_BASE64='${wasmBase64}';window.GPT2_MODEL_BASE64='${gpt2Base64}';\n` +
         bundleText;
     bundleText = bundleText.replace(
         /\/\/#[ \t]*sourceMappingURL=.*(?:\r?\n)?/g,
@@ -315,7 +315,6 @@ async function bundle() {
         .replace(/\.\.\/lib\/bundle\.esm\.min\.js/g, "./assets/lib/bundle.esm.min.js");
     await fs.writeFile(bundlePath, bundleText);
     outHtml = outHtml
-        .replace(/<script[\s\S]*?d3\.v7\.min\.js[\s\S]*?<\/script>\s*/g, "")
         .replace(
             /<script[\s\S]*?bundle\.esm\.min\.js[\s\S]*?<\/script>\s*/g,
             "",

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,12 @@
     <div id="depth-legend" role="region" aria-label="Depth Legend"></div>
     <footer id="disclaimer" style="font-size: 0.8rem; margin: 1rem; text-align:center;">
       This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
-    </footer>
+</footer>
+    <script
+      src="d3.v7.min.js"
+      integrity="sha384-QqrLqBpBJfpJ/24ZmCV87BPpk+Sj9GkH5DzKZdwS4d47ZojhpdfvBiF+BgWe8zX8"
+      crossorigin="anonymous"
+    ></script>
     <script>
       const SW_URL = 'service-worker.js';
       const SW_HASH = 'sha384-ITQvGaSQBg4EGhxnB0OuTBcb9mYff22hfLOPenTASEQMJ4eKhFZb/TJbdttP4tRh';


### PR DESCRIPTION
## Summary
- avoid bundling d3 in insight.bundle.js
- keep d3 script tag in generated Insight docs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js docs/alpha_agi_insight_v1/index.html`
- `python check_env.py --auto-install`
- `python scripts/verify_insight_offline.py` *(fails: integrity check for insight.bundle.js)*

------
https://chatgpt.com/codex/tasks/task_e_68802ac9e95083339f0f080d4f47f106