### PR TITLE
[alpha_factory] verify openai-agents attrs

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -484,7 +484,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                     openai_agents_found = True
                     try:
                         mod = importlib.import_module("agents")
-                        openai_agents_attr_ok = hasattr(mod, "OpenAIAgent") or hasattr(mod, "Agent")
+                        openai_agents_attr_ok = all(hasattr(mod, a) for a in ("AgentRuntime", "Agent", "Tool"))
                     except Exception:
                         openai_agents_attr_ok = False
                 else:
@@ -493,7 +493,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 openai_agents_found = True
                 try:
                     mod = importlib.import_module(import_name)
-                    openai_agents_attr_ok = hasattr(mod, "OpenAIAgent") or hasattr(mod, "Agent")
+                    openai_agents_attr_ok = all(hasattr(mod, a) for a in ("AgentRuntime", "Agent", "Tool"))
                 except Exception:
                     openai_agents_attr_ok = False
             if not openai_agents_attr_ok:
@@ -572,7 +572,10 @@ def main(argv: Optional[List[str]] = None) -> int:
                     print("  -", hint_msg)
 
     if openai_agents_found and not openai_agents_attr_ok:
-        print("WARNING: openai_agents package lacks required API; skipping auto-install")
+        print(
+            "WARNING: openai_agents package lacks expected attributes. "
+            "Install the real 'openai-agents' package with: pip install openai-agents"
+        )
     elif openai_agents_found:
         try:
             mod = importlib.import_module("openai_agents")


### PR DESCRIPTION
## Summary
- check_env verifies AgentRuntime, Agent, Tool are present in openai_agents
- advise installing the real openai-agents package when attributes missing
- test for the new fallback behavior

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files check_env.py tests/test_check_env_openai_agents_version.py`
- `pytest tests/test_check_env_openai_agents_version.py::TestCheckEnvOpenAIAgentsVersion::test_missing_attributes_skips_version_check -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d55198788333a0e29e9294efe25b