### PR TITLE
[alpha_factory] update docs for python 3.13 ceiling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pre-commit run --files .github/workflows/ci.yml
 
 ## Quick Checklist
 
-Ensure **Python 3.11–3.14** and **Node.js 22** are installed before running the tools.
+Ensure **Python 3.11–3.13** and **Node.js 22** are installed before running the tools.
 
 Before opening a pull request, verify the environment and run the tests:
 

--- a/alpha_factory_v1/demos/solving_agi_governance/README.md
+++ b/alpha_factory_v1/demos/solving_agi_governance/README.md
@@ -107,7 +107,7 @@ Python standard library.
 ---
 
 ### Requirements
-* Python 3.11–3.14 (<3.15). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
+* Python 3.11–3.13 (<3.14). See [AGENTS.md](https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/AGENTS.md)
 * Install the optional runtime packages:
   ```bash
   pip install -r alpha_factory_v1/demos/solving_agi_governance/requirements.txt


### PR DESCRIPTION
## Summary
- clarify supported python version range in docs

## Testing
- `pre-commit run --files alpha_factory_v1/demos/solving_agi_governance/README.md CONTRIBUTING.md .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -m smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_6883041f9f288333b9a92dbb934177fe