### PR TITLE
[alpha_factory] patch heartbeat tests

### DIFF
--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -99,10 +99,14 @@ class TestAgentRegistryFunctions(unittest.TestCase):
 
     def test_get_agent_health_queue(self):
         from alpha_factory_v1.backend import agents as agents_mod
+        from alpha_factory_v1.backend.agents import registry as registry_mod
         from queue import Queue
 
-        saved_q = agents_mod._HEALTH_Q
-        agents_mod._HEALTH_Q = Queue()
+        saved_agents_q = agents_mod._HEALTH_Q
+        saved_registry_q = registry_mod._HEALTH_Q
+        tmp_q = Queue()
+        agents_mod._HEALTH_Q = tmp_q
+        registry_mod._HEALTH_Q = tmp_q
 
         class WrapAgent(AgentBase):
             NAME = "wrap"
@@ -122,7 +126,8 @@ class TestAgentRegistryFunctions(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIsInstance(latency, float)
 
-        agents_mod._HEALTH_Q = saved_q
+        agents_mod._HEALTH_Q = saved_agents_q
+        registry_mod._HEALTH_Q = saved_registry_q
 
     def test_list_agents_detail(self):
         class DAgent(AgentBase):


### PR DESCRIPTION
## Summary
- update heartbeat tests to patch both agents queues
- import BaseAgent lazily so selecting tests avoids circular imports

## Testing
- `pre-commit run --files tests/test_agents.py tests/test_agents_registry.py`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest tests/test_agents.py::test_agent_registration_and_heartbeat tests/test_agents_registry.py::TestAgentRegistryFunctions::test_get_agent_health_queue -q`

------
https://chatgpt.com/codex/tasks/task_e_688525affa9c8333801f7aaf3139ee0b