### PR TITLE
fix: enforce pre-commit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,8 +769,8 @@ curl -X POST http://localhost:8000/simulate \
 See [AGENTS.md](AGENTS.md) for the full contributor guide.
 
 ### Pre‑commit Hooks
-After running `./codex/setup.sh`, which installs `pre-commit==4.2.0`
-automatically when missing, install the hooks and run a full check:
+After running `./codex/setup.sh`, which ensures `pre-commit==4.2.0`
+is installed, install the hooks and run a full check:
 
 ```bash
 # Install the exact version if the setup script didn't already
@@ -794,7 +794,8 @@ all hooks succeed.
 Run `python check_env.py --auto-install` before invoking these commands so
 optional hook dependencies are installed. When working offline, pass
 `--wheelhouse <dir>` or set `WHEELHOUSE` to install from a local cache. If
-`pre-commit` isn't found, install it with `pip install pre-commit==4.2.0`.
+`pre-commit` isn't found or the version differs, install it with
+`pip install pre-commit==4.2.0`.
 
 When editing the web UI, preserve existing ARIA labels so the interface
 remains accessible.

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -46,9 +46,12 @@ if (( node_major < 22 )); then
   exit 1
 fi
 
-# Ensure pre-commit is available for git hooks
-if ! command -v pre-commit >/dev/null; then
-  $PYTHON -m pip install --quiet "${wheel_opts[@]}" pre-commit==4.2.0
+# Ensure pre-commit 4.2.0 is available for git hooks
+required_pre_commit=4.2.0
+current_pre_commit=$(command -v pre-commit >/dev/null && pre-commit --version 2>/dev/null | awk '{print $2}')
+if [[ -z "$current_pre_commit" || "$current_pre_commit" != "$required_pre_commit" ]]; then
+  echo "Installing pre-commit==$required_pre_commit" >&2
+  $PYTHON -m pip install --quiet "${wheel_opts[@]}" pre-commit=="$required_pre_commit"
 fi
 
 # Install package in editable mode


### PR DESCRIPTION
## Summary
- enforce `pre-commit==4.2.0` in setup script
- clarify docs about the exact version check

## Testing
- `pre-commit run --files README.md codex/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68898e4b75fc83338442b7e0a6fd7ae2