### PR TITLE
Fix local action path in setup-insight-assets

### DIFF
--- a/.github/actions/setup-insight-assets/action.yml
+++ b/.github/actions/setup-insight-assets/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Generate asset key
       id: asset-key
-      uses: ../generate-asset-key
+      uses: ./.github/actions/generate-asset-key
     - name: Cache Pyodide and GPT-2 assets
       id: asset-cache
       uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684


### PR DESCRIPTION
## Summary
- fix path to generate-asset-key in setup-insight-assets action

## Testing
- `pre-commit run --files .github/actions/setup-insight-assets/action.yml`
- `pre-commit run actionlint --files $(git ls-files '.github/workflows/*.yml')`

------
https://chatgpt.com/codex/tasks/task_e_68863332e3c88333931776beb13556c9