### PR TITLE
[alpha_factory] align docs with Node 22 requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Please report security vulnerabilities as described in our [Security Policy](SEC
 - Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**)
 - Docker and Docker Compose (Compose ≥2.5)
 - Git
-- Node.js 20 for the web client and browser demo. A `.nvmrc` is provided, so run
+- Node.js 22 for the web client and browser demo. A `.nvmrc` is provided, so run
   `nvm use` before installing Node dependencies.
 - See [Updating Browser Assets](alpha_factory_v1/scripts/README.md#updating-browser-assets)
   for instructions on refreshing the Pyodide runtime used by the Insight Browser demo.

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ and [Docker Quickstart](#docker-quickstart) sections below.
 
 For the browser-based version, see
 [insight_browser_v1/index.md](alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md).
-It requires **Node.js ≥20**. Install the dependencies with
+It requires **Node.js ≥22**. Install the dependencies with
 `npm ci` and build the static assets with `npm run build` before launching.
 The repository includes a `.nvmrc` file so you can simply run `nvm use` to
 select the correct Node version.

--- a/internal_docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/internal_docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -9,7 +9,7 @@ Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for an auto
 The steps below triple-verify environment integrity, rebuild all assets and deploy a consistently beautiful gallery. Revisit them whenever the demos or documentation change.
 
 ## 1. Validate the Environment
-1. Install **Python 3.11+** and **Node.js 20+**.
+1. Install **Python 3.11+** and **Node.js 22+**.
 2. Confirm the versions:
    ```bash
    python --version

--- a/internal_docs/GITHUB_PAGES_DEMO_TASKS.md
+++ b/internal_docs/GITHUB_PAGES_DEMO_TASKS.md
@@ -5,7 +5,7 @@
 This short sprint guides Codex through publishing the entire **Alpha‑Factory v1** demo gallery to GitHub Pages. The goal is a polished subdirectory that showcases every demo in real time and remains effortless for non‑technical users to deploy.
 
 ## 1. Environment Checks
-1. Install **Python 3.11+** and **Node.js 20+**.
+1. Install **Python 3.11+** and **Node.js 22+**.
 2. Run the preflight script:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
@@ -70,7 +70,7 @@ Run the wrapper to rebuild and publish the entire site in one step:
 python scripts/edge_human_knowledge_pages_sprint.py
 ```
 
-Prerequisites: **Python 3.11+**, **Node.js 20+** and `mkdocs`. This script mirrors the [Docs workflow](../.github/workflows/docs.yml) which the repository owner triggers manually to deploy the site.
+Prerequisites: **Python 3.11+**, **Node.js 22+** and `mkdocs`. This script mirrors the [Docs workflow](../.github/workflows/docs.yml) which the repository owner triggers manually to deploy the site.
 
 When running inside CI, set `CI_SKIP_ENV_CHECK=1` to avoid repeating the environment installation step:
 

--- a/internal_docs/INSIGHT_ACCESS_SPRINT.md
+++ b/internal_docs/INSIGHT_ACCESS_SPRINT.md
@@ -6,7 +6,7 @@ This short guide distills the essential steps required to build and publish the 
 
 ## 1. Environment Preparation
 
-1. Install **Python 3.11+** and **Node.js 20+**.
+1. Install **Python 3.11+** and **Node.js 22+**.
 2. Install `mkdocs`, `mkdocs-material` and `playwright`:
    ```bash
    pip install mkdocs mkdocs-material playwright

--- a/internal_docs/INSIGHT_SPRINT_PLAN.md
+++ b/internal_docs/INSIGHT_SPRINT_PLAN.md
@@ -3,8 +3,7 @@
 
 This document outlines the minimal tasks required to publish the **α‑AGI Insight v1** demo to GitHub Pages so that users can experience the full browser-based simulation, including the animated meta‑agentic tree search.
 
-## 1. Prepare the Environment
-- Install **Python 3.11+**, **Node.js 20+**, `mkdocs`, `mkdocs-material` and `playwright`.
+- Install **Python 3.11+**, **Node.js 22+**, `mkdocs`, `mkdocs-material` and `playwright`.
 - Run `node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js` to confirm the Node version.
 - Execute `python scripts/check_python_deps.py` and `python check_env.py --auto-install` to install optional dependencies.
 


### PR DESCRIPTION
## Summary
- update Node.js instructions in AGENTS.md
- bump Node requirement references in internal docs
- document Node.js ≥22 in README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files AGENTS.md README.md internal_docs/AT_THE_EDGE_OF_HUMAN_KNOWLEDGE_DEMO_TASKS_SPRINT.md internal_docs/GITHUB_PAGES_DEMO_TASKS.md internal_docs/INSIGHT_ACCESS_SPRINT.md internal_docs/INSIGHT_SPRINT_PLAN.md`
- `pytest` *(fails: VerifyWheelSigTests, test_wasm_bridge, test_wheel_signature, test_workbox_hash_mismatch, test_world_model_config, test_world_model_open_endedness, test_world_model_reload, test_world_model_safety, TestMessaging, test_replay_metrics, test_replay_scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68804752fe688333a1689fb44f1f4efc