### PR TITLE
[alpha_factory] docs: fix base image comment

### DIFF
--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -10,7 +10,7 @@
 #                                                                            #
 #  Build switches                                                            #
 #  ─────────────────────────────────────────────────────────────────────────  #
-#  BASE_IMAGE           ‑ Parent image for Stage 1 (default python:3.14).    #
+#  BASE_IMAGE           ‑ Parent image for Stage 1 (default python:3.13).    #
 #                        Pass  nvidia/cuda:12.4.0-runtime‑ubuntu22.04        #
 #                        for a GPU‑enabled variant.                          #
 #  INSTALL_UI           ‑ Set to "0" to skip the UI build stage.           #


### PR DESCRIPTION
## Summary
- update comment to mention `python:3.13` as the default base image

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/Dockerfile` *(fails: KeyboardInterrupt)*
- `pytest tests/test_ping_agent.py tests/test_af_requests.py`
- `pytest` *(fails: 4 failed, 60 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6882b1521c2c8333a78683a65c8a7355