### PR TITLE
[alpha_factory] ensure ledger cleanup after tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ import sys
 import types
 import importlib.util
 import socket
+import shutil
+from pathlib import Path
 from typing import Any
 
 # Ensure runtime dependencies are present before collecting tests
@@ -125,3 +127,12 @@ def scenario_2020_mrna() -> replay.Scenario:
 @pytest.fixture  # type: ignore[misc]
 def scenario(request: pytest.FixtureRequest) -> replay.Scenario:
     return request.getfixturevalue(request.param)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_ledger_dir() -> None:
+    """Remove the default ledger directory created during tests."""
+    yield
+    ledger = Path("ledger")
+    if ledger.exists():
+        shutil.rmtree(ledger, ignore_errors=True)


### PR DESCRIPTION
## Summary
- remove leftover `ledger/` after test runs via a session fixture

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files tests/conftest.py`
- `pytest tests/test_cli.py::test_show_results_missing -q`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_688787fc617c8333a6ee2bfa8e05392f