### PR TITLE
fix: validate withdraw amount

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -127,6 +127,7 @@ contract StakeManager is Ownable {
 
     /// @notice Withdraws available stake for a specific role
     function withdrawStake(Role role, uint256 amount) external {
+        require(amount > 0, "amount 0");
         if (role == Role.Agent) {
             require(agentStakes[msg.sender] >= amount, "insufficient");
             uint256 remaining = agentStakes[msg.sender] - amount;


### PR DESCRIPTION
## Summary
- guard against zero-value stake withdrawals

## Testing
- `pre-commit run --hook-stage manual black --files contracts/v2/StakeManager.sol contracts/v2/JobRegistry.sol` *(fails: Interrupted (KeyboardInterrupt) during semgrep environment initialization)*
- `pytest tests/test_slash_e2e.py::test_slash_on_forged_ledger -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa275dd3c8333a24f0e8fca315a7f