### PR TITLE
docs: align Python version range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The instructions below apply to all contributors and automated agents.
 All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 Please report security vulnerabilities as described in our [Security Policy](SECURITY.md).
 ## Prerequisites
-- Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**)
+- Python 3.11 or 3.12 (**Python ≥3.11 and <3.13**)
 - Docker and Docker Compose (Compose ≥2.5)
 - Git
 - Node.js 22 for the web client and browser demo. A `.nvmrc` is provided, so run


### PR DESCRIPTION
## Summary
- fix AGENTS.md to mention Python 3.12 instead of 3.13

## Testing
- `pre-commit run --files AGENTS.md`
- `python check_env.py --auto-install`


------
https://chatgpt.com/codex/tasks/task_e_68808c93cd3c8333b5d2e57e3bdb4ef2