### PR TITLE
[alpha_factory] update Docker Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,25 @@
 FROM python:3.13-slim
 # Base image matches the highest Python version used in CI (currently 3.13)
 
-# install build tools and npm for the React UI
+# install build tools and Node.js 22.7.0 for the React UI
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg build-essential git \
         rustc cargo postgresql-client patch && \
     git --version && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
+    export NODE_VERSION=22.7.0 NODE_DIST=node-v22.7.0-linux-x64.tar.xz && \
+    curl -fsSLO "https://nodejs.org/dist/v$NODE_VERSION/$NODE_DIST" && \
+    curl -fsSLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt" && \
+    grep " $NODE_DIST$" SHASUMS256.txt | sha256sum -c - && \
+    tar -xJf "$NODE_DIST" -C /usr/local --strip-components=1 && \
+    rm "$NODE_DIST" SHASUMS256.txt && \
+    ln -s /usr/local/bin/node /usr/local/bin/nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # upgrade pip to avoid outdated versions
 RUN python -m pip install --upgrade "pip<25" setuptools wheel
 
-# Verify Node installation is >=22 (NodeSource script sets up latest LTS)
+# Verify Node installation is exactly 22.7.0
 RUN node --version
 
 WORKDIR /app

--- a/alpha_factory_v1/Dockerfile
+++ b/alpha_factory_v1/Dockerfile
@@ -25,7 +25,7 @@ ARG INSTALL_UI=1
 #######################################################################
 #  Stage 0 — (optional) Build static Trace‑graph front‑end            #
 #######################################################################
-FROM node:22-bookworm-slim AS ui-build
+FROM node:22.7.0-bookworm-slim AS ui-build
 ARG INSTALL_UI
 RUN if [ "$INSTALL_UI" = "0" ]; then echo "Skipping UI build stage" && exit 0; fi
 WORKDIR /ui

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile
@@ -6,11 +6,16 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg build-essential git && \
     git --version && \
-        curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
+    export NODE_VERSION=22.7.0 NODE_DIST=node-v22.7.0-linux-x64.tar.xz && \
+    curl -fsSLO "https://nodejs.org/dist/v$NODE_VERSION/$NODE_DIST" && \
+    curl -fsSLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt" && \
+    grep " $NODE_DIST$" SHASUMS256.txt | sha256sum -c - && \
+    tar -xJf "$NODE_DIST" -C /usr/local --strip-components=1 && \
+    rm "$NODE_DIST" SHASUMS256.txt && \
+    ln -s /usr/local/bin/node /usr/local/bin/nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Verify Node installation is >=22 (NodeSource script sets up latest LTS)
+# Verify Node installation is exactly 22.7.0
 RUN node --version
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- pin Node 22.7.0 in Dockerfile
- update alpha_factory image to use Node 22.7.0
- match demo infrastructure Dockerfile

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files Dockerfile alpha_factory_v1/demos/alpha_agi_insight_v1/infrastructure/Dockerfile alpha_factory_v1/Dockerfile`
- `pytest` *(fails: 128 failed, 360 passed, 65 skipped, 1 xfailed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68851054d420833395951f862ce6c4ab