### PR TITLE
feat: overhaul staking and escrow logic

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -15,13 +15,16 @@ contract StakeManager is Ownable {
 
     enum Role {
         Agent,
+        Employer,
         Validator
     }
 
     mapping(address => uint256) public agentStakes;
+    mapping(address => uint256) public employerStakes;
     mapping(address => uint256) public validatorStakes;
 
     uint256 public minStakeAgent;
+    uint256 public minStakeEmployer;
     uint256 public minStakeValidator;
 
     uint256 public feePct; // basis points
@@ -29,12 +32,20 @@ contract StakeManager is Ownable {
 
     mapping(address => uint256) public agiTypePayoutPct;
     address[] public agiTypes;
+    mapping(uint256 => uint256) public jobEscrows;
 
     event StakeDeposited(address indexed user, Role role, uint256 amount);
     event StakeWithdrawn(address indexed user, Role role, uint256 amount);
-    event FundsLocked(address indexed user, uint256 amount);
-    event FundsReleased(address indexed user, uint256 amount, uint256 fee, uint256 burn);
+    event FundsLocked(uint256 indexed jobId, address indexed employer, uint256 amount);
+    event FundsReleased(
+        uint256 indexed jobId,
+        address indexed recipient,
+        uint256 amount,
+        uint256 fee,
+        uint256 burn
+    );
     event StakeSlashed(
+        uint256 indexed jobId,
         address indexed offender,
         address indexed employer,
         uint256 amount,
@@ -43,7 +54,7 @@ contract StakeManager is Ownable {
     );
 
     constructor(address _token, address _treasury) Ownable(msg.sender) {
-        agiToken = IERC20(_token);
+        agiToken = IERC20(_token); // default $AGIALPHA (6 decimals)
         treasury = _treasury;
     }
 
@@ -72,6 +83,11 @@ contract StakeManager is Ownable {
     /// @notice Sets minimum stake for agents
     function setMinStakeAgent(uint256 amount) external onlyOwner {
         minStakeAgent = amount;
+    }
+
+    /// @notice Sets minimum stake for employers
+    function setMinStakeEmployer(uint256 amount) external onlyOwner {
+        minStakeEmployer = amount;
     }
 
     /// @notice Sets minimum stake for validators
@@ -117,6 +133,10 @@ contract StakeManager is Ownable {
             uint256 newStake = agentStakes[msg.sender] + amount;
             require(newStake >= minStakeAgent, "below min");
             agentStakes[msg.sender] = newStake;
+        } else if (role == Role.Employer) {
+            uint256 newStake = employerStakes[msg.sender] + amount;
+            require(newStake >= minStakeEmployer, "below min");
+            employerStakes[msg.sender] = newStake;
         } else {
             uint256 newStake = validatorStakes[msg.sender] + amount;
             require(newStake >= minStakeValidator, "below min");
@@ -133,6 +153,11 @@ contract StakeManager is Ownable {
             uint256 remaining = agentStakes[msg.sender] - amount;
             require(remaining == 0 || remaining >= minStakeAgent, "below min");
             agentStakes[msg.sender] = remaining;
+        } else if (role == Role.Employer) {
+            require(employerStakes[msg.sender] >= amount, "insufficient");
+            uint256 remaining = employerStakes[msg.sender] - amount;
+            require(remaining == 0 || remaining >= minStakeEmployer, "below min");
+            employerStakes[msg.sender] = remaining;
         } else {
             require(validatorStakes[msg.sender] >= amount, "insufficient");
             uint256 remaining = validatorStakes[msg.sender] - amount;
@@ -148,30 +173,50 @@ contract StakeManager is Ownable {
         _;
     }
 
-    /// @notice Locks client funds for a job
-    function lock(address user, uint256 amount) public onlyJobRegistry {
-        require(agentStakes[user] >= amount, "insufficient");
-        agentStakes[user] -= amount;
-        emit FundsLocked(user, amount);
+    /// @notice Locks employer funds for a job
+    function lock(uint256 jobId, address employer, uint256 amount) public onlyJobRegistry {
+        require(jobEscrows[jobId] == 0, "escrow exists");
+        agiToken.transferFrom(employer, address(this), amount);
+        jobEscrows[jobId] = amount;
+        emit FundsLocked(jobId, employer, amount);
     }
 
-    /// @notice Releases locked funds applying fees and burns
-    function release(address user, uint256 amount) public onlyJobRegistry {
+    /// @notice Releases locked funds applying fees, burns and validator rewards
+    function release(
+        uint256 jobId,
+        address recipient,
+        address[] calldata validators,
+        uint256 validatorPct
+    ) public onlyJobRegistry {
+        uint256 amount = jobEscrows[jobId];
+        require(amount > 0, "no escrow");
+        delete jobEscrows[jobId];
+
         uint256 fee = (amount * feePct) / 10_000;
         uint256 burn = (amount * burnPct) / 10_000;
-        uint256 payout = amount - fee - burn;
+        uint256 net = amount - fee - burn;
+
+        uint256 validatorReward = (net * validatorPct) / 100;
+        uint256 perValidator = validators.length > 0 ? validatorReward / validators.length : 0;
+        uint256 payout = net - (perValidator * validators.length);
+
         uint256 pct = 10_000;
         for (uint256 i = 0; i < agiTypes.length; i++) {
             address nft = agiTypes[i];
-            if (agiTypePayoutPct[nft] > pct && IERC721(nft).balanceOf(user) > 0) {
+            if (agiTypePayoutPct[nft] > pct && IERC721(nft).balanceOf(recipient) > 0) {
                 pct = agiTypePayoutPct[nft];
             }
         }
         payout = (payout * pct) / 10_000;
+
         if (fee > 0) agiToken.transfer(treasury, fee);
         if (burn > 0) agiToken.transfer(address(0), burn);
-        agiToken.transfer(user, payout);
-        emit FundsReleased(user, payout, fee, burn);
+        for (uint256 i = 0; i < validators.length; i++) {
+            if (perValidator > 0) agiToken.transfer(validators[i], perValidator);
+        }
+        agiToken.transfer(recipient, payout);
+
+        emit FundsReleased(jobId, recipient, payout, fee, burn);
     }
 
     modifier onlySlasher() {
@@ -184,7 +229,8 @@ contract StakeManager is Ownable {
         address offender,
         address employer,
         uint256 amount,
-        uint256 burnPctOverride
+        uint256 burnPctOverride,
+        uint256 jobId
     ) external onlySlasher {
         uint256 available = validatorStakes[offender];
         if (available >= amount) {
@@ -202,7 +248,7 @@ contract StakeManager is Ownable {
         if (burnAmount > 0) {
             agiToken.transfer(address(0), burnAmount);
         }
-        emit StakeSlashed(offender, employer, amount, compensation, burnAmount);
+        emit StakeSlashed(jobId, offender, employer, amount, compensation, burnAmount);
     }
 }
 


### PR DESCRIPTION
## Summary
- separate agent, employer, and validator stakes
- lock funds from employer wallets and track escrow per job
- distribute validator rewards on release with configurable percentage

## Testing
- `pre-commit run --files contracts/v2/StakeManager.sol contracts/v2/JobRegistry.sol contracts/v2/ValidationModule.sol`


------
https://chatgpt.com/codex/tasks/task_e_68a8a8b32f388333a3a01d83b0530775