### PR TITLE
fix: retag deploy images from sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,10 +659,12 @@ jobs:
         run: docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous || true
       - name: Push previous tag
         run: docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:previous || true
-      - name: Push new image
+      - name: Pull release image
+        run: docker pull ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }}
+      - name: Tag and push new image
         run: |
-          docker tag "$DOCKER_IMAGE:ci" ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}
-          docker tag "$DOCKER_IMAGE:ci" ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}
+          docker tag ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.sha }} ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
           docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:${{ github.ref_name }}
           docker push ghcr.io/$repo_owner_lower/$DOCKER_IMAGE:latest
       - name: Sign release images


### PR DESCRIPTION
## Summary
- pull image by commit SHA before tagging and pushing in deploy job

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e2baa0368833383165e3febd7e990