### PR TITLE
Fix optional middleware and improve offline fallback

### DIFF
--- a/alpha_factory_v1/backend/adk_bridge.py
+++ b/alpha_factory_v1/backend/adk_bridge.py
@@ -148,7 +148,9 @@ def maybe_launch(*, host: str | None = None, port: int | None = None, **uvicorn_
 
     # Inject optional auth-middleware exactly once
     if _TOKEN:
-        router.app.middleware("http")(_auth_middleware())
+        app = getattr(router, "app", None)
+        if app is not None and hasattr(app, "middleware"):
+            app.middleware("http")(_auth_middleware())
 
     def _serve() -> None:  # run inside daemon-thread
         import uvicorn

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -41,33 +41,10 @@ try:  # optional dependency
 
                 asyncio.run(self._runner.run(self._agent, ""))
 
-except Exception:  # pragma: no cover - fallback stub
-
-    class Agent:  # type: ignore[misc]
-        pass
-
-    class AgentRuntime:  # type: ignore[misc]
-        def __init__(self, *_: object, **__: object) -> None:
-            pass
-
-        def register(self, *_: object, **__: object) -> None:
-            pass
-
-        def run(self) -> None:
-            print("OpenAI Agents bridge disabled.")
-
-    class OpenAIAgent:  # type: ignore[misc]
-        def __init__(self, *_: object, **__: object) -> None:
-            pass
-
-        async def __call__(self, _text: str) -> str:  # pragma: no cover - stub
-            return "ok"
-
-    def Tool(*_args: object, **_kwargs: object):  # type: ignore[misc]
-        def decorator(func):
-            return func
-
-        return decorator
+except Exception as exc:  # pragma: no cover - fallback stub
+    raise ModuleNotFoundError(
+        "OpenAI Agents SDK is required to run the meta-evolution demo"
+    ) from exc
 
 
 try:
@@ -88,7 +65,11 @@ import os
 from typing import cast
 
 from .meta_evolver import MetaEvolver
-from .curriculum_env import CurriculumEnv
+try:
+    from .curriculum_env import CurriculumEnv
+except ModuleNotFoundError:  # gymnasium optional
+    class CurriculumEnv:  # type: ignore[misc]
+        pass
 from .utils import build_llm
 
 


### PR DESCRIPTION
## Summary
- avoid crash when google ADK router stub lacks `middleware`
- raise clear error if OpenAI Agents SDK isn't installed
- handle missing `gymnasium` when importing curriculum env

## Testing
- `pytest tests/test_adk_gateway_startup.py::test_maybe_launch_starts_uvicorn -q`
- `pytest tests/test_agent_muzero_entrypoint.py::test_launch_dashboard_missing_gradio -q`
- `pytest tests/test_aiga_bridge_no_agents.py::test_aiga_bridge_no_agents -q`
- `pre-commit run --files alpha_factory_v1/backend/adk_bridge.py alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_6886dc0a0d708333930ca668359f8f24