### PR TITLE
[alpha_factory] sync python version requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The instructions below apply to all contributors and automated agents.
 All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 Please report security vulnerabilities as described in our [Security Policy](SECURITY.md).
 ## Prerequisites
-- Python 3.11–3.14 (**Python ≥3.11, <3.15**)
+- Python 3.11–3.13 (**Python ≥3.11, <3.14**)
 - Docker and Docker Compose (Compose ≥2.5)
 - Git
 - Node.js 22 for the web client and browser demo. A `.nvmrc` is provided, so run
@@ -46,10 +46,10 @@ docker --version
 docker compose version
 git --version
 ```
-Python must report 3.11–3.14 and Docker Compose must be at least 2.5.
+Python must report 3.11–3.13 and Docker Compose must be at least 2.5.
 
 ## Development Environment
-- Create and activate a Python 3.11–3.14 (**Python ≥3.11, <3.15**) virtual
+- Create and activate a Python 3.11–3.13 (**Python ≥3.11, <3.14**) virtual
   environment before running the setup script. On Linux or macOS:
   ```bash
   python3 -m venv .venv
@@ -261,7 +261,7 @@ template). The sample file now lists every variable with its default value.
 | `CROSS_ALPHA_MODEL` | OpenAI model for the discovery tool when `OPENAI_API_KEY` is set | `gpt-4o-mini` |
 
 ## Coding Style
-- Use Python 3.11–3.14 (**Python ≥3.11, <3.15**) and include type hints for public APIs.
+- Use Python 3.11–3.13 (**Python ≥3.11, <3.14**) and include type hints for public APIs.
 - Indent with 4 spaces and keep lines under 120 characters.
 - `.editorconfig` enforces UTF-8 encoding, LF line endings and the 120-character limit for Python and Markdown files.
 - Provide concise [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings
@@ -388,7 +388,7 @@ issues locally before dispatching the workflow.
 
 ### Troubleshooting
 - If the stack fails to start, verify Docker and Docker Compose are running.
-- Setup errors usually mean Python is older than 3.11. Use Python 3.11–3.14 (>=3.11,<3.15).
+- Setup errors usually mean Python is older than 3.11. Use Python 3.11–3.13 (>=3.11,<3.14).
 - When working offline, build the wheelhouse with `scripts/build_offline_wheels.sh` on a
   machine with internet access, copy the `wheels/` directory to the repository root and set
   `WHEELHOUSE=$(pwd)/wheels` before running `python check_env.py --auto-install` or the tests.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The repository owner triggers the [Docs workflow](.github/workflows/docs.yml) fr
 
 ### Publish Demo Gallery
 
-Ensure **Python 3.11–3.14** (<3.15) and **Node 22+** are installed, then deploy the gallery
+Ensure **Python 3.11–3.13** (<3.14) and **Node 22+** are installed, then deploy the gallery
 and docs with a single command:
 
 ```bash
@@ -107,7 +107,7 @@ checks and offline validation. Use the shell or Python version:
 python scripts/edge_human_knowledge_pages_sprint.py
 ```
 
-Ensure **Python 3.11–3.14** (<3.15), **Node 22+** and `mkdocs` are installed. The
+Ensure **Python 3.11–3.13** (<3.14), **Node 22+** and `mkdocs` are installed. The
 script mirrors the [Docs workflow](.github/workflows/docs.yml) used for manual
 deployment.
 
@@ -240,7 +240,7 @@ python scripts/download_gpt2_small.py models/
 
 As a last resort use `python scripts/download_openai_gpt2.py 124M`.
 
-Requires **Python 3.11–3.14 (<3.15) and **Docker Compose ≥2.5**.
+Requires **Python 3.11–3.13 (<3.14)** and **Docker Compose ≥2.5**.
 
 Alternatively, run the pre-built image directly:
 ```bash
@@ -721,7 +721,7 @@ source .venv/bin/activate
 pip install -r requirements.lock  # pinned versions for deterministic setup
 # Optional ADK/MCP integration
 pip install google-adk mcp
-# Requires Python 3.11–3.14 (<3.15)
+# Requires Python 3.11–3.13 (<3.14)
 ./quickstart.sh
 Run `pre-commit run --all-files` after the dependencies finish installing.
 # Open http://localhost:8000/docs in your browser
@@ -800,7 +800,7 @@ Install the Python dependencies with the helper script:
 ```bash
 scripts/setup_env.sh
 ```
-The script checks for Python 3.11–3.14 and installs `requirements.txt` and
+The script checks for Python 3.11–3.13 and installs `requirements.txt` and
 `requirements-dev.txt`.
 
 When preparing an offline environment, build a wheelhouse on a machine with

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,7 +91,7 @@ Downstream users should consult this section when upgrading.
   mypy, the full Pytest matrix, Windows/macOS smoke tests, an offline docs
   build, the Docker build and pushes images on tags.
 - Lock files must be regenerated with `pip-compile --allow-unsafe`.
-- Requires **Python 3.11–3.14** and **Node.js 22**.
+- Requires **Python 3.11–3.13** and **Node.js 22**.
 
 
 ## [1.0.3] - 2025-07-10

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -15,7 +15,7 @@ repository owner triggers it from the GitHub Actions UI.
    actor does not match `github.repository_owner` the pipeline exits
    immediately. Contributors will see a skipped run unless the repository owner
    clicks **Run workflow**.
-4. Confirm **Python&nbsp;3.11–3.14** and **Node.js&nbsp;22** are installed.
+4. Confirm **Python&nbsp;3.11–3.13** and **Node.js&nbsp;22** are installed.
 5. Run `pre-commit run --all-files` so the hooks pass before pushing.
 
 When invoked on a tagged commit the pipeline also builds and publishes a Docker

--- a/docs/HOSTING_INSTRUCTIONS.md
+++ b/docs/HOSTING_INSTRUCTIONS.md
@@ -30,7 +30,7 @@ only affects loading pinned Insight demo runs.
 
 ## Prerequisites
 
-- **Python 3.11–3.14**
+- **Python 3.11–3.13**
 - `mkdocs`, `mkdocs-material` and `playwright`
 - **Node.js 22+** *(optional, only for building the React dashboard)*
 - Run `node alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build/version_check.js` to verify Node ≥22 before building

--- a/docs/WINDOWS_SETUP.md
+++ b/docs/WINDOWS_SETUP.md
@@ -16,7 +16,7 @@ wsl --update
 Clone the repository inside your WSL home directory to avoid path translation issues.
 
 ## Recommended Python distribution
-Install Python 3.11–3.14 from [python.org](https://www.python.org/downloads/). The Microsoft Store version often restricts permissions.
+Install Python 3.11–3.13 from [python.org](https://www.python.org/downloads/). The Microsoft Store version often restricts permissions.
 Create the virtual environment from PowerShell or your WSL shell:
 
 ```powershell

--- a/docs/demos/alpha_asi_world_model.md
+++ b/docs/demos/alpha_asi_world_model.md
@@ -247,7 +247,7 @@ Need help? Open an issue → **@MontrealAI/alpha-factory-core**.
 
 ## 10  Production checklist ✅
 
- - Ensure `python3 --version` returns 3.11–3.14.
+ - Ensure `python3 --version` returns 3.11–3.13.
 - Install dependencies: `pip install -r requirements.txt`.
 - Launch via `./deploy_alpha_asi_world_model_demo.sh` and visit `http://localhost:7860`.
 - The script sets `NO_LLM=1` automatically when `OPENAI_API_KEY` is unset.

--- a/docs/demos/era_of_experience.md
+++ b/docs/demos/era_of_experience.md
@@ -34,7 +34,7 @@ Within 60 seconds you will witness an agent <em>rewrite its own playbook</em> e
 
 - **Docker 24+** with the Compose plugin
 - At least **4 CPU cores** (https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/era_of_experience/or a modest GPU) for smooth local runs
-- **Python 3.11–3.14** available as `python3` for environment checks
+- **Python 3.11–3.13** available as `python3` for environment checks
 - Run `python3 ../../../check_env.py --demo era_experience --auto-install` and
   ensure it completes successfully before starting the Docker stack.
 - *(https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/alpha_factory_v1/demos/era_of_experience/Optional)* `OPENAI_API_KEY` for cloud LLMs — leave blank to use the built‑in Mixtral via Ollama

--- a/docs/demos/solving_agi_governance.md
+++ b/docs/demos/solving_agi_governance.md
@@ -113,7 +113,7 @@ Python standard library.
 ---
 
 ### Requirements
-* Python 3.11–3.14 (<3.15). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
+* Python 3.11–3.13 (<3.14). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
 * Install the optional runtime packages:
   ```bash
   pip install -r alpha_factory_v1/demos/solving_agi_governance/requirements.txt
@@ -126,7 +126,7 @@ Python standard library.
   `openai-agents>=0.0.17` used by the Agents bridge.
 
 ### 9 · Running the Demo
-The CLI simulator has **no third‑party dependencies**—use Python 3.11–3.14.
+The CLI simulator has **no third‑party dependencies**—use Python 3.11–3.13.
 
 Clone the repository and launch the Monte‑Carlo simulator:
 
@@ -157,7 +157,7 @@ governance-sim --agents 500 --summary
    pip install -r alpha_factory_v1/demos/solving_agi_governance/requirements.txt
    ```
 
-2. **Install** the package in a fresh **Python 3.11–3.14** virtual environment:
+2. **Install** the package in a fresh **Python 3.11–3.13** virtual environment:
 
    ```bash
    python -m pip install -e .[tests]
@@ -178,7 +178,7 @@ governance-sim --agents 500 --summary
    python -m unittest discover -s alpha_factory_v1/tests -p 'test_governance_sim.py'
    ```
 
-If you encounter issues, ensure Python 3.11–3.14 is in your PATH and that
+If you encounter issues, ensure Python 3.11–3.13 is in your PATH and that
 no corporate firewall interferes with package installation. This demo
 is self-contained and does not require network access once installed.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ API credentials.
 
 ## Installing prerequisites
 
-1. Install **Python 3.11–3.14** and create a virtual environment:
+1. Install **Python 3.11–3.13** and create a virtual environment:
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
@@ -76,7 +76,7 @@ docker run --rm -p 8000:8000 \
   -v $(pwd)/.env:/app/.env montrealai/alpha-factory:latest
 ```
 
-Only the Python **3.14** build updates the `latest` tag.
+Only the Python **3.13** build updates the `latest` tag.
 
 Copy `.env.sample` to `.env` and add your API keys to enable cloud features. Without keys, the program falls back to the
 local Meta‑Agentic Tree Search:


### PR DESCRIPTION
## Summary
- sync documentation with current Python support (3.11–3.13)

## Testing
- `pre-commit run --files AGENTS.md README.md docs/CHANGELOG.md docs/CI_WORKFLOW.md docs/HOSTING_INSTRUCTIONS.md docs/WINDOWS_SETUP.md docs/demos/alpha_asi_world_model.md docs/demos/era_of_experience.md docs/demos/solving_agi_governance.md docs/quickstart.md`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError: API...)*

------
https://chatgpt.com/codex/tasks/task_e_688287276d888333a0e096edaa7b30a4