### PR TITLE
[alpha_factory] Pin setuptools for demo build

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock
@@ -4230,7 +4230,8 @@ zipp==3.23.0 \
     --hash=sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166
     # via importlib-metadata
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes and the requirement is not
-# satisfied by a package already installed. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c \
+    # via grpcio-tools


### PR DESCRIPTION
## Summary
- pin `setuptools` in `alpha_agi_insight_v1/requirements.lock` so pip hash-checking installs succeed

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock`
- `pytest tests/security/test_csp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68803734ffc88333822c97c67f0a325a