### PR TITLE
[alpha_factory] update docs for Python 3.14 docker tag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,8 +65,8 @@ Downstream users should consult this section when upgrading.
 - Upgraded the Insight demo to **streamlit 1.46** so NumPy 2.x installs cleanly.
  - The Docker image now installs **rustc** and **cargo** to build crates like
    `blake3` on Python 3.13.
- - The workflow pushes version-specific Docker tags `py311` and `py313` for each
-  build and signs both images with cosign.
+ - The workflow pushes version-specific Docker tags `py311`, `py312`, `py313` and
+   `py314` for each build and signs all images with cosign.
 - `ci.yml` now caches Node dependencies using `cache-dependency-path` so the
   "Dependencies lock file is not found" warning no longer appears.
 ## [0.1.0-alpha] - 2024-05-01

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,7 +76,7 @@ docker run --rm -p 8000:8000 \
   -v $(pwd)/.env:/app/.env montrealai/alpha-factory:latest
 ```
 
-Only the Python **3.13** build updates the `latest` tag.
+Only the Python **3.14** build updates the `latest` tag.
 
 Copy `.env.sample` to `.env` and add your API keys to enable cloud features. Without keys, the program falls back to the
 local Meta‑Agentic Tree Search:


### PR DESCRIPTION
## Summary
- clarify which Python build updates the `latest` docker tag
- mention all pushed docker tags in the changelog

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files docs/quickstart.md docs/CHANGELOG.md`
- `pytest -q` *(fails: TestAgentAIGAEntry.test_import_without_openaiagent)*

------
https://chatgpt.com/codex/tasks/task_e_68823823bdbc83339b50b88ad30c6192