### PR TITLE
fix: improve MetaRefinementAgent bottleneck detection

### DIFF
--- a/alpha_factory_v1/core/agents/meta_refinement_agent.py
+++ b/alpha_factory_v1/core/agents/meta_refinement_agent.py
@@ -60,7 +60,7 @@ class MetaRefinementAgent:
                 delta = ts - prev_ts
                 if delta > max_delta:
                     max_delta = delta
-                    target = str(rec.get("hash", ""))
+                    target = str(rec.get("module") or rec.get("agent") or rec.get("hash", ""))
             prev_ts = ts
         return target
 


### PR DESCRIPTION
## Summary
- ensure `_detect_bottleneck` falls back to module/agent name

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_meta_refinement_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d6cb07fc83339b4294861b70ab33