### PR TITLE
Fix ADK module import

### DIFF
--- a/alpha_factory_v1/backend/adk_bridge.py
+++ b/alpha_factory_v1/backend/adk_bridge.py
@@ -42,18 +42,22 @@ _TOKEN = os.getenv("ALPHA_FACTORY_ADK_TOKEN") or None  # optional auth
 _HOST = os.getenv("ALPHA_FACTORY_ADK_HOST", "0.0.0.0")
 _PORT = int(os.getenv("ALPHA_FACTORY_ADK_PORT", "9000"))
 
+adk = None
 try:  # runtime optional dependency
-    import google_adk as adk  # pip install google-adk
+    import google_adk as adk  # packaged as "google-adk"
+except ModuleNotFoundError:  # fallback to the namespaced import
+    try:
+        from google import adk  # type: ignore
+    except Exception:
+        adk = None
 
-    _ADK_OK = True
-except ModuleNotFoundError:  # graceful degradation
-    _ADK_OK = False
-    if _ENABLE:
-        logger.warning(
-            "ADK integration requested but google-adk package is missing. "
-            "Run  ➜  pip install google-adk   or disable ADK via "
-            "ALPHA_FACTORY_ENABLE_ADK=false."
-        )
+_ADK_OK = adk is not None
+if not _ADK_OK and _ENABLE:
+    logger.warning(
+        "ADK integration requested but google-adk package is missing. "
+        "Run  ➜  pip install google-adk   or disable ADK via "
+        "ALPHA_FACTORY_ENABLE_ADK=false."
+    )
 
 
 # Guard-function lets callers know whether ADK functionality is live


### PR DESCRIPTION
## Summary
- handle `google.adk` as a fallback when `google_adk` is missing

## Testing
- `pre-commit run --files alpha_factory_v1/backend/adk_bridge.py`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pytest --cov --cov-report=xml -q` *(fails: 15 failed, 125 passed, 32 skipped, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885a3882a60833390329602f09a63ff