### PR TITLE
feat: emit events for StakeManager setters

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -64,6 +64,16 @@ contract StakeManager is Ownable, ReentrancyGuard {
         uint256 compensation,
         uint256 burned
     );
+    event TreasuryUpdated(address indexed treasury);
+    event JobRegistryUpdated(address indexed jobRegistry);
+    event SlasherUpdated(address indexed slasher);
+    event MinStakeAgentUpdated(uint256 amount);
+    event MinStakeEmployerUpdated(uint256 amount);
+    event MinStakeValidatorUpdated(uint256 amount);
+    event FeePctUpdated(uint256 pct);
+    event BurnPctUpdated(uint256 pct);
+    event AGITypeAdded(address indexed nft, uint256 payoutPct);
+    event AGITypeRemoved(address indexed nft);
 
     constructor(address _treasury) Ownable(msg.sender) {
         agiToken = IERC20(Constants.AGIALPHA); // uses $AGIALPHA (18 decimals)
@@ -78,49 +88,58 @@ contract StakeManager is Ownable, ReentrancyGuard {
     /// @param _treasury New treasury address
     function setTreasury(address _treasury) external onlyOwner {
         treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
     }
 
     /// @notice Sets the JobRegistry authorized to lock and release funds
     function setJobRegistry(address _registry) external onlyOwner {
         jobRegistry = _registry;
+        emit JobRegistryUpdated(_registry);
     }
 
     /// @notice Sets the contract allowed to slash stakes
     function setSlasher(address _slasher) external onlyOwner {
         slasher = _slasher;
+        emit SlasherUpdated(_slasher);
     }
 
     /// @notice Sets minimum stake for agents
     function setMinStakeAgent(uint256 amount) external onlyOwner {
         minStakeAgent = amount;
+        emit MinStakeAgentUpdated(amount);
     }
 
     /// @notice Sets minimum stake for employers
     function setMinStakeEmployer(uint256 amount) external onlyOwner {
         minStakeEmployer = amount;
+        emit MinStakeEmployerUpdated(amount);
     }
 
     /// @notice Sets minimum stake for validators
     function setMinStakeValidator(uint256 amount) external onlyOwner {
         minStakeValidator = amount;
+        emit MinStakeValidatorUpdated(amount);
     }
 
     /// @notice Sets protocol fee percentage in basis points
     function setFeePct(uint256 pct) external onlyOwner {
         require(pct <= 10_000, "pct too high");
         feePct = pct;
+        emit FeePctUpdated(pct);
     }
 
     /// @notice Sets burn percentage in basis points
     function setBurnPct(uint256 pct) external onlyOwner {
         require(pct <= 10_000, "pct too high");
         burnPct = pct;
+        emit BurnPctUpdated(pct);
     }
 
     /// @notice Adds an AGI type NFT and its payout percentage
     function addAGIType(address nft, uint256 payoutPct) external onlyOwner {
         agiTypePayoutPct[nft] = payoutPct;
         agiTypes.push(nft);
+        emit AGITypeAdded(nft, payoutPct);
     }
 
     /// @notice Removes an AGI type NFT
@@ -133,6 +152,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
                 break;
             }
         }
+        emit AGITypeRemoved(nft);
     }
 
     /// @notice Deposits AGI tokens as stake for a specific role

--- a/tests/contracts/contracts/v2/StakeManager.sol
+++ b/tests/contracts/contracts/v2/StakeManager.sol
@@ -64,6 +64,16 @@ contract StakeManager is Ownable, ReentrancyGuard {
         uint256 compensation,
         uint256 burned
     );
+    event TreasuryUpdated(address indexed treasury);
+    event JobRegistryUpdated(address indexed jobRegistry);
+    event SlasherUpdated(address indexed slasher);
+    event MinStakeAgentUpdated(uint256 amount);
+    event MinStakeEmployerUpdated(uint256 amount);
+    event MinStakeValidatorUpdated(uint256 amount);
+    event FeePctUpdated(uint256 pct);
+    event BurnPctUpdated(uint256 pct);
+    event AGITypeAdded(address indexed nft, uint256 payoutPct);
+    event AGITypeRemoved(address indexed nft);
 
     constructor(address _agiToken, address _treasury) Ownable(msg.sender) {
         agiToken = IERC20(_agiToken);
@@ -78,49 +88,58 @@ contract StakeManager is Ownable, ReentrancyGuard {
     /// @param _treasury New treasury address
     function setTreasury(address _treasury) external onlyOwner {
         treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
     }
 
     /// @notice Sets the JobRegistry authorized to lock and release funds
     function setJobRegistry(address _registry) external onlyOwner {
         jobRegistry = _registry;
+        emit JobRegistryUpdated(_registry);
     }
 
     /// @notice Sets the contract allowed to slash stakes
     function setSlasher(address _slasher) external onlyOwner {
         slasher = _slasher;
+        emit SlasherUpdated(_slasher);
     }
 
     /// @notice Sets minimum stake for agents
     function setMinStakeAgent(uint256 amount) external onlyOwner {
         minStakeAgent = amount;
+        emit MinStakeAgentUpdated(amount);
     }
 
     /// @notice Sets minimum stake for employers
     function setMinStakeEmployer(uint256 amount) external onlyOwner {
         minStakeEmployer = amount;
+        emit MinStakeEmployerUpdated(amount);
     }
 
     /// @notice Sets minimum stake for validators
     function setMinStakeValidator(uint256 amount) external onlyOwner {
         minStakeValidator = amount;
+        emit MinStakeValidatorUpdated(amount);
     }
 
     /// @notice Sets protocol fee percentage in basis points
     function setFeePct(uint256 pct) external onlyOwner {
         require(pct <= 10_000, "pct too high");
         feePct = pct;
+        emit FeePctUpdated(pct);
     }
 
     /// @notice Sets burn percentage in basis points
     function setBurnPct(uint256 pct) external onlyOwner {
         require(pct <= 10_000, "pct too high");
         burnPct = pct;
+        emit BurnPctUpdated(pct);
     }
 
     /// @notice Adds an AGI type NFT and its payout percentage
     function addAGIType(address nft, uint256 payoutPct) external onlyOwner {
         agiTypePayoutPct[nft] = payoutPct;
         agiTypes.push(nft);
+        emit AGITypeAdded(nft, payoutPct);
     }
 
     /// @notice Removes an AGI type NFT
@@ -133,6 +152,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
                 break;
             }
         }
+        emit AGITypeRemoved(nft);
     }
 
     /// @notice Deposits AGI tokens as stake for a specific role

--- a/tests/contracts/test/stakeManager.events.test.js
+++ b/tests/contracts/test/stakeManager.events.test.js
@@ -1,0 +1,89 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+async function deployStakeManager() {
+  const Mock = await ethers.getContractFactory(
+    "contracts/v2/mocks/MockAGI.sol:MockAGI"
+  );
+  const agi = await Mock.deploy(18);
+  await agi.waitForDeployment();
+  const StakeManager = await ethers.getContractFactory(
+    "contracts/v2/StakeManager.sol:StakeManager"
+  );
+  const stake = await StakeManager.deploy(await agi.getAddress(), ethers.ZeroAddress);
+  await stake.waitForDeployment();
+  return { agi, stake };
+}
+
+describe("StakeManager setters emit events", function () {
+  let owner, addr1, addr2, addr3, addr4;
+  let stake;
+
+  beforeEach(async function () {
+    await ethers.provider.send("hardhat_reset", []);
+    [owner, addr1, addr2, addr3, addr4] = await ethers.getSigners();
+    ({ stake } = await deployStakeManager());
+  });
+
+  it("emits TreasuryUpdated", async function () {
+    await expect(stake.setTreasury(addr1.address))
+      .to.emit(stake, "TreasuryUpdated")
+      .withArgs(addr1.address);
+  });
+
+  it("emits JobRegistryUpdated", async function () {
+    await expect(stake.setJobRegistry(addr1.address))
+      .to.emit(stake, "JobRegistryUpdated")
+      .withArgs(addr1.address);
+  });
+
+  it("emits SlasherUpdated", async function () {
+    await expect(stake.setSlasher(addr1.address))
+      .to.emit(stake, "SlasherUpdated")
+      .withArgs(addr1.address);
+  });
+
+  it("emits MinStakeAgentUpdated", async function () {
+    await expect(stake.setMinStakeAgent(100))
+      .to.emit(stake, "MinStakeAgentUpdated")
+      .withArgs(100);
+  });
+
+  it("emits MinStakeEmployerUpdated", async function () {
+    await expect(stake.setMinStakeEmployer(200))
+      .to.emit(stake, "MinStakeEmployerUpdated")
+      .withArgs(200);
+  });
+
+  it("emits MinStakeValidatorUpdated", async function () {
+    await expect(stake.setMinStakeValidator(300))
+      .to.emit(stake, "MinStakeValidatorUpdated")
+      .withArgs(300);
+  });
+
+  it("emits FeePctUpdated", async function () {
+    await expect(stake.setFeePct(100))
+      .to.emit(stake, "FeePctUpdated")
+      .withArgs(100);
+  });
+
+  it("emits BurnPctUpdated", async function () {
+    await expect(stake.setBurnPct(200))
+      .to.emit(stake, "BurnPctUpdated")
+      .withArgs(200);
+  });
+
+  it("emits AGITypeAdded", async function () {
+    await expect(stake.addAGIType(addr2.address, 500))
+      .to.emit(stake, "AGITypeAdded")
+      .withArgs(addr2.address, 500);
+  });
+
+  it("emits AGITypeRemoved", async function () {
+    await stake.addAGIType(addr2.address, 500);
+    await expect(stake.removeAGIType(addr2.address))
+      .to.emit(stake, "AGITypeRemoved")
+      .withArgs(addr2.address);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add events for StakeManager mutable parameters
- emit events from all setter functions
- test StakeManager setters for correct event emission

## Testing
- `pre-commit run --files contracts/v2/StakeManager.sol tests/contracts/contracts/v2/StakeManager.sol tests/contracts/test/stakeManager.events.test.js` *(fails: KeyboardInterrupt)*
- `cd tests/contracts && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35480d4348333a527d5f1da3fe0b8