### PR TITLE
ci: lint docs with xargs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,7 @@ jobs:
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Lint docs with pre-commit
-        run: pre-commit run --files $(git ls-files 'docs/**')
+        run: git ls-files -z 'docs/**' | xargs -0 pre-commit run --files
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Build documentation
@@ -481,7 +481,7 @@ jobs:
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Lint docs with pre-commit
-        run: pre-commit run --files $(git ls-files 'docs/**')
+        run: git ls-files -z 'docs/**' | xargs -0 pre-commit run --files
         env:
           PRE_COMMIT_HOME: .cache/pre-commit
       - name: Build insight browser


### PR DESCRIPTION
## Summary
- use xargs when running docs pre-commit lint to avoid long arg lists

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688e7abe6eac83339d918caf6f28f97e