### PR TITLE
feat: add token unit conversion helpers

### DIFF
--- a/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.py
+++ b/alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.py
@@ -50,6 +50,7 @@ from typing import Dict, List, Sequence
 import httpx
 from eth_account import Account  # type: ignore
 from web3 import HTTPProvider, Web3  # type: ignore
+from alpha_factory_v1.utils.token_utils import to_token_units
 
 # Alpha‑Factory primitives (import‑safe even when run standalone)
 try:
@@ -244,7 +245,8 @@ def _dispatch_payout(eur_amount: float, wallet: str):
         raise RuntimeError("RPC_URL not set; cannot dispatch on‑chain payout.")
     w3 = Web3(HTTPProvider(rpc))
     acct = Account.from_key(os.getenv("PRIVATE_KEY"))
-    wei_amt = int(eur_amount * 1e18 / 1.07)  # assume 1 $AGIALPHA ≈ €1.07
+    token_amt = eur_amount / 1.07  # assume 1 $AGIALPHA ≈ €1.07
+    wei_amt = to_token_units(token_amt)
     tx = {
         "to": wallet,
         "value": wei_amt,

--- a/alpha_factory_v1/utils/__init__.py
+++ b/alpha_factory_v1/utils/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 """Utility helpers for Alpha-Factory."""
 
-__all__ = ["env"]
+__all__ = ["env", "token_utils"]

--- a/alpha_factory_v1/utils/token_utils.py
+++ b/alpha_factory_v1/utils/token_utils.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utility functions for AGIALPHA token unit conversion."""
+
+AGIALPHA_DECIMALS = 18
+UNIT = 10**AGIALPHA_DECIMALS
+
+
+def to_token_units(amount: float | int) -> int:
+    """Convert a token amount to base units."""
+    return int(amount * UNIT)
+
+
+def from_token_units(amount: int) -> float:
+    """Convert base units to whole tokens."""
+    return amount / UNIT

--- a/contracts/v2/TokenUtils.sol
+++ b/contracts/v2/TokenUtils.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./Constants.sol";
+
+/// @title TokenUtils
+/// @notice Helper functions for converting between whole $AGIALPHA tokens and
+/// their smallest units.
+library TokenUtils {
+    uint256 internal constant UNIT = 10 ** uint256(Constants.AGIALPHA_DECIMALS);
+
+    /// @notice Converts whole tokens to base units (wei-style)
+    /// @param amount Amount in whole tokens
+    /// @return Amount scaled by 10**18
+    function toTokenUnits(uint256 amount) internal pure returns (uint256) {
+        return amount * UNIT;
+    }
+
+    /// @notice Converts base units to whole tokens
+    /// @param amount Amount in base units
+    /// @return Amount divided by 10**18
+    function fromTokenUnits(uint256 amount) internal pure returns (uint256) {
+        return amount / UNIT;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add TokenUtils.sol library for AGIALPHA conversions
- expose Python token_utils and remove manual `1e18` literals in royalty payout demo

## Testing
- `pre-commit run --files contracts/v2/TokenUtils.sol alpha_factory_v1/utils/token_utils.py alpha_factory_v1/utils/__init__.py alpha_factory_v1/demos/meta_agentic_agi_v3/businesses/royalty_radar.py`

------
https://chatgpt.com/codex/tasks/task_e_68b33edf6c6483338d7a3d4620175647