### PR TITLE
[alpha_factory] Add timeout-minutes to CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
   owner-check:
     name: "Verify owner"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
@@ -59,6 +60,7 @@ jobs:
     name: "🧹 Ruff + 🏷️ Mypy"
     needs: owner-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: ci-on-demand        # ⇦ optional: add reviewers in repo Settings → Environments
     strategy:
       fail-fast: false
@@ -125,6 +127,7 @@ jobs:
     name: "✅ Pytest"
     needs: owner-check
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment: ci-on-demand
     env:
       SANDBOX_IMAGE: selfheal-sandbox:latest
@@ -243,6 +246,7 @@ jobs:
     if: always()
     needs: [lint-type, tests]
     runs-on: windows-latest
+    timeout-minutes: 30
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -289,6 +293,7 @@ jobs:
     needs: [lint-type, tests]
     environment: ci-on-demand
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
@@ -334,6 +339,7 @@ jobs:
     if: always()
     needs: [lint-type, tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       SANDBOX_IMAGE: selfheal-sandbox:latest
       PWA_TIMEOUT_MS: '120000'
@@ -380,6 +386,7 @@ jobs:
     if: always()
     needs: [lint-type, tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       pull-requests: write
     environment: ci-on-demand
@@ -462,6 +469,7 @@ jobs:
     if: always()
     needs: [lint-type, tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write
     # This job builds and pushes the image.
@@ -576,6 +584,7 @@ jobs:
     if: ${{ always() && startsWith(github.ref, 'refs/tags/') }}
     needs: [tests, docker]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- set `timeout-minutes` for owner-check, lint-type, tests and other CI jobs
- keep jobs from running indefinitely

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: 213 failed, 579 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6884447f670883339ac9827a87964f3b