### PR TITLE
docs: add pre-commit reminder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,9 @@ Before opening a pull request, verify the environment and run the tests:
 ```bash
 python scripts/check_python_deps.py
 python check_env.py --auto-install
-pre-commit run --all-files
+pre-commit run --files <changed-files>  # ensure this passes before running tests
 pytest
+pre-commit run --all-files
 ```
 
 See [AGENTS.md](AGENTS.md#pull-requests) for more details.


### PR DESCRIPTION
## Summary
- recommend running `pre-commit run --files <changed-files>` before running tests

## Testing
- `pre-commit run --files CONTRIBUTING.md`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest -q` *(fails: tests/test_adk_gateway_startup.py::test_maybe_launch_starts_uvicorn, tests/test_agent_muzero_entrypoint.py::test_launch_dashboard_missing_gradio, tests/test_aiga_bridge_no_agents.py::test_aiga_bridge_no_agents, tests/test_aiga_openai_bridge_offline.py::test_aiga_openai_bridge_offline, tests/test_aiga_service_e2e.py::test_aiga_service_health, tests/test_adk_gateway.py::test_docs_authenticated, tests/test_adk_gateway.py::test_docs_invalid_token)*
- `pre-commit run --all-files` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6886516aaa488333bb8610936d17c8e8