### PR TITLE
[alpha_factory] Fix module-level skip

### DIFF
--- a/tests/test_aiga_agents_bridge.py
+++ b/tests/test_aiga_agents_bridge.py
@@ -17,7 +17,7 @@ openai_agents = pytest.importorskip("openai_agents", minversion="0.0.17")
 import inspect
 
 if "Minimal stub" in inspect.getsource(openai_agents):
-    pytest.skip("openai_agents stub present")
+    pytest.skip("openai_agents stub present", allow_module_level=True)
 pytest.importorskip("gymnasium", minversion="0.29")
 pytest.importorskip("google_adk")
 


### PR DESCRIPTION
## Summary
- allow module-level skip in `test_aiga_agents_bridge`

## Testing
- `pre-commit run --files tests/test_aiga_agents_bridge.py`
- `python check_env.py --auto-install`
- `pytest tests/test_aiga_agents_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68881d5d0648833387f641e3cdd2dfc0