### PR TITLE
[alpha_factory] enforce openai_agents version check

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -585,16 +585,10 @@ def main(argv: Optional[List[str]] = None) -> int:
             except Exception:
                 mod = None
         mod_spec = getattr(mod, "__spec__", None)
-        if mod_spec is None:
-            print("WARNING: openai_agents package lacks __spec__ metadata; skipping version check")
-        elif allow_basic:
-            if getattr(mod_spec, "loader", None) and not check_openai_agents_version():
-                return 1
-        else:
-            if getattr(mod_spec, "loader", None) is None:
-                print("WARNING: openai_agents package lacks __spec__ metadata")
-            elif not check_openai_agents_version():
-                return 1
+        if mod_spec is None or getattr(mod_spec, "loader", None) is None:
+            print("WARNING: openai_agents package lacks __spec__ metadata")
+        if not check_openai_agents_version():
+            return 1
 
     if demo == "macro_sentinel" and not os.getenv("ETHERSCAN_API_KEY"):
         print("WARNING: ETHERSCAN_API_KEY is unset; Etherscan collector disabled")

--- a/tests/test_check_env_openai_agents_version.py
+++ b/tests/test_check_env_openai_agents_version.py
@@ -73,18 +73,16 @@ class TestCheckEnvOpenAIAgentsVersion(unittest.TestCase):
                 return None
             return importlib.util.find_spec(name, *args, **kwargs)
 
-        def _raise() -> bool:
-            raise AssertionError("check_openai_agents_version should not run")
-
         with (
             mock.patch("importlib.import_module", side_effect=_fake_import),
             mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
             mock.patch.object(check_env, "REQUIRED", []),
             mock.patch.object(check_env, "OPTIONAL", ["openai_agents"]),
             mock.patch.object(check_env, "warn_missing_core", lambda: []),
-            mock.patch.object(check_env, "check_openai_agents_version", _raise),
+            mock.patch.object(check_env, "check_openai_agents_version", return_value=True) as chk,
         ):
             self.assertEqual(check_env.main(["--allow-basic-fallback"]), 0)
+            chk.assert_called_once()
 
     def test_missing_spec_skips_check_without_flag(self) -> None:
         fake_mod = types.SimpleNamespace(
@@ -105,18 +103,16 @@ class TestCheckEnvOpenAIAgentsVersion(unittest.TestCase):
                 return None
             return importlib.util.find_spec(name, *args, **kwargs)
 
-        def _raise() -> bool:
-            raise AssertionError("check_openai_agents_version should not run")
-
         with (
             mock.patch("importlib.import_module", side_effect=_fake_import),
             mock.patch("importlib.util.find_spec", side_effect=_fake_find_spec),
             mock.patch.object(check_env, "REQUIRED", []),
             mock.patch.object(check_env, "OPTIONAL", ["openai_agents"]),
             mock.patch.object(check_env, "warn_missing_core", lambda: []),
-            mock.patch.object(check_env, "check_openai_agents_version", _raise),
+            mock.patch.object(check_env, "check_openai_agents_version", return_value=True) as chk,
         ):
             self.assertEqual(check_env.main([]), 0)
+            chk.assert_called_once()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- always check openai_agents version when present
- update version-check tests

## Testing
- `pre-commit run --files check_env.py tests/test_check_env_openai_agents_version.py`
- `pytest tests/test_check_env_openai_agents_version.py tests/test_preflight_openai_agents_version.py -q` *(fails: Environment check failed, run 'python check_env.py --auto-install')*

------
https://chatgpt.com/codex/tasks/task_e_6887a1ed96ac83339068c4ca5b5e11e5