### PR TITLE
Fix CI owner check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Verify owner
-        uses: ./.github/actions/ensure-owner
+        shell: bash
+        run: |
+          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
+            echo "Only the repository owner can run this workflow."
+            exit 1
+          fi
       - name: Compute repo_owner_lower
         id: owner
         shell: bash


### PR DESCRIPTION
## Summary
- inline the owner verification logic in the CI workflow

## Testing
- `python check_env.py --auto-install`
- `pytest tests/test_agents.py::test_grpc_bus_tls_message_exchange -q`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: environment build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688b81f88ba88333bab57c1898b72522