### PR TITLE
[alpha_factory] add setup-env action

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Setup CI Environment
+description: Build sandbox image, install Playwright browsers and show tool versions.
+runs:
+  using: composite
+  steps:
+    - name: Build sandbox image
+      shell: bash
+      run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
+    - name: Show tool versions
+      shell: bash
+      run: |
+        python --version
+        node --version
+        docker --version
+        docker compose version
+        git --version
+    - name: Install Playwright browsers
+      shell: bash
+      run: python -m playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,6 @@ jobs:
           # Use parameter expansion to avoid spawning subshells
           repo_owner_lower="${GITHUB_REPOSITORY_OWNER,,}"
           echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_OUTPUT"
-      - name: Show tool versions
-        run: |
-          python --version
-          node --version
-          docker --version
-          docker compose version
-          git --version
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy (${{ matrix.python-version }})"
@@ -175,18 +168,13 @@ jobs:
         run: |
           python scripts/check_python_deps.py
           python check_env.py --auto-install --demo macro_sentinel
-      - name: Build sandbox image
-        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       # Install Node.js and cache dependencies using both lockfiles
       - uses: actions/setup-node@v4.4.0 # 49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: ${{ env.NODE_LOCKFILES }}
-      - name: Show tool versions
-        run: |
-          python --version
-          node --version
+      - uses: ./.github/actions/setup-env
       - uses: ./.github/actions/setup-insight-assets
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
@@ -196,8 +184,6 @@ jobs:
         run: npx update-browserslist-db --update-db --yes
       - name: Audit insight browser dependencies
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 audit --production --audit-level=high
-      - name: Install Playwright browsers
-        run: python -m playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
       - name: Run insight browser tests
         env:
           CI: 'true'
@@ -374,8 +360,6 @@ jobs:
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Build sandbox image
-        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -399,18 +383,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: ${{ env.NODE_LOCKFILES }}
-      - name: Show tool versions
-        run: |
-          python --version
-          node --version
-          docker --version
-          docker compose version
-          git --version
+      - uses: ./.github/actions/setup-env
       - name: Build insight browser
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 run build
       # asset fetching handled by setup-insight-assets
-      - name: Install Playwright browsers
-        run: python -m playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
       - name: Install pre-commit
         run: pip install pre-commit==4.2.0
         env:
@@ -437,8 +413,6 @@ jobs:
       PWA_TIMEOUT_MS: '120000'
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Build sandbox image
-        run: docker build -t "$SANDBOX_IMAGE" -f sandbox.Dockerfile .
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
@@ -454,21 +428,13 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: ${{ env.NODE_LOCKFILES }}
-      - name: Show tool versions
-        run: |
-          python --version
-          node --version
-          docker --version
-          docker compose version
-          git --version
+      - uses: ./.github/actions/setup-env
       - name: Install base dependencies
         run: python check_env.py --auto-install
       - name: Install docs requirements
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-docs.lock
-      - name: Install Playwright browsers
-        run: python -m playwright install chromium webkit firefox
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Install web client dependencies
@@ -504,8 +470,6 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Install Playwright browsers
-        run: python -m playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
       - name: Install Playwright browsers (Node)
         run: npx playwright install
       - name: Verify demo pages
@@ -542,10 +506,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: ${{ env.NODE_LOCKFILES }}
-      - name: Show tool versions
-        run: |
-          python --version
-          node --version
+      - uses: ./.github/actions/setup-env
       - name: Install insight browser dependencies
         run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Update browserslist database (Insight demo)
@@ -559,8 +520,6 @@ jobs:
       - uses: ./.github/actions/setup-insight-assets
       - name: Audit insight browser dependencies
         run: npm --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1 audit --production --audit-level=high
-      - name: Install Playwright browsers
-        run: python -m playwright install chromium webkit firefox || echo "SKIP_WEBKIT_TESTS=1" >> "$GITHUB_ENV"
       - name: Run insight browser tests
         env:
           CI: 'true'


### PR DESCRIPTION
## Summary
- add `.github/actions/setup-env` composite action for sandbox image, tool versions and Playwright setup
- reuse action in CI to cut down duplication

## Testing
- `python3 scripts/check_python_deps.py` *(fails: Missing packages)*
- `python3 check_env.py --auto-install` *(failed: externally managed environment)*
- `pre-commit run --files .github/actions/setup-env/action.yml .github/workflows/ci.yml` *(command not found)*
- `pytest -k test_ping_agent.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a34f5e1fc8333a336d8bf04f3c6f3