### PR TITLE
Fix CI job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           git --version
 
   lint-type:
-    name: "🧹 Ruff + 🏷️ Mypy"
+    name: "🧹 Ruff + 🏷️ Mypy (${{ matrix.python-version }})"
     needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -132,7 +132,7 @@ jobs:
         run: mypy --config-file mypy.ini
 
   tests:
-    name: "✅ Pytest"
+    name: "✅ Pytest (${{ matrix.python-version }})"
     needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- clarify job names for lint and tests with Python version matrices

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python check_env.py --auto-install`
- `pytest --maxfail=1 -q` *(fails: test_agent_logging.py::test_market_agent_logs_exception)*

------
https://chatgpt.com/codex/tasks/task_e_68897d8cf3a48333b73eef3a306f873a