### PR TITLE
test: use explicit AGIALPHA token address

### DIFF
--- a/tests/contracts/contracts/v2/CertificateNFT.sol
+++ b/tests/contracts/contracts/v2/CertificateNFT.sol
@@ -27,10 +27,10 @@ contract CertificateNFT is ERC721, Ownable {
     event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
     event NFTDelisted(uint256 indexed tokenId);
 
-    constructor() ERC721("CertificateNFT", "CERT") Ownable(msg.sender) {
-        agiAlpha = IERC20(Constants.AGIALPHA);
+    constructor(address _agiToken) ERC721("CertificateNFT", "CERT") Ownable(msg.sender) {
+        agiAlpha = IERC20(_agiToken);
         require(
-            IERC20Metadata(Constants.AGIALPHA).decimals() == Constants.AGIALPHA_DECIMALS,
+            IERC20Metadata(_agiToken).decimals() == Constants.AGIALPHA_DECIMALS,
             "wrong decimals"
         );
     }

--- a/tests/contracts/contracts/v2/StakeManager.sol
+++ b/tests/contracts/contracts/v2/StakeManager.sol
@@ -56,11 +56,11 @@ contract StakeManager is Ownable {
         uint256 burned
     );
 
-    constructor(address _treasury) Ownable(msg.sender) {
-        agiToken = IERC20(Constants.AGIALPHA); // uses $AGIALPHA (18 decimals)
+    constructor(address _agiToken, address _treasury) Ownable(msg.sender) {
+        agiToken = IERC20(_agiToken);
         treasury = _treasury;
         require(
-            IERC20Metadata(Constants.AGIALPHA).decimals() == Constants.AGIALPHA_DECIMALS,
+            IERC20Metadata(_agiToken).decimals() == Constants.AGIALPHA_DECIMALS,
             "wrong decimals"
         );
     }


### PR DESCRIPTION
## Summary
- let StakeManager and CertificateNFT take an AGIALPHA token address on deployment
- update Hardhat integration tests to deploy a mock AGIALPHA and pass its address
- parse token amounts with `ethers.parseUnits(value, 18)`

## Testing
- `pre-commit run --files tests/contracts/contracts/v2/StakeManager.sol tests/contracts/contracts/v2/CertificateNFT.sol tests/contracts/test/agiAlpha.test.js`
- `cd tests/contracts && npm ci`
- `cd tests/contracts && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b347ae8ecc83339bada7e331f13061