### PR TITLE
test: skip google adk bridge

### DIFF
--- a/tests/test_aiga_agents_bridge.py
+++ b/tests/test_aiga_agents_bridge.py
@@ -15,6 +15,7 @@ import pytest
 
 pytest.importorskip("openai_agents", minversion="0.0.17")
 pytest.importorskip("gymnasium", minversion="0.29")
+pytest.importorskip("google_adk")
 
 
 def test_bridge_launch() -> None:


### PR DESCRIPTION
## Summary
- skip aiga agents bridge tests when google_adk isn't installed

## Testing
- `pre-commit run --files tests/test_aiga_agents_bridge.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: runtime not reachable, module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68859ef301bc8333b837a0faba7443e4