### PR TITLE
docs: align CI a11y threshold

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -55,8 +55,8 @@ previous `latest` image so production always points at a working build.
 - **📦 Deploy** – pushes the image and release assets on tags.
 - **♿ Accessibility audit** – runs `@axe-core/cli --stdout` on the built web client
   and calculates a score via `scripts/axe_score.py`. The pipeline fails if the
-  score is below the `a11y-threshold` input (default 90).
-  Keep this threshold at least 90 to maintain baseline accessibility.
+  score is below the `a11y-threshold` input (default 95).
+  Keep this threshold at least 95 to maintain baseline accessibility.
 
 Caching for Python and Node dependencies is enabled. The project stores
 `package-lock.json` files under the demo and web client folders rather than at


### PR DESCRIPTION
## Summary
- update docs/CI_WORKFLOW to reflect 95-point accessibility goal

## Testing
- `python scripts/check_python_deps.py`
- `python check_env.py --auto-install`
- `pre-commit run --files docs/CI_WORKFLOW.md`
- `pytest` *(fails: ModuleNotFoundError, KeyboardInterrupt)*
- `pre-commit run --all-files` *(fails: Node.js 22+ required)*

------
https://chatgpt.com/codex/tasks/task_e_688ba39874788333b2ca8ca5e0f4873d