### PR TITLE
fix: allow pytest fixture injection in agent test

### DIFF
--- a/tests/test_agent_aiga_entrypoint.py
+++ b/tests/test_agent_aiga_entrypoint.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 import py_compile
-import unittest
 from pathlib import Path
 import importlib
 import sys
@@ -10,7 +9,7 @@ import pytest
 ENTRYPOINT = Path("alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py")
 
 
-class TestAgentAIGAEntry(unittest.TestCase):
+class TestAgentAIGAEntry:
     def test_entrypoint_compiles(self):
         py_compile.compile(ENTRYPOINT, doraise=True)
 
@@ -51,6 +50,9 @@ class TestAgentAIGAEntry(unittest.TestCase):
             utils_stub,
         )
 
+        gradio_stub = types.ModuleType("gradio")
+        monkeypatch.setitem(sys.modules, "gradio", gradio_stub)
+
         evo_stub = types.ModuleType("meta_evolver")
 
         class DummyEvolver:
@@ -89,7 +91,3 @@ class TestAgentAIGAEntry(unittest.TestCase):
         mod = importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.agent_aiga_entrypoint")
         assert mod.OpenAIAgent is Agent
         assert isinstance(mod.service.evolver, DummyEvolver)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
## Summary
- make `TestAgentAIGAEntry` a plain class so pytest fixtures work
- stub `gradio` in the test to avoid missing dependency

## Testing
- `pre-commit run --files tests/test_agent_aiga_entrypoint.py`
- `pytest tests/test_agent_aiga_entrypoint.py::TestAgentAIGAEntry::test_import_without_openaiagent -q`

------
https://chatgpt.com/codex/tasks/task_e_68852189b6788333acb085bb69588425