### PR TITLE
Sync openai_agents pins

### DIFF
--- a/requirements-demo-cpu.lock
+++ b/requirements-demo-cpu.lock
@@ -606,9 +606,9 @@ openai==1.97.0 \
     --hash=sha256:0be349569ccaa4fb54f97bb808423fd29ccaeb1246ee1be762e0c81a47bae0aa \
     --hash=sha256:a1c24d96f4609f3f7f51c9e1c2606d97cc6e334833438659cfd687e9c972c610
     # via openai-agents
-openai-agents==0.1.0 \
-    --hash=sha256:6a8ef71d3f20aecba0f01bca2e059590d1c23f5adc02d780cb5921ea8a7ca774 \
-    --hash=sha256:a697a4fdd881a7a16db8c0dcafba0f17d9e90b6236a4b79923bd043b6ae86d80
+openai-agents==0.0.17 \
+    --hash=sha256:44f9c8e80b461c64cfdcf55d162ca8bb0594f4b2ada48daf1be34a8d4cd0759f \
+    --hash=sha256:924e0be145b42fb8984e35ab9d14e4948a2251c3b122a02ca989b223e4d39c27
     # via -r requirements-demo.txt
 orjson==3.11.0 \
     --hash=sha256:02dd4f0a1a2be943a104ce5f3ec092631ee3e9f0b4bb9eeee3400430bd94ddef \

--- a/requirements-demo.lock
+++ b/requirements-demo.lock
@@ -732,9 +732,9 @@ openai==1.97.1 \
     --hash=sha256:4e96bbdf672ec3d44968c9ea39d2c375891db1acc1794668d8149d5fa6000606 \
     --hash=sha256:a744b27ae624e3d4135225da9b1c89c107a2a7e5bc4c93e5b7b5214772ce7a4e
     # via openai-agents
-openai-agents==0.1.0 \
-    --hash=sha256:6a8ef71d3f20aecba0f01bca2e059590d1c23f5adc02d780cb5921ea8a7ca774 \
-    --hash=sha256:a697a4fdd881a7a16db8c0dcafba0f17d9e90b6236a4b79923bd043b6ae86d80
+openai-agents==0.0.17 \
+    --hash=sha256:44f9c8e80b461c64cfdcf55d162ca8bb0594f4b2ada48daf1be34a8d4cd0759f \
+    --hash=sha256:924e0be145b42fb8984e35ab9d14e4948a2251c3b122a02ca989b223e4d39c27
     # via -r requirements-demo.txt
 orjson==3.11.0 \
     --hash=sha256:02dd4f0a1a2be943a104ce5f3ec092631ee3e9f0b4bb9eeee3400430bd94ddef \

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -5,6 +5,6 @@ gymnasium[classic-control]>=0.29
 gradio>=5.38.0
 audioop-lts==0.2.1; python_version >= "3.13"
 filelock>=3.13
-openai-agents>=0.0.17,<0.2
+openai-agents==0.0.17
 tqdm~=4.67
 


### PR DESCRIPTION
## Summary
- pin openai-agents 0.0.17 for demo extras
- sync demo lock files with the same version

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install --skip-net-check`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`
- `pre-commit run --files requirements-demo.txt requirements-demo.lock requirements-demo-cpu.lock`

------
https://chatgpt.com/codex/tasks/task_e_6888428434088333a34f5eaa73ab68ec