### PR TITLE
[alpha_factory] handle missing optional deps in preflight

### DIFF
--- a/alpha_factory_v1/tests/test_preflight.py
+++ b/alpha_factory_v1/tests/test_preflight.py
@@ -77,7 +77,7 @@ class PreflightTest(unittest.TestCase):
             check_cmd=lambda cmd: True,
             check_docker_daemon=lambda: True,
             check_docker_compose=lambda: True,
-            check_pkg=lambda pkg: True,
+            check_pkg=lambda pkg, optional=False: True,
             ensure_dir=lambda p: None,
             banner=lambda *a, **k: None,
         ):
@@ -88,7 +88,7 @@ class PreflightTest(unittest.TestCase):
             check_cmd=lambda cmd: False,
             check_docker_daemon=lambda: False,
             check_docker_compose=lambda: False,
-            check_pkg=lambda pkg: False,
+            check_pkg=lambda pkg, optional=False: False,
             ensure_dir=lambda p: None,
             banner=lambda *a, **k: None,
             check_network=lambda: True,
@@ -103,7 +103,7 @@ class PreflightTest(unittest.TestCase):
             check_cmd=lambda cmd: True,
             check_docker_daemon=lambda: True,
             check_docker_compose=lambda: True,
-            check_pkg=lambda pkg: True,
+            check_pkg=lambda pkg, optional=False: True,
             ensure_dir=lambda p: None,
             banner=lambda *a, **k: None,
         ):

--- a/tests/test_preflight_optional_missing.py
+++ b/tests/test_preflight_optional_missing.py
@@ -13,14 +13,13 @@ from alpha_factory_v1.scripts import preflight
 
 class TestPreflightOptionalMissing(unittest.TestCase):
     def test_missing_optional_packages_ok(self) -> None:
-        def fake_check_pkg(name: str) -> bool:
-            # Required packages are always present
-            if name in {"pytest", "prometheus_client"}:
-                return True
-            # Simulate all optional deps missing
-            if name in preflight.OPTIONAL_DEPS:
-                return False
+        def fake_check_pkg(name: str, optional: bool = False) -> bool:
             return True
+
+        def fake_find_spec(name: str):
+            if name in {"pytest", "prometheus_client"}:
+                return object()
+            return None
 
         patches = [
             mock.patch.object(preflight, "check_python", return_value=True),
@@ -30,6 +29,7 @@ class TestPreflightOptionalMissing(unittest.TestCase):
             mock.patch.object(preflight, "check_docker_compose", return_value=True),
             mock.patch.object(preflight, "check_patch_in_sandbox", return_value=True),
             mock.patch.object(preflight, "check_pkg", side_effect=fake_check_pkg),
+            mock.patch("importlib.util.find_spec", side_effect=fake_find_spec),
             mock.patch.object(preflight, "check_openai_agents_version", return_value=True),
             mock.patch.object(preflight, "ensure_dir", return_value=None),
         ]


### PR DESCRIPTION
## Summary
- treat optional packages as warnings in `preflight.check_pkg`
- adjust optional package detection
- update unit tests for new function signature

## Testing
- `pre-commit run --files alpha_factory_v1/scripts/preflight.py alpha_factory_v1/tests/test_preflight.py tests/test_preflight_optional_missing.py`
- `pytest -q` *(fails: test_agent_aiga_entrypoint.py, test_agents.py, test_agents_registry.py, test_aiga_agents_bridge.py, ...)*

------
https://chatgpt.com/codex/tasks/task_e_688182d4571483339f534a83525d362c