### PR TITLE
ci: add Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
 # Verified 2025-08-02T02:04:24Z via `python tools/update_actions.py` and `pre-commit` (Codex run).
-# The Python matrix targets stable versions 3.11–3.12.
-# Matrix verifies long-term support versions 3.11 and 3.12.
+# The Python matrix targets stable versions 3.11–3.13.
+# Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,
 # full documentation builds, Docker image creation and deployment.
 # After editing this workflow run:
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- add Python 3.13 to lint-type and tests matrices
- document expanded Python support in CI workflow comments

## Testing
- `python tools/update_actions.py`
- `python check_env.py --auto-install`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688d7c39635883338000f35eb2000e39