### PR TITLE
feat: add JobRegistry v2 contract

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+interface IValidationModule {
+    function validate(uint256 jobId, bytes calldata data) external returns (bool);
+}
+
+interface IStakeManager {
+    function lock(address user, uint256 amount) external;
+    function release(address user, uint256 amount) external;
+}
+
+interface IReputationEngine {
+    function onApply(address user) external;
+    function onFinalize(address user, bool success) external;
+}
+
+interface IDisputeModule {
+    function onFinalize(uint256 jobId) external;
+}
+
+interface ICertificateNFT {
+    function mint(address to, uint256 jobId) external;
+}
+
+contract JobRegistry is Ownable {
+    enum Status {
+        None,
+        Created,
+        Applied,
+        Submitted,
+        Finalized
+    }
+
+    struct Job {
+        address client;      // 20 bytes
+        uint96 reward;       // 12 bytes (fits with client in one slot)
+        address worker;      // 20 bytes
+        uint40 createdAt;    // 5 bytes
+        uint40 deadline;     // 5 bytes
+        Status status;       // 1 byte
+    }
+
+    uint256 public nextJobId;
+    mapping(uint256 => Job) public jobs;
+
+    IValidationModule public validationModule;
+    IStakeManager public stakeManager;
+    IReputationEngine public reputationEngine;
+    IDisputeModule public disputeModule;
+    ICertificateNFT public certificateNFT;
+
+    event JobCreated(uint256 indexed jobId, address indexed client, uint96 reward, uint40 deadline);
+    event JobApplied(uint256 indexed jobId, address indexed worker);
+    event JobSubmitted(uint256 indexed jobId, address indexed worker, bytes submission);
+    event JobFinalized(uint256 indexed jobId, address indexed worker);
+    event ModulesUpdated(
+        address validationModule,
+        address stakeManager,
+        address reputationEngine,
+        address disputeModule,
+        address certificateNFT
+    );
+
+    constructor() Ownable(msg.sender) {}
+
+    /// @notice Sets module contract addresses
+    /// @param _validation Address of validation module
+    /// @param _stake Address of stake manager
+    /// @param _reputation Address of reputation engine
+    /// @param _dispute Address of dispute module
+    /// @param _certificate Address of certificate NFT
+    function setModules(
+        address _validation,
+        address _stake,
+        address _reputation,
+        address _dispute,
+        address _certificate
+    ) external onlyOwner {
+        validationModule = IValidationModule(_validation);
+        stakeManager = IStakeManager(_stake);
+        reputationEngine = IReputationEngine(_reputation);
+        disputeModule = IDisputeModule(_dispute);
+        certificateNFT = ICertificateNFT(_certificate);
+        emit ModulesUpdated(_validation, _stake, _reputation, _dispute, _certificate);
+    }
+
+    /// @notice Creates a new job and locks client stake
+    /// @param reward Payment amount locked in the stake manager
+    /// @param deadline Unix timestamp for job deadline
+    /// @return jobId Identifier of the created job
+    function createJob(uint96 reward, uint40 deadline) external returns (uint256 jobId) {
+        stakeManager.lock(msg.sender, reward);
+        jobId = ++nextJobId;
+        jobs[jobId] = Job({
+            client: msg.sender,
+            reward: reward,
+            worker: address(0),
+            createdAt: uint40(block.timestamp),
+            deadline: deadline,
+            status: Status.Created
+        });
+        emit JobCreated(jobId, msg.sender, reward, deadline);
+    }
+
+    /// @notice Applies for an open job
+    /// @param jobId Identifier of the job
+    function apply(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.status == Status.Created, "invalid status");
+        reputationEngine.onApply(msg.sender);
+        job.worker = msg.sender;
+        job.status = Status.Applied;
+        emit JobApplied(jobId, msg.sender);
+    }
+
+    /// @notice Submits work for a job, validated by validation module
+    /// @param jobId Identifier of the job
+    /// @param data Submission payload
+    function submit(uint256 jobId, bytes calldata data) external {
+        Job storage job = jobs[jobId];
+        require(job.worker == msg.sender, "not worker");
+        require(job.status == Status.Applied, "invalid status");
+        require(validationModule.validate(jobId, data), "validation failed");
+        job.status = Status.Submitted;
+        emit JobSubmitted(jobId, msg.sender, data);
+    }
+
+    /// @notice Finalizes a job and releases payment
+    /// @param jobId Identifier of the job
+    function finalize(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.client == msg.sender, "not client");
+        require(job.status == Status.Submitted, "invalid status");
+        stakeManager.release(job.worker, job.reward);
+        reputationEngine.onFinalize(job.worker, true);
+        if (address(disputeModule) != address(0)) {
+            disputeModule.onFinalize(jobId);
+        }
+        if (address(certificateNFT) != address(0)) {
+            certificateNFT.mint(job.worker, jobId);
+        }
+        job.status = Status.Finalized;
+        emit JobFinalized(jobId, job.worker);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add JobRegistry contract with packed job struct and state machine
- allow owner to configure validation/stake/reputation/dispute/certificate modules
- emit events for job lifecycle transitions

## Testing
- `pre-commit run --files contracts/v2/JobRegistry.sol`

------
https://chatgpt.com/codex/tasks/task_e_68964b90457483338fc06592d3e3e978