### PR TITLE
fix: ensure owner job checks out repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     outputs:
       repo_owner_lower: ${{ steps.owner.outputs.repo_owner_lower }}
     steps:
+      - uses: actions/checkout@v4.2.2 # required for local actions
       - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         id: owner


### PR DESCRIPTION
## Summary
- run `actions/checkout` before using local action to verify repo owner

## Testing
- `pytest tests/test_agents.py::test_grpc_bus_tls_message_exchange -q`
- `pre-commit run --files .github/workflows/ci.yml` *(failed: interrupted while installing environments)*

------
https://chatgpt.com/codex/tasks/task_e_688a8c3f12808333881108bd832ea69d