### PR TITLE
[alpha_factory] fix unused import

### DIFF
--- a/alpha_factory_v1/backend/agents/__init__.py
+++ b/alpha_factory_v1/backend/agents/__init__.py
@@ -6,7 +6,6 @@ from .registry import (
     AGENT_REGISTRY,
     CAPABILITY_GRAPH,
     AgentMetadata,
-    StubAgent,
     Counter,
     Gauge,
     Histogram,


### PR DESCRIPTION
## Summary
- remove leftover StubAgent import

## Testing
- `pre-commit run --files alpha_factory_v1/backend/agents/__init__.py`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68892e89a8a08333a0877f6f0d507cca