### PR TITLE
docs: ignore bundle artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Treat compiled bundle artifacts as generated files
+*.bundle.js linguist-generated -diff
+*.bundle.js.map linguist-generated -diff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,7 @@ install dependencies without internet access.
 - Keep commits focused and descriptive. Use meaningful commit messages.
 - Ensure `git status` shows a clean working tree before committing.
 - Remove stray build artifacts with `git clean -fd` if needed.
+- Large bundle artifacts (`*.bundle.js` and `*.bundle.js.map`) are marked as generated in `.gitattributes` so search tools skip them.
   - Follow the [Quick Checklist](CONTRIBUTING.md#quick-checklist) before committing.
     Run `python scripts/check_python_deps.py`, `python check_env.py --auto-install`,
     `pre-commit run --all-files` and `pytest`. Document any remaining test failures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ pre-commit run --all-files   # first time to set up caches
 ```
 Run `pre-commit run --all-files` again before opening a pull request to ensure
 repository-wide checks pass.
+- Large bundle artifacts (`*.bundle.js` and `*.bundle.js.map`) are marked as generated in `.gitattributes`, so pre-commit and search tools ignore them.
 Use `pre-commit run --files docs/demos/<page>.md` to catch missing preview
 images. Each page under `docs/demos/` must start with a preview image using
 `![preview](...)`.


### PR DESCRIPTION
## Summary
- mark `*.bundle.js*` files as generated via `.gitattributes`
- mention bundle exclusions in contributor docs

## Testing
- `SKIP=semgrep pre-commit run --files .gitattributes AGENTS.md CONTRIBUTING.md`
- `pytest` *(fails: test_market_agent_logs_exception, test_research_agent_logs_exception, test_aiga_openai_bridge_offline, TestAlphaAgiInsightBridge::test_bridge_fallback)*
- `SKIP=semgrep,eslint-insight-browser pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_688844d1a680833388c71df1b332ed6a