### PR TITLE
[alpha_factory] Adjust deploy trigger logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,7 +674,7 @@ jobs:
 
   deploy:
     name: "📦 Deploy"
-    if: ${{ always() && startsWith(github.ref, 'refs/tags/') }}
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [tests, docker]
     runs-on: ubuntu-latest
     environment: ci-on-demand


### PR DESCRIPTION
## Summary
- ensure the deploy job only runs for tags
- keep rollback logic intact

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_68839511abbc8333a66181fb1f5d915e