### PR TITLE
[alpha_factory] pin cosign installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.5.3'
+          cosign-release: 'v2.2.4'
       - name: Sign web client artifact
         if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign-blob --yes --output-signature web-client.tar.gz.sig web-client.tar.gz
@@ -554,7 +554,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.5.3'
+          cosign-release: 'v2.2.4'
       - name: Sign image
         run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
       - name: Verify image signature
@@ -581,7 +581,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.5.3'
+          cosign-release: 'v2.2.4'
       - name: Pull previous image
         run: docker pull ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest || true
       - name: Tag previous


### PR DESCRIPTION
## Summary
- pin cosign installer to stable v2.2.4 in the CI workflow

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: 14 failed, 78 passed, 34 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6883e7fed70c8333911b2460b720124e