### PR TITLE
[alpha_factory] fix: address mypy errors and add annotations

### DIFF
--- a/alpha_factory_v1/core/agents/guards/embedding_orthogonaliser.py
+++ b/alpha_factory_v1/core/agents/guards/embedding_orthogonaliser.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import random
-from typing import Sequence
+from typing import Sequence, TYPE_CHECKING
 
 try:
     import numpy as np
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
-    np = None  # type: ignore
+    np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    import numpy as np
 
 __all__ = ["EmbeddingOrthogonaliser"]
 
@@ -24,14 +27,15 @@ class EmbeddingOrthogonaliser:
         self._counter = 0
         self._proj = self._new_projection()
 
-    def _new_projection(self):
+    def _new_projection(self) -> list[list[float]] | "np.ndarray":
+        """Return a new random orthogonal projection matrix."""
         if np is not None:
             mat = np.asarray(
                 [[self._rng.gauss(0.0, 1.0) for _ in range(self.dim)] for _ in range(self.dim)],
                 dtype="float32",
             )
             q, _ = np.linalg.qr(mat)
-            return q
+            return np.asarray(q, dtype="float32")  # type: ignore[no-any-return]
         mat = [[self._rng.gauss(0.0, 1.0) for _ in range(self.dim)] for _ in range(self.dim)]
         for i in range(self.dim):
             for j in range(i):
@@ -43,7 +47,7 @@ class EmbeddingOrthogonaliser:
                 mat[i][k] /= norm
         return mat
 
-    def project(self, vec: Sequence[float] | np.ndarray) -> np.ndarray:
+    def project(self, vec: Sequence[float] | np.ndarray) -> np.ndarray | list[float]:
         """Return ``vec`` multiplied by the current projection matrix."""
         if self._counter % self.steps == 0:
             self._proj = self._new_projection()
@@ -52,9 +56,9 @@ class EmbeddingOrthogonaliser:
             arr = np.asarray(vec, dtype="float32")
             if arr.ndim == 1:
                 arr = arr.reshape(1, -1)
-            return (arr @ np.asarray(self._proj).T).reshape(-1)
+            return (arr @ np.asarray(self._proj).T).reshape(-1)  # type: ignore[no-any-return]
         arr = [float(x) for x in vec]
         out = [sum(a * b for a, b in zip(arr, col)) for col in zip(*self._proj)]
         if np is not None:
             return np.asarray(out, dtype="float32")
-        return out  # type: ignore[return-value]
+        return out

--- a/alpha_factory_v1/core/evaluators/novelty.py
+++ b/alpha_factory_v1/core/evaluators/novelty.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import numpy as np
 
 try:  # optional heavy deps
     from sentence_transformers import SentenceTransformer
 except Exception:  # pragma: no cover - offline
-    SentenceTransformer = None  # type: ignore
+    SentenceTransformer = None
 
 try:
-    import faiss  # type: ignore
+    import faiss
 except Exception:  # pragma: no cover - offline
-    faiss = None  # type: ignore
+    faiss = None
 
 _LOG = logging.getLogger(__name__)
 _MODEL: SentenceTransformer | None = None
@@ -34,22 +35,22 @@ def embed(text: str) -> np.ndarray:
     """Return the MiniLM embedding for ``text``."""
     model = _get_model()
     vec = model.encode([text], normalize_embeddings=True)
-    return np.asarray(vec, dtype="float32")
+    return np.asarray(vec, dtype="float32")  # type: ignore[no-any-return]
 
 
 def _softmax(x: np.ndarray) -> np.ndarray:
     e = np.exp(x - float(np.max(x)))
-    return e / (e.sum() + 1e-12)
+    return e / (e.sum() + 1e-12)  # type: ignore[no-any-return]
 
 
 class NoveltyIndex:
     """In-memory FAISS index tracking the embedding mean."""
 
     def __init__(self) -> None:
-        self.dim = _DIM
-        self.index = faiss.IndexFlatIP(self.dim) if faiss else None
-        self.mean = np.zeros(self.dim, dtype="float32")
-        self.count = 0
+        self.dim: int = _DIM
+        self.index: faiss.IndexFlatIP | None = faiss.IndexFlatIP(self.dim) if faiss else None
+        self.mean: np.ndarray = np.zeros(self.dim, dtype="float32")
+        self.count: int = 0
 
     def add(self, text: str) -> None:
         """Index the embedding of ``text`` and update the mean vector."""


### PR DESCRIPTION
## Summary
- adjust novelty and embedding guards to satisfy mypy
- add small annotations and ignore comments

## Testing
- `black alpha_factory_v1/core/evaluators/novelty.py alpha_factory_v1/core/agents/guards/embedding_orthogonaliser.py --check`
- `ruff check alpha_factory_v1/core/evaluators/novelty.py alpha_factory_v1/core/agents/guards/embedding_orthogonaliser.py`
- `flake8 alpha_factory_v1/core/evaluators/novelty.py alpha_factory_v1/core/agents/guards/embedding_orthogonaliser.py`
- `mypy --config-file mypy.ini alpha_factory_v1/core/evaluators/novelty.py alpha_factory_v1/core/agents/guards/embedding_orthogonaliser.py`
- `pytest tests/test_code_diff.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886be4fc41c8333a303920e1e70d8ef