### PR TITLE
[alpha_factory] Update CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# The Python matrix targets stable versions 3.11–3.13.
+# The Python matrix targets stable versions 3.11–3.12.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,
 # full documentation builds, Docker image creation and deployment.
 name: "🚀 CI — Insight Demo"
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
@@ -284,7 +284,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -332,7 +332,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'


### PR DESCRIPTION
## Summary
- keep manual workflow to run tests and deployment
- drop unsupported Python 3.13 from all jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest` *(fails: tests/test_aiga_openai_bridge_offline.py::test_aiga_openai_bridge_offline, tests/test_alpha_agi_insight_bridge.py::TestAlphaAgiInsightBridge::test_bridge_fallback)*

------
https://chatgpt.com/codex/tasks/task_e_688c0f1cdb688333bf5803d2c28ad97c