### PR TITLE
[alpha_factory] restrict python range

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -32,16 +32,15 @@ else:
         return bool(Version(a) < Version(b))
 
 
-# Supported Python versions: >=3.11 and <3.15 (3.11–3.14 inclusive).
-# Updated to accept Python 3.13 and Python 3.14.
+# Supported Python versions: >=3.11 and <3.14 (3.11–3.13 inclusive).
 MIN_PY = (3, 11)
-MAX_PY = (3, 15)
+MAX_PY = (3, 14)
 PY_RANGE = f"{MIN_PY[0]}.{MIN_PY[1]}–{MAX_PY[0]}.{MAX_PY[1] - 1}"
 MEM_DIR = Path(os.getenv("AF_MEMORY_DIR", f"{tempfile.gettempdir()}/alphafactory"))
 MIN_OPENAI_AGENTS_VERSION = "0.0.17"
 # Use the latest stable Python base image for sandbox builds
 # Default sandbox uses the latest stable Python image
-DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "python:3.14-slim")
+DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "python:3.13-slim")
 
 COLORS = {
     "RED": "\033[31m",

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -11,10 +11,10 @@ print(f"{sys.version_info.major}.{sys.version_info.minor}")
 PY
 )"
 case "$version" in
-  3.11|3.12|3.13|3.14)
+  3.11|3.12|3.13)
     ;;
   *)
-    echo "Python 3.11–3.14 required; found $version" >&2
+    echo "Python 3.11–3.13 required; found $version" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- tweak setup_env.sh to only allow Python 3.11–3.13
- enforce Python <3.14 in preflight.py and use python:3.13-slim

## Testing
- `pre-commit run --files scripts/setup_env.sh alpha_factory_v1/scripts/preflight.py`
- `pytest -q` *(fails: VerifyWheelSigTests::test_valid_signature, test_wasm_bridge.py::test_pyodide_load_failure, test_wheel_signature.py::TestWheelSignature::test_verify_wheel, test_workbox_integrity.py::test_workbox_hash_mismatch, test_world_model_config.py::test_bool_env_override, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6882aa372f408333b9667150cefdd166