### PR TITLE
Update CI docs for local action

### DIFF
--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -115,6 +115,10 @@ pre-commit run --files .github/workflows/ci.yml
 
 This lints the YAML and pins action versions so the pipeline stays reproducible.
 
+When adding local composite actions like `.github/actions/ensure-owner`, ensure
+`actions/checkout` executes first. GitHub skips checkout on manual dispatch
+without this step and later jobs fail with "Can't find 'action.yml'" errors.
+
 The workflow uploads benchmark and coverage artifacts only when the files exist. This avoids noisy "file not found" warnings on failed runs.
 
 ## Avoid skipped jobs


### PR DESCRIPTION
## Summary
- document that actions/checkout must run before using local actions in the CI workflow

## Testing
- `pre-commit run --files docs/CI_WORKFLOW.md`
- `pytest tests/test_aiga_openai_bridge_offline.py::test_aiga_openai_bridge_offline -q`

------
https://chatgpt.com/codex/tasks/task_e_688be0b1242083339a375cd1f8825610