### PR TITLE
ci: prevent downstream jobs from skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
   windows-smoke:
     name: "Windows Smoke"
     if: ${{ always() && needs.owner-check.result == 'success' }}
-    needs: [owner-check, lint-type, tests]
+    needs: owner-check
     runs-on: windows-latest
     timeout-minutes: 30
     environment: ci-on-demand
@@ -332,7 +332,7 @@ jobs:
   macos-smoke:
     name: "macOS Smoke"
     if: ${{ always() && needs.owner-check.result == 'success' }}
-    needs: [owner-check, lint-type, tests]
+    needs: owner-check
     environment: ci-on-demand
     runs-on: macos-latest
     timeout-minutes: 30
@@ -382,7 +382,7 @@ jobs:
   docs-check:
     name: "📜 MkDocs"
     if: ${{ always() && needs.owner-check.result == 'success' }}
-    needs: [owner-check, lint-type, tests]
+    needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -432,7 +432,7 @@ jobs:
   docs-build:
     name: "📚 Docs Build"
     if: ${{ always() && needs.owner-check.result == 'success' }}
-    needs: [owner-check, lint-type, tests]
+    needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -516,7 +516,7 @@ jobs:
   docker:
     name: "🐳 Docker build"
     if: ${{ always() && needs.owner-check.result == 'success' }}
-    needs: [owner-check, lint-type, tests]
+    needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:


### PR DESCRIPTION
## Summary
- ensure smoke, docs, and docker jobs depend only on owner-check so they still run when earlier jobs fail

## Testing
- `python tools/update_actions.py .github/workflows/ci.yml`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688d6d3074d48333a6e9b4fceeb53660