### PR TITLE
[alpha_factory] skip aiga bridge test when openai stub used

### DIFF
--- a/tests/test_aiga_agents_bridge.py
+++ b/tests/test_aiga_agents_bridge.py
@@ -13,7 +13,11 @@ from typing import Any
 
 import pytest
 
-pytest.importorskip("openai_agents", minversion="0.0.17")
+openai_agents = pytest.importorskip("openai_agents", minversion="0.0.17")
+import inspect
+
+if "Minimal stub" in inspect.getsource(openai_agents):
+    pytest.skip("openai_agents stub present")
 pytest.importorskip("gymnasium", minversion="0.29")
 pytest.importorskip("google_adk")
 


### PR DESCRIPTION
## Summary
- skip `tests/test_aiga_agents_bridge.py` when the bundled OpenAI Agents stub is present

## Testing
- `pre-commit run --files tests/test_aiga_agents_bridge.py`
- `pytest tests/test_aiga_agents_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68863e6cf9f0833396ccee2e5ef12882