### PR TITLE
Fix API error responses

### DIFF
--- a/alpha_factory_v1/core/interface/api_server.py
+++ b/alpha_factory_v1/core/interface/api_server.py
@@ -139,6 +139,11 @@ if app is not None:
 
     security = HTTPBearer()
 
+    async def _http_exception_handler(request: Request, exc: HTTPException) -> Response:
+        return problem_response(exc)
+
+    app.add_exception_handler(HTTPException, _http_exception_handler)
+
     def _noop(*_a: Any, **_kw: Any) -> Any:
         class _N:
             def labels(self, *_a: Any, **_kw: Any) -> "_N":

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py
@@ -79,6 +79,11 @@ API_TOKEN_DEFAULT = "changeme"
 app = FastAPI(title="α‑AGI Insight") if FastAPI is not None else None
 
 if app is not None:
+
+    async def _http_exception_handler(request: Request, exc: HTTPException) -> Response:
+        return problem_response(exc)
+
+    app.add_exception_handler(HTTPException, _http_exception_handler)
     app_f: FastAPI = app
     app_f.state.orchestrator = None
     app_f.state.task = None


### PR DESCRIPTION
## Summary
- ensure API server always responds with RFC 7807 problem JSON when raising HTTP errors

## Testing
- `pre-commit run --files alpha_factory_v1/core/interface/api_server.py alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6886e4978f4883338ba622be5005c4ea