### PR TITLE
[alpha_factory] sync Dockerfile base images with CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
 FROM python:3.13-slim
+# Base image must match the highest Python version used in CI (currently 3.13)
 
 # install build tools and npm for the React UI
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -248,10 +248,15 @@ docker run --pull=always -p 8000:8000 ghcr.io/montrealai/alpha-factory:latest
 ```
 
 The workflow publishes a separate image for each Python version with tags
-`py311`, `py312`, `py313` and `py314`. Only the Python **3.14** build also
+`py311`, `py312` and `py313`. Only the Python **3.13** build also
 updates the `latest` tag so
 `ghcr.io/montrealai/alpha-factory:latest` always refers to the most recent
-Python 3.14 image.
+Python 3.13 image.
+
+> **Note**
+> The Dockerfiles in this repository pin the base image to Python 3.13.
+> Keep this in sync with the highest Python version listed in the CI
+> matrix when updating workflows.
 
 Replace `latest` with a commit SHA to run that exact build:
 

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.13-slim
+# Base image must match the highest Python version used in CI (currently 3.13)
 
 # install system deps
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- keep Dockerfile base image aligned with CI Python (3.13)
- match infrastructure Dockerfile with 3.13 as well
- note this sync in README and update tags

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files Dockerfile infrastructure/Dockerfile README.md`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688271aa4e3883339d2bb17090c65b86