### PR TITLE
[alpha_factory] Auto-install requests in update_actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,16 +78,11 @@ images. Each page under `docs/demos/` must start with a preview image using
 `![preview](...)`.
 Workflow YAML files are linted by `pre-commit`. A local hook automatically
 runs `python tools/update_actions.py` whenever files in `.github/workflows/`
-change. You can also run it manually:
+change. The script will install `requests` automatically if it's missing.
+You can also run it manually:
 
 ```bash
 pre-commit run --files .github/workflows/ci.yml
-
-If the hook reports that `requests` is missing, install it with:
-
-```bash
-pip install -r requirements-dev.txt
-```
 
 ## Quick Checklist
 


### PR DESCRIPTION
## Summary
- allow `tools/update_actions.py` to auto-install `requests`
- mention automatic install in CONTRIBUTING guide

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest` *(fails: test_aiga_openai_bridge_offline - KeyboardInterrupt)*
- `pre-commit run --files tools/update_actions.py CONTRIBUTING.md` *(fails: environment setup interrupted)*
- `pre-commit run --all-files` *(fails: environment setup interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688a31c87a8c8333a55ddd416765efc3