### PR TITLE
Fix test logging offline handling

### DIFF
--- a/tests/test_agent_logging.py
+++ b/tests/test_agent_logging.py
@@ -19,7 +19,10 @@ class DummyCtx:
         raise RuntimeError("boom")
 
 
-def test_market_agent_logs_exception(caplog: pytest.LogCaptureFixture) -> None:
+def test_market_agent_logs_exception(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AGI_INSIGHT_OFFLINE", raising=False)
     cfg = config.Settings(bus_port=0, openai_api_key="k")
     bus = DummyBus(cfg)
     led = DummyLedger()
@@ -49,7 +52,10 @@ def test_strategy_agent_logs_exception(monkeypatch):
         warn.assert_called_once()
 
 
-def test_research_agent_logs_exception(caplog: pytest.LogCaptureFixture) -> None:
+def test_research_agent_logs_exception(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AGI_INSIGHT_OFFLINE", raising=False)
     cfg = config.Settings(bus_port=0, openai_api_key="k")
     bus = DummyBus(cfg)
     led = DummyLedger()


### PR DESCRIPTION
## Summary
- ensure agent logging tests unset AGI_INSIGHT_OFFLINE

## Testing
- `pytest tests/test_agent_logging.py::test_market_agent_logs_exception -q`
- `pytest tests/test_agent_logging.py::test_research_agent_logs_exception -q`
- `pytest --cov --cov-report=xml --cov-fail-under=80` *(fails: 7 failed, 133 passed)*
- `pre-commit run --files tests/test_agent_logging.py .github/workflows/ci.yml` *(fails: KeyboardInterrupt during environment install)*

------
https://chatgpt.com/codex/tasks/task_e_688a21e8a9ec8333b41392eb7e761063