### PR TITLE
[alpha_factory] update runtime images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 # install build tools and npm for the React UI
 RUN apt-get update && \
@@ -9,14 +9,14 @@ RUN apt-get update && \
         curl ca-certificates gnupg build-essential git \
         rustc cargo postgresql-client patch && \
     git --version && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # upgrade pip to avoid outdated versions
 RUN python -m pip install --upgrade "pip<25" setuptools wheel
 
-# Verify Node installation is >=20 (NodeSource script sets up latest LTS)
+# Verify Node installation is >=22 (NodeSource script sets up latest LTS)
 RUN node --version
 
 WORKDIR /app

--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -10,7 +10,7 @@
 #                                                                            #
 #  Build switches                                                            #
 #  ─────────────────────────────────────────────────────────────────────────  #
-#  BASE_IMAGE           ‑ Parent image for Stage 1 (default python:3.13).    #
+#  BASE_IMAGE           ‑ Parent image for Stage 1 (default python:3.14).    #
 #                        Pass  nvidia/cuda:12.4.0-runtime‑ubuntu22.04        #
 #                        for a GPU‑enabled variant.                          #
 #  INSTALL_UI           ‑ Set to "0" to skip the UI build stage.           #
@@ -19,13 +19,13 @@
 #######################################################################
 #  Global ARGs must precede every FROM that references them           #
 #######################################################################
-ARG BASE_IMAGE=python:3.13-slim
+ARG BASE_IMAGE=python:3.14-slim
 ARG INSTALL_UI=1
 
 #######################################################################
 #  Stage 0 — (optional) Build static Trace‑graph front‑end            #
 #######################################################################
-FROM node:20.19.4-bookworm-slim AS ui-build
+FROM node:22-bookworm-slim AS ui-build
 ARG INSTALL_UI
 RUN if [ "$INSTALL_UI" = "0" ]; then echo "Skipping UI build stage" && exit 0; fi
 WORKDIR /ui

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -6,11 +6,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg build-essential git && \
     git --version && \
-        curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+        curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Verify Node installation is >=20 (NodeSource script sets up latest LTS)
+# Verify Node installation is >=22 (NodeSource script sets up latest LTS)
 RUN node --version
 
 WORKDIR /app

--- a/alpha_factory_v1/docker-compose.override.yml
+++ b/alpha_factory_v1/docker-compose.override.yml
@@ -61,7 +61,7 @@ services:
   ui:
     <<: *restart_policy
     container_name: alphafactory-ui-dev
-    image: node:20-bookworm-slim
+    image: node:22-bookworm-slim
     working_dir: /ui
     command: ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "3000"]
     ports:

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Minimal runtime image for the quickstart script
-FROM python:3.13.5-slim
+FROM python:3.14-slim
 
 # confirm git availability
 RUN apt-get update && apt-get install -y --no-install-recommends git && git --version && rm -rf /var/lib/apt/lists/*

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.5-slim
+FROM python:3.14-slim
 
 # install system deps
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/sandbox.Dockerfile
+++ b/sandbox.Dockerfile
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-FROM python:3.13.5-slim
+FROM python:3.14-slim
 RUN apt-get update && apt-get install -y --no-install-recommends patch \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- base Docker images now use `python:3.14-slim`
- switch Node setup scripts to NodeSource 22
- build UI with `node:22-bookworm-slim`

## Testing
- `pre-commit run --files Dockerfile alpha_factory_v1/Dockerfile infrastructure/Dockerfile docker/quickstart/Dockerfile sandbox.Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile alpha_factory_v1/docker-compose.override.yml`
- `pytest` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68823510b7008333b1d96bf1858acade