### PR TITLE
chore: refresh CI workflow timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # Deploys a Docker image with rollback on failure.
 # Later jobs run unconditionally but check `needs.owner-check.result == 'success'`
 # so they skip when owner verification fails.
-# Verified 2025-08-03T05:33:50Z via `python tools/update_actions.py` and `pre-commit`.
+# Verified 2025-08-03T05:50:37Z via `python tools/update_actions.py` and `pre-commit`.
 # The Python matrix targets stable versions 3.11–3.13.
 # Matrix verifies long-term support versions 3.11–3.13.
 # Jobs cover linting, unit tests, Windows and macOS smoke tests,


### PR DESCRIPTION
## Summary
- refresh CI workflow verification timestamp

## Testing
- `python tools/update_actions.py`
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_688ef6cdb87c8333b7b448a73b41cdd0