### PR TITLE
[alpha_factory] restrict Docker actions to tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,27 +596,32 @@ jobs:
         run: |
           docker run --rm -e RUN_MODE=cli "$DOCKER_IMAGE:ci" simulate --horizon 1 --offline
       - name: Login to GHCR
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push image
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           docker tag "$DOCKER_IMAGE:ci" ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
           docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
       - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
           cosign-release: 'v2.2.4'
       - name: Sign image
+        if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
       - name: Verify image signature
+        if: startsWith(github.ref, 'refs/tags/')
         run: cosign verify ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
   deploy:
     name: "📦 Deploy"
-    if: ${{ always() && needs.owner-check.result == 'success' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.owner-check.result == 'success' }}
     needs: [owner-check, tests, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
## Summary
- run Docker push/sign steps only for tags
- run deploy job only for release tags

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml docs/CI_WORKFLOW.md`
- `pytest tests/test_agent_logging.py::test_market_agent_logs_exception -q`


------
https://chatgpt.com/codex/tasks/task_e_68895fd6f4c08333a56d53fa25c1e38d