### PR TITLE
[alpha_factory] enforce openai-agents version check

### DIFF
--- a/alpha_factory_v1/scripts/preflight.py
+++ b/alpha_factory_v1/scripts/preflight.py
@@ -265,10 +265,10 @@ def check_openai_agents_version(min_version: str = MIN_OPENAI_AGENTS_VERSION) ->
     version = mod.__version__
     if _version_lt(version, min_version):
         banner(
-            f"{module_name} {version} detected; >={min_version} recommended",
-            "YELLOW",
+            f"{module_name} {version} detected; >={min_version} required",
+            "RED",
         )
-        return True
+        return False
     banner(f"{module_name} {version} detected", "GREEN")
     return True
 

--- a/tests/test_preflight_openai_agents_version.py
+++ b/tests/test_preflight_openai_agents_version.py
@@ -11,7 +11,7 @@ from alpha_factory_v1.scripts import preflight
 
 class TestPreflightOpenAIAgentsVersion(unittest.TestCase):
     def _run_check(self, module_name: str, version: str | None) -> bool:
-        fake_mod = types.SimpleNamespace()
+        fake_mod = types.SimpleNamespace(__spec__=object())
         if version is not None:
             fake_mod.__version__ = version
         orig_import_module = importlib.import_module
@@ -52,18 +52,20 @@ class TestPreflightOpenAIAgentsVersion(unittest.TestCase):
 
     def test_missing_spec_skips_check(self) -> None:
         fake_mod = types.SimpleNamespace(__spec__=None)
+        orig_import_module = importlib.import_module
+        orig_find_spec = importlib.util.find_spec
 
         def _fake_import(name: str, *args: Any, **kwargs: Any) -> object:
             if name == "openai_agents":
                 return fake_mod
-            return importlib.import_module(name, *args, **kwargs)
+            return orig_import_module(name, *args, **kwargs)
 
         def _fake_find_spec(name: str, *args: Any, **kwargs: Any) -> object:
             if name == "openai_agents":
                 return object()
             if name == "agents":
                 return None
-            return importlib.util.find_spec(name, *args, **kwargs)
+            return orig_find_spec(name, *args, **kwargs)
 
         with (
             mock.patch("importlib.import_module", side_effect=_fake_import),


### PR DESCRIPTION
## Summary
- fail preflight if `openai_agents` is too old
- fix recursion in version tests and ensure fake modules include `__spec__`

## Testing
- `pre-commit run --files alpha_factory_v1/scripts/preflight.py tests/test_preflight_openai_agents_version.py`
- `pytest tests/test_preflight_openai_agents_version.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68853e5a2b788333a67beae8b9fd1332