### PR TITLE
[alpha_factory] update Dockerfiles to python 3.13-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
-FROM python:3.13.5-slim
+FROM python:3.13-slim
 
 # install build tools and npm for the React UI
 RUN apt-get update && \
@@ -28,7 +28,7 @@ RUN python -m pip install --upgrade pip
 # Install demo-specific Python dependencies
 COPY alpha_factory_v1/demos/alpha_agi_insight_v1/requirements.lock /tmp/requirements-demo.lock
 RUN if [ -f /tmp/requirements-demo.lock ]; then \
-      pip install --no-cache-dir -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock; \
+      pip install --no-cache-dir --require-hashes -r /tmp/requirements-demo.lock && rm /tmp/requirements-demo.lock; \
     else \
       echo "Missing demo requirements" && exit 1; \
     fi

--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -10,7 +10,7 @@
 #                                                                            #
 #  Build switches                                                            #
 #  ─────────────────────────────────────────────────────────────────────────  #
-#  BASE_IMAGE           ‑ Parent image for Stage 1 (default python:3.11).    #
+#  BASE_IMAGE           ‑ Parent image for Stage 1 (default python:3.13).    #
 #                        Pass  nvidia/cuda:12.4.0-runtime‑ubuntu22.04        #
 #                        for a GPU‑enabled variant.                          #
 #  INSTALL_UI           ‑ Set to "0" to skip the UI build stage.           #
@@ -19,7 +19,7 @@
 #######################################################################
 #  Global ARGs must precede every FROM that references them           #
 #######################################################################
-ARG BASE_IMAGE=python:3.11.13-slim-bookworm
+ARG BASE_IMAGE=python:3.13-slim
 ARG INSTALL_UI=1
 
 #######################################################################
@@ -84,7 +84,7 @@ COPY backend/requirements.txt /tmp/requirements.txt
 #  The lock file is preferred (if the project maintains one).  
 #  Fallback to plain requirements for dev checkouts.
 RUN if [ -f /tmp/requirements-lock.txt ]; then \
-        pip install --no-cache-dir -r /tmp/requirements-lock.txt; \
+        pip install --no-cache-dir --require-hashes -r /tmp/requirements-lock.txt; \
     else \
         pip install --no-cache-dir -r /tmp/requirements.txt; \
     fi && \


### PR DESCRIPTION
## Summary
- use the latest stable `python:3.13-slim` base image
- install requirements from lock files with `--require-hashes`

## Testing
- `pre-commit run --files Dockerfile alpha_factory_v1/Dockerfile`
- `pytest` *(fails: 35 failed, 122 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68818c54154483339ab99accfc407310