### PR TITLE
[alpha_factory] fix CI owner step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
       repo_owner_lower: ${{ steps.owner.outputs.repo_owner_lower }}
     steps:
       - uses: actions/checkout@v4.2.2 # required for local actions
-      - uses: ./.github/actions/ensure-owner
+      - name: Verify owner
+        uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         id: owner
         shell: bash


### PR DESCRIPTION
## Summary
- ensure the owner verification step has a descriptive name in CI

## Testing
- `pre-commit run actionlint --files .github/workflows/ci.yml` *(failed: timed out while installing semgrep)*
- `python check_env.py --auto-install`
- `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov`


------
https://chatgpt.com/codex/tasks/task_e_688a99e8b2348333a7ce17c5fb21aae7