### PR TITLE
Update install instructions to use lock files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
           cache-dependency-path: |
             requirements.lock
             requirements-dev.lock
-            requirements-demo-cpu.lock
             alpha_factory_v1/backend/requirements-lock.txt
 
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -150,14 +149,12 @@ jobs:
           cache-dependency-path: |
             requirements.lock
             requirements-dev.lock
-            requirements-demo-cpu.lock
             alpha_factory_v1/backend/requirements-lock.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
           pip install -r requirements-dev.lock
-          pip install -r requirements-demo-cpu.lock
           pip install -r alpha_factory_v1/backend/requirements-lock.txt
       - name: Verify environment
         run: |
@@ -266,10 +263,10 @@ jobs:
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - name: Install dependencies
+      - name: Install dependencies  # install from lock files (rdkit-pypi snapshot removed)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
+          pip install -r requirements.lock
           pip install -r alpha_factory_v1/backend/requirements-lock.txt
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -312,10 +309,11 @@ jobs:
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
-      - name: Install dependencies
+      - name: Install dependencies  # install from lock files (rdkit-pypi snapshot removed)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-cpu.lock -r requirements-demo-cpu.lock
+          pip install -r requirements.lock
+          pip install -r alpha_factory_v1/backend/requirements-lock.txt
       - name: Install macOS extras
         run: pip install appnope==0.1.4
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020

--- a/README.md
+++ b/README.md
@@ -1418,8 +1418,8 @@ Install the optional test dependencies with:
 
 ```bash
 pip install -r requirements-dev.txt
-pip install -r requirements-demo.txt  # adds numpy, torch and extras
-pip install -r requirements-demo-cpu.lock  # deterministic CPU setup
+pip install -r requirements.lock  # pinned versions for deterministic setup
+pip install -r alpha_factory_v1/backend/requirements-lock.txt  # includes RDKit
 ```
 
 Install the project in editable mode so tests resolve imports:


### PR DESCRIPTION
## Summary
- install packages from `requirements.lock` and backend lock in README
- update CI workflow to use the new lock files and comment about dropping the old `rdkit-pypi` snapshot

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68864e2e34d48333a811a198a76892cd