### PR TITLE
[alpha_factory] Add Python 3.13 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# The Python matrix targets stable versions 3.11 and 3.12. The workflow also includes
+# The Python matrix targets stable versions 3.11, 3.12 and 3.13. The workflow also includes
 # Windows and macOS smoke tests, full documentation builds and Docker deployment.
 name: "🚀 CI"
 
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ pre-commit run --all-files
 Launch the CI workflow manually via **Actions → 🚀 CI — Insight Demo** and click
 **Run workflow** as described in [AGENTS.md](AGENTS.md#starting-the-ci-pipeline).
 The workflow performs linting, type checks, the full unit test matrix on Python
-3.11 and 3.12, Windows and macOS smoke tests, documentation builds, Docker
+3.11, 3.12 and 3.13, Windows and macOS smoke tests, documentation builds, Docker
 builds and an optional deploy step for tagged releases.
 
 ### Verify Docker image signature


### PR DESCRIPTION
## Summary
- extend Python matrix in CI workflow to include Python 3.13
- document the updated matrix in the workflow header and README

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pyenv shell 3.13.3 && pre-commit run --files .github/workflows/ci.yml` *(fails: Failed building wheel for shellcheck_py)*

------
https://chatgpt.com/codex/tasks/task_e_688a2de3e9a08333956b9a555bd28e8c