### PR TITLE
[alpha_factory] Update CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- add Python 3.13 to `lint-type` and `tests` matrices

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml --cov-fail-under=80` *(fails: test_agent_logging.py::test_market_agent_logs_exception et al.)*

------
https://chatgpt.com/codex/tasks/task_e_6889641a4e80833391b997d656e8d2b6