### PR TITLE
[alpha_factory] clarify heavy extras for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,7 +1182,10 @@ git clone --branch v0.1.0-alpha https://github.com/MontrealAI/AGI-Alpha-Agent-v0
 cd AGI-Alpha-Agent-v0
 ./quickstart.sh --preflight   # optional environment check
 python check_env.py --auto-install  # verify & auto-install deps (10 min timeout)
-# Install heavy optional packages such as openai_agents and gymnasium:
+# Install heavy optional packages such as openai_agents, gymnasium and google_adk.
+# Running tests without these extras will skip or fail the modules that depend on
+# them. Use ALPHA_FACTORY_FULL=1 with check_env.py to ensure they install. See
+# `tests/README.md` for detailed instructions.
 ALPHA_FACTORY_FULL=1 python check_env.py --auto-install
 # Install runtime dependencies
 pip install -r requirements.lock


### PR DESCRIPTION
## Summary
- document that openai_agents, gymnasium and google_adk are needed for full test coverage
- mention tests/README for using `check_env.py --auto-install` with `ALPHA_FACTORY_FULL=1`

## Testing
- `python scripts/check_python_deps.py`
- `ALPHA_FACTORY_FULL=1 python check_env.py --auto-install` *(fails: Operation cancelled)*
- `pre-commit run --files README.md` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: 6 failed, 83 passed, 34 skipped, 1 xfailed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688640b65c208333962bbe9d323b31dc