### PR TITLE
[alpha_factory] update Docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 # install build tools and npm for the React UI
 RUN apt-get update && \

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 # install system deps
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- use `python:3.13-slim` for the demo Dockerfile
- use `python:3.13-slim` for the infrastructure image

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError and other test failures)*
- `pip-compile` *(failed: AttributeError: 'function' object has no attribute 'cache_clear')*
- `docker build` *(skipped: Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68825847438c8333a1f0d9bc0866e41e