### PR TITLE
[alpha_factory] update backend lock file

### DIFF
--- a/alpha_factory_v1/backend/requirements-lock.txt
+++ b/alpha_factory_v1/backend/requirements-lock.txt
@@ -1221,7 +1221,6 @@ jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
-    #   fastapi
     #   flask
     #   litellm
     #   llama-cpp-python
@@ -2730,9 +2729,7 @@ python-dotenv==1.0.1 \
 python-multipart==0.0.20 \
     --hash=sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104 \
     --hash=sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13
-    # via
-    #   fastapi
-    #   mcp
+    # via mcp
 pytz==2025.2 \
     --hash=sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3 \
     --hash=sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00


### PR DESCRIPTION
## Summary
- run pip-compile on alpha_factory backend requirements

## Testing
- `pre-commit run --files alpha_factory_v1/backend/requirements-lock.txt`
- `pytest` *(fails: VerifyWheelSigTests::test_valid_signature, test_wasm_bridge.py::test_pyodide_load_failure, test_wheel_signature, test_workbox_integrity, test_world_model_config, test_world_model_open_endedness, test_world_model_reload, test_world_model_safety, TestMessaging::test_rpc_auth, test_replay_metrics, test_replay_scenarios)*


------
https://chatgpt.com/codex/tasks/task_e_6881679cff00833394e47c023456d54a