### PR TITLE
Fix CLI disclaimer printing during tests

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py
@@ -53,12 +53,19 @@ __all__ = [
 class DisclaimerGroup(click.Group):
     """Group that prints a short disclaimer before any output."""
 
+    @staticmethod
+    def _enabled() -> bool:
+        if os.environ.get("NO_DISCLAIMER"):
+            return False
+        return sys.stdout.isatty()
+
     def get_help(self, ctx: click.Context) -> str:  # pragma: no cover - CLI
         help_text = super().get_help(ctx)
-        return f"{DISCLAIMER}\n\n{help_text}"
+        return f"{DISCLAIMER}\n\n{help_text}" if self._enabled() else help_text
 
     def invoke(self, ctx: click.Context) -> Any:  # pragma: no cover - CLI
-        click.echo(DISCLAIMER)
+        if self._enabled():
+            click.echo(DISCLAIMER)
         return super().invoke(ctx)
 
 

--- a/alpha_factory_v1/utils/disclaimer.py
+++ b/alpha_factory_v1/utils/disclaimer.py
@@ -7,9 +7,21 @@ _DOCS_PATH = Path(__file__).resolve().parents[2] / "docs" / "DISCLAIMER_SNIPPET.
 DISCLAIMER: str = _DOCS_PATH.read_text(encoding="utf-8").strip()
 
 
+import os
+import sys
+
+
+def _enabled() -> bool:
+    """Return True when the disclaimer should be printed."""
+    if os.environ.get("NO_DISCLAIMER"):
+        return False
+    return sys.stdout.isatty()
+
+
 def print_disclaimer() -> None:
-    """Print the project disclaimer."""
-    print(DISCLAIMER)
+    """Print the project disclaimer when enabled."""
+    if _enabled():
+        print(DISCLAIMER)
 
 
 __all__ = ["DISCLAIMER", "print_disclaimer"]


### PR DESCRIPTION
## Summary
- avoid printing the disclaimer when stdout isn't a TTY
- guard `print_disclaimer()` with the same check

## Testing
- `pre-commit run --files alpha_factory_v1/utils/disclaimer.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/cli.py`
- `pytest tests/test_cli.py::test_simulate_export_json -q`
- `pytest tests/test_forecast.py::test_innovation_gain_positive -q`
- `pytest tests/test_cli_runner_ext.py::test_simulate_export_formats -q`

------
https://chatgpt.com/codex/tasks/task_e_6885326897148333b164de1d920d8603