### PR TITLE
ci: drop Python 3.13 from matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
 # Verified 2025-08-02T12:17:07Z via `python tools/update_actions.py` and `pre-commit`.
-# The Python matrix targets stable versions 3.11–3.13.
-# Matrix verifies long-term support versions 3.11–3.13.
+# The Python matrix targets stable versions 3.11–3.12.
+# Matrix verifies long-term support versions 3.11–3.12.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,
 # full documentation builds, Docker image creation and deployment.
 # After editing this workflow run:
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- remove Python 3.13 from lint-type and tests matrices
- document supported Python versions as 3.11–3.12

## Testing
- `python3.13 --version` *(fails: command not found)*
- `python check_env.py --auto-install`
- `pytest tests/test_benchmark.py -q` *(fails: API_TOKEN environment variable must be set)*
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e1c6b7868833384bdc0cb56cf4a15