### PR TITLE
chore: update ci workflow timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Deploys a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-02T14:42:01Z via `python tools/update_actions.py` and `pre-commit`.
+# Verified 2025-08-02T21:10:31Z via `python tools/update_actions.py` and `pre-commit`.
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,


### PR DESCRIPTION
## Summary
- refresh CI workflow verification timestamp after re-running update_actions.py and pre-commit

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_benchmark.py -q` *(fails: API_TOKEN environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688e7d2008608333a299ad95cbc660f5