### PR TITLE
ci: drop checkout from owner check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
     outputs:
       repo_owner_lower: ${{ steps.owner.outputs.repo_owner_lower }}
     steps:
-      - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         id: owner


### PR DESCRIPTION
## Summary
- remove checkout step from the owner-check job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688a54a8a12483338f93139155d93e46