### PR TITLE
[alpha_factory] clarify API_TOKEN docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,6 +1300,12 @@ start if `NEO4J_PASSWORD` remains `REPLACE_ME` or is missing.
 Set `API_TOKEN` to a strong secret so that the REST API can authenticate
 incoming requests. Clients must send `Authorization: Bearer <token>`.
 The server aborts if `API_TOKEN` equals `REPLACE_ME_TOKEN`.
+
+#### API Token Requirement
+
+Before starting the API server or running the test suite, ensure `API_TOKEN`
+is set to a non-default value. The examples in `tests/test_api_status.py` use
+`test-token` as a reference token for local runs.
 Use `API_RATE_LIMIT` to limit requests per minute per IP (default `60`).
 If more than 5% of requests return HTTP `429` within a minute, the server calls
 `utils.alerts.send_alert` to report excessive throttling.


### PR DESCRIPTION
## Summary
- document that API_TOKEN must be changed from the default before running the API server or tests
- mention the example token used in `tests/test_api_status.py`

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files README.md`
- `pytest tests/test_api_status.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cefc013883339ed4381e881e04bb