### PR TITLE
feat: expand core settings

### DIFF
--- a/alpha_factory_v1/core/agents/base_agent.py
+++ b/alpha_factory_v1/core/agents/base_agent.py
@@ -18,8 +18,9 @@ except Exception:  # pragma: no cover - optional
     LLMProvider = None
 
 from ...common.utils import messaging
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.adk_adapter import ADKAdapter
-from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.mcp_adapter import MCPAdapter
+
+ADKAdapter = None
+MCPAdapter = None
 
 if TYPE_CHECKING:  # pragma: no cover - type hint only
     from ...common.utils.logging import Ledger
@@ -77,8 +78,27 @@ class BaseAgent:
                     )
                 except Exception:
                     self.llm = LLMProvider() if LLMProvider is not None else None
-        self.adk = ADKAdapter() if ADKAdapter.is_available() else None
-        self.mcp = MCPAdapter() if MCPAdapter.is_available() else None
+        global ADKAdapter, MCPAdapter
+        if ADKAdapter is None:
+            try:  # pragma: no cover - optional dependency
+                from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.adk_adapter import (
+                    ADKAdapter as _ADKAdapter,
+                )
+
+                ADKAdapter = _ADKAdapter
+            except Exception:
+                ADKAdapter = None
+        if MCPAdapter is None:
+            try:  # pragma: no cover - optional dependency
+                from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents.mcp_adapter import (
+                    MCPAdapter as _MCPAdapter,
+                )
+
+                MCPAdapter = _MCPAdapter
+            except Exception:
+                MCPAdapter = None
+        self.adk = ADKAdapter() if ADKAdapter and ADKAdapter.is_available() else None
+        self.mcp = MCPAdapter() if MCPAdapter and MCPAdapter.is_available() else None
         self._handler = self._on_envelope
         self.bus.subscribe(self.name, self._handler)
 

--- a/alpha_factory_v1/core/orchestrator.py
+++ b/alpha_factory_v1/core/orchestrator.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, cast
 
-from .agents import (
+from alpha_factory_v1.demos.alpha_agi_insight_v1.src.agents import (
     planning_agent,
     research_agent,
     strategy_agent,

--- a/alpha_factory_v1/core/utils/config.py
+++ b/alpha_factory_v1/core/utils/config.py
@@ -108,6 +108,27 @@ class Settings(SettingsBase):
     bus_port: int = Field(default=6006, alias="AGI_INSIGHT_BUS_PORT")
     ledger_path: str = Field(default="./ledger/audit.db", alias="AGI_INSIGHT_LEDGER_PATH")
     seed: Optional[int] = Field(default=None, alias="SEED")
+    memory_path: Optional[str] = Field(default=None, alias="AGI_INSIGHT_MEMORY_PATH")
+    broker_url: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BROKER_URL")
+    bus_token: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_TOKEN")
+    bus_cert: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_CERT")
+    bus_key: Optional[str] = Field(default=None, alias="AGI_INSIGHT_BUS_KEY")
+    bus_fail_limit: int = Field(default=3, alias="AGI_INSIGHT_BUS_FAIL_LIMIT")
+    alert_webhook_url: Optional[str] = Field(default=None, alias="ALERT_WEBHOOK_URL")
+    allow_insecure: bool = Field(default=False, alias="AGI_INSIGHT_ALLOW_INSECURE")
+    broadcast: bool = Field(default=True, alias="AGI_INSIGHT_BROADCAST")
+    solana_rpc_url: str = Field(default="https://api.testnet.solana.com", alias="AGI_INSIGHT_SOLANA_URL")
+    solana_wallet: Optional[str] = Field(default=None, alias="AGI_INSIGHT_SOLANA_WALLET")
+    solana_wallet_file: Optional[str] = Field(default=None, alias="AGI_INSIGHT_SOLANA_WALLET_FILE")
+    model_name: str = Field(default="gpt-4o-mini", alias="AGI_MODEL_NAME")
+    temperature: float = Field(default=0.2, alias="AGI_TEMPERATURE")
+    context_window: int = Field(default=8192, alias="AGI_CONTEXT_WINDOW")
+    json_logs: bool = Field(default=False, alias="AGI_INSIGHT_JSON_LOGS")
+    db_type: str = Field(default="sqlite", alias="AGI_INSIGHT_DB")
+    island_backends: dict[str, str] = Field(
+        default_factory=lambda: {"default": "gpt-4o"},
+        alias="AGI_ISLAND_BACKENDS",
+    )
     self_improve_template: str = Field(
         default=str(Path(__file__).resolve().parents[1] / "prompts" / "self_improve.yaml"),
         alias="SELF_IMPROVE_TEMPLATE",
@@ -116,11 +137,32 @@ class Settings(SettingsBase):
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - exercised in tests
         super().__init__(**data)
+        raw = os.getenv("AGI_ISLAND_BACKENDS")
+        if raw and not data.get("island_backends"):
+            mapping = {}
+            for part in raw.split(","):
+                if "=" in part:
+                    k, v = part.split("=", 1)
+                    mapping[k.strip()] = v.strip()
+            if mapping:
+                self.island_backends = mapping
         if not self.openai_api_key:
             self.openai_api_key = get_secret("OPENAI_API_KEY")
         if not self.openai_api_key:
             _log.warning("OPENAI_API_KEY missing – offline mode enabled")
             self.offline = True
+        if self.offline:
+            self.broadcast = False
+        if not self.solana_wallet and self.solana_wallet_file:
+            try:
+                self.solana_wallet = Path(self.solana_wallet_file).read_text(encoding="utf-8").strip()
+            except Exception as exc:  # pragma: no cover - optional
+                _log.warning("Failed to load wallet file %s: %s", self.solana_wallet_file, exc)
+        if self.bus_cert and self.bus_key:
+            if not self.bus_token or self.bus_token == "change_this_token":
+                raise ValueError(
+                    "AGI_INSIGHT_BUS_TOKEN must be set and cannot be 'change_this_token' when TLS is enabled"
+                )
         try:
             raw = yaml.safe_load(Path(self.self_improve_template).read_text(encoding="utf-8"))
         except (OSError, yaml.YAMLError) as exc:


### PR DESCRIPTION
## Summary
- support JSON log configuration in `core.utils.config`
- avoid circular imports when loading agents

## Testing
- `pre-commit run --files alpha_factory_v1/core/utils/config.py alpha_factory_v1/core/agents/base_agent.py alpha_factory_v1/core/orchestrator.py`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pytest tests/test_agents.py::test_monitor_restart_and_ledger_log -q` *(fails: AttributeError: 'Settings' object has no attribute 'solana_rpc_url')*

------
https://chatgpt.com/codex/tasks/task_e_688528e9f0548333887d0997f95a7ffb