### PR TITLE
chore(ci): refresh workflow verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Deploys a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-03T01:21:08Z via `python tools/update_actions.py` and `pre-commit`.
+# Verified 2025-08-03T02:32:07Z via `python tools/update_actions.py` and `pre-commit`.
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,


### PR DESCRIPTION
## Summary
- refresh CI workflow verification timestamp

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(fails: tests/test_aiga_agents_import.py::test_import_with_agents_only, tests/test_alpha_agi_insight_bridge.py::TestAlphaAgiInsightBridge::test_bridge_fallback, tests/test_alpha_opportunity_stub.py::test_runtime_port_env, tests/test_api_server_subprocess.py::test_simulate_curve_subprocess, tests/test_api_server_subprocess.py::test_problem_json_subprocess, tests/test_api_server_subprocess.py::test_ws_progress_token_param)*

------
https://chatgpt.com/codex/tasks/task_e_688ec850d8888333a0be7d6281fcdcf1