### PR TITLE
Fix owner check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,15 @@ jobs:
         with:
           fetch-depth: 0
       - id: ensure
-        uses: ./.github/actions/ensure-owner
+        name: Verify repository owner
+        shell: bash
+        run: |
+          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
+            echo "Only the repository owner can run this workflow."
+            exit 1
+          fi
+          repo_owner_lower="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_OUTPUT"
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy (${{ matrix.python-version }})"


### PR DESCRIPTION
## Summary
- inline owner validation steps so the workflow doesn't rely on a local action

## Testing
- `pytest tests/test_agents.py::test_grpc_bus_tls_message_exchange -q`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: KeyboardInterrupt during semgrep env setup)*

------
https://chatgpt.com/codex/tasks/task_e_688b9ae7a87883339bb0906fb5a687b9