### PR TITLE
[alpha_factory] Verify docs SRI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,8 @@ jobs:
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run build
       - name: Build gallery site
         run: ./scripts/build_gallery_site.sh
+      - name: Check Insight SRI
+        run: python scripts/check_insight_sri.py
       - name: Verify downloaded assets
         run: |
           python scripts/fetch_assets.py --verify-only || (


### PR DESCRIPTION
## Summary
- insert a step that runs `check_insight_sri.py` after the Insight bundle is built

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(fails: 11 failed, 69 passed, 34 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6882f35e849883338b9a59c416b11080