### PR TITLE
[alpha_factory] stub google_adk for tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@
 
 from importlib.util import find_spec
 from pathlib import Path
+import os
 import sys
 
 # Allow tests to run from the repository without installing the package
@@ -17,10 +18,13 @@ if STUBS.is_dir():
         sys.path.append(str(STUBS))
     import importlib
 
-    try:
-        adk_spec = find_spec("google_adk") or find_spec("google.adk")
-    except ModuleNotFoundError:
+    if os.environ.get("SKIP_GOOGLE_ADK", "1") not in {"0", "false", "False"}:
         adk_spec = None
+    else:
+        try:
+            adk_spec = find_spec("google_adk") or find_spec("google.adk")
+        except ModuleNotFoundError:
+            adk_spec = None
     if adk_spec is None:
         pass
     else:


### PR DESCRIPTION
## Summary
- avoid loading heavy google_adk package during tests
- use application state in API server static tests

## Testing
- `pytest -q tests/test_api_server_static.py`
- `pre-commit run --files tests/__init__.py` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6888fdc374948333ade920fae0d8cff7