### PR TITLE
ci: limit global permissions to contents read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ on:
         required: false
         default: "95"
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- use `permissions: contents: read` in CI workflow
- confirm job-level permissions still cover package publish and release steps

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e87fc27a48333bce6d548747ff3b2