### PR TITLE
ci: refresh workflow verification timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-01T22:42:00Z via `python tools/update_actions.py` and `pre-commit` (Codex run).
+# Verified 2025-08-01T23:21:01Z via `python tools/update_actions.py` and `pre-commit` (Codex run).
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11 and 3.12 alongside 3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,


### PR DESCRIPTION
## Summary
- rerun update_actions, run pre-commit hooks
- update the verification timestamp in `ci.yml`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688d4a6d6650833399aa984644f8de46