### PR TITLE
ci: restrict deploy job to tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,7 +621,7 @@ jobs:
 
   deploy:
     name: "📦 Deploy"
-    if: ${{ needs.owner-check.result == 'success' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.owner-check.result == 'success' }}
     needs: [owner-check, lint-type, tests, windows-smoke, macos-smoke, docs-check, docs-build, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
## Summary
- deploy workflow only on tag pushes after owner verification

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e083e3a448333a08d23663514f521