### PR TITLE
[alpha_factory] Update Python version in world model README

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/README.md
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/README.md
@@ -253,7 +253,7 @@ Need help? Open an issue → **@MontrealAI/alpha-factory-core**.
 
 ## 10  Production checklist ✅
 
-- Ensure `python3 --version` returns 3.11–3.12.
+ - Ensure `python3 --version` returns 3.11–3.13.
 - Install dependencies: `pip install -r requirements.txt`.
 - Launch via `./deploy_alpha_asi_world_model_demo.sh` and visit `http://localhost:7860`.
 - The script sets `NO_LLM=1` automatically when `OPENAI_API_KEY` is unset.


### PR DESCRIPTION
## Summary
- docs: bump Python version range to 3.11–3.13 in the world model demo README

## Testing
- `pre-commit run --files alpha_factory_v1/demos/alpha_asi_world_model/README.md`

------
https://chatgpt.com/codex/tasks/task_e_688cb6ff7ed48333950a0a1b7531410c