### PR TITLE
feat: hardcode AGIALPHA token constants

### DIFF
--- a/contracts/v2/Constants.sol
+++ b/contracts/v2/Constants.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+library Constants {
+    address constant AGIALPHA = 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA;
+    uint8 constant AGIALPHA_DECIMALS = 18;
+}
+

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "./Constants.sol";
 
 /// @title StakeManager
 /// @notice Handles staking and escrow of AGI tokens for jobs and validators
@@ -53,15 +55,13 @@ contract StakeManager is Ownable {
         uint256 burned
     );
 
-    constructor(address _token, address _treasury) Ownable(msg.sender) {
-        agiToken = IERC20(_token); // default $AGIALPHA (6 decimals)
+    constructor(address _treasury) Ownable(msg.sender) {
+        agiToken = IERC20(Constants.AGIALPHA); // uses $AGIALPHA (18 decimals)
         treasury = _treasury;
-    }
-
-    /// @notice Updates the AGI token address
-    /// @param _token New token address
-    function setToken(address _token) external onlyOwner {
-        agiToken = IERC20(_token);
+        require(
+            IERC20Metadata(Constants.AGIALPHA).decimals() == Constants.AGIALPHA_DECIMALS,
+            "wrong decimals"
+        );
     }
 
     /// @notice Updates the treasury address


### PR DESCRIPTION
## Summary
- add reusable `Constants.sol` for AGIALPHA token address and decimals
- initialize StakeManager with AGIALPHA constant and verify token decimals
- drop runtime token setter in favor of fixed constant

## Testing
- `pre-commit run --files contracts/v2/StakeManager.sol contracts/v2/Constants.sol`


------
https://chatgpt.com/codex/tasks/task_e_68b3313e17bc8333b83788dd62fb1ac0