### PR TITLE
Fix owner-check checkout path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
+          path: .
       - id: ensure
         # Local composite action validates the workflow initiator
         # Ensure checkout ran beforehand so action files are available.


### PR DESCRIPTION
## Summary
- specify checkout path in CI owner-check

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_ping_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688c183d693c8333855e18a3408d75f0