### PR TITLE
ci: enumerate docs for pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,7 @@ jobs:
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Lint docs with pre-commit
-        run: pre-commit run --files docs
+        run: pre-commit run --files $(git ls-files 'docs/**')
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Build documentation
@@ -483,7 +483,7 @@ jobs:
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Lint docs with pre-commit
-        run: pre-commit run --files docs
+        run: pre-commit run --files $(git ls-files 'docs/**')
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Build insight browser


### PR DESCRIPTION
## Summary
- run pre-commit on explicit doc paths in CI

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688d7f5399208333b1a2f9871b7076a7