### PR TITLE
feat: add Certificate NFT

### DIFF
--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title CertificateNFT
+/// @notice ERC721 token representing job completion certificates with optional marketplace functionality
+contract CertificateNFT is ERC721, Ownable {
+    IERC20 public agiAlpha;
+    address public jobRegistry;
+    string private baseTokenURI;
+
+    struct Listing {
+        address seller;
+        uint256 price;
+    }
+
+    mapping(uint256 => Listing) public listings;
+
+    event NFTIssued(address indexed to, uint256 indexed tokenId, uint256 indexed jobId);
+    event NFTListed(uint256 indexed tokenId, address indexed seller, uint256 price);
+    event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
+    event NFTDelisted(uint256 indexed tokenId);
+
+    constructor(address _agiAlpha) ERC721("CertificateNFT", "CERT") Ownable(msg.sender) {
+        agiAlpha = IERC20(_agiAlpha);
+    }
+
+    /// @notice Sets the JobRegistry authorized to mint certificates
+    function setJobRegistry(address registry) external onlyOwner {
+        jobRegistry = registry;
+    }
+
+    /// @notice Updates the base URI for token metadata
+    function setBaseURI(string memory uri) external onlyOwner {
+        baseTokenURI = uri;
+    }
+
+    /// @dev Returns the base URI for token metadata
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+
+    /// @notice Mints a certificate NFT for a completed job
+    function mint(address to, uint256 jobId) external {
+        require(msg.sender == jobRegistry, "not registry");
+        _safeMint(to, jobId);
+        emit NFTIssued(to, jobId, jobId);
+    }
+
+    /// @notice Lists a certificate NFT for sale
+    function list(uint256 tokenId, uint256 price) external {
+        require(ownerOf(tokenId) == msg.sender, "not owner");
+        require(price > 0, "price 0");
+        listings[tokenId] = Listing({seller: msg.sender, price: price});
+        emit NFTListed(tokenId, msg.sender, price);
+    }
+
+    /// @notice Removes a certificate NFT from sale
+    function delist(uint256 tokenId) external {
+        Listing memory listing = listings[tokenId];
+        require(listing.seller == msg.sender, "not seller");
+        delete listings[tokenId];
+        emit NFTDelisted(tokenId);
+    }
+
+    /// @notice Purchases a listed certificate NFT using $AGIALPHA tokens
+    function purchase(uint256 tokenId) external {
+        Listing memory listing = listings[tokenId];
+        require(listing.price > 0, "not listed");
+        require(ownerOf(tokenId) == listing.seller, "not seller");
+        agiAlpha.transferFrom(msg.sender, listing.seller, listing.price);
+        delete listings[tokenId];
+        _transfer(listing.seller, msg.sender, tokenId);
+        emit NFTPurchased(tokenId, msg.sender, listing.price);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CertificateNFT ERC721 with job-registry-controlled minting and base URI setter
- implement simple marketplace to list, purchase, and delist certificates using $AGIALPHA

## Testing
- `pre-commit run black --files contracts/v2/CertificateNFT.sol`
- `pre-commit run ruff --files contracts/v2/CertificateNFT.sol`
- `pre-commit run ruff-format --files contracts/v2/CertificateNFT.sol`
- `pre-commit run flake8 --files contracts/v2/CertificateNFT.sol`
- `pytest -q` *(fails: AttributeError: module 'alpha_factory_v1.demos.aiga_m...' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b7768edc8333b1d6db36d9f49867