### PR TITLE
docs: add backend lock file instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,20 @@ mv requirements-cpu.new requirements-cpu.lock
 Run the same command with `requirements-demo.txt` as the sole input to update
 `requirements-demo-cpu.lock`.
 
+### Backend Lock File
+
+Refresh the backend lock file whenever `alpha_factory_v1/backend/requirements.txt`
+changes:
+
+```bash
+pip-compile --upgrade --allow-unsafe --generate-hashes \
+  --output-file alpha_factory_v1/backend/requirements-lock.txt \
+  alpha_factory_v1/backend/requirements.txt
+```
+
+All lock files must include hashes so the Docker images can verify packages at
+build time.
+
 ### Pre-commit in Air-Gapped Setups
 
 When offline, build the wheelhouse first and point `pre-commit` to it:


### PR DESCRIPTION
## Summary
- document how to regenerate `alpha_factory_v1/backend/requirements-lock.txt`
- note that hashes are required for all lock files

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files CONTRIBUTING.md` *(fails: KeyboardInterrupt)*
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68812b94e1c48333a9984c770598f6b7