### PR TITLE
fix: guard certificate marketplace against reentrancy

### DIFF
--- a/tests/contracts/contracts/v2/mocks/MaliciousCertToken.sol
+++ b/tests/contracts/contracts/v2/mocks/MaliciousCertToken.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../CertificateNFT.sol";
+
+contract MaliciousCertToken is ERC20 {
+    CertificateNFT public cert;
+    bool public attack;
+    uint256 public tokenId;
+
+    constructor() ERC20("Malicious AGI", "MAGI") {}
+
+    function setCert(address _cert) external {
+        cert = CertificateNFT(_cert);
+    }
+
+    function setAttack(bool _attack, uint256 _tokenId) external {
+        attack = _attack;
+        tokenId = _tokenId;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        super._update(from, to, value);
+        if (attack) {
+            attack = false;
+            cert.purchase(tokenId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- secure CertificateNFT with ReentrancyGuard and SafeERC20
- finalize purchase before taking payment to thwart reentrancy
- test malicious ERC-20 to ensure certificate purchase resists reentrancy

## Testing
- `pre-commit run --files contracts/v2/CertificateNFT.sol tests/contracts/contracts/v2/CertificateNFT.sol tests/contracts/contracts/v2/mocks/MaliciousCertToken.sol tests/contracts/test/agiAlpha.test.js`
- `cd tests/contracts && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35726a3fc83338cf550b4037d75d6