### PR TITLE
[alpha_factory] clean up docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,10 +637,6 @@ jobs:
       - name: Smoke test image
         run: |
           docker run --rm -e RUN_MODE=cli "$DOCKER_IMAGE:ci" simulate --horizon 1 --offline
-      - name: Compute repo_owner_lower
-        run: |
-          repo_owner_lower=$(echo "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')
-          echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_ENV"
       - name: Login to GHCR
         uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
         with:


### PR DESCRIPTION
## Summary
- remove duplicate `Compute repo_owner_lower` step from `docker` job
- keep early step so later steps can reuse the variable

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6883b23ad9a4833397cb2a918034a597