### PR TITLE
ci: refresh workflow verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Deploys a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-02T23:58:40Z via `python tools/update_actions.py` and `pre-commit`.
+# Verified 2025-08-03T00:58:54Z via `python tools/update_actions.py` and `pre-commit`.
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,


### PR DESCRIPTION
## Summary
- refresh workflow verification timestamp and confirm manual owner-dispatched CI remains intact

## Testing
- `python tools/update_actions.py .github/workflows/ci.yml`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688eb07eee0883338c151d8e80ec15d1