### PR TITLE
fix: remove duplicate asset cache restore step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,17 +155,6 @@ jobs:
           key: assets-${{ steps.asset-key-docs-build.outputs.key }}-${{ runner.os }}-py${{ matrix.python-version }}
           restore-keys: |
             assets-${{ runner.os }}-py${{ matrix.python-version }}-
-      - id: asset-key-docker
-        uses: ./.github/actions/generate-asset-key
-      - name: Restore Insight asset cache
-        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
-        with:
-          path: |
-            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm
-            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/wasm_llm
-          key: assets-${{ steps.asset-key-docker.outputs.key }}-${{ runner.os }}-py${{ matrix.python-version }}
-          restore-keys: |
-            assets-${{ runner.os }}-py${{ matrix.python-version }}-
       - name: Fetch insight browser assets
         run: |
           set -e


### PR DESCRIPTION
## Summary
- drop redundant Insight asset cache restore from `tests` job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688397287bc0833395c08171c0e1a625