### PR TITLE
[alpha_factory] Document checkout requirement for owner check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
           fetch-depth: 0
       - id: ensure
         # Local composite action validates the workflow initiator
-        # Ensure checkout ran beforehand so action files are available
+        # Ensure checkout ran beforehand so action files are available.
+        # Without a prior checkout step GitHub Actions reports:
+        # "Can't find 'action.yml' or 'Dockerfile' under '.github/actions/ensure-owner'"
         uses: ./.github/actions/ensure-owner
 
   lint-type:


### PR DESCRIPTION
## Summary
- expand comment in CI workflow to explain missing `action.yml` error

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(failed: KeyboardInterrupt)*
- `pytest tests/test_agents.py::test_grpc_bus_tls_message_exchange -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688bb36f24a0833389834a1df885f1f9