### PR TITLE
test: assert middleware state

### DIFF
--- a/tests/test_api_server_static.py
+++ b/tests/test_api_server_static.py
@@ -40,6 +40,8 @@ def test_throttle_alert(monkeypatch: pytest.MonkeyPatch) -> None:
 
     metrics = cast(MetricsMiddleware, api.app.state.metrics)
     limiter = cast(SimpleRateLimiter, api.app.state.limiter)
+    assert metrics is not None, "Metrics middleware missing"
+    assert limiter is not None, "Rate limiter missing"
     metrics.window_start = time.time() - 61
     limiter.counters["testclient"] = deque()
 


### PR DESCRIPTION
## Summary
- ensure metrics middleware and rate limiter exist before poking state in the API static tests

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_api_server_static.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68890bef01fc8333a5638f5321430a89