### PR TITLE
[alpha_factory] cache node deps and playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,258 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: ${{ env.NODE_LOCKFILES }}
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
+            alpha_factory_v1/core/interface/web_client/node_modules
+            alpha_factory_v1/core/interface/web_client/staking/node_modules
+            alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - name: Show tool versions
         run: |
           python --version
@@ -112,11 +364,8 @@ jobs:
         run: pip install pre-commit==4.2.0
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
-      - name: Clean insight browser node_modules
-        run: |
-          rm -rf alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/node_modules
-          npm cache verify
-          npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
+      - name: Install insight browser dependencies
+        run: npm ci --prefix alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1
       - name: Run pre-commit checks
         run: pre-commit run --all-files
         env:


### PR DESCRIPTION
## Summary
- cache node_modules and Playwright browsers in CI
- reuse caches across workflow jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: update-actions modified files)*

------
https://chatgpt.com/codex/tasks/task_e_688a3b61a50083338d7f2a0af324f413