### PR TITLE
[alpha_factory] clarify environment check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,9 +400,11 @@ issues locally before dispatching the workflow.
   `python check_env.py --auto-install` (pass `--wheelhouse <path>` when offline)
   if required.
  - Always execute `python check_env.py --auto-install` before running the tests
-   or `pre-commit` so optional dependencies install correctly. When offline,
-  provide `--wheelhouse <dir>` or set `WHEELHOUSE` to your wheel cache. The
-  repository no longer ships a full wheelhouse because some wheels exceed
+   or `pre-commit` so optional dependencies like `openai_agents` and
+   `gymnasium` install correctly. Set `ALPHA_FACTORY_FULL=1` to pull in the
+   heavier extras. When offline, provide `--wheelhouse <dir>` or set
+   `WHEELHOUSE` to your wheel cache. The repository no longer ships a full
+   wheelhouse because some wheels exceed
   GitHub's 100 MB size limit. Build the wheelhouse with
   `scripts/build_offline_wheels.sh` on a machine with internet access and copy
   the resulting directory to `wheels/`. Set `WHEELHOUSE=$(pwd)/wheels` and

--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,8 @@ git clone --branch v0.1.0-alpha https://github.com/MontrealAI/AGI-Alpha-Agent-v0
 cd AGI-Alpha-Agent-v0
 ./quickstart.sh --preflight   # optional environment check
 python check_env.py --auto-install  # verify & auto-install deps (10 min timeout)
+# Install heavy optional packages such as openai_agents and gymnasium:
+ALPHA_FACTORY_FULL=1 python check_env.py --auto-install
 # Install runtime dependencies
 pip install -r requirements.lock
 # (If this fails with a network error, create a wheelhouse and rerun
@@ -1400,6 +1402,10 @@ Unit tests can be executed with the bundled helper script:
 ```bash
 python -m alpha_factory_v1.scripts.run_tests
 ```
+
+Always run `python check_env.py --auto-install` beforehand so optional
+dependencies like `openai_agents` and `gymnasium` are present. Use
+`ALPHA_FACTORY_FULL=1` to install heavy extras.
 
 The helper validates the target directory, prefers `pytest` when
 available and otherwise falls back to `unittest`. Ensure all tests pass

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -75,6 +75,7 @@ elif [[ "${MINIMAL_INSTALL:-0}" == "1" ]]; then
     pytest-httpx
     numpy
     pandas
+    gymnasium[classic-control]
     playwright
     plotly
     websockets
@@ -121,6 +122,7 @@ else
     orjson
     ortools
     pandas
+    gymnasium[classic-control]
     playwright
     plotly
     prometheus-client
@@ -160,6 +162,9 @@ fi
 check_env_opts=()
 if [[ -n "${WHEELHOUSE:-}" ]]; then
   check_env_opts+=(--wheelhouse "$WHEELHOUSE")
+fi
+if [[ "${FULL_INSTALL:-0}" == "1" ]]; then
+  export ALPHA_FACTORY_FULL=1
 fi
 $PYTHON check_env.py --auto-install "${check_env_opts[@]}"
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # See docs/DISCLAIMER_SNIPPET.md
 # Wrapper script for alpha_factory_v1/quickstart.sh
-# Provides a friendly top-level entry point.
+# Provides a friendly top-level entry point. Set ALPHA_FACTORY_FULL=1
+# to install optional packages like openai_agents and gymnasium.
 
 set -Eeuo pipefail
 trap 'echo -e "\n\u274c Error on line $LINENO" >&2' ERR
@@ -15,6 +16,8 @@ if [ -n "${WHEELHOUSE:-}" ]; then
 else
     python check_env.py --auto-install
 fi
+
+echo "Tip: set ALPHA_FACTORY_FULL=1 to include heavy optional packages"
 
 exec "$SCRIPT_DIR/alpha_factory_v1/quickstart.sh" "$@"
 


### PR DESCRIPTION
## Summary
- document in README and AGENTS that `python check_env.py --auto-install` must run before tests
- note `ALPHA_FACTORY_FULL=1` for heavy extras
- install gymnasium via `codex/setup.sh`
- show hint in quickstart script

## Testing
- `pre-commit run --files AGENTS.md README.md codex/setup.sh quickstart.sh`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py`

------
https://chatgpt.com/codex/tasks/task_e_68856ee0f124833389cb6418c10a8b0e