### PR TITLE
Fix tests and OpenAI error reference

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py
@@ -90,7 +90,7 @@ def convert_alpha(alpha: str, *, ledger: Path | None = None, model: str = "gpt-4
             plan = json.loads(resp.choices[0].message.content)
             if not isinstance(plan, dict):
                 plan = SAMPLE_PLAN
-        except openai.error.OpenAIError as e:
+        except openai.OpenAIError as e:
             logging.error(f"OpenAI API call failed: {e}. Falling back to SAMPLE_PLAN.")
             plan = SAMPLE_PLAN
         except json.JSONDecodeError as e:

--- a/tests/test_alpha_opportunity_stub.py
+++ b/tests/test_alpha_opportunity_stub.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # mypy: ignore-errors
 import py_compile
-import unittest
 from pathlib import Path
 from typing import Callable
 import pytest
@@ -9,49 +8,45 @@ import pytest
 STUB = Path("alpha_factory_v1/demos/aiga_meta_evolution/alpha_opportunity_stub.py")
 
 
-class TestAlphaOpportunityStub(unittest.TestCase):
-    def test_stub_compiles(self) -> None:
-        py_compile.compile(str(STUB), doraise=True)
-
-    def test_runtime_port_env(self, monkeypatch: "pytest.MonkeyPatch") -> None:
-        """AgentRuntime receives AGENTS_RUNTIME_PORT."""
-        import importlib
-        import sys
-        import types
-
-        captured: dict[str, int] = {}
-
-        class DummyRuntime:
-            def __init__(self, *a: object, port: int = 5001, **_k: object) -> None:
-                captured["port"] = port
-
-            def register(self, *_a: object, **_k: object) -> None:
-                pass
-
-            def run(self) -> None:
-                pass
-
-        stub = types.ModuleType("openai_agents")
-        stub.Agent = object
-        stub.AgentRuntime = DummyRuntime
-        stub.OpenAIAgent = object
-
-        def _tool(*_a: object, **_k: object) -> Callable[[object], object]:
-            def dec(f: object) -> object:
-                return f
-
-            return dec
-
-        stub.Tool = _tool
-        monkeypatch.setitem(sys.modules, "openai_agents", stub)
-        monkeypatch.delitem(sys.modules, "agents", raising=False)
-        monkeypatch.setenv("AGENTS_RUNTIME_PORT", "6101")
-
-        mod = importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.alpha_opportunity_stub")
-        importlib.reload(mod)
-        mod.main([])
-        self.assertEqual(captured["port"], 6101)
+def test_stub_compiles() -> None:
+    py_compile.compile(str(STUB), doraise=True)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_runtime_port_env(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """AgentRuntime receives AGENTS_RUNTIME_PORT."""
+    import importlib
+    import sys
+    import types
+
+    captured: dict[str, int] = {}
+
+    class DummyRuntime:
+        def __init__(self, *a: object, port: int = 5001, **_k: object) -> None:
+            captured["port"] = port
+
+        def register(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def run(self) -> None:
+            pass
+
+    stub = types.ModuleType("openai_agents")
+    stub.Agent = object
+    stub.AgentRuntime = DummyRuntime
+    stub.OpenAIAgent = object
+
+    def _tool(*_a: object, **_k: object) -> Callable[[object], object]:
+        def dec(f: object) -> object:
+            return f
+
+        return dec
+
+    stub.Tool = _tool
+    monkeypatch.setitem(sys.modules, "openai_agents", stub)
+    monkeypatch.delitem(sys.modules, "agents", raising=False)
+    monkeypatch.setenv("AGENTS_RUNTIME_PORT", "6101")
+
+    mod = importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.alpha_opportunity_stub")
+    importlib.reload(mod)
+    mod.main([])
+    assert captured["port"] == 6101


### PR DESCRIPTION
## Summary
- fix OpenAI exception handling
- convert AlphaOpportunity stub tests to pytest

## Testing
- `pre-commit run --files tests/test_alpha_opportunity_stub.py alpha_factory_v1/demos/aiga_meta_evolution/alpha_conversion_stub.py`

------
https://chatgpt.com/codex/tasks/task_e_6886c4c6c6788333804ade97becbd535