### PR TITLE
Update CI to limit mutation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
           python check_env.py --auto-install${WHEELHOUSE:+ --wheelhouse "$WHEELHOUSE"}
           pytest --cov --cov-report=xml --cov-fail-under=80
       - name: Mutation tests
+        if: matrix.python-version == '3.11'
         run: |
           mutmut run --paths-to-mutate alpha_factory_v1/demos/alpha_agi_insight_v1/src --runner "pytest -q"
       - name: Run benchmark


### PR DESCRIPTION
## Summary
- only run mutation tests for Python 3.11

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_6884ddefb2608333b962299a8c62ab28