### PR TITLE
[alpha_factory] fix owner check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,18 +57,11 @@ jobs:
       - uses: actions/checkout@v4.2.2 # required for local actions
         with:
           fetch-depth: 0
-      - name: Verify owner
-        shell: bash
-        run: |
-          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
-            echo "Only the repository owner can run this workflow."
-            exit 1
-          fi
+      - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         id: owner
         shell: bash
         run: |
-          # Use parameter expansion to avoid spawning subshells
           repo_owner_lower="${GITHUB_REPOSITORY_OWNER,,}"
           echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- use the local `ensure-owner` composite action for consistency

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_aiga_openai_bridge_offline.py::test_aiga_openai_bridge_offline -q`


------
https://chatgpt.com/codex/tasks/task_e_688b85a39d688333a9bd474fd401f905