### PR TITLE
[alpha_factory] raise accessibility threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
       a11y-threshold:
         description: "Minimum Axe accessibility score"
         required: false
-        default: "90"
+        default: "95"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- bump CI a11y threshold to 95

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml` *(failed: KeyboardInterrupt)*
- `pytest --cov --cov-report=xml --cov-fail-under=80 tests/test_agent_logging.py::test_market_agent_logs_exception` *(failed: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6889983ad14883339f04bca2c4f67155