### PR TITLE
[alpha_factory] Clarify Cypress tests removed

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -30,7 +30,7 @@ previous `latest` image so production always points at a working build.
 
 - **🧹 Ruff + 🏷️ Mypy** – lint and type checks.
 - **✅ Pytest** – unit tests and front‑end checks.
-- **🎯 Cypress** – end-to-end UI tests. Uses `cypress-io/github-action` to start the Vite dev server and run the suite. If `PERCY_TOKEN` is set the action uploads snapshots to Percy.
+- **🎯 Cypress (removed)** – the workflow no longer executes Cypress tests. End‑to‑end checks run via Playwright inside the **✅ Pytest** job.
 - **Windows/Mac Smoke** – lightweight sanity tests on Windows and macOS.
 - **📜 MkDocs** – basic documentation build.
 - **📚 Docs Build** – full docs site verification with an offline check. The job runs


### PR DESCRIPTION
## Summary
- update CI docs to note that Cypress tests have been removed

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py -q`
- *(pre-commit failed to complete due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6885057e5d088333962a291fbe02808f