### PR TITLE
Ensure EvolverAgent launch logs are captured

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -174,12 +174,12 @@ def main() -> None:
     runtime = AgentRuntime(api_key=None, port=AGENT_PORT)
     agent = EvolverAgent()
     runtime.register(agent)
-    print("Registered EvolverAgent with runtime")
+    print("Registered EvolverAgent with runtime", flush=True)
 
     if ADK_AVAILABLE:
         auto_register([agent])
         maybe_launch()
-        print("EvolverAgent exposed via ADK gateway")
+        print("EvolverAgent exposed via ADK gateway", flush=True)
 
     runtime.run()
 

--- a/tests/test_aiga_agents_bridge.py
+++ b/tests/test_aiga_agents_bridge.py
@@ -37,7 +37,8 @@ def test_bridge_launch() -> None:
         if proc.poll() is None:
             proc.kill()
             proc.wait(timeout=5)
-    assert "EvolverAgent" in out
+    assert "Registered EvolverAgent with runtime" in out
+    assert "EvolverAgent exposed via ADK gateway" in out
 
 
 def test_evolve_tool() -> None:


### PR DESCRIPTION
## Summary
- flush registration messages from the openai agents bridge
- check for exact log lines in `test_bridge_launch`

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py tests/test_aiga_agents_bridge.py`
- `pytest tests/test_aiga_agents_bridge.py -k test_bridge_launch -vv` *(fails: skipped due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_688594294e4883338d37e52ce040ce22