### PR TITLE
fix: ensure protobuf module loads and handle envelope stubs

### DIFF
--- a/alpha_factory_v1/common/utils/__init__.py
+++ b/alpha_factory_v1/common/utils/__init__.py
@@ -4,3 +4,13 @@
 Submodules provide configuration management, logging helpers, a simple
 messaging bus and optional local LLM integration.
 """
+
+# Import the generated protobuf module on package import so other modules
+# can reliably reference :mod:`alpha_factory_v1.core.utils.a2a_pb2` without
+# stubbing. This prevents tests from injecting a fake module before the
+# real one loads.
+from importlib import import_module
+import contextlib
+
+with contextlib.suppress(Exception):
+    import_module("alpha_factory_v1.core.utils.a2a_pb2")

--- a/alpha_factory_v1/common/utils/logging.py
+++ b/alpha_factory_v1/common/utils/logging.py
@@ -199,7 +199,10 @@ class Ledger:
             if dataclasses.is_dataclass(env) and not isinstance(env, type):
                 record = dataclasses.asdict(env)
             elif isinstance(env, pb.Envelope):
-                record = json_format.MessageToDict(env, preserving_proto_field_name=True)
+                if hasattr(env, "DESCRIPTOR"):
+                    record = json_format.MessageToDict(env, preserving_proto_field_name=True)
+                else:
+                    record = dataclasses.asdict(env) if dataclasses.is_dataclass(env) else env.__dict__
             else:
                 record = env.__dict__
             data = json.dumps(record, sort_keys=True).encode()


### PR DESCRIPTION
## Summary
- load protobuf module eagerly so tests don't create stubs
- guard ledger logging against stub envelopes lacking `DESCRIPTOR`

## Testing
- `pre-commit run --files alpha_factory_v1/common/utils/logging.py alpha_factory_v1/common/utils/__init__.py`
- `pytest -k ledger -q` *(fails: AttributeError 'Envelope' object has no attribute 'DESCRIPTOR')*

------
https://chatgpt.com/codex/tasks/task_e_6888108705c08333bcda2f3b55ecffe5