### PR TITLE
ci: invalidate node caches on version changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,15 +108,17 @@ jobs:
             alpha_factory_v1/core/interface/web_client/node_modules
             alpha_factory_v1/core/interface/web_client/staking/node_modules
             alpha_factory_v1/demos/alpha_agi_insight_v1/src/interface/web_client/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}-${{ hashFiles('.nvmrc') }}
           restore-keys: |
+            node-modules-${{ runner.os }}-${{ hashFiles('.nvmrc') }}-
             node-modules-${{ runner.os }}-
       - name: Cache Playwright browsers
         uses: actions/cache@v4.2.3 # 5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}
+          key: playwright-${{ runner.os }}-${{ hashFiles(env.NODE_LOCKFILES) }}-${{ hashFiles('.nvmrc') }}
           restore-keys: |
+            playwright-${{ runner.os }}-${{ hashFiles('.nvmrc') }}-
             playwright-${{ runner.os }}-
       - name: Show tool versions
         run: |


### PR DESCRIPTION
## Summary
- cache node_modules and Playwright browsers with Node version hash

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688e3448464883338e984fb4ccf51f5d