### PR TITLE
[alpha_factory] Add id-token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: write
+      id-token: write
     # This job builds and pushes the image.
     environment: ci-on-demand
     steps:
@@ -631,6 +632,10 @@ jobs:
     needs: [owner-check, tests, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     environment: ci-on-demand
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- allow docker job to request OpenID token
- give deploy job explicit permissions

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pytest` *(failed: test_aiga_openai_bridge_offline)*

------
https://chatgpt.com/codex/tasks/task_e_688b6947af788333bcd281c3f8769ebd