### PR TITLE
fix: improve google_adk stub handling

### DIFF
--- a/stubs/google_adk/__init__.py
+++ b/stubs/google_adk/__init__.py
@@ -39,4 +39,8 @@ else:
     class AgentException(Exception):
         pass
 
+    class Agent:
+        def __init__(self, *args, **kwargs):
+            pass
+
 __all__ = [k for k in globals().keys() if not k.startswith("_")]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,16 @@ if STUBS.is_dir():
     if find_spec("openai_agents") is None:
         sys.path.append(str(STUBS))
     import importlib
-    adk_spec = find_spec("google_adk") or find_spec("google.adk")
+    try:
+        adk_spec = find_spec("google_adk") or find_spec("google.adk")
+    except ModuleNotFoundError:
+        adk_spec = None
+    if adk_spec is None:
+        pass
+    else:
+        module = importlib.import_module(adk_spec.name)
+        if adk_spec.name == "google.adk" and find_spec("google_adk") is None:
+            sys.modules.setdefault("google_adk", module)
     if adk_spec is None or not hasattr(importlib.import_module(adk_spec.name), "task"):
         sys.path.insert(0, str(STUBS))
         importlib.invalidate_caches()


### PR DESCRIPTION
## Summary
- add minimal `Agent` stub
- map real `google.adk` to `google_adk` when needed

## Testing
- `pytest -q` *(fails: 6 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885a1be36708333b3a721cce2caf8e4