### PR TITLE
Improve owner-check output

### DIFF
--- a/.github/actions/ensure-owner/action.yml
+++ b/.github/actions/ensure-owner/action.yml
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 name: Ensure Repository Owner
 description: Fail if the workflow is triggered by someone other than the repository owner.
+outputs:
+  repo_owner_lower:
+    description: Lowercase repository owner
+    value: ${{ steps.set-owner.outputs.repo_owner_lower }}
 runs:
   using: composite
   steps:
@@ -11,3 +15,9 @@ runs:
           echo "Only the repository owner can run this workflow."
           exit 1
         fi
+    - name: Set owner output
+      id: set-owner
+      shell: bash
+      run: |
+        repo_owner_lower="${GITHUB_REPOSITORY_OWNER,,}"
+        echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,20 +51,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
-      repo_owner_lower: ${{ steps.owner.outputs.repo_owner_lower }}
+      repo_owner_lower: ${{ steps.ensure.outputs.repo_owner_lower }}
     steps:
       # Checkout is mandatory before invoking local composite actions
       - uses: actions/checkout@v4.2.2 # required for local actions
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/ensure-owner
-      - name: Compute repo_owner_lower
-        id: owner
-        shell: bash
-        run: |
-          # Use parameter expansion to avoid spawning subshells
-          repo_owner_lower="${GITHUB_REPOSITORY_OWNER,,}"
-          echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_OUTPUT"
+      - id: ensure
+        uses: ./.github/actions/ensure-owner
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy (${{ matrix.python-version }})"


### PR DESCRIPTION
## Summary
- expose lowercase repo owner from ensure-owner composite action
- use the new output in the CI workflow

## Testing
- `pre-commit run --files .github/actions/ensure-owner/action.yml .github/workflows/ci.yml`
- `pytest` *(fails: test_aiga_openai_bridge_offline and test_alpha_agi_insight_bridge.test_bridge_fallback)*

------
https://chatgpt.com/codex/tasks/task_e_688b96d1f18483339809ae1f5d6e91fb