### PR TITLE
[alpha_factory] Update offline pip compile docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,11 @@ Follow these steps when installing without internet access:
 
 - Generate a deterministic lock file with hashes:
   ```bash
-  pip-compile --generate-hashes --output-file requirements.lock requirements.txt
+  pip-compile --allow-unsafe --generate-hashes --output-file requirements.lock requirements.txt
   ```
   Run this command whenever you edit `requirements*.txt` so the lock file stays
   in sync.
+  See [CONTRIBUTING.md#running-pip-compile](CONTRIBUTING.md#running-pip-compile) for more details.
 
 - Install from the lock file to reproduce identical environments:
   ```bash

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,7 +78,8 @@ def _wait_ready(proc: subprocess.Popen[bytes], url: str, *, interval: float = 0.
         time.sleep(interval)
     stdout, stderr = proc.communicate()
     raise AssertionError(
-        f"server did not start within {attempts * interval:.1f}s\nexit code {proc.poll()}\nstdout:\n{stdout.decode()}\nstderr:\n{stderr.decode()}"
+        f"server did not start within {attempts * interval:.1f}s\n"
+        f"exit code {proc.poll()}\nstdout:\n{stdout.decode()}\nstderr:\n{stderr.decode()}"
     )
 
 


### PR DESCRIPTION
## Summary
- mention --allow-unsafe flag in offline setup docs
- link to the Contributing guide for pip-compile usage
- fix a long string in `tests/test_metrics.py`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files AGENTS.md tests/test_metrics.py`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d52ee538833390adb618281ae197