### PR TITLE
[alpha_factory] fix import order

### DIFF
--- a/alpha_factory_v1/backend/agents/registry.py
+++ b/alpha_factory_v1/backend/agents/registry.py
@@ -6,9 +6,9 @@ import asyncio
 import inspect
 import json
 import logging
+import os
 
 logger = logging.getLogger("alpha_factory.agents")
-import os
 import queue
 import threading
 import time


### PR DESCRIPTION
## Summary
- move `import os` above logger initialization in `registry.py`

## Testing
- `pre-commit run --files alpha_factory_v1/backend/agents/registry.py`
- `pytest` *(fails: AttributeError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_6886b7c013848333a4e205f1536bcfce