### PR TITLE
Add pre-commit usage docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,12 +61,14 @@ If you skip the setup script, manually install these tools with
 `tools/setup_precommit.sh` to install `pre-commit` and configure the hook
 without the full environment setup.
 
-Install the git hooks once and run them before each commit:
+Install the git hooks once and run them before each commit. Always
+execute `pre-commit run --files <changed-files>` prior to committing to
+catch lint errors early:
 
 ```bash
 pre-commit install
 python check_env.py --auto-install  # add --wheelhouse <dir> when offline
-pre-commit run --all-files
+pre-commit run --all-files   # first time to set up caches
 ```
 Run `pre-commit run --all-files` again before opening a pull request to ensure
 repository-wide checks pass.
@@ -89,6 +91,7 @@ pip install -r requirements-dev.txt
 ## Quick Checklist
 
 Ensure **Python 3.11–3.13** and **Node.js 22** are installed before running the tools.
+Before committing, run `pre-commit run --files <changed-files>` to lint only your modifications.
 
 Before opening a pull request, verify the environment and run the tests:
 

--- a/README.md
+++ b/README.md
@@ -769,9 +769,11 @@ curl -X POST http://localhost:8000/simulate \
 See [AGENTS.md](AGENTS.md) for the full contributor guide.
 
 ### Pre‑commit Hooks
-After running `./codex/setup.sh`, install the hooks and run a full check:
+After running `./codex/setup.sh`, which installs `pre-commit==4.2.0`
+automatically when missing, install the hooks and run a full check:
 
 ```bash
+# Install the exact version if the setup script didn't already
 pip install pre-commit==4.2.0
 pre-commit install
 pre-commit run --all-files   # verify hooks after setup

--- a/alpha_factory_v1/common/utils/retry.py
+++ b/alpha_factory_v1/common/utils/retry.py
@@ -18,11 +18,13 @@ T = TypeVar("T")
 
 
 @overload
-def with_retry(func: Callable[P, Awaitable[T]], *, max_tries: int = 3) -> Callable[P, Awaitable[T]]: ...
+def with_retry(func: Callable[P, Awaitable[T]], *, max_tries: int = 3) -> Callable[P, Awaitable[T]]:
+    ...
 
 
 @overload
-def with_retry(func: Callable[P, T], *, max_tries: int = 3) -> Callable[P, T]: ...
+def with_retry(func: Callable[P, T], *, max_tries: int = 3) -> Callable[P, T]:
+    ...
 
 
 def with_retry(func: Callable[P, Any], *, max_tries: int = 3) -> Callable[P, Any]:

--- a/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/openai_agents_bridge.py
@@ -42,9 +42,7 @@ try:  # optional dependency
                 asyncio.run(self._runner.run(self._agent, ""))
 
 except Exception as exc:  # pragma: no cover - fallback stub
-    raise ModuleNotFoundError(
-        "OpenAI Agents SDK is required to run the meta-evolution demo"
-    ) from exc
+    raise ModuleNotFoundError("OpenAI Agents SDK is required to run the meta-evolution demo") from exc
 
 
 try:
@@ -65,11 +63,15 @@ import os
 from typing import cast
 
 from .meta_evolver import MetaEvolver
+
 try:
     from .curriculum_env import CurriculumEnv
 except ModuleNotFoundError:  # gymnasium optional
+
     class CurriculumEnv:  # type: ignore[misc]
         pass
+
+
 from .utils import build_llm
 
 

--- a/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/utils.py
@@ -17,6 +17,7 @@ except ImportError:
     try:  # pragma: no cover - fallback for legacy package
         from agents import OpenAIAgent
     except Exception as exc:  # pragma: no cover - optional dependency
+
         class OpenAIAgent:  # type: ignore[misc]
             def __init__(self, *a, **kw):
                 pass

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -48,7 +48,7 @@ fi
 
 # Ensure pre-commit is available for git hooks
 if ! command -v pre-commit >/dev/null; then
-  $PYTHON -m pip install --quiet "${wheel_opts[@]}" pre-commit
+  $PYTHON -m pip install --quiet "${wheel_opts[@]}" pre-commit==4.2.0
 fi
 
 # Install package in editable mode

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,7 @@ if STUBS.is_dir():
     if find_spec("openai_agents") is None:
         sys.path.append(str(STUBS))
     import importlib
+
     try:
         adk_spec = find_spec("google_adk") or find_spec("google.adk")
     except ModuleNotFoundError:

--- a/tests/test_agent_aiga_entrypoint.py
+++ b/tests/test_agent_aiga_entrypoint.py
@@ -92,6 +92,4 @@ class TestAgentAIGAEntry:
             None,
         )
         with pytest.raises(ModuleNotFoundError):
-            importlib.import_module(
-                "alpha_factory_v1.demos.aiga_meta_evolution.agent_aiga_entrypoint"
-            )
+            importlib.import_module("alpha_factory_v1.demos.aiga_meta_evolution.agent_aiga_entrypoint")

--- a/tests/test_aiga_workflow.py
+++ b/tests/test_aiga_workflow.py
@@ -96,9 +96,7 @@ class AgentRuntime:
     (directory / "alpha_opportunity_stub.py").write_text(
         "def identify_alpha(domain: str = 'finance'):\n    return 'stub-alpha'"
     )
-    (directory / "alpha_conversion_stub.py").write_text(
-        "def convert_alpha(alpha: str):\n    return {}"
-    )
+    (directory / "alpha_conversion_stub.py").write_text("def convert_alpha(alpha: str):\n    return {}")
 
 
 @pytest.mark.xfail(reason="workflow runtime unstable in CI")


### PR DESCRIPTION
## Summary
- mention pre-commit 4.2.0 install in README
- pin version install in `codex/setup.sh`
- remind contributors to run pre-commit before committing
- format sources via `pre-commit`

## Testing
- `pre-commit run --all-files` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688782b043f48333b69806bcde85daba