### PR TITLE
[alpha_factory] Update docs SRI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,8 +497,6 @@ jobs:
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run build
       - name: Build gallery site
         run: ./scripts/build_gallery_site.sh
-      - name: Check Insight SRI
-        run: python scripts/check_insight_sri.py
       - name: Verify downloaded assets
         run: |
           python scripts/fetch_assets.py --verify-only || (
@@ -507,7 +505,7 @@ jobs:
             npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run fetch-assets &&
             python scripts/fetch_assets.py --verify-only
           )
-      - name: Verify Insight SRI
+      - name: Check Insight SRI
         run: python scripts/check_insight_sri.py
       - name: Detect Pyodide changes
         id: pyodide-diff-docs


### PR DESCRIPTION
## Summary
- remove extra SRI verification step
- keep a single check after docs build

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --all-files` *(fails: Node.js 22+ is required)*
- `pytest -q` *(fails: 215 failed, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882f8303e488333bbfae4b583bc0da4