### PR TITLE
[alpha_factory] clarify Python version support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The instructions below apply to all contributors and automated agents.
 All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 Please report security vulnerabilities as described in our [Security Policy](SECURITY.md).
 ## Prerequisites
- - Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**)
+ - Python 3.11–3.13 (**Python ≥3.11, <3.14**)
 - Docker and Docker Compose (Compose ≥2.5)
 - Git
 - Node.js 22 for the web client and browser demo. A `.nvmrc` is provided, so run
@@ -46,10 +46,10 @@ docker --version
 docker compose version
 git --version
 ```
-Python must report 3.11 or 3.13 and Docker Compose must be at least 2.5.
+Python must report 3.11–3.13 and Docker Compose must be at least 2.5.
 
 ## Development Environment
-- Create and activate a Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**) virtual
+- Create and activate a Python 3.11–3.13 (**Python ≥3.11, <3.14**) virtual
   environment before running the setup script. On Linux or macOS:
   ```bash
   python3 -m venv .venv
@@ -261,7 +261,7 @@ template). The sample file now lists every variable with its default value.
 | `CROSS_ALPHA_MODEL` | OpenAI model for the discovery tool when `OPENAI_API_KEY` is set | `gpt-4o-mini` |
 
 ## Coding Style
-- Use Python 3.11 or 3.13 (**Python ≥3.11 and <3.14**) and include type hints for public APIs.
+- Use Python 3.11–3.13 (**Python ≥3.11, <3.14**) and include type hints for public APIs.
 - Indent with 4 spaces and keep lines under 120 characters.
 - `.editorconfig` enforces UTF-8 encoding, LF line endings and the 120-character limit for Python and Markdown files.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
@@ -388,7 +388,7 @@ issues locally before dispatching the workflow.
 
 ### Troubleshooting
 - If the stack fails to start, verify Docker and Docker Compose are running.
-- Setup errors usually mean Python is older than 3.11. Use Python 3.11 or 3.13 (>=3.11,<3.14).
+- Setup errors usually mean Python is older than 3.11. Use Python 3.11–3.13 (>=3.11,<3.14).
 - When working offline, build the wheelhouse with `scripts/build_offline_wheels.sh` on a
   machine with internet access, copy the `wheels/` directory to the repository root and set
   `WHEELHOUSE=$(pwd)/wheels` before running `python check_env.py --auto-install` or the tests.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) fr
 
 ### Publish Demo Gallery
 
-Ensure **Python 3.11+** and **Node 22+** are installed, then deploy the gallery
+Ensure **Python 3.11–3.13** (<3.14) and **Node 22+** are installed, then deploy the gallery
 and docs with a single command:
 
 ```bash
@@ -107,7 +107,7 @@ checks and offline validation. Use the shell or Python version:
 python scripts/edge_human_knowledge_pages_sprint.py
 ```
 
-Ensure **Python 3.11+**, **Node 22+** and `mkdocs` are installed. The
+Ensure **Python 3.11–3.13** (<3.14), **Node 22+** and `mkdocs` are installed. The
 script mirrors the [Docs workflow](.github/workflows/docs.yml) used for manual
 deployment.
 
@@ -240,7 +240,7 @@ python scripts/download_gpt2_small.py models/
 
 As a last resort use `python scripts/download_openai_gpt2.py 124M`.
 
-Requires **Python 3.11 or 3.13** and **Docker Compose ≥2.5**.
+Requires **Python 3.11–3.13** (<3.14) and **Docker Compose ≥2.5**.
 
 Alternatively, run the pre-built image directly:
 ```bash

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -266,7 +266,7 @@ OPTIONAL_DEPS = {
 def main(argv: list[str] | None = None) -> None:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Validate environment")
+    parser = argparse.ArgumentParser(description="Validate environment (Python >=3.11, <3.14)")
     parser.add_argument("--offline", action="store_true", help="Skip network checks")
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
## Summary
- document that Python 3.11–3.13 are supported
- sync `preflight.py` help text with docs

## Testing
- `pre-commit run --files AGENTS.md README.md alpha_factory_v1/scripts/preflight.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py`


------
https://chatgpt.com/codex/tasks/task_e_688122666ab48333bede098a04dec204