### PR TITLE
docs: note absence of third-party subscription deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md
 
 Please read **AGENTS.md** carefully before opening issues or submitting pull requests.
 
+## Dependency Policy
+
+Avoid introducing third-party subscription services such as Chainlink VRF. New code and examples should remain self-contained without external subscription-based dependencies.
+
 ## Type Checking the Demo
 
 Run mypy only on the demo package while iterating:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ accept no liability for losses incurred from using this software.
 
 **Ready to explore? [Launch the α‑AGI Insight demo](https://montrealai.github.io/AGI-Alpha-Agent-v0/alpha_agi_insight_v1/) to see it in action.**
 
+### Security Note
+
+This project intentionally avoids reliance on Chainlink VRF or similar third-party subscription services. Randomness and related features are derived locally so the system remains self-contained and auditable.
+
 ### Quick Demo
 
 Non-technical users can try the project with zero setup. Simply visit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,10 @@ until we have addressed it.
 
 Thank you for helping keep this project safe.
 
+## Third-party Services
+
+This project avoids Chainlink VRF and other subscription-based dependencies. Keep new contributions free of external service requirements.
+
 ## CI security workflow
 
 The GitHub Actions workflow [`security.yml`](.github/workflows/security.yml) builds and signs the container image. It generates CycloneDX SBOM files for the Python and Node packages, scans the final image with Trivy and fails if any high or critical vulnerabilities are found. After a successful scan the image is signed with `cosign` and an SLSA provenance file is attached to the GitHub Release along with the SBOMs.


### PR DESCRIPTION
## Summary
- clarify in README that the project avoids Chainlink VRF and third-party subscription services
- document the no-subscription policy in SECURITY and CONTRIBUTING guidelines

## Testing
- `python check_env.py --auto-install`
- `pre-commit run --files README.md SECURITY.md CONTRIBUTING.md` *(fails: KeyboardInterrupt during semgrep env setup)*
- `pytest -q` *(fails: KeyboardInterrupt during imports)*

------
https://chatgpt.com/codex/tasks/task_e_68b34552adfc8333a5e635101a2ca5fa