### PR TITLE
[alpha_factory] Update cosign release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: 'v2.5.3'
       - name: Sign web client artifact
         if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign-blob --yes --output-signature web-client.tar.gz.sig web-client.tar.gz
@@ -560,7 +560,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: 'v2.5.3'
       - name: Sign image
         run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
       - name: Verify image signature
@@ -592,7 +592,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: 'v2.5.3'
       - name: Pull previous image
         run: docker pull ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest || true
       - name: Tag previous


### PR DESCRIPTION
## Summary
- bump cosign to v2.5.3 for docker signing

## Checks
- [x] `pre-commit run --files .github/workflows/ci.yml`
- [x] `pre-commit run --all-files`
- [x] `python check_env.py --auto-install`
- [x] `pytest --cov --cov-report=xml` *(fails: see log)*

## Testing
- `pre-commit` succeeded
- `pytest` failed: 216 failed, 578 passed, 75 skipped

------
https://chatgpt.com/codex/tasks/task_e_6883ffacf6508333b6bdeb0f4d3c4f6e