### PR TITLE
[alpha_factory] handle missing requests in update_pyodide

### DIFF
--- a/scripts/update_pyodide.py
+++ b/scripts/update_pyodide.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: Apache-2.0
 # See docs/DISCLAIMER_SNIPPET.md
-"""Update Pyodide runtime checksums in fetch_assets.py."""
+"""Update Pyodide runtime checksums in fetch_assets.py.
+
+Usage:
+    python update_pyodide.py <version>
+"""
 
 from __future__ import annotations
 
@@ -14,7 +18,11 @@ import sys
 from pathlib import Path
 from typing import Dict
 
-import requests  # type: ignore
+try:
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover - handled at runtime
+    sys.stderr.write("Missing 'requests'. Install with 'pip install requests' or use requirements-dev.txt'.\n")
+    sys.exit(1)
 
 
 def fetch(url: str) -> bytes:


### PR DESCRIPTION
## Summary
- clarify usage in `update_pyodide.py`
- exit gracefully when `requests` isn't installed

## Testing
- `pre-commit run --files scripts/update_pyodide.py`
- `pytest` *(fails: AttributeError, KeyError, AssertionError, ModuleNotFoundError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6884feca3574833388e63c980dc67ff9