### PR TITLE
test: skip openai-agents stub tests when package installed

### DIFF
--- a/tests/test_adk_gateway_startup.py
+++ b/tests/test_adk_gateway_startup.py
@@ -60,6 +60,10 @@ def test_maybe_launch_starts_uvicorn(stub_adk, monkeypatch):
     assert called == {"app": module._ensure_router().app, "host": "1.2.3.4", "port": 1234}
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("openai_agents") is not None,
+    reason="openai-agents installed",
+)
 def test_openai_agents_stub_call(monkeypatch):
     """Calling Agent from the shim should raise ModuleNotFoundError."""
     sys.modules.pop("openai_agents", None)

--- a/tests/test_agents_fallback.py
+++ b/tests/test_agents_fallback.py
@@ -18,6 +18,10 @@ MODULES = [
 
 
 @pytest.mark.parametrize("present", ["openai_agents", "agents"])
+@pytest.mark.skipif(
+    importlib.util.find_spec("openai_agents") is not None,
+    reason="openai-agents installed",
+)
 def test_agents_import_fallback(monkeypatch, present):
     """Ensure modules import with either package name."""
     missing = "agents" if present == "openai_agents" else "openai_agents"


### PR DESCRIPTION
## Summary
- ensure stub tests skip when the real `openai-agents` is present

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files tests/test_adk_gateway_startup.py tests/test_agents_fallback.py`
- `pytest tests/test_adk_gateway_startup.py tests/test_agents_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6880dd84b4b483339c5f1b69d93c4c9f