### PR TITLE
[alpha_factory] update smoke jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -289,7 +289,7 @@ jobs:
           python check_env.py --auto-install
       - id: asset-key-docker
         uses: ./.github/actions/generate-asset-key
-      - name: Cache Insight assets
+      - name: Restore Insight asset cache
         uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
@@ -329,7 +329,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -350,7 +350,7 @@ jobs:
           python check_env.py --auto-install
       - id: asset-key-docker
         uses: ./.github/actions/generate-asset-key
-      - name: Cache Insight assets
+      - name: Restore Insight asset cache
         uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |


### PR DESCRIPTION
## Summary
- bump Python to 3.13 for Windows/macOS smoke tests
- restore Insight asset caching

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688188d85bb083339aee683043be25fe