### PR TITLE
Improve owner check in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
         id: owner
         shell: bash
         run: |
-          repo_owner_lower=$(echo "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')
+          # Use parameter expansion to avoid spawning subshells
+          repo_owner_lower="${GITHUB_REPOSITORY_OWNER,,}"
           echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_OUTPUT"
       - name: Show tool versions
         run: |


### PR DESCRIPTION
## Summary
- refine repository owner check in CI workflow

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_agent_logging.py::test_market_agent_logs_exception -q`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: interrupted before completion)*

------
https://chatgpt.com/codex/tasks/task_e_688a05483a188333b82908b88e22b36c