### PR TITLE
Improve dependency-based test skips

### DIFF
--- a/tests/test_aiga_agents_bridge.py
+++ b/tests/test_aiga_agents_bridge.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import importlib.util
 import subprocess
 import sys
 import time
@@ -14,13 +13,10 @@ from typing import Any
 
 import pytest
 
-_SKIP: Any = pytest.mark.skipif(
-    importlib.util.find_spec("openai_agents") is None or importlib.util.find_spec("gymnasium") is None,
-    reason="openai_agents or gymnasium not installed",
-)
+pytest.importorskip("openai_agents", minversion="0.0.17")
+pytest.importorskip("gymnasium", minversion="0.29")
 
 
-@_SKIP  # type: ignore[misc]
 def test_bridge_launch() -> None:
     """Start ``openai_agents_bridge.main`` and confirm registration."""
     proc = subprocess.Popen(
@@ -44,7 +40,6 @@ def test_bridge_launch() -> None:
     assert "EvolverAgent" in out
 
 
-@_SKIP  # type: ignore[misc]
 def test_evolve_tool() -> None:
     """Invoke ``evolve`` once and verify ``best_alpha`` output."""
     mod = importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.openai_agents_bridge")

--- a/tests/test_aiga_service.py
+++ b/tests/test_aiga_service.py
@@ -10,7 +10,7 @@ import types
 
 import pytest
 
-pytest.importorskip("gymnasium", reason="gymnasium required for environment")
+pytest.importorskip("gymnasium", minversion="0.29", reason="gymnasium required for environment")
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_aiga_service_mixtral.py
+++ b/tests/test_aiga_service_mixtral.py
@@ -14,7 +14,7 @@ import requests
 import pytest
 
 pytest.importorskip("prometheus_client")
-pytest.importorskip("gymnasium")
+pytest.importorskip("gymnasium", minversion="0.29")
 pytest.importorskip("fastapi")
 
 ENTRYPOINT = "alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py"

--- a/tests/test_governance_bridge_adk_runtime.py
+++ b/tests/test_governance_bridge_adk_runtime.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import importlib.util
 import os
 import subprocess
 import time
@@ -10,10 +9,9 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("openai_agents") is None,
-    reason="openai_agents not installed",
-)
+pytest.importorskip("openai_agents", minversion="0.0.17")
+
+
 def test_governance_bridge_adk_runtime(tmp_path: Path) -> None:
     """Launch governance-bridge with ADK enabled and verify logs."""
     stub = tmp_path / "google_adk.py"

--- a/tests/test_governance_bridge_cli.py
+++ b/tests/test_governance_bridge_cli.py
@@ -1,16 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Ensure the governance-bridge CLI is available."""
 
-import importlib.util
 import subprocess
 
 import pytest
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("openai_agents") is None,
-    reason="openai_agents not installed",
-)
+pytest.importorskip("openai_agents", minversion="0.0.17")
+
+
 def test_governance_bridge_help() -> None:
     """Verify the console script prints usage information."""
     result = subprocess.run(
@@ -23,10 +21,6 @@ def test_governance_bridge_help() -> None:
     assert "usage" in result.stdout.lower()
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("openai_agents") is None,
-    reason="openai_agents not installed",
-)
 def test_governance_bridge_port_arg() -> None:
     """Verify the CLI accepts the --port option."""
     result = subprocess.run(

--- a/tests/test_governance_bridge_runtime.py
+++ b/tests/test_governance_bridge_runtime.py
@@ -1,17 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import importlib.util
 import subprocess
 import time
 
 import pytest
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("openai_agents") is None,
-    reason="openai_agents not installed",
-)
+pytest.importorskip("openai_agents", minversion="0.0.17")
+
+
 def test_governance_bridge_runtime() -> None:
     """Launch governance-bridge and verify agent registration."""
     proc = subprocess.Popen(

--- a/tests/test_meta_agentic_tree_search_demo.py
+++ b/tests/test_meta_agentic_tree_search_demo.py
@@ -309,7 +309,7 @@ class TestMetaAgenticTreeSearchDemo(unittest.TestCase):
 
 
 def test_bridge_online_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    pytest.importorskip("openai_agents")
+    pytest.importorskip("openai_agents", minversion="0.0.17")
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     result = subprocess.run(
         [

--- a/tests/test_patcher_core_cli.py
+++ b/tests/test_patcher_core_cli.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib.util
 import os
 import shutil
 import subprocess
@@ -20,11 +19,9 @@ pytest.skip(
 
 pytestmark = [
     pytest.mark.skipif(shutil.which("patch") is None, reason="patch not installed"),
-    pytest.mark.skipif(
-        importlib.util.find_spec("openai_agents") is None,
-        reason="openai_agents not installed",
-    ),
 ]
+
+pytest.importorskip("openai_agents", minversion="0.0.17")
 
 
 def test_patcher_core_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_rate_lock.py
+++ b/tests/test_rate_lock.py
@@ -15,11 +15,11 @@ try:
     import openai_agents
 except Exception:
     pass
-pytest.importorskip("gymnasium")
+pytest.importorskip("gymnasium", minversion="0.29")
 sys.path.insert(0, str(root))
 from alpha_factory_v1.demos.aiga_meta_evolution import agent_aiga_entrypoint as mod
 
-oa = pytest.importorskip("openai_agents")
+oa = pytest.importorskip("openai_agents", minversion="0.0.17")
 if not hasattr(oa, "OpenAIAgent"):
     pytest.skip("openai_agents missing OpenAIAgent", allow_module_level=True)
 


### PR DESCRIPTION
## Summary
- skip AI-GA agents bridge tests when openai_agents or gymnasium are outdated
- require openai_agents 0.0.17+ for governance bridge and patcher_core tests
- skip rate lock, service, and mixtral tests when gymnasium <0.29
- detect openai_agents and google_adk versions for inspector and integrations tests

## Testing
- `pre-commit run --files tests/test_aiga_agents_bridge.py tests/test_governance_bridge_cli.py tests/test_governance_bridge_runtime.py tests/test_governance_bridge_adk_runtime.py tests/test_patcher_core_cli.py tests/test_external_integrations.py tests/test_inspector_bridge_runtime.py tests/test_rate_lock.py tests/test_aiga_service.py tests/test_aiga_service_mixtral.py tests/test_meta_agentic_tree_search_demo.py`
- `pytest -q tests/test_aiga_agents_bridge.py tests/test_governance_bridge_cli.py tests/test_governance_bridge_runtime.py tests/test_governance_bridge_adk_runtime.py tests/test_patcher_core_cli.py tests/test_external_integrations.py tests/test_inspector_bridge_runtime.py tests/test_rate_lock.py tests/test_aiga_service.py tests/test_aiga_service_mixtral.py tests/test_meta_agentic_tree_search_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_68856c1bc8908333ad4f56fccbcb2923