### PR TITLE
[alpha_factory] add missing SPDX headers

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 pytest_plugins = ("tests.conftest",)

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/__init__.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/tests/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 pytest_plugins = ("tests.conftest",)

--- a/alpha_factory_v1/tests/__init__.py
+++ b/alpha_factory_v1/tests/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 pytest_plugins = ("tests.conftest",)

--- a/scripts/check_insight_sri.py
+++ b/scripts/check_insight_sri.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Verify SRI hash for ``insight.bundle.js``.
 
 The script checks that the ``integrity`` attribute in ``index.html`` matches the

--- a/stubs/google_adk/__init__.py
+++ b/stubs/google_adk/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Compatibility shim for the `google_adk` package.
 
 If the real package is installed under ``google.adk`` this module re-exports

--- a/tests/security/test_csp.py
+++ b/tests/security/test_csp.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import base64
 import hashlib
 import re

--- a/tests/test_agent_runner_utils.py
+++ b/tests/test_agent_runner_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import asyncio
 from alpha_factory_v1.backend.agent_runner import _env_float, maybe_await, utc_now

--- a/tests/test_portfolio_basic.py
+++ b/tests/test_portfolio_basic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import json
 import tempfile

--- a/tests/test_trace_hub.py
+++ b/tests/test_trace_hub.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 from unittest import mock


### PR DESCRIPTION
## Summary
- add Apache 2.0 SPDX tags to various tests and scripts

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/__init__.py alpha_factory_v1/demos/alpha_agi_insight_v1/tests/__init__.py alpha_factory_v1/tests/__init__.py scripts/check_insight_sri.py stubs/google_adk/__init__.py tests/security/test_csp.py tests/test_agent_runner_utils.py tests/test_portfolio_basic.py tests/test_trace_hub.py`
- `pytest tests/test_agent_runner_utils.py tests/test_portfolio_basic.py tests/test_trace_hub.py tests/security/test_csp.py`
- `pre-commit run --all-files` *(fails: Node.js 22+ required)*

------
https://chatgpt.com/codex/tasks/task_e_6886f710ca548333957462c1e816202f