### PR TITLE
fix: pin setuptools for backend

### DIFF
--- a/alpha_factory_v1/backend/requirements-lock.txt
+++ b/alpha_factory_v1/backend/requirements-lock.txt
@@ -75,3 +75,9 @@ noaa-sdk==0.1.21
 # ────────── Local-model fallbacks (no-API-key mode) ────────────────────
 llama-cpp-python==0.2.37
 ctransformers==0.2.27
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
+    # via grpcio-tools

--- a/alpha_factory_v1/backend/requirements.txt
+++ b/alpha_factory_v1/backend/requirements.txt
@@ -36,6 +36,9 @@ anthropic>=0.21         # Claude & MCP bridge
 litellm>=1.31           # local gateway / fallback router
 tiktoken>=0.5
 grpcio-tools
+# `grpcio-tools` requires setuptools during installation when hashes are
+# enforced. Include it explicitly so pip can verify the hash in CI.
+setuptools>=80
 
 # Google ADK – optional Agent-to-Agent federation (A2A protocol)
 google-adk>=0.3.0        # https://pypi.org/project/google-adk/


### PR DESCRIPTION
## Summary
- pin setuptools dependency so backend lock file works with pip's hash mode

## Testing
- `pre-commit run --files alpha_factory_v1/backend/requirements.txt alpha_factory_v1/backend/requirements-lock.txt .github/workflows/ci.yml`
- `pytest -k "smoke" -q`

------
https://chatgpt.com/codex/tasks/task_e_68803d457f2c8333921fcecb25c024a5