### PR TITLE
[alpha_factory] Fix MetaEvolver seed

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py
@@ -227,7 +227,10 @@ class MetaEvolver:
         self.ckpt_dir = pathlib.Path(checkpoint_dir)
         self.ckpt_dir.mkdir(parents=True, exist_ok=True)
         self.llm = llm
-        self.rng = random.Random(int("A1GA", 16))
+        # Use a deterministic seed derived from ASCII bytes so the
+        # meta-evolution runs reproducibly regardless of Python version.
+        seed = int.from_bytes(b"A1GA", "big")
+        self.rng = random.Random(seed)
         self.gen = 0
         self.history: List[Tuple[int, float]] = []
         self._archive: List[np.ndarray] = []


### PR DESCRIPTION
## Summary
- avoid invalid hex parsing in meta evolver

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/meta_evolver.py`
- `pytest -q` *(fails: 9 failed, 85 passed, 32 skipped, 1 xfailed, 4 warnings, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885c903d9fc8333964dfa149e04e1c3