### PR TITLE
fix: stub and metrics cleanup

### DIFF
--- a/alpha_factory_v1/core/archive/db.py
+++ b/alpha_factory_v1/core/archive/db.py
@@ -11,10 +11,11 @@ from pathlib import Path
 from typing import Iterator, Optional
 
 from sqlalchemy import Boolean, Column, Float, String, create_engine
-from sqlalchemy.orm import Session, declarative_base
+from sqlalchemy.orm import Session, DeclarativeBase
 
 
-Base = declarative_base()
+class Base(DeclarativeBase):
+    pass
 
 
 @dataclass(slots=True)

--- a/alpha_factory_v1/core/monitoring/metrics.py
+++ b/alpha_factory_v1/core/monitoring/metrics.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Optional
 
 try:
-    from prometheus_client import Counter, Gauge  # type: ignore
+    from prometheus_client import Counter, Gauge
 except Exception:  # pragma: no cover - optional
-    Counter = Gauge = None  # type: ignore
+    Counter = Gauge = None
+
+Counter: Optional[Any]
+Gauge: Optional[Any]
 
 from alpha_factory_v1.backend.metrics_registry import get_metric
 

--- a/alpha_factory_v1/core/self_edit/tools.py
+++ b/alpha_factory_v1/core/self_edit/tools.py
@@ -51,7 +51,7 @@ except ModuleNotFoundError:  # pragma: no cover - stub fallbacks
 
         JsonSchema = dict[str, Any]
 
-    adk = _Adk()
+    adk: Any = _Adk()
     _HAVE_ADK = False
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/stubs/google_adk/__init__.pyi
+++ b/stubs/google_adk/__init__.pyi
@@ -1,0 +1,16 @@
+from typing import Any, Callable
+
+class Agent:
+    def __init__(self, name: str) -> None: ...
+
+class JsonSchema(dict[str, Any]): ...
+
+def task(*args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
+
+class Router:
+    app: Any
+    def register_agent(self, agent: Agent) -> None: ...
+
+class AgentException(Exception): ...
+
+__all__: list[str]


### PR DESCRIPTION
## Summary
- add type hints for google_adk stub
- clean up optional prometheus metrics import
- declare DeclarativeBase for SQLAlchemy models

## Testing
- `pre-commit run --files stubs/google_adk/__init__.pyi alpha_factory_v1/core/archive/db.py alpha_factory_v1/core/monitoring/metrics.py alpha_factory_v1/core/self_edit/tools.py`
- `pytest tests/test_agent_logging.py tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68893af9634c8333baa3491b35e9ee09