### PR TITLE
[alpha_factory] update CI owner step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# The Python matrix targets stable versions 3.11–3.12.
+# The Python matrix targets stable versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,
 # full documentation builds, Docker image creation and deployment.
 name: "🚀 CI — Insight Demo"
@@ -58,15 +58,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: ensure
-        name: Verify repository owner
-        shell: bash
-        run: |
-          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
-            echo "Only the repository owner can run this workflow."
-            exit 1
-          fi
-          repo_owner_lower="${GITHUB_REPOSITORY_OWNER,,}"
-          echo "repo_owner_lower=$repo_owner_lower" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/ensure-owner
 
   lint-type:
     name: "🧹 Ruff + 🏷️ Mypy (${{ matrix.python-version }})"


### PR DESCRIPTION
## Summary
- document Python 3.11–3.13 for CI matrix
- reuse `ensure-owner` composite action

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688bac96be1c83338c5a96e2ebe33220