### PR TITLE
Add openai_agents compatibility shim

### DIFF
--- a/openai_agents/__init__.py
+++ b/openai_agents/__init__.py
@@ -1,0 +1,12 @@
+"""Compatibility wrapper for the ``openai_agents`` import path."""
+from agents import *  # noqa: F401,F403
+from agents import __all__ as _agents_all
+from agents import __version__
+
+# Older SDKs expose ``OpenAIAgent``. Map it to ``Agent`` when missing.
+if 'OpenAIAgent' not in globals() and 'Agent' in globals():
+    OpenAIAgent = globals()['Agent']  # type: ignore
+
+__all__ = list(_agents_all)
+if 'OpenAIAgent' in globals() and 'OpenAIAgent' not in __all__:
+    __all__.append('OpenAIAgent')


### PR DESCRIPTION
## Summary
- map `openai_agents` import path to the newer `agents` package

## Testing
- `pytest tests/test_rate_lock.py::test_concurrent_requests -q` *(fails: ImportError from agents)*

------
https://chatgpt.com/codex/tasks/task_e_688575df0a108333868643118bea1c3f