### PR TITLE
[alpha_factory] fix failing tests

### DIFF
--- a/tests/test_aiga_agents_bridge.py
+++ b/tests/test_aiga_agents_bridge.py
@@ -15,8 +15,8 @@ from typing import Any
 import pytest
 
 _SKIP: Any = pytest.mark.skipif(
-    importlib.util.find_spec("openai_agents") is None,
-    reason="openai_agents not installed",
+    importlib.util.find_spec("openai_agents") is None or importlib.util.find_spec("gymnasium") is None,
+    reason="openai_agents or gymnasium not installed",
 )
 
 


### PR DESCRIPTION
## Summary
- skip bridge launch test when gymnasium is absent
- handle Struct payloads in monitor test and adjust restart wait

## Testing
- `pre-commit run --files tests/test_agents.py tests/test_aiga_agents_bridge.py`
- `pytest tests/test_aiga_agents_bridge.py::test_bridge_launch tests/test_agents.py::test_monitor_restart_and_ledger_log -q`

------
https://chatgpt.com/codex/tasks/task_e_68855ef8f57c83339ac69c3c44624dff