### PR TITLE
Fix CI Python matrix and update docs integrity

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -143,7 +143,7 @@ jobs:
           cosign verify "ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:$PY_TAG"
 
       - name: Tag and push latest image
-        if: matrix.python-version == '3.14'
+        if: matrix.python-version == '3.13'
         run: |
           docker tag "ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:${{ github.sha }}" \
             "ghcr.io/$REPO_OWNER_LC/$DOCKER_IMAGE:latest"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION_MATRIX: "3.11,3.12,3.13,3.14"
+  PYTHON_VERSION_MATRIX: "3.11,3.12,3.13"
 
 jobs:
   smoke:
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Check dispatch token
         if: github.actor != github.repository_owner

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -93,7 +93,7 @@
         });
       }
     </script>
-    <script type="module" src="insight.bundle.js" integrity="sha384-HIAkVCB0dMx2E1NaMzF7iRZto1ft/KEZ+2Xf43L12nAD5WlaQm0ua4iFqU1oQgsP" crossorigin="anonymous"></script>
+    <script type="module" src="insight.bundle.js" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
 <p><a href="../index.html">⬅️ Back to Gallery</a></p>
 <p class="snippet"><a href="../DISCLAIMER_SNIPPET/">See docs/DISCLAIMER_SNIPPET.md</a></p>


### PR DESCRIPTION
## Summary
- remove Python 3.14 from build-and-test and smoke matrices
- update tagging condition for latest Python version
- clear stale integrity hash in Insight docs

## Testing
- `pre-commit run --files .github/workflows/build-and-test.yml .github/workflows/smoke.yml docs/alpha_agi_insight_v1/index.html`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest` *(interrupted after initial tests due to run time)*

------
https://chatgpt.com/codex/tasks/task_e_6882b9dc82548333af737dceb4a14f70