### PR TITLE
Update docs for Python 3.12 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 ```
 
 The workflow publishes a separate image for each Python version with tags
-`py311` and `py313`. Only the Python **3.13** build also updates the `latest`
-tag so `ghcr.io/montrealai/alpha-factory:latest` always refers to the most
-recent Python 3.13 image.
+`py311`, `py312` and `py313`. Only the Python **3.13** build also updates the
+`latest` tag so `ghcr.io/montrealai/alpha-factory:latest` always refers to the
+most recent Python 3.13 image.
 
 Replace `latest` with a commit SHA to run that exact build:
 


### PR DESCRIPTION
## Summary
- mention new `py312` image in README

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_results_dir_permissions.py::test_existing_results_dir_permissions -q`
- `pre-commit` *(failed: environment setup too heavy)*
- `docker build` *(failed: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68813b6e6b748333a4f0a4401a32003f