### PR TITLE
fix: update insight SRI and build order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,8 @@ jobs:
             python scripts/update_pyodide.py 0.28.0 &&
             npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets
           )
+      - name: Build insight browser
+        run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run build
       - name: Verify downloaded assets
         run: |
           python scripts/fetch_assets.py --verify-only || (
@@ -491,6 +493,8 @@ jobs:
         run: npx update-browserslist-db --update-db --yes
       - name: Install pre-commit
         run: pip install pre-commit==4.2.0
+      - name: Build insight browser
+        run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run build
       - name: Build gallery site
         run: ./scripts/build_gallery_site.sh
       - name: Verify downloaded assets

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html
@@ -106,6 +106,6 @@
         });
       }
     </script>
-    <script type="module" src="insight.bundle.js" integrity="sha384-KKPV3VcnYmdpDiGm+znqoQoONf5yziROEwV9kWuNOlT8/erUdCkW+SBkp5NIKZC/" crossorigin="anonymous"></script>
+    <script type="module" src="insight.bundle.js" integrity="sha384-0lxWd5yd7VddiNNQtH2xnEVsZHoVlkdYWBz1LBi90/9OdkROD1dnM03FTFqjeN9a" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild insight browser and update SRI reference
- run insight build before asset verification in docs workflows

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.html`
- `pre-commit run --files .github/workflows/ci.yml`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68826e2963f48333a6319fbf73b816f6