### PR TITLE
[alpha_factory] extend python warning

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -58,12 +58,22 @@ def banner(msg: str, color: str = "GREEN") -> None:
 
 
 def check_python() -> bool:
-    if sys.version_info < MIN_PY or sys.version_info >= MAX_PY:
+    """Return ``True`` when the running interpreter is within the supported range."""
+
+    if sys.version_info < MIN_PY:
         banner(
-            f"Python {MIN_PY[0]}.{MIN_PY[1]}+ and <{MAX_PY[0]}.{MAX_PY[1]} required",
+            f"Python {MIN_PY[0]}.{MIN_PY[1]}+ required",
             "RED",
         )
         return False
+
+    if sys.version_info >= MAX_PY:
+        banner(
+            f"Python {sys.version.split()[0]} is newer than tested; proceeding",
+            "YELLOW",
+        )
+        return True
+
     banner(f"Python {sys.version.split()[0]} detected", "GREEN")
     return True
 


### PR DESCRIPTION
## Summary
- adjust Python version check to warn on newer versions instead of hard-failing

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run ruff --files alpha_factory_v1/scripts/preflight.py`
- `pytest -k smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_6881b595800083338470c1a43ae1c1d0