### PR TITLE
[alpha_factory] improve test cache paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: 'requirements.lock'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-demo-cpu.lock
+            alpha_factory_v1/backend/requirements-lock.txt
 
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -142,7 +146,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: 'requirements.lock'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-demo-cpu.lock
+            alpha_factory_v1/backend/requirements-lock.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -355,7 +363,7 @@ jobs:
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: .cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -416,7 +424,7 @@ jobs:
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: .cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
## Summary
- update `cache-dependency-path` for the tests job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(fails: test suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_6884e5cc4c1c8333939d23673c3dd6e2