### PR TITLE
[alpha_factory] test: close unused coroutines

### DIFF
--- a/tests/test_alpha_agi_business_3_v1.py
+++ b/tests/test_alpha_agi_business_3_v1.py
@@ -577,7 +577,9 @@ def test_run_cycle_uses_asyncio_run(monkeypatch: pytest.MonkeyPatch) -> None:
     mod.run_cycle(mod.Orchestrator(), mod.AgentFin(), mod.AgentRes(), mod.AgentEne(), mod.AgentGdl(), mod.Model())
 
     assert called.get("coro") is not None
-    assert getattr(called["coro"], "cr_code", None) is dummy_cycle.__code__
+    coro = called["coro"]
+    assert getattr(coro, "cr_code", None) is dummy_cycle.__code__
+    coro.close()
 
 
 def test_run_cycle_creates_task(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -604,3 +606,4 @@ def test_run_cycle_creates_task(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert dummy_loop.coro is not None
     assert getattr(dummy_loop.coro, "cr_code", None) is dummy_cycle.__code__
+    dummy_loop.coro.close()


### PR DESCRIPTION
## Summary
- silence runtime warnings by closing unused coroutines in tests

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files tests/test_alpha_agi_business_3_v1.py` *(fails: Interrupted while initializing environment)*
- `pytest tests/test_alpha_agi_business_3_v1.py::test_run_cycle_uses_asyncio_run tests/test_alpha_agi_business_3_v1.py::test_run_cycle_creates_task -q`
- `pytest -q` *(fails: 42 failed, 363 passed, 63 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6889260902d88333970cc6f45c43a9c2