### PR TITLE
Fix SRI for insight service worker

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -47,7 +47,7 @@
     ></script>
     <script>
       const SW_URL = 'service-worker.js';
-      const SW_HASH = 'sha384-ITQvGaSQBg4EGhxnB0OuTBcb9mYff22hfLOPenTASEQMJ4eKhFZb/TJbdttP4tRh';
+      const SW_HASH = 'sha384-kQo+PZJcRiSq81DoHg7dyh+D8v/XRPNke0/dvpo2pT968hYeKRy2hfcZk4KYSIh5';
       // Replaced with the SHA-384 digest of service-worker.js during
       // `npm run build` (or `python manual_build.py`)
       if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- update `SW_HASH` in docs to match `service-worker.js`

## Testing
- `pre-commit run --files docs/alpha_agi_insight_v1/index.html`
- `pytest tests/test_benchmark.py` *(fails: RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_6882de70cb5883339a0f9158c8de5ff0