### PR TITLE
[alpha_factory] Add postponed annotations to test

### DIFF
--- a/tests/test_agent_logging.py
+++ b/tests/test_agent_logging.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 from unittest import mock
 import pytest


### PR DESCRIPTION
## Summary
- enable postponed evaluation of annotations in `tests/test_agent_logging.py`
- confirm no other test needs the future import

## Testing
- `pre-commit run --files tests/test_agent_logging.py`
- `pytest tests/test_agent_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ef77f6dc833383f62388ef324413