### PR TITLE
Enable PR comments in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ permissions:
   actions: read
   checks:  write
   packages: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- allow the CI workflow to post pull request comments

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml` *(failed: KeyboardInterrupt)*
- `pytest tests/test_agent_logging.py::test_market_agent_logs_exception -q`


------
https://chatgpt.com/codex/tasks/task_e_6889942ee4d08333934d23d962e21ff2