### PR TITLE
chore(ci): refresh workflow verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-02T00:27:38Z via `python tools/update_actions.py` and `pre-commit` (Codex run).
+# Verified 2025-08-02T01:40:03Z via `python tools/update_actions.py` and `pre-commit` (Codex run).
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11 and 3.12 alongside 3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,


### PR DESCRIPTION
## Summary
- refresh workflow verification timestamp
- confirm manual-only CI dispatch with full job coverage

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688d6a91e84483338c3af82272157bc3