### PR TITLE
ci: scope workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,7 @@ on:
         required: false
         default: "95"
 
-permissions:
-  contents: read
-  actions: read
-  checks:  write
-  packages: write
-  pull-requests: write
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -174,6 +169,8 @@ jobs:
     needs: owner-check
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      pull-requests: write
     environment: ci-on-demand
     env:
       SANDBOX_IMAGE: selfheal-sandbox:latest
@@ -521,7 +518,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      contents: write
+      packages: write
       id-token: write
     # This job builds and pushes the image.
     environment: ci-on-demand


### PR DESCRIPTION
## Summary
- default to read-only GitHub token across the CI workflow
- specify pull request access for tests and docs build jobs
- allow docker build job to push packages and use OIDC

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688e36624c308333859310e38f0996bb