### PR TITLE
[alpha_factory] fix disclaimer link paths

### DIFF
--- a/alpha_factory_v1/README.md
+++ b/alpha_factory_v1/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/backend/README.md
+++ b/alpha_factory_v1/backend/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha-Factory Backend

--- a/alpha_factory_v1/dashboards/README.md
+++ b/alpha_factory_v1/dashboards/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha Factory Dashboards

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/API.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 # API Overview
 
 This demo exposes a minimal REST and WebSocket interface implemented in `src.interface.api_server`. All requests must include `Authorization: Bearer $API_TOKEN`.

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Changelog

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/DESIGN.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # α‑AGI Insight v1 – Design Overview

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/docs/bus_tls.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Bus TLS Setup

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/index.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ### 🔬 Browser-only Insight demo

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.md
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/index.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Alpha AGI Insight Web Client

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 - 2025‑04‑25 Initial auto‑generated docs bundle

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/agents_overview.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/api_reference.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/quickstart.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Quick‑Start

--- a/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/docs/safety_notes.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ## Disclaimer

--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 ```mermaid

--- a/alpha_factory_v1/docs/README.md
+++ b/alpha_factory_v1/docs/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Documentation Overview

--- a/alpha_factory_v1/docs/REMOTE_SWARM.md
+++ b/alpha_factory_v1/docs/REMOTE_SWARM.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # Remote Swarm Quick‑start

--- a/alpha_factory_v1/docs/alpha_agi_agent.md
+++ b/alpha_factory_v1/docs/alpha_agi_agent.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/docs/alpha_agi_business.md
+++ b/alpha_factory_v1/docs/alpha_agi_business.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 

--- a/alpha_factory_v1/tests/README.md
+++ b/alpha_factory_v1/tests/README.md
@@ -1,4 +1,4 @@
-[See docs/DISCLAIMER_SNIPPET.md](../../../DISCLAIMER_SNIPPET.md)
+[See docs/DISCLAIMER_SNIPPET.md](../../DISCLAIMER_SNIPPET.md)
 This repository is a conceptual research prototype. References to "AGI" and "superintelligence" describe aspirational goals and do not indicate the presence of a real general intelligence. Use at your own risk. Nothing herein constitutes financial advice. MontrealAI and the maintainers accept no liability for losses incurred from using this software.
 
 # 🧪 Test Suite · Alpha‑Factory v1 👁


### PR DESCRIPTION
## Summary
- update various README files so disclaimer links correctly reference the project root

## Testing
- `pre-commit run --files $(git status --porcelain | awk '{print $2}' | tr '\n' ' ')`
- `python check_env.py --auto-install`
- `pytest tests/test_code_diff.py::test_code_diff_offline -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b951e940833393870ee1f06bc3b1