### PR TITLE
[alpha_factory] Ensure downstream jobs run always

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,7 +674,7 @@ jobs:
 
   deploy:
     name: "📦 Deploy"
-    if: ${{ success() && startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ always() && startsWith(github.ref, 'refs/tags/') }}
     needs: [tests, docker]
     runs-on: ubuntu-latest
     environment: ci-on-demand


### PR DESCRIPTION
## Summary
- adjust deploy job condition to include `always()`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 4 failed, 51 passed, 34 skipped, 1 xfailed)*

------
https://chatgpt.com/codex/tasks/task_e_6882f0ba50088333ab37aa1c4240422b