### PR TITLE
Fix packaging path for disclaimer file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ packages = [
 include-package-data = true
 
 [tool.setuptools.package-data]
-"alpha_factory_v1" = ["py.typed", "../DISCLAIMER_SNIPPET.md"]
+"alpha_factory_v1" = ["py.typed", "../docs/DISCLAIMER_SNIPPET.md"]
 "alpha_factory_v1.demos.alpha_agi_insight_v1" = ["py.typed"]
 "alpha_factory_v1.core.interface.web_client" = ["dist/**"]
 "alpha_factory_v1.demos.alpha_agi_insight_v1.src.interface.web_client" = ["dist/**"]


### PR DESCRIPTION
## Summary
- include the docs disclaimer snippet in the `alpha_factory_v1` package

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_insight_api_server.py::test_root_disclaimer_plain -vv`
- `pytest tests/test_check_env_openai_agents_version.py::TestCheckEnvOpenAIAgentsVersion::test_new_version_ok -vv`


------
https://chatgpt.com/codex/tasks/task_e_6888bdd1b4b4833387d89ba33ac80059