### PR TITLE
[alpha_factory] expose harness helpers

### DIFF
--- a/alpha_factory_v1/core/self_evolution/harness.py
+++ b/alpha_factory_v1/core/self_evolution/harness.py
@@ -17,6 +17,14 @@ from alpha_factory_v1.demos.self_healing_repo import patcher_core
 
 IMAGE = os.getenv("SELF_EVOLUTION_IMAGE", "python:3.11-slim")
 
+__all__ = [
+    "apply_patch",
+    "vote_and_merge",
+    "patcher_core",
+    "_run_tests",
+    "run_preflight",
+]
+
 
 def _run_tests(repo: Path) -> int:
     """Run the repository's test suite in a Docker container.


### PR DESCRIPTION
## Summary
- expose apply_patch, vote_and_merge, patcher_core and test helpers in harness

## Testing
- `pre-commit run --files alpha_factory_v1/core/self_evolution/harness.py`
- `mypy --config-file mypy.ini alpha_factory_v1/core/self_evolution/harness.py`


------
https://chatgpt.com/codex/tasks/task_e_6888c8ea326c8333bf3656aafb55ff91