### PR TITLE
ci: run deploy on manual workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@
 # Runs only via manual dispatch by the repository owner using the "Run workflow" button.
 # Access is restricted through the owner-check job to ensure only the repository
 # owner can start this pipeline.
-# Tagged releases deploy a Docker image with rollback on failure.
+# Deploys a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-02T10:34:41Z via `python tools/update_actions.py` and manual `actionlint` (pre-commit semgrep install blocked).
+# Verified 2025-08-02T12:17:07Z via `python tools/update_actions.py` and `pre-commit`.
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,
@@ -560,28 +560,23 @@ jobs:
           make build_web
           test -f alpha_factory_v1/core/interface/web_client/dist/index.html
       - name: Archive web client dist
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           tar -czf web-client.tar.gz -C alpha_factory_v1/core/interface/web_client/dist .
           sha256sum web-client.tar.gz > web-client.sha256
       - name: Install cosign
-        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
           cosign-release: 'v2.5.3'
       - name: Sign web client artifact
-        if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign-blob --yes --output-signature web-client.tar.gz.sig web-client.tar.gz
       - name: Verify web client signature
-        if: startsWith(github.ref, 'refs/tags/')
         run: cosign verify-blob --signature web-client.tar.gz.sig web-client.tar.gz
       - name: Check web client artifact
-        if: startsWith(github.ref, 'refs/tags/')
         id: web-client-check
         run: |
           if [[ -f web-client.tar.gz ]]; then echo "found=true" >> "$GITHUB_OUTPUT"; fi
       - uses: actions/upload-artifact@v4.6.2 # ea165f8d65b6e75b540449e92b4886f43607fa02
-        if: startsWith(github.ref, 'refs/tags/') && steps.web-client-check.outputs.found == 'true'
+        if: steps.web-client-check.outputs.found == 'true'
         with:
           name: web-client
           path: |
@@ -606,32 +601,27 @@ jobs:
         run: |
           docker run --rm -e RUN_MODE=cli "$DOCKER_IMAGE:ci" simulate --horizon 1 --offline
       - name: Login to GHCR
-        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v3.4.0 # 74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push image
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           docker tag "$DOCKER_IMAGE:ci" ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
           docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
       - name: Install cosign
-        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3.9.2 # d58896d6a1865668819e1d91763c7751a165e159
         with:
           cosign-release: 'v2.5.3'
       - name: Sign image
-        if: startsWith(github.ref, 'refs/tags/')
         run: cosign sign --yes ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
       - name: Verify image signature
-        if: startsWith(github.ref, 'refs/tags/')
         run: cosign verify ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
 
   deploy:
     name: "📦 Deploy"
-    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.owner-check.result == 'success' }}
+    if: ${{ needs.owner-check.result == 'success' }}
     needs: [owner-check, lint-type, tests, windows-smoke, macos-smoke, docs-check, docs-build, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
## Summary
- ensure artifact signing, image publishing, and deployment run for any manual dispatch
- keep workflow manual-only with owner check

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688dffa53dd883339f9b32381d5f9470