### PR TITLE
[alpha_factory] update ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
+      - name: Show tool versions
+        run: |
+          python --version
+          node --version
+          docker --version
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy"


### PR DESCRIPTION
## Summary
- show Python, Node, and Docker versions during owner check

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(skipped heavy hooks)*
- `pytest tests/test_benchmark.py -q` *(failed: RuntimeError: API...)*

------
https://chatgpt.com/codex/tasks/task_e_68843b90ef948333bdec8a1c96566f83