### PR TITLE
[alpha_factory] improve owner check handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy (${{ matrix.python-version }})"
+    if: ${{ always() && needs.owner-check.result == 'success' }}
     needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -157,6 +158,7 @@ jobs:
 
   tests:
     name: "✅ Pytest (${{ matrix.python-version }})"
+    if: ${{ always() && needs.owner-check.result == 'success' }}
     needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- ensure lint and test jobs skip when owner verification fails

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: KeyboardInterrupt while installing environments)*
- `pytest tests/test_agents.py::test_grpc_bus_tls_message_exchange -q`

------
https://chatgpt.com/codex/tasks/task_e_688a88a751c08333b306f47896286820