### PR TITLE
[alpha_factory] ci: verify insight SRI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,8 @@ jobs:
             npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets &&
             python scripts/fetch_assets.py --verify-only
           )
+      - name: Verify Insight SRI
+        run: python scripts/check_insight_sri.py
       - name: Detect Pyodide changes
         id: pyodide-diff-docs
         run: |

--- a/scripts/check_insight_sri.py
+++ b/scripts/check_insight_sri.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Verify SRI hash for insight.bundle.js."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path("docs/alpha_agi_insight_v1")
+BUNDLE = DOCS_DIR / "insight.bundle.js"
+INDEX = DOCS_DIR / "index.html"
+
+
+def _sha384(path: Path) -> str:
+    return base64.b64encode(hashlib.sha384(path.read_bytes()).digest()).decode()
+
+
+def main() -> int:
+    if not BUNDLE.is_file() or not INDEX.is_file():
+        print("insight bundle or index.html missing", file=sys.stderr)
+        return 1
+    html = INDEX.read_text()
+    match = re.search(r"integrity=['\"]([^'\"]+)['\"]", html)
+    if not match:
+        print("integrity attribute missing", file=sys.stderr)
+        return 1
+    expected = "sha384-" + _sha384(BUNDLE)
+    if match.group(1) != expected:
+        print(f"SRI mismatch: {match.group(1)} != {expected}", file=sys.stderr)
+        return 1
+    print("insight bundle integrity verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a script to verify the insight bundle's SRI hash
- check the generated bundle integrity in the docs-build job

## Testing
- `pre-commit run --files scripts/check_insight_sri.py .github/workflows/ci.yml`
- `pytest tests/test_docs_bundle_hash.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6882d0dd831c83338711482f769480f9