### PR TITLE
fix: correct calc demo

### DIFF
--- a/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/calc.py
+++ b/alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/calc.py
@@ -2,5 +2,5 @@
 
 
 def add(a: int, b: int) -> int:
-    """Return the sum of a and b, intentionally broken."""
-    return a - b
+    """Return the sum of ``a`` and ``b``."""
+    return a + b


### PR DESCRIPTION
## Summary
- patch the sample calculator demo so `add()` returns a+b

## Testing
- `pytest alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/test_calc.py -q`
- `pre-commit run --files alpha_factory_v1/demos/self_healing_repo/sample_broken_calc/calc.py`

------
https://chatgpt.com/codex/tasks/task_e_6886f08e98f4833382cdb2652abd3855