### PR TITLE
[alpha_factory] add minimal smoke test instructions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -119,6 +119,16 @@ ALPHA_FACTORY_FULL=1 python check_env.py --auto-install
 Use `--wheelhouse <dir>` or set `WHEELHOUSE` when offline so the command
 installs from your local wheel cache.
 
+### Minimal smoke test
+
+Run a single test to verify the environment:
+
+```bash
+pytest tests/test_ping_agent.py -q
+```
+
+If this passes, proceed to the quick health check below.
+
 ### Quick health check
 
 Run the smoke tests to confirm the core dependencies work:


### PR DESCRIPTION
## Summary
- mention a one-file smoke test in the root test suite README

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files tests/README.md`
- `pytest tests/test_ping_agent.py -q` *(fails: openai_agents 0.0.0 detected; >=0.0.17 required)*
- `pre-commit run --all-files` *(fails: Node.js 22+ is required)*

------
https://chatgpt.com/codex/tasks/task_e_6887a8f0e34c8333b031162317470311