### PR TITLE
Fix alert webhook tests

### DIFF
--- a/alpha_factory_v1/common/utils/messaging.py
+++ b/alpha_factory_v1/common/utils/messaging.py
@@ -20,6 +20,7 @@ from cachetools import TTLCache
 from .config import Settings
 from google.protobuf import json_format
 from typing import TYPE_CHECKING
+from alpha_factory_v1.core.utils import alerts
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from alpha_factory_v1.core.utils.tracing import span, bus_messages_total
@@ -86,6 +87,10 @@ class A2ABus:
     ) -> None:
         """Stop the bus when exiting an async context."""
         await self.stop()
+
+    def alert(self, message: str, url: str | None = None) -> None:
+        """Send an alert using :func:`alerts.send_alert`."""
+        alerts.send_alert(message, url or self.settings.alert_webhook_url)
 
     def subscribe(self, topic: str, handler: Callable[[EnvelopeLike], Awaitable[None] | None]) -> None:
         self._subs.setdefault(topic, []).append(handler)

--- a/tests/test_alert_webhook.py
+++ b/tests/test_alert_webhook.py
@@ -18,7 +18,7 @@ class DummyLedger:
         self.events = []
 
     def log(self, env) -> None:  # type: ignore[override]
-        self.events.append(env.payload.get("event"))
+        self.events.append(env.payload["event"])
 
     def start_merkle_task(self, *_a, **_kw) -> None:  # pragma: no cover - test stub
         pass


### PR DESCRIPTION
## Summary
- add `alert()` helper to `A2ABus`
- update alert webhook tests for protobuf Struct payload

## Testing
- `pre-commit run --files alpha_factory_v1/common/utils/messaging.py tests/test_alert_webhook.py`
- `pytest tests/test_alert_webhook.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6885565367d483338c4b6d9cc9e3f432