### PR TITLE
Fix README disclaimer spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ site/
 # Coverage files
 coverage.xml
 .coverage*
+
+# Local databases
+archive.db
+solutions.duckdb

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md) This repository is a conceptual research prototype.
+[See docs/DISCLAIMER_SNIPPET.md](docs/DISCLAIMER_SNIPPET.md)
+
+This repository is a conceptual research prototype.
 References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real
 general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers
 accept no liability for losses incurred from using this software.


### PR DESCRIPTION
## Summary
- ensure disclaimer appears on its own line
- ignore local database files

## Testing
- `pre-commit run --files README.md .gitignore`


------
https://chatgpt.com/codex/tasks/task_e_6886c1a01b408333aebdc79fc3336287