### PR TITLE
[alpha_factory] increase meta refinement agent coverage

### DIFF
--- a/tests/test_meta_refinement_agent.py
+++ b/tests/test_meta_refinement_agent.py
@@ -115,3 +115,31 @@ def test_refinement_proposes_cycle_adjustment(tmp_path: Path) -> None:
 
     called_diff = vote.call_args.args[1]
     assert "increase cycle" in called_diff
+
+
+def test_detect_bottleneck_selects_largest_gap(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    agent = MetaRefinementAgent(repo, tmp_path / "logs")
+    entries = [
+        {"module": "a", "ts": 0},
+        {"module": "b", "ts": 2},
+        {"module": "c", "ts": 8},
+    ]
+    assert agent._detect_bottleneck(entries) == "c"
+
+
+def test_create_patch_no_entries(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    agent = MetaRefinementAgent(repo, tmp_path / "logs")
+    patch = agent._create_patch([])
+    assert "optimise performance" in patch
+
+
+def test_init_sets_default_stake(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    reg = StakeRegistry()
+    assert "meta" not in reg.stakes
+    MetaRefinementAgent(repo, logs, reg)
+    assert reg.stakes["meta"] == 1.0


### PR DESCRIPTION
## Summary
- improve meta_refinement_agent test coverage
- add tests for detection, patch generation and stake initialization

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_meta_refinement_agent.py --cov=alpha_factory_v1.core.agents.meta_refinement_agent --cov-report=xml --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_6888dde1562083339e80f2fa2641b6ad