### PR TITLE
[alpha_factory] Add Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- update CI to test against Python 3.13 alongside 3.11 and 3.12

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_688a100a03b883338d9d7a5011118082