### PR TITLE
fix: update test module paths

### DIFF
--- a/tests/test_api_server_subprocess.py
+++ b/tests/test_api_server_subprocess.py
@@ -29,11 +29,11 @@ def _free_port() -> int:
 def test_simulate_curve_subprocess() -> None:
     port = _free_port()
     env = os.environ.copy()
-    env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
+    env["PYTHONPATH"] = f"{STUB_DIR}:{env.get('PYTHONPATH', '')}"
     cmd = [
         sys.executable,
         "-m",
-        "src.interface.api_server",
+        "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server",
         "--host",
         "127.0.0.1",
         "--port",
@@ -82,14 +82,14 @@ def _start_server(port: int, env: dict[str, str] | None = None) -> subprocess.Po
     cmd = [
         sys.executable,
         "-m",
-        "src.interface.api_server",
+        "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server",
         "--host",
         "127.0.0.1",
         "--port",
         str(port),
     ]
     env = env or os.environ.copy()
-    env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
+    env["PYTHONPATH"] = f"{STUB_DIR}:{env.get('PYTHONPATH', '')}"
     return subprocess.Popen(
         cmd,
         env=env,
@@ -110,7 +110,7 @@ def _start_demo_server(port: int, env: dict[str, str] | None = None) -> subproce
         str(port),
     ]
     env = env or os.environ.copy()
-    env["PYTHONPATH"] = f"{STUB_DIR}:{ROOT}:{env.get('PYTHONPATH', '')}"
+    env["PYTHONPATH"] = f"{STUB_DIR}:{env.get('PYTHONPATH', '')}"
     return subprocess.Popen(
         cmd,
         env=env,

--- a/tests/test_lineage_dashboard.py
+++ b/tests/test_lineage_dashboard.py
@@ -39,7 +39,7 @@ def test_build_tree(tmp_path: Path) -> None:
 
 
 def test_main_no_streamlit(monkeypatch: pytest.MonkeyPatch) -> None:
-    mod_name = "src.interface.lineage_dashboard"
+    mod_name = "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.lineage_dashboard"
     monkeypatch.setitem(sys.modules, "streamlit", None)
     monkeypatch.setitem(sys.modules, "streamlit_autorefresh", None)
     mod = importlib.reload(importlib.import_module(mod_name))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -30,7 +30,7 @@ def _start_server(port: int, env: dict[str, str] | None = None) -> subprocess.Po
     cmd = [
         sys.executable,
         "-m",
-        "src.interface.api_server",
+        "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.api_server",
         "--host",
         "127.0.0.1",
         "--port",


### PR DESCRIPTION
## Summary
- update server paths in tests
- remove unused PYTHONPATH additions

## Testing
- `pre-commit run --files tests/test_api_server_subprocess.py tests/test_metrics.py tests/test_lineage_dashboard.py`
- `python check_env.py --auto-install`
- `pytest tests/test_api_server_subprocess.py tests/test_metrics.py tests/test_lineage_dashboard.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68854a23e6fc8333954e6209c0afb610