### PR TITLE
fix: harden StakeManager against reentrancy

### DIFF
--- a/tests/contracts/contracts/v2/mocks/MaliciousToken.sol
+++ b/tests/contracts/contracts/v2/mocks/MaliciousToken.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../StakeManager.sol";
+
+contract MaliciousToken is ERC20 {
+    StakeManager public stake;
+    bool public attack;
+
+    constructor() ERC20("Malicious AGI", "MAGI") {}
+
+    function setStake(address _stake) external {
+        stake = StakeManager(_stake);
+    }
+
+    function setAttack(bool _attack) external {
+        attack = _attack;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        super._update(from, to, value);
+        if (attack) {
+            attack = false;
+            // attempt to reenter StakeManager
+            stake.withdrawStake(StakeManager.Role.Agent, 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- secure StakeManager with OpenZeppelin ReentrancyGuard and SafeERC20
- guard stake and escrow flows with nonReentrant and safer token transfers
- test malicious token reentrancy attempts

## Testing
- `pre-commit run --files contracts/v2/StakeManager.sol tests/contracts/contracts/v2/StakeManager.sol tests/contracts/contracts/v2/mocks/MaliciousToken.sol tests/contracts/test/agiAlpha.test.js`
- `cd tests/contracts && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35027f25483339d4885180f1c117d