### PR TITLE
ci: order smoke and docs jobs after lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
   windows-smoke:
     name: "Windows Smoke"
     if: always()
-    needs: [tests]
+    needs: [lint-type, tests]
     runs-on: windows-latest
     environment: ci-on-demand
     steps:
@@ -281,7 +281,7 @@ jobs:
   macos-smoke:
     name: "macOS Smoke"
     if: always()
-    needs: [tests]
+    needs: [lint-type, tests]
     environment: ci-on-demand
     runs-on: macos-latest
     steps:
@@ -327,7 +327,7 @@ jobs:
   docs-check:
     name: "📜 MkDocs"
     if: always()
-    needs: [tests]
+    needs: [lint-type, tests]
     runs-on: ubuntu-latest
     env:
       SANDBOX_IMAGE: selfheal-sandbox:latest
@@ -373,7 +373,7 @@ jobs:
   docs-build:
     name: "📚 Docs Build"
     if: always()
-    needs: [tests]
+    needs: [lint-type, tests]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -455,7 +455,7 @@ jobs:
   docker:
     name: "🐳 Docker build"
     if: always()
-    needs: [tests]
+    needs: [lint-type, tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- order smoke and docs jobs after lint

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError: API...)*

------
https://chatgpt.com/codex/tasks/task_e_688436baf9948333b23d64496651e695