### PR TITLE
[alpha_factory] integrate Insight CLI

### DIFF
--- a/alpha_factory_v1/core/interface/cli.py
+++ b/alpha_factory_v1/core/interface/cli.py
@@ -8,6 +8,11 @@ import click
 from alpha_factory_v1.core.self_evolution import harness
 from alpha_factory_v1.core.governance.stake_registry import StakeRegistry
 
+try:
+    from alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface import cli as _insight_cli
+except Exception:  # pragma: no cover - optional
+    _insight_cli = None
+
 
 @click.group()
 def orch() -> None:
@@ -25,5 +30,57 @@ def self_test(patch: str) -> None:
     click.echo("accepted" if accepted else "rejected")
 
 
+if _insight_cli is not None:
+    # Re-export the full Insight demo CLI when available
+    main = _insight_cli.main  # type: ignore[attr-defined]
+    for _name in (
+        "agents_status",
+        "run_orchestrator",
+        "api_server_cmd",
+        "self_improver_cmd",
+        "simulate",
+        "show_results",
+        "show_memory",
+        "explore",
+        "replay",
+        "archive",
+        "archive_ls",
+        "evolve_cmd",
+        "transfer_test_cmd",
+    ):
+        if hasattr(_insight_cli, _name):
+            globals()[_name] = getattr(_insight_cli, _name)
+else:
+
+    @click.group()
+    def main() -> None:
+        """α‑Factory command line interface."""
+
+    main.add_command(orch)
+
+    def agents_status(*_a: object, **_kw: object) -> None:
+        raise click.ClickException("Insight demo not installed")
+
+
+__all__ = ["main", "orch"]
+for _x in (
+    "agents_status",
+    "run_orchestrator",
+    "api_server_cmd",
+    "self_improver_cmd",
+    "simulate",
+    "show_results",
+    "show_memory",
+    "explore",
+    "replay",
+    "archive",
+    "archive_ls",
+    "evolve_cmd",
+    "transfer_test_cmd",
+):
+    if _x in globals():
+        __all__.append(_x)
+
+
 if __name__ == "__main__":  # pragma: no cover
-    orch()
+    main()


### PR DESCRIPTION
## Summary
- re-export the alpha_agi_insight_v1 CLI from core CLI
- keep basic orch commands available as a fallback

## Testing
- `pre-commit run --files alpha_factory_v1/core/interface/cli.py`
- `pytest -q` *(fails: test_aiga_openai_bridge_offline, TestAlphaAgiInsightBridge::test_bridge_fallback)*

------
https://chatgpt.com/codex/tasks/task_e_6887902fb41483338d8dc11fae083139