### PR TITLE
ci: target Python 3.11–3.12 in manual workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@
 # Tagged releases deploy a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-02T01:40:03Z via `python tools/update_actions.py` and `pre-commit` (Codex run).
-# The Python matrix targets stable versions 3.11–3.13.
-# Matrix verifies long-term support versions 3.11 and 3.12 alongside 3.13.
+# Verified 2025-08-02T02:04:24Z via `python tools/update_actions.py` and `pre-commit` (Codex run).
+# The Python matrix targets stable versions 3.11–3.12.
+# Matrix verifies long-term support versions 3.11 and 3.12.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,
 # full documentation builds, Docker image creation and deployment.
 # After editing this workflow run:
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
@@ -292,7 +292,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -340,7 +340,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -393,7 +393,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
@@ -446,7 +446,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
@@ -528,7 +528,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Export repo_owner_lower
@@ -635,7 +635,7 @@ jobs:
   deploy:
     name: "📦 Deploy"
     if: ${{ startsWith(github.ref, 'refs/tags/') && needs.owner-check.result == 'success' }}
-    needs: [owner-check, tests, docker]
+    needs: [owner-check, lint-type, tests, windows-smoke, macos-smoke, docs-build, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:


### PR DESCRIPTION
## Summary
- run linting and tests only on Python 3.11 and 3.12
- use Python 3.12 for smoke, docs, and docker jobs
- gate deploy on all CI jobs

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688d71532c908333b781549efa4b0519