### PR TITLE
[alpha_factory] use ensure-owner action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # required for local actions
         with:
           fetch-depth: 0
-      - name: Verify owner
-        shell: bash
-        run: |
-          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
-            echo "Only the repository owner can run this workflow."
-            exit 1
-          fi
+      - uses: ./.github/actions/ensure-owner
       - name: Compute repo_owner_lower
         id: owner
         shell: bash


### PR DESCRIPTION
## Summary
- use the local ensure-owner composite action in `owner-check`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest --cov --cov-report=xml` *(fails: test_aiga_openai_bridge_offline)*

------
https://chatgpt.com/codex/tasks/task_e_688b93f029c883338f8a651c5a813f74