### PR TITLE
docs: document ERC20 approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1786,6 +1786,24 @@ ultimate α‑signal engine.
 - **Address:** `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`
 - **Decimals:** `18` (ERC‑20 standard; 1 token = 1e18 base units)
 
+#### ERC‑20 Approvals
+
+Staking and job escrow pull funds via `transferFrom`, so each account must
+`approve` the `StakeManager` contract before staking or posting a job. `$AGIALPHA`
+uses 18 decimals, meaning `1e18` represents one token.
+
+```bash
+# Allow the StakeManager to move 100 AGIALPHA for your stake
+cast send 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA \
+  "approve(address,uint256)" $STAKEMANAGER 100e18
+
+# Authorize 50 AGIALPHA to be locked as job escrow
+cast send 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA \
+  "approve(address,uint256)" $STAKEMANAGER 50e18
+```
+
+Replace `$STAKEMANAGER` with the deployed contract address.
+
 <a name="15-license"></a>
 ## 15 · License
 

--- a/docs/DEPLOYMENT_QUICKSTART.md
+++ b/docs/DEPLOYMENT_QUICKSTART.md
@@ -7,6 +7,24 @@ This guide summarizes how to publish the **α‑AGI Insight** demo using GitHub 
 - **Token Address:** `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`
 - **Token Decimals:** `18` (ERC‑20 standard; 1 token = 1e18 base units)
 
+## ERC‑20 Approvals for Staking and Escrow
+
+The `StakeManager` contract pulls `$AGIALPHA` via `transferFrom`. Before staking
+or locking job funds, approve the contract to move tokens on your behalf. The
+token uses 18 decimals, so `1e18` equals one token.
+
+```bash
+# Approve 100 AGIALPHA for staking
+cast send 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA \
+  "approve(address,uint256)" $STAKEMANAGER 100e18
+
+# Approve 50 AGIALPHA for job escrow
+cast send 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA \
+  "approve(address,uint256)" $STAKEMANAGER 50e18
+```
+
+Replace `$STAKEMANAGER` with the deployed contract address.
+
 ## Prerequisites
 
 - **Python ≥3.11** with `mkdocs` installed


### PR DESCRIPTION
## Summary
- document required ERC-20 approvals for staking and job escrow
- add `approve` examples using 18-decimal AGIALPHA amounts

## Testing
- `pre-commit run --files README.md docs/DEPLOYMENT_QUICKSTART.md`


------
https://chatgpt.com/codex/tasks/task_e_68b340e1cb688333b38a3f6df7f49682