### PR TITLE
[alpha_factory] Add SRI integrity test

### DIFF
--- a/tests/test_insight_sri.py
+++ b/tests/test_insight_sri.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from pathlib import Path
+
+
+def test_insight_bundle_sri() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    insight_dir = repo / "docs" / "alpha_agi_insight_v1"
+    bundle = insight_dir / "insight.bundle.js"
+    html = insight_dir / "index.html"
+
+    digest = hashlib.sha384(bundle.read_bytes()).digest()
+    expected = "sha384-" + base64.b64encode(digest).decode()
+
+    text = html.read_text()
+    match = re.search(r"<script[^>]*src=['\"]insight.bundle.js['\"][^>]*>", text)
+    assert match, "script tag for insight.bundle.js missing"
+    sri = re.search(r"integrity=['\"]([^'\"]+)['\"]", match.group(0))
+    assert sri, "integrity attribute missing"
+    assert sri.group(1) == expected


### PR DESCRIPTION
## Summary
- add test_insight_sri to verify insight.bundle.js integrity hash

## Testing
- `pre-commit run --files tests/test_insight_sri.py`
- `pytest -q tests/test_insight_sri.py`


------
https://chatgpt.com/codex/tasks/task_e_688301c69e248333880e671b414c3381