### PR TITLE
[alpha_factory] ensure CI uses local action correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     outputs:
       repo_owner_lower: ${{ steps.owner.outputs.repo_owner_lower }}
     steps:
+      # Checkout is mandatory before invoking local composite actions
       - uses: actions/checkout@v4.2.2 # required for local actions
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- clarify that checkout must run before calling local actions in CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest --maxfail=1 -q` *(1 failure: test_aiga_openai_bridge_offline.py::test_aiga_openai_bridge_offline)*

------
https://chatgpt.com/codex/tasks/task_e_688b6c5bfa1c8333ac24aad261230acd