### PR TITLE
Update CI Python matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -152,7 +152,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- extend lint and test jobs to include Python 3.13

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `python check_env.py --auto-install`
- `pytest tests/test_agent_logging.py::test_market_agent_logs_exception -q`


------
https://chatgpt.com/codex/tasks/task_e_68899d242cb88333926e73df768a44e6