### PR TITLE
[alpha_factory] fix: drop python 3.13 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# The Python matrix targets stable versions 3.11 and 3.12 plus pre-release 3.13
-# for early compatibility testing. The workflow also includes
+# The Python matrix targets stable versions 3.11 and 3.12. The workflow also includes
 # Windows and macOS smoke tests, full documentation builds and Docker deployment.
 name: "🚀 CI"
 
@@ -67,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -140,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
@@ -260,7 +259,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -306,7 +305,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -359,7 +358,7 @@ jobs:
         run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
@@ -420,7 +419,7 @@ jobs:
         run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
@@ -509,7 +508,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Compute repo_owner_lower


### PR DESCRIPTION
## Summary
- keep CI using stable Python versions only

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68897163e1c08333bfda78ee2ddb9f5c