### PR TITLE
chore(ci): add py3.13 to manual workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@
 # Deploys a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-02T12:17:07Z via `python tools/update_actions.py` and `pre-commit`.
-# The Python matrix targets stable versions 3.11–3.12.
-# Matrix verifies long-term support versions 3.11–3.12.
+# Verified 2025-08-02T14:27:13Z via `python tools/update_actions.py` and `pre-commit`.
+# The Python matrix targets stable versions 3.11–3.13.
+# Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,
 # full documentation builds, Docker image creation and deployment.
 # After editing this workflow run:
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       # checkout required for local composite actions
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
@@ -290,7 +290,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -338,7 +338,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           architecture: 'x64'
           cache: pip
           cache-dependency-path: 'requirements.lock'
@@ -391,7 +391,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
@@ -443,7 +443,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Cache pre-commit
@@ -525,7 +525,7 @@ jobs:
       - uses: actions/checkout@v4.2.2 # 11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@v5.6.0 # a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: 'requirements.lock'
       - name: Export repo_owner_lower


### PR DESCRIPTION
## Summary
- extend lint and test matrix to Python 3.13
- run smoke, docs and docker jobs on Python 3.13

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688e1f5afa148333ac15392ec4bf7c96