### PR TITLE
[alpha_factory] clarify always() in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@
 # Access is restricted through the owner-check job to ensure only the repository
 # owner can start this pipeline.
 # Tagged releases deploy a Docker image with rollback on failure.
-# Jobs use `if: always()` so later stages still run even when earlier checks fail.
+# Later jobs use `if: always()` so they still run even when earlier checks fail.
 # The Python matrix covers versions **3.11–3.13** and the workflow includes
 # Windows and macOS smoke tests, full documentation builds and Docker deployment.
 name: "🚀 CI"


### PR DESCRIPTION
## Summary
- improve workflow comment about using `if: always()` for later jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -k ""` *(fails: VerifyWheelSigTests::test_valid_signature, test_pyodide_load_failure, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68844b3c5a2883338216c452be1553ca