### PR TITLE
[alpha_factory] extend python compatibility

### DIFF
--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -107,7 +107,7 @@ Python standard library.
 ---
 
 ### Requirements
-* Python 3.11 or 3.12 (<3.13). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
+* Python 3.11–3.14 (<3.15). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
 * Install the optional runtime packages:
   ```bash
   pip install -r alpha_factory_v1/demos/solving_agi_governance/requirements.txt

--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -32,7 +32,7 @@ else:
         return bool(Version(a) < Version(b))
 
 
-# Supported Python versions: >=3.11 and <3.15 (3.11–3.14)
+# Supported Python versions: >=3.11 and <3.15 (3.11–3.14 inclusive)
 MIN_PY = (3, 11)
 MAX_PY = (3, 15)
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "alpha-factory-v1"
 version = "0.1.0-alpha"
 description = "Alpha-Factory v1"
 readme = "README.md"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11,<3.15"
 license = "Apache-2.0"
 
 [tool.setuptools]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ jupyter_core
 appnope; sys_platform == "darwin"
 gymnasium[classic-control]
 gradio
-audioop-lts; python_version >= "3.13"
+audioop-lts==0.2.1; python_version >= "3.13"
 aiohttp
 qdrant-client
 pytest==8.4.1


### PR DESCRIPTION
## Summary
- support Python 3.13+ in project metadata
- update preflight check comment
- pin `audioop-lts` for Gradio tests
- refresh governance demo docs

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `python alpha_factory_v1/scripts/preflight.py --offline` *(fails: docker missing)*
- `pre-commit run --all-files` *(interrupted: KeyboardInterrupt)*
- `pytest -k "" -q` *(fails: 3 failed, 48 passed, 34 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68814a42a0508333a3f0ee1ce1bdf963