### PR TITLE
[alpha_factory] docs: clarify ensure-owner comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
         # Ensure checkout ran beforehand so action files are available.
         # Without a prior checkout step GitHub Actions reports:
         # "Can't find 'action.yml' or 'Dockerfile' under '.github/actions/ensure-owner'"
+        # The ensure-owner action fails fast if someone other than the
+        # repository owner triggers the workflow. This protects subsequent
+        # jobs from running under untrusted contexts.
         uses: ./.github/actions/ensure-owner
 
   lint-type:


### PR DESCRIPTION
## Summary
- expand comment on ensure-owner job explaining what it does

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: interrupted)*
- `pytest` *(fails: interrupted after 64 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c2233e8048333a69dbd64ff888116