### PR TITLE
[alpha_factory] align cosign version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.5.3'
+          cosign-release: 'v2.2.4'
       - name: Sign web client artifact
         if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign-blob --yes --output-signature web-client.tar.gz.sig web-client.tar.gz
@@ -560,7 +560,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.5.3'
+          cosign-release: 'v2.2.4'
       - name: Sign image
         run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
       - name: Verify image signature
@@ -592,7 +592,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.5.3'
+          cosign-release: 'v2.2.4'
       - name: Pull previous image
         run: docker pull ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest || true
       - name: Tag previous


### PR DESCRIPTION
## Summary
- keep manual owner trigger comment in CI
- match cosign version with other workflows

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688430f29cf88333bbc2a7104ab5f384