### PR TITLE
chore: refresh CI workflow verification timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Deploys a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-03T00:58:54Z via `python tools/update_actions.py` and `pre-commit`.
+# Verified 2025-08-03T01:21:08Z via `python tools/update_actions.py` and `pre-commit`.
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,


### PR DESCRIPTION
## Summary
- refresh CI workflow verification timestamp after running update_actions and pre-commit

## Testing
- `python tools/update_actions.py .github/workflows/ci.yml`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688eb5f98f188333a637809d81288087