### PR TITLE
[alpha_factory] ensure docker job always runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,7 @@ jobs:
 
   docker:
     name: "🐳 Docker build"
+    if: always()
     needs: [tests]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- mark Docker build job with `if: always()` so it runs even when tests fail

## Testing
- `pre-commit run --all-files`
- `pytest -m smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_6883c04a39b08333878512d999e73cde