### PR TITLE
docs: clarify owner check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 #
 # Validates the demo with lint, type checks, unit tests and Docker build.
 # Runs only via manual dispatch by the repository owner using the "Run workflow" button.
+# Access is restricted through the owner-check job to ensure only the repository
+# owner can start this pipeline.
 # Tagged releases deploy a Docker image with rollback on failure.
 name: "🚀 CI"
 


### PR DESCRIPTION
## Summary
- note in the CI workflow that the owner-check job restricts access

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -k 'benchmark or smoke' -q` *(fails: ImportError: sentence-transformers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883c7627adc833397d0bff614ffab6a