### PR TITLE
[alpha_factory] add workflow update hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,12 @@ repos:
         entry: python scripts/verify_html_disclaimer.py
         language: python
         pass_filenames: false
+      - id: update-actions
+        name: Update workflow action versions
+        entry: python tools/update_actions.py
+        language: system
+        files: ^\.github/workflows/
+        pass_filenames: false
       - id: py-compile
         name: Validate Python syntax with py_compile
         entry: python -m py_compile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,11 +73,17 @@ repository-wide checks pass.
 Use `pre-commit run --files docs/demos/<page>.md` to catch missing preview
 images. Each page under `docs/demos/` must start with a preview image using
 `![preview](...)`.
-Run `python tools/update_actions.py` before committing workflow changes to pull
-the latest action tags. Then run `pre-commit` so the YAML passes `actionlint`:
+Workflow YAML files are linted by `pre-commit`. A local hook automatically
+runs `python tools/update_actions.py` whenever files in `.github/workflows/`
+change. You can also run it manually:
 
 ```bash
 pre-commit run --files .github/workflows/ci.yml
+
+If the hook reports that `requests` is missing, install it with:
+
+```bash
+pip install -r requirements-dev.txt
 ```
 
 ## Quick Checklist

--- a/tools/update_actions.py
+++ b/tools/update_actions.py
@@ -13,7 +13,11 @@ import re
 import sys
 from pathlib import Path
 
-import requests
+try:
+    import requests
+except ImportError:  # pragma: no cover - handled at runtime
+    sys.stderr.write("The 'requests' package is required. Install it with 'pip install -r requirements-dev.txt'.\n")
+    sys.exit(1)
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
 


### PR DESCRIPTION
## Summary
- run tools/update_actions.py via pre-commit when workflows change
- warn if `requests` is missing
- document the new hook

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --all-files` *(fails: Node.js 22+ required)*
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6884fa77102883338d6290056d5e2a53