### PR TITLE
[alpha_factory] fix test ledger payload check

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -278,7 +278,11 @@ def test_codegen_agent_sandbox_blocks_import(monkeypatch) -> None:
     agent = codegen_agent.CodeGenAgent(bus, ledger)
 
     agent.execute_in_sandbox("import os\nprint('hi')")
-    errs = [r.payload.get("stderr", "") for r in ledger.records if "stderr" in r.payload]
+    errs = [
+        r.payload.get("stderr", "") if hasattr(r.payload, "get") else r.payload["stderr"]
+        for r in ledger.records
+        if (hasattr(r.payload, "__contains__") and "stderr" in r.payload)
+    ]
     assert errs and "ImportError" in errs[-1]
 
 


### PR DESCRIPTION
## Summary
- prevent `AttributeError` in tests when ledger payload uses a `Struct`

## Testing
- `pre-commit run --files tests/test_agents.py`
- `pytest -q tests/test_agents.py::test_monitor_restart_and_ledger_log tests/test_agents.py::test_codegen_agent_sandbox_blocks_import`

------
https://chatgpt.com/codex/tasks/task_e_688595e2d3248333aadf6daf5e36f882