### PR TITLE
docs: enforce Node.js 22

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/index.md
+++ b/alpha_factory_v1/core/interface/web_client/index.md
@@ -7,7 +7,7 @@ This directory contains a small React interface built with [Vite](https://vitejs
 
 ## Setup
 
-This project requires **Node.js ≥20**. The Vite build depends on
+This project requires **Node.js 22**. The Vite build depends on
 `@vitejs/plugin-vue` 6 to support Vite 7.
 
 ```bash

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -13,7 +13,7 @@ import {
     generateServiceWorker,
 } from "./build/common.js";
 import { injectEnv } from "./build/env_inject.js";
-import { requireNode20 } from "./build/version_check.js";
+import { requireNode22 } from "./build/version_check.js";
 import { validateEnv } from "./build/env_validate.js";
 
 const manifest = JSON.parse(
@@ -23,7 +23,7 @@ const manifest = JSON.parse(
     ),
 );
 
-requireNode20();
+requireNode22();
 
 function applyCsp(html, base) {
     const hashes = [];

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { pathToFileURL } from 'url';
 
-export function requireNode20() {
+export function requireNode22() {
   const [major] = process.versions.node.split('.').map(Number);
-  if (major < 20) {
+  if (major < 22) {
     console.error(
-      `Node.js 20+ is required. Current version: ${process.versions.node}`
+      `Node.js 22+ is required. Current version: ${process.versions.node}`
     );
     process.exit(1);
   }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  requireNode20();
+  requireNode22();
 }

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -10,8 +10,10 @@ Open [../../../../insight_browser_quickstart.pdf](../../../../insight_browser_qu
 for a concise overview of the build and launch steps.
 
 ## Prerequisites
-- **Node.js ≥20** is required for offline PWA support and by `manual_build.py`
+- **Node.js 22** is required for offline PWA support and by `manual_build.py`
   to generate the service worker.
+- Run `nvm use` to activate the version from `.nvmrc` before installing
+  dependencies.
 - **Python ≥3.11** is required when using `manual_build.py`.
 - `package-lock.json` must remain checked in so `npm ci` installs the exact
   versions specified.
@@ -23,12 +25,12 @@ Verify your Node.js version before running the build script:
 node build/version_check.js
 ```
 The output should be empty for a valid setup. Only run `manual_build.py` when
-this requirement is met. The `package.json` also enforces Node.js 20 or newer
+this requirement is met. The `package.json` also enforces Node.js 22 or newer
 via the `engines` field.
 
 ## Windows Setup
 
-Download and install [Node.js 20](https://nodejs.org/en/download) and
+Download and install [Node.js 22](https://nodejs.org/en/download) and
 [Python 3.11](https://www.python.org/downloads/) before running the build
 scripts. Open PowerShell in this directory and verify the versions:
 
@@ -204,7 +206,7 @@ Use `manual_build.py` for air‑gapped environments:
    the model directly from the official mirror.
    The build scripts verify these files no longer contain the word `"placeholder"`.
    Failing to replace placeholders will break offline mode.
-3. Run `node build/version_check.js` to ensure Node.js **v20** or newer is
+3. Run `node build/version_check.js` to ensure Node.js **v22** or newer is
    installed. `manual_build.py` exits if this check fails.
 4. `python manual_build.py` – or run `./manual_build.ps1` – bundles the app,
    generates `dist/sw.js` and embeds your `.env` settings.
@@ -281,7 +283,7 @@ gateway, verifying checksums to ensure each asset is intact.
 
 ### Offline Build Steps
 
-Requires **Node.js ≥20** and **Python ≥3.11**.
+Requires **Node.js 22** and **Python ≥3.11**.
 
 1. Copy `.env.sample` to `.env` and set the variables.
 2. Run `WEB3_STORAGE_TOKEN=<token> npm run fetch-assets` to download the WASM runtime and model files.
@@ -373,7 +375,7 @@ the local GPT‑2 critic.
 
 ## Running Browser Tests
 
-The demo includes a small Playwright and Pytest suite. **Node.js ≥20** is
+The demo includes a small Playwright and Pytest suite. **Node.js 22** is
 required. After fetching the WebAssembly assets run the tests with Playwright in
 offline mode:
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.ps1
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.ps1
@@ -6,11 +6,11 @@ $ErrorActionPreference = 'Stop'
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 Set-Location $scriptDir
 
-# Verify Node.js 20+
+# Verify Node.js 22+
 try {
     node build/version_check.js
 } catch {
-    Write-Error 'Node.js 20+ is required.'
+    Write-Error 'Node.js 22+ is required.'
     exit 1
 }
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -46,9 +46,9 @@ try:
         check=True,
     )
 except FileNotFoundError:
-    sys.exit("Node.js 20+ is required. Install Node.js and ensure 'node' is in your PATH.")  # noqa: E501
+    sys.exit("Node.js 22+ is required. Install Node.js and ensure 'node' is in your PATH.")  # noqa: E501
 except subprocess.CalledProcessError:
-    sys.exit("Node.js 20+ is required.")
+    sys.exit("Node.js 22+ is required.")
 
 # load environment variables
 env_file = Path(__file__).resolve().parent / ".env"

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -4,10 +4,10 @@
   "version": "0.1.0",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
-    "preinstall": "node -e \"const m=parseInt(process.versions.node); if(m<20){console.error('Node.js 20+ is required. Current version: '+process.versions.node); process.exit(1);} \"",
+    "preinstall": "node -e \"const m=parseInt(process.versions.node); if(m<22){console.error('Node.js 22+ is required. Current version: '+process.versions.node); process.exit(1);} \"",
     "lint": "eslint --config eslint.config.js src --ext .js,.ts",
     "build": "node build.js",
     "fetch-assets": "node -e \"console.log('Using PYODIDE_BASE_URL:', process.env.PYODIDE_BASE_URL)\" && python ../../../../scripts/fetch_assets.py",

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.ps1
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = 'Stop'
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 Set-Location $scriptDir
 
-# Ensure Node.js 20+
+# Ensure Node.js 22+
 node build/version_check.js
 
 if (Test-Path 'node_modules') {

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.sh
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/setup.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Ensure Node.js 20+
+# Ensure Node.js 22+
 node build/version_check.js
 
 if [[ -d node_modules ]]; then

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_node_version.py
@@ -7,10 +7,10 @@ from unittest import mock
 import pytest
 
 
-def test_requires_node_20() -> None:
+def test_requires_node_22() -> None:
     browser_dir = Path(__file__).resolve().parents[1]
     script = browser_dir / "build.js"
-    node_code = "Object.defineProperty(process.versions,'node',{value:'19.0.0'});" f" import('./{script.name}')"
+    node_code = "Object.defineProperty(process.versions,'node',{value:'21.0.0'});" f" import('./{script.name}')"
     res = subprocess.run(
         ["node", "-e", node_code],
         cwd=browser_dir,
@@ -18,7 +18,7 @@ def test_requires_node_20() -> None:
         capture_output=True,
     )
     assert res.returncode == 1
-    assert "Node.js 20+ is required. Current version: 19.0.0" in res.stderr
+    assert "Node.js 22+ is required. Current version: 21.0.0" in res.stderr
 
 
 def test_allows_node_22() -> None:

--- a/internal_docs/ADVANCED_GITHUB_PAGES_DEMO_SPRINT.md
+++ b/internal_docs/ADVANCED_GITHUB_PAGES_DEMO_SPRINT.md
@@ -7,8 +7,9 @@ This sprint details how Codex can publish every demo under `alpha_factory_v1/dem
 Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for a complete one-command deployment.
 
 ## 1. Verify the Environment
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Execute the preflight script:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Execute the preflight script:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
    ```

--- a/internal_docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
+++ b/internal_docs/AT_THE_EDGE_OF_KNOWLEDGE_DEMO_TASKS_SPRINT.md
@@ -7,8 +7,9 @@ This sprint condenses the steps required for Codex to expose every advanced demo
 Run `./scripts/edge_of_knowledge_sprint.sh` from the repository root for a one-command deployment.
 
 ## 1. Validate the Environment
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Run the preflight script:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Run the preflight script:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
 3. Verify the Node version:

--- a/internal_docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
+++ b/internal_docs/CODEX_ADVANCED_DEMO_PAGES_SPRINT.md
@@ -5,8 +5,9 @@
 This sprint outlines a robust sequence to publish the **Alpha‑Factory** demo gallery on GitHub Pages. It builds upon the existing automation scripts so each showcase unfolds organically and remains trivial to deploy by non‑technical users.
 
 ## 1. Environment Validation
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Run the preflight check:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Run the preflight check:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
    ```

--- a/internal_docs/CODEX_DEMO_PAGES_SPRINT.md
+++ b/internal_docs/CODEX_DEMO_PAGES_SPRINT.md
@@ -6,8 +6,9 @@ This short guide outlines how Codex can publish the full Alpha‑Factory demo ga
 
 ## 1. Environment Setup
 
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Install `mkdocs`, `mkdocs-material` and `playwright` via `pip`:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Install `mkdocs`, `mkdocs-material` and `playwright` via `pip`:
    ```bash
    pip install mkdocs mkdocs-material playwright
    ```

--- a/internal_docs/CODEX_INSIGHT_PAGES_SPRINT.md
+++ b/internal_docs/CODEX_INSIGHT_PAGES_SPRINT.md
@@ -6,8 +6,9 @@ This short guide provides a step-by-step sprint for Codex to ensure the **α‑A
 
 ## 1. Environment Setup
 
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Install `mkdocs`, `mkdocs-material` and `playwright` via `pip`:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Install `mkdocs`, `mkdocs-material` and `playwright` via `pip`:
    ```bash
    pip install mkdocs mkdocs-material playwright
    ```

--- a/internal_docs/CODEX_SUPER_DEMO_PAGES_SPRINT.md
+++ b/internal_docs/CODEX_SUPER_DEMO_PAGES_SPRINT.md
@@ -9,8 +9,9 @@ launch each showcase directly from a browser and watch it unfold in real time.
 
 ## 1. Validate the Environment
 
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Run the preflight check:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Run the preflight check:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
    ```

--- a/internal_docs/DEMO_ACCESS_SPRINT.md
+++ b/internal_docs/DEMO_ACCESS_SPRINT.md
@@ -6,8 +6,9 @@ This short sprint distills how Codex can publish the **Alpha‑Factory v1** demo
 
 ## 1. Verify the Environment
 
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Run the preflight check:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Run the preflight check:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
    ```

--- a/internal_docs/EDGE_DEMO_PAGES_SPRINT.md
+++ b/internal_docs/EDGE_DEMO_PAGES_SPRINT.md
@@ -6,8 +6,9 @@ This short guide details how Codex can expose every Alpha‑Factory demo via Git
 
 ## 1. Prepare the Environment
 
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Run the preflight script:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Run the preflight script:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
    ```

--- a/internal_docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
+++ b/internal_docs/EDGE_OF_HUMAN_KNOWLEDGE_PAGES_SPRINT.md
@@ -5,8 +5,9 @@
 This sprint explains how Codex can publish the **Alpha-Factory** demo gallery to GitHub Pages so each showcase plays back organically with a single command. Use the shell wrapper `scripts/edge_human_knowledge_pages_sprint.sh` or the cross‑platform Python version `scripts/edge_human_knowledge_pages_sprint.py` which call the full deployment workflow and print the final URL.
 
 ## Quick Start
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Run the wrapper:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Run the wrapper:
    ```bash
    ./scripts/edge_human_knowledge_pages_sprint.sh
    # or on systems without Bash

--- a/internal_docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
+++ b/internal_docs/EDGE_OF_KNOWLEDGE_DEMO_SPRINT.md
@@ -5,12 +5,14 @@
 This sprint distils how Codex can publish the entire **Alpha‑Factory v1** demo suite to GitHub Pages so that every showcase unfolds in real time and remains effortless for non‑technical users to explore.
 
 ## 1. Environment Validation
-1. Install **Python 3.11+** and **Node.js 20+**.
+1. Install **Python 3.11+** and **Node.js 22+**.
 2. Run the preflight script:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
    ```
 3. Verify the Node version:
+
+4. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
    ```bash
    node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js
    ```

--- a/internal_docs/USER_FRIENDLY_DEMO_PAGES_SPRINT.md
+++ b/internal_docs/USER_FRIENDLY_DEMO_PAGES_SPRINT.md
@@ -5,8 +5,9 @@
 This sprint ensures that every advanced demo in `alpha_factory_v1/demos/` unfolds visually and elegantly on GitHub Pages. The tasks combine the existing automation scripts with best practices so non‑technical users can deploy the gallery from a subdirectory with a single command.
 
 ## 1. Validate the Environment
-1. Install **Python 3.11+** and **Node.js 20+**.
-2. Run the preflight check:
+1. Install **Python 3.11+** and **Node.js 22+**.
+2. Run `nvm use` to activate the version from `.nvmrc` before installing dependencies.
+3. Run the preflight check:
    ```bash
    python alpha_factory_v1/scripts/preflight.py
    ```

--- a/scripts/build_insight_docs.sh
+++ b/scripts/build_insight_docs.sh
@@ -30,7 +30,7 @@ fi
 
 # Ensure the correct Node.js version before running npm
 if ! node "$BROWSER_DIR/build/version_check.js"; then
-    echo "ERROR: Node.js 20+ is required to build the Insight docs." >&2
+    echo "ERROR: Node.js 22+ is required to build the Insight docs." >&2
     exit 1
 fi
 

--- a/scripts/publish_insight_pages.sh
+++ b/scripts/publish_insight_pages.sh
@@ -9,7 +9,7 @@ cd "$REPO_ROOT"
 
 BROWSER_DIR="alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1"
 if ! node "$BROWSER_DIR/build/version_check.js"; then
-    echo "ERROR: Node.js 20+ is required to publish the Insight docs." >&2
+    echo "ERROR: Node.js 22+ is required to publish the Insight docs." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- require Node.js 22 in Insight browser scripts and docs
- update package.json engines field
- adjust Node version tests
- document running `nvm use` before installing dependencies

## Testing
- `python alpha_factory_v1/scripts/preflight.py` *(fails: docker missing)*
- `pre-commit run --files $(git status --short | awk '{print $2}')`

------
https://chatgpt.com/codex/tasks/task_e_6880f57301848333bd1fc5b34c569fe9