### PR TITLE
feat: enhance validation workflow

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -6,6 +6,7 @@ import "./IdentityLib.sol";
 
 interface IValidationModule {
     function validate(uint256 jobId, bytes calldata data) external returns (bool);
+    function validationResult(uint256 jobId) external view returns (bool);
 }
 
 interface IStakeManager {
@@ -241,6 +242,7 @@ contract JobRegistry is Ownable {
     function finalize(uint256 jobId) external onlyOwner {
         Job storage job = jobs[jobId];
         require(job.status == Status.Submitted, "invalid status");
+        require(validationModule.validationResult(jobId), "validation failed");
         stakeManager.release(job.worker, job.reward);
         reputationEngine.onFinalize(job.worker, true);
         if (address(disputeModule) != address(0)) {


### PR DESCRIPTION
## Summary
- add configurable commit/reveal windows, validator count, selection seed, staking + slashing params
- select validators from allowlisted pool with stake and blacklist checks
- expose validation results and gate job finalization on successful tally

## Testing
- `pre-commit run --files contracts/v2/ValidationModule.sol contracts/v2/JobRegistry.sol`


------
https://chatgpt.com/codex/tasks/task_e_689f7e0eef0c8333b519bc64faa6365c