### PR TITLE
[alpha_factory] pin pre-commit 4.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ the container includes the new dependencies.
 Run `./codex/setup.sh` to install project dependencies. The script also
 installs `pre-commit` and all lint tools before configuring the git hook.
 If you skip the setup script, manually install these tools with
-`pip install pre-commit -r requirements-dev.txt` and then run
+`pip install pre-commit==4.2.0 -r requirements-dev.txt` and then run
 `pre-commit install` once. Alternatively, execute
 `tools/setup_precommit.sh` to install `pre-commit` and configure the hook
 without the full environment setup.

--- a/README.md
+++ b/README.md
@@ -763,7 +763,7 @@ See [AGENTS.md](AGENTS.md) for the full contributor guide.
 After running `./codex/setup.sh`, install the hooks and run a full check:
 
 ```bash
-pip install pre-commit
+pip install pre-commit==4.2.0
 pre-commit install
 pre-commit run --all-files   # verify hooks after setup
 pre-commit run --files <paths>   # before each commit
@@ -783,7 +783,7 @@ all hooks succeed.
 Run `python check_env.py --auto-install` before invoking these commands so
 optional hook dependencies are installed. When working offline, pass
 `--wheelhouse <dir>` or set `WHEELHOUSE` to install from a local cache. If
-`pre-commit` isn't found, install it with `pip install pre-commit`.
+`pre-commit` isn't found, install it with `pip install pre-commit==4.2.0`.
 
 When editing the web UI, preserve existing ARIA labels so the interface
 remains accessible.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ API credentials.
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
-   pip install -U pip pre-commit
+   pip install -U pip pre-commit==4.2.0
    ```
 2. Install **Docker** and **Docker Compose** (Compose ≥2.5).
 3. Install **Node.js 22** for the web client. Run `nvm use` to activate the version from `.nvmrc`.

--- a/internal_docs/INSIGHT_SPRINT_PLAN.md
+++ b/internal_docs/INSIGHT_SPRINT_PLAN.md
@@ -5,7 +5,11 @@ This document outlines the minimal tasks required to publish the **α‑AGI Insi
 
 - Install **Python 3.11+**, **Node.js 22+**, `mkdocs`, `mkdocs-material` and `playwright`.
 - Run `node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js` to confirm the Node version.
-- Execute `python scripts/check_python_deps.py` and `python check_env.py --auto-install` to install optional dependencies.
+ - Execute `python scripts/check_python_deps.py` and `python check_env.py --auto-install` to install optional dependencies.
+ - Install `pre-commit` **4.2.0** so linting matches CI:
+   ```bash
+   pip install pre-commit==4.2.0
+   ```
 
 ## 2. Build the Static Demo
 - From the repository root, run `./scripts/edge_human_knowledge_pages_sprint.sh`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -164,7 +164,7 @@ They simply verify that the core package imports succeed.
    wheelhouse" message. Provide `--wheelhouse <dir>` (or set `WHEELHOUSE`) to run
    the tests offline. Preparing this directory via `scripts/build_offline_wheels.sh`
    is therefore a mandatory prerequisite when testing in air‑gapped setups.
-12. If `pre-commit` isn't found, install it with `pip install pre-commit` and run
+12. If `pre-commit` isn't found, install it with `pip install pre-commit==4.2.0` and run
    `pre-commit install` once to enable the git hooks referenced in
    [AGENTS.md](../AGENTS.md).
 13. Build the web assets so `dist/sw.js` exists:


### PR DESCRIPTION
## Summary
- document pre-commit version 4.2.0 in README, CONTRIBUTING and tests docs
- show installation step in quickstart guide
- note the required pre-commit version in INSIGHT_SPRINT_PLAN

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files CONTRIBUTING.md README.md docs/quickstart.md internal_docs/INSIGHT_SPRINT_PLAN.md tests/README.md`
- `pytest` *(fails: AttributeError, AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6880ebe9ba7c833391f42cef919597b1