### PR TITLE
[alpha_factory] fix openai_agents spec

### DIFF
--- a/openai_agents/__init__.py
+++ b/openai_agents/__init__.py
@@ -6,7 +6,7 @@ Provides basic classes so demos import without the real SDK."""
 import importlib.machinery
 
 _loader = importlib.machinery.SourceFileLoader(__name__, __file__)
-__spec__ = importlib.machinery.ModuleSpec(__name__, _loader)
+__spec__ = importlib.machinery.ModuleSpec(__name__, _loader, origin=__file__)
 
 __version__ = "0.0.17"
 

--- a/stubs/openai_agents/__init__.py
+++ b/stubs/openai_agents/__init__.py
@@ -5,9 +5,10 @@ Provides basic classes so demos import without the real SDK."""
 
 import importlib.machinery
 
-__spec__ = importlib.machinery.ModuleSpec("openai_agents", None)
+_loader = importlib.machinery.SourceFileLoader(__name__, __file__)
+__spec__ = importlib.machinery.ModuleSpec(__name__, _loader, origin=__file__)
 
-__version__ = "0.0.0"
+__version__ = "0.0.17"
 
 
 class AgentRuntime:


### PR DESCRIPTION
## Summary
- update the stub module spec for `openai_agents`
- sync the stubs version used when tests run

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files openai_agents/__init__.py stubs/openai_agents/__init__.py`
- `pytest tests/test_failed_agent_discovery.py -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6887bc2160688333a5f3fe3cf25d8cda