### PR TITLE
[alpha_factory] update sandbox base image

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -36,7 +36,8 @@ MIN_PY = (3, 11)
 MAX_PY = (3, 15)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
 MIN_OPENAI_AGENTS_VERSION = "0.0.17"
-DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "python:3.11-slim")
+# Use the latest stable Python base image for sandbox builds
+DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "python:3.13-slim")
 
 COLORS = {
     "RED": "\033[31m",


### PR DESCRIPTION
## Summary
- use Python 3.13 slim as the default sandbox image

## Testing
- `pre-commit` *(failed: environment setup interrupted)*
- `pytest -m smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_68814062b4a48333b5cefdd56609c0c4