### PR TITLE
feat: add commit-reveal validation module

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+interface IStakeManager {
+    function reward(address user, uint256 amount) external;
+    function slash(address user, uint256 amount) external;
+}
+
+interface IReputationEngine {
+    function onValidate(address user, bool success) external;
+}
+
+interface IValidationModule {
+    function validate(uint256 jobId, bytes calldata data) external returns (bool);
+}
+
+contract ValidationModule is Ownable, IValidationModule {
+    struct Vote {
+        bytes32 commit;
+        bool revealed;
+        bool vote;
+    }
+
+    struct Round {
+        uint64 commitEnd;
+        uint64 revealEnd;
+        address[] validators;
+        bool tallied;
+        bool result;
+        mapping(address => Vote) votes;
+    }
+
+    uint256 public commitWindow;
+    uint256 public revealWindow;
+    uint256[] public validatorCountTiers;
+    uint256[] public slashingPercentages; // basis points
+    uint256 public selectionSeed;
+
+    IStakeManager public stakeManager;
+    IReputationEngine public reputationEngine;
+
+    mapping(uint256 => Round) private rounds;
+
+    event ValidatorSelected(uint256 indexed jobId, address indexed validator);
+    event VoteCommitted(uint256 indexed jobId, address indexed validator);
+    event VoteRevealed(uint256 indexed jobId, address indexed validator, bool vote);
+    event Tallied(uint256 indexed jobId, bool result);
+    event ParametersUpdated();
+
+    constructor(address _stakeManager, address _reputation) Ownable(msg.sender) {
+        stakeManager = IStakeManager(_stakeManager);
+        reputationEngine = IReputationEngine(_reputation);
+    }
+
+    function validate(uint256 jobId, bytes calldata) external override returns (bool) {
+        Round storage r = rounds[jobId];
+        require(r.commitEnd == 0, "exists");
+        r.commitEnd = uint64(block.timestamp + commitWindow);
+        r.revealEnd = uint64(block.timestamp + commitWindow + revealWindow);
+        uint256 count = validatorCountTiers.length > 0 ? validatorCountTiers[0] : 0;
+        r.validators = new address[](count);
+        for (uint256 i = 0; i < count; i++) {
+            address v = address(uint160(uint256(keccak256(abi.encode(blockhash(block.number - 1 - i), selectionSeed, jobId, i)))));
+            r.validators[i] = v;
+            emit ValidatorSelected(jobId, v);
+        }
+        return true;
+    }
+
+    function commitVote(uint256 jobId, bytes32 commitHash) external {
+        Round storage r = rounds[jobId];
+        require(block.timestamp <= r.commitEnd, "commit over");
+        require(isValidator(jobId, msg.sender), "not validator");
+        Vote storage v = r.votes[msg.sender];
+        require(v.commit == bytes32(0), "committed");
+        v.commit = commitHash;
+        emit VoteCommitted(jobId, msg.sender);
+    }
+
+    function revealVote(uint256 jobId, bool vote, bytes32 salt) external {
+        Round storage r = rounds[jobId];
+        require(block.timestamp > r.commitEnd && block.timestamp <= r.revealEnd, "not reveal phase");
+        Vote storage v = r.votes[msg.sender];
+        require(v.commit == keccak256(abi.encode(vote, salt)), "invalid reveal");
+        require(!v.revealed, "revealed");
+        v.revealed = true;
+        v.vote = vote;
+        emit VoteRevealed(jobId, msg.sender, vote);
+    }
+
+    function tally(uint256 jobId, uint256 reward) external {
+        Round storage r = rounds[jobId];
+        require(block.timestamp > r.revealEnd, "reveal not over");
+        require(!r.tallied, "tallied");
+        uint256 yes;
+        uint256 no;
+        uint256 slashAmount = (reward * (slashingPercentages.length > 0 ? slashingPercentages[0] : 0)) / 10_000;
+        for (uint256 i = 0; i < r.validators.length; i++) {
+            address validator = r.validators[i];
+            Vote storage v = r.votes[validator];
+            if (v.revealed) {
+                if (v.vote) {
+                    yes++;
+                } else {
+                    no++;
+                }
+            } else {
+                stakeManager.slash(validator, slashAmount);
+                reputationEngine.onValidate(validator, false);
+            }
+        }
+        r.result = yes >= no; // tie defaults to success
+        r.tallied = true;
+        for (uint256 i = 0; i < r.validators.length; i++) {
+            address validator = r.validators[i];
+            Vote storage v = r.votes[validator];
+            if (v.revealed) {
+                if (v.vote == r.result) {
+                    stakeManager.reward(validator, reward);
+                    reputationEngine.onValidate(validator, true);
+                } else {
+                    stakeManager.slash(validator, slashAmount);
+                    reputationEngine.onValidate(validator, false);
+                }
+            }
+        }
+        emit Tallied(jobId, r.result);
+    }
+
+    function isValidator(uint256 jobId, address user) public view returns (bool) {
+        Round storage r = rounds[jobId];
+        for (uint256 i = 0; i < r.validators.length; i++) {
+            if (r.validators[i] == user) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function setWindows(uint256 commitWindow_, uint256 revealWindow_) external onlyOwner {
+        commitWindow = commitWindow_;
+        revealWindow = revealWindow_;
+        emit ParametersUpdated();
+    }
+
+    function setValidatorCountTiers(uint256[] calldata counts) external onlyOwner {
+        validatorCountTiers = counts;
+        emit ParametersUpdated();
+    }
+
+    function setSlashingPercentages(uint256[] calldata pcts) external onlyOwner {
+        slashingPercentages = pcts;
+        emit ParametersUpdated();
+    }
+
+    function setSelectionSeed(uint256 seed) external onlyOwner {
+        selectionSeed = seed;
+        emit ParametersUpdated();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add validation module implementing commit-reveal voting with random validator selection
- tally votes, issuing stake rewards and slashes
- owner configurable windows, validator tiers, slashing percentages, and selection seed

## Testing
- `solcjs --bin contracts/v2/ValidationModule.sol` *(fails: Source "@openzeppelin/contracts/access/Ownable.sol" not found)*
- `pre-commit run --files contracts/v2/ValidationModule.sol`


------
https://chatgpt.com/codex/tasks/task_e_689650e40d2c8333bc93aee42805c0cc