### PR TITLE
[alpha_factory] fix openai bridge env

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
+++ b/alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py
@@ -171,6 +171,7 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.bridge:
         host = os.getenv("BUSINESS_HOST", f"http://localhost:{args.port}")
+        os.environ["AGENTS_RUNTIME_PORT"] = str(args.runtime_port)
         _start_bridge(host, args.runtime_port)
 
     if args.open_ui:


### PR DESCRIPTION
## Summary
- set `AGENTS_RUNTIME_PORT` before starting the OpenAI bridge

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_business_v1/run_business_v1_local.py`
- `pytest tests/test_alpha_business_v1_script.py::TestAlphaBusinessV1Script::test_runtime_port_env -q`
- `pytest -q` *(fails: 8 failed, 2 errors out of 171 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6886c939a7b4833396a4499aa10d9ca7