### PR TITLE
[alpha_factory] bump ortools requirement

### DIFF
--- a/alpha_factory_v1/requirements.txt
+++ b/alpha_factory_v1/requirements.txt
@@ -22,7 +22,7 @@ chromadb>=0.5.23
 
 # ─────────── Numerical / optimisation stack ────────────────────────────
 scipy>=1.12
-ortools>=9.7.2996       # CP-SAT / MILP for Manufacturing & SupplyChain
+ortools>=9.14          # CP-SAT / MILP for Manufacturing & SupplyChain
 transformers>=0.20
 accelerate>=0.27
 sentencepiece>=0.1.99


### PR DESCRIPTION
## Summary
- update ortools requirement to 9.14 or newer

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/requirements.txt` *(failed: initialization interrupted)*
- `pytest tests/test_smoke.py` *(no tests ran)*
- `docker build` *(failed: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688274a47f7483339b8946ec1bd77be9