### PR TITLE
[alpha_factory] expose middleware on app state

### DIFF
--- a/alpha_factory_v1/core/interface/api_server.py
+++ b/alpha_factory_v1/core/interface/api_server.py
@@ -253,6 +253,18 @@ if app is not None:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app_f.middleware_stack = app_f.build_middleware_stack()
+    stack = app_f.middleware_stack
+    limiter = None
+    metrics_mw = None
+    while hasattr(stack, "app"):
+        if isinstance(stack, SimpleRateLimiter):
+            limiter = stack
+        if isinstance(stack, MetricsMiddleware):
+            metrics_mw = stack
+        stack = stack.app
+    app_f.state.limiter = limiter
+    app_f.state.metrics = metrics_mw
     app_f.include_router(metrics_router)
     app_f.state.orchestrator = None
     app_f.state.orch_task = None

--- a/tests/test_api_server_static.py
+++ b/tests/test_api_server_static.py
@@ -30,9 +30,8 @@ def test_throttle_alert(monkeypatch: pytest.MonkeyPatch) -> None:
     client.get("/runs", headers=headers)
     client.get("/runs", headers=headers)
 
-    stack = api.app.middleware_stack
-    metrics = stack.app.app
-    limiter = metrics.app
+    metrics = api.app.state.metrics
+    limiter = api.app.state.limiter
     metrics.window_start = time.time() - 61
     limiter.counters["testclient"] = deque()
 


### PR DESCRIPTION
## Summary
- cache middleware objects on app.state for reuse
- adjust static server tests to use these references

## Testing
- `pre-commit run --files alpha_factory_v1/core/interface/api_server.py tests/test_api_server_static.py`
- `pytest tests/test_api_server_static.py`


------
https://chatgpt.com/codex/tasks/task_e_6888e8182fd08333b5d82a71439e2387