### PR TITLE
[alpha_factory] update Node.js requirement

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/README.md
@@ -214,7 +214,7 @@ graph TD
 
 > **Prerequisites**
 > • Python ≥ 3.11 • Git • Docker (only for container mode)
-> *(Optional)* Node ≥ 20 if you plan to rebuild the React front-end.
+> *(Optional)* Node ≥ 22 if you plan to rebuild the React front-end.
 
 Or try the hosted notebook: [colab_alpha_agi_insight_v1.ipynb](colab_alpha_agi_insight_v1.ipynb).
 
@@ -431,7 +431,7 @@ Typical REST endpoints:
 
 ### 5.3 Rebuilding the React dashboard
 
-Install [Node.js](https://nodejs.org/) **≥ 20** if you want to rebuild the front‑end.
+Install [Node.js](https://nodejs.org/) **≥ 22** if you want to rebuild the front‑end.
 From the repository root run:
 
 ```bash

--- a/docs/demos/alpha_agi_insight_v1.md
+++ b/docs/demos/alpha_agi_insight_v1.md
@@ -219,7 +219,7 @@ graph TD
 
 > **Prerequisites**
 > • Python ≥ 3.11 • Git • Docker (https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/only for container mode)
-> *(https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/Optional)* Node ≥ 20 if you plan to rebuild the React front-end.
+> *(https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/Optional)* Node ≥ 22 if you plan to rebuild the React front-end.
 
 Or try the hosted notebook: [colab_alpha_agi_insight_v1.ipynb](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/alpha_agi_insight_v1/colab_alpha_agi_insight_v1.ipynb).
 


### PR DESCRIPTION
## Summary
- correct documentation to require Node.js 22

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/README.md docs/demos/alpha_agi_insight_v1.md`
- `pytest` *(fails: 22 failed, 114 passed, 34 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6880fdd99cd08333853217426a00910a