### PR TITLE
ci: document always-running jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@
 # Access is restricted through the owner-check job to ensure only the repository
 # owner can start this pipeline.
 # Tagged releases deploy a Docker image with rollback on failure.
+# Jobs use 'if: always()' to ensure later stages still run even when earlier
+# steps fail.
 name: "🚀 CI"
 
 on:


### PR DESCRIPTION
## Summary
- clarify that jobs run even on failure

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -k "smoke" -q`


------
https://chatgpt.com/codex/tasks/task_e_6883cfb89ba883338bd180e0e196cae0