### PR TITLE
[alpha_factory] Update Python max version

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -33,7 +33,7 @@ else:
 
 
 MIN_PY = (3, 11)
-MAX_PY = (3, 13)
+MAX_PY = (3, 14)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
 MIN_OPENAI_AGENTS_VERSION = "0.0.17"
 DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "python:3.11-slim")


### PR DESCRIPTION
## Summary
- allow Python 3.14 in `preflight.py`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/scripts/preflight.py`
- `pytest` *(fails: 72 failed, 273 passed, 62 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6881097cb2d08333b8e34dfb85577503