### PR TITLE
[alpha_factory] update Python matrix for 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11.9", "3.13.0"]
+        python-version: ["3.11.9", "3.12.3", "3.13.0"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11.9", "3.13.0"]
+        python-version: ["3.11.9", "3.12.3", "3.13.0"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- add Python 3.12.3 to the CI job matrices
- keep Windows and macOS smoke tests on 3.11

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`
- `pre-commit run --all-files`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68812533265c8333b6b771d2c2f984f5