### PR TITLE
[alpha_factory] fix typos

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample
@@ -28,7 +28,7 @@ OLLAMA_BASE_URL="http://ollama:11434/v1"  # local LM endpoint when offline
 SERVICE_NAME="aiga-meta-evolution"
 GRADIO_PORT=7862                        # UI
 API_PORT=8000                           # FastAPI
-PUBLIC_URL="http://localhost"           # overriden behind reverse proxy
+PUBLIC_URL="http://localhost"           # overridden behind reverse proxy
 CORS_ALLOW_ORIGINS="*"                 # comma‑sep list for production
 
 ###############################################################################

--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -234,7 +234,7 @@ bus liveness even on a clean clone.)*
    `POETGenerator.propose`.  
 2. **Swap learner** → Implement `.act/.remember/.train` in a new class;
    StrategyAgent can trigger hot-swap via `{"cmd":"swap_learner"}`.  
-3. **External micro-service** → Re-use `BaseAgent`; deploy as HTTP worker that
+3. **External micro-service** → Reuse `BaseAgent`; deploy as HTTP worker that
    bridges to A2A via WebSockets.
 
 ---


### PR DESCRIPTION
## Summary
- fix "overriden" spelling in config sample
- remove hyphen from "Reuse" in ASI world model README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/aiga_meta_evolution/config.env.sample alpha_factory_v1/demos/alpha_asi_world_model/README.md`
- `pytest -k 'test_code_diff' -q`


------
https://chatgpt.com/codex/tasks/task_e_6886e22bd0bc833382e69243d92953f5