### PR TITLE
Update cosign version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,7 +563,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: 'v2.5.3'
       - name: Sign web client artifact
         if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign-blob --yes --output-signature web-client.tar.gz.sig web-client.tar.gz
@@ -616,7 +616,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: 'v2.5.3'
       - name: Sign image
         if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
@@ -655,7 +655,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: 'v2.5.3'
       - name: Pull previous image
         run: docker pull ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest || true
       - name: Tag previous


### PR DESCRIPTION
## Summary
- use cosign v2.5.3 in CI workflows

## Checks
- `pre-commit run --files .github/workflows/ci.yml`
- `python check_env.py --auto-install`
- `pytest --cov --cov-report=xml` *(fails: 2 failed, 132 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c1eb42410833390ed6ed72ffb03ed