### PR TITLE
[alpha_factory] update infrastructure base image

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.13-slim
-# Base image matches the highest Python version used in CI (currently 3.13)
+FROM python:3.12-slim
+# Base image matches one of the supported Python versions (>=3.11,<3.14)
 
 # install system deps
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- use the supported Python 3.12 slim image for the infra Dockerfile

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files infrastructure/Dockerfile`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `docker build -f infrastructure/Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838de22db88333a95c569fc15eef37