### PR TITLE
[alpha_factory] Improve retry handling and ablation types

### DIFF
--- a/alpha_factory_v1/common/utils/retry.py
+++ b/alpha_factory_v1/common/utils/retry.py
@@ -18,13 +18,11 @@ T = TypeVar("T")
 
 
 @overload
-def with_retry(func: Callable[P, Awaitable[T]], *, max_tries: int = 3) -> Callable[P, Awaitable[T]]:
-    ...
+def with_retry(func: Callable[P, Awaitable[T]], *, max_tries: int = 3) -> Callable[P, Awaitable[T]]: ...
 
 
 @overload
-def with_retry(func: Callable[P, T], *, max_tries: int = 3) -> Callable[P, T]:
-    ...
+def with_retry(func: Callable[P, T], *, max_tries: int = 3) -> Callable[P, T]: ...
 
 
 def with_retry(func: Callable[P, Any], *, max_tries: int = 3) -> Callable[P, Any]:
@@ -72,7 +70,7 @@ def with_retry(func: Callable[P, Any], *, max_tries: int = 3) -> Callable[P, Any
                     await asyncio.sleep(2**attempt * 0.1)
             raise AssertionError("unreachable")
 
-        return cast(Callable[P, Any], wrapper_async)
+        return wrapper_async
 
     def wrapper_sync(*args: P.args, **kwargs: P.kwargs) -> Any:
         for attempt in range(max_tries):
@@ -91,4 +89,4 @@ def with_retry(func: Callable[P, Any], *, max_tries: int = 3) -> Callable[P, Any
                 time.sleep(2**attempt * 0.1)
         raise AssertionError("unreachable")
 
-    return cast(Callable[P, Any], wrapper_sync)
+    return wrapper_sync

--- a/alpha_factory_v1/core/tools/ablation_runner.py
+++ b/alpha_factory_v1/core/tools/ablation_runner.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict, List, cast
 
 try:  # graceful fallback when matplotlib is unavailable
     import matplotlib
@@ -21,8 +21,8 @@ try:  # graceful fallback when matplotlib is unavailable
     import numpy as np
 except Exception:  # pragma: no cover - optional dependency missing
     matplotlib = None
-    plt = None  # type: ignore[assignment]
-    np = None  # type: ignore[assignment]
+    plt = cast(Any, None)
+    np = cast(Any, None)
 
 from alpha_factory_v1.demos.self_healing_repo.patcher_core import apply_patch
 from alpha_factory_v1.core.eval.fitness import compute_fitness
@@ -56,8 +56,8 @@ def _run_bench(repo: Path, flags: Dict[str, bool]) -> float:
         check=True,
     )
     results = json.loads(proc.stdout)
-    metrics = compute_fitness(results)
-    score = metrics.get("swe_mini", {}).get("pass_rate", 0.0)
+    metrics = compute_fitness(cast(List[Dict[str, Any]], results))
+    score: float = metrics.get("swe_mini", {}).get("pass_rate", 0.0)
     # simple synthetic penalty when features disabled
     for enabled in flags.values():
         if not enabled:


### PR DESCRIPTION
## Summary
- remove unnecessary casts in retry decorator
- type ablation runner helper better

## Testing
- `pre-commit run --files alpha_factory_v1/common/utils/retry.py alpha_factory_v1/core/tools/ablation_runner.py`
- `mypy alpha_factory_v1/common/utils/retry.py alpha_factory_v1/core/tools/ablation_runner.py`
- `pytest tests/test_adk_gateway.py::test_docs_invalid_token -q` *(fails: httpx.ConnectError)*

------
https://chatgpt.com/codex/tasks/task_e_688775a437c48333a166de97f2167128