### PR TITLE
[alpha_factory] docker: align base image with CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # When changing build dependencies here, mirror the updates in
 # alpha_factory_v1/Dockerfile to keep both images consistent.
 FROM python:3.13-slim
-# Base image must match the highest Python version used in CI (currently 3.13)
+# Base image matches the highest Python version used in CI (currently 3.13)
 
 # install build tools and npm for the React UI
 RUN apt-get update && \

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.13-slim
-# Base image must match the highest Python version used in CI (currently 3.13)
+# Base image matches the highest Python version used in CI (currently 3.13)
 
 # install system deps
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- clarify base image comments to confirm Python 3.13 support

## Testing
- `pre-commit run --files Dockerfile infrastructure/Dockerfile`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --maxfail=1 -q`
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ee1197188333b95ea0b9e83a49e9