### PR TITLE
Fix variable name in quickstart script

### DIFF
--- a/alpha_factory_v1/quickstart.sh
+++ b/alpha_factory_v1/quickstart.sh
@@ -33,8 +33,8 @@ warn() { color 33 "$1"; }
 
 prompt() {
   if [[ $WIZARD -eq 1 ]]; then
-    read -rp "$1 [Y/n] " ans
-    [[ ${ans:-Y} =~ ^[Yy]$ ]]
+    read -rp "$1 [Y/n] " answer
+    [[ ${answer:-Y} =~ ^[Yy]$ ]]
   else
     return 0
   fi


### PR DESCRIPTION
## Summary
- adjust interactive prompt variable name in `quickstart.sh`

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_adk_agent.py::test_adk_summariser_runs -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c0dfee7083338b95054a75a29903