### PR TITLE
ci: restrict deploy job to tag refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
 
   deploy:
     name: "📦 Deploy"
-    if: ${{ needs.owner-check.result == 'success' }}
+    if: ${{ needs.owner-check.result == 'success' && startsWith(github.ref, 'refs/tags/') }}
     needs: [owner-check, lint-type, tests, windows-smoke, macos-smoke, docs-check, docs-build, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
## Summary
- limit deploy job to tag refs

## Testing
- `python check_env.py --auto-install`
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e2783617c8333a75cc751a0ece9c3