### PR TITLE
Clarify Python versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# The Python matrix covers versions **3.11–3.13** and the workflow includes
+# The Python matrix targets stable versions 3.11 and 3.12 plus pre-release 3.13
+# for early compatibility testing. The workflow also includes
 # Windows and macOS smoke tests, full documentation builds and Docker deployment.
 name: "🚀 CI"
 


### PR DESCRIPTION
## Summary
- clarify stable Python versions in the CI workflow header

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python check_env.py --auto-install`
- `pytest tests/test_agent_logging.py::test_market_agent_logs_exception -q`

------
https://chatgpt.com/codex/tasks/task_e_6889667ccd2c8333a6af4cfe4a39f8b5