### PR TITLE
[alpha_factory] Update cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: .cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -416,7 +416,7 @@ jobs:
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: .cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
## Summary
- bump actions/cache in ci workflow to v4.2.3

## Testing
- `pre-commit run --all-files` *(fails: Node.js 22+ is required)*
- `pytest tests/test_benchmark.py -q` *(fails: RuntimeError during benchmark)*

------
https://chatgpt.com/codex/tasks/task_e_6884e37a1b348333bf47433dafd77a95