### PR TITLE
feat: enforce agent stake requirement when applying

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -18,6 +18,8 @@ interface IStakeManager {
         address[] calldata validators,
         uint256 validatorPct
     ) external;
+    function agentStakes(address user) external view returns (uint256);
+    function minStakeAgent() external view returns (uint256);
 }
 
 interface IReputationEngine {
@@ -241,6 +243,9 @@ contract JobRegistry is Ownable {
         );
         Job storage job = jobs[jobId];
         require(job.status == Status.Created, "invalid status");
+        uint256 agentStake = stakeManager.agentStakes(msg.sender);
+        uint256 minStake = stakeManager.minStakeAgent();
+        require(agentStake >= minStake, "stake too low");
         uint256 duration = job.deadline - job.createdAt;
         reputationEngine.onApply(msg.sender, job.reward, duration);
         job.worker = msg.sender;

--- a/tests/contracts/contracts/v2/IdentityLib.sol
+++ b/tests/contracts/contracts/v2/IdentityLib.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+library IdentityLib {
+    function verify(
+        address,
+        string memory,
+        bytes32[] memory,
+        bytes32
+    ) internal pure returns (bool) {
+        return true;
+    }
+}

--- a/tests/contracts/contracts/v2/JobRegistry.sol
+++ b/tests/contracts/contracts/v2/JobRegistry.sol
@@ -2,31 +2,330 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "./IdentityLib.sol";
+
+interface IValidationModule {
+    function validate(uint256 jobId, bytes calldata data) external returns (bool);
+    function validationResult(uint256 jobId) external view returns (bool);
+    function getWinningValidators(uint256 jobId) external view returns (address[] memory);
+}
+
+interface IStakeManager {
+    function lock(uint256 jobId, address employer, uint256 amount) external;
+    function release(
+        uint256 jobId,
+        address recipient,
+        address[] calldata validators,
+        uint256 validatorPct
+    ) external;
+    function agentStakes(address user) external view returns (uint256);
+    function minStakeAgent() external view returns (uint256);
+}
+
+interface IReputationEngine {
+    function onApply(address user, uint256 reward, uint256 duration) external;
+    function onFinalize(address user, uint256 reward, uint256 duration, bool success) external;
+    function isBlacklisted(address user) external view returns (bool);
+    function reputationOf(address user) external view returns (uint256);
+    function meetsThreshold(address user) external view returns (bool);
+}
+
+interface IDisputeModule {
+    function onFinalize(uint256 jobId) external;
+    function dispute(uint256 jobId, address employer, address worker) external;
+}
+
+interface ICertificateNFT {
+    function mint(address to, uint256 jobId) external;
+}
+
+interface ITaxPolicy {
+    function isAcknowledged(address user) external view returns (bool);
+}
 
 contract JobRegistry is Ownable {
+    enum Status {
+        None,
+        Created,
+        Applied,
+        Submitted,
+        Finalized
+    }
+
+    struct Job {
+        address client;      // 20 bytes
+        uint96 reward;       // 12 bytes (fits with client in one slot)
+        address worker;      // 20 bytes
+        uint40 createdAt;    // 5 bytes
+        uint40 deadline;     // 5 bytes
+        Status status;       // 1 byte
+    }
+
+    uint256 public nextJobId;
+    mapping(uint256 => Job) public jobs;
+
+    IValidationModule public validationModule;
+    IStakeManager public stakeManager;
+    IReputationEngine public reputationEngine;
+    IDisputeModule public disputeModule;
+    ICertificateNFT public certificateNFT;
+    ITaxPolicy public taxPolicy;
+
+    bytes32 public agentRootNode;
+    bytes32 public clubRootNode;
+    bytes32 public agentMerkleRoot;
+    bytes32 public validatorMerkleRoot;
+
+    mapping(address => bool) public additionalAgents;
+    mapping(address => bool) public additionalValidators;
+
     uint96 public maxJobReward;
     uint40 public maxJobDuration;
     uint256 public validatorRewardPct;
 
+    event JobCreated(uint256 indexed jobId, address indexed client, uint96 reward, uint40 deadline);
+    event JobApplied(uint256 indexed jobId, address indexed worker);
+    event JobSubmitted(uint256 indexed jobId, address indexed client, address indexed worker, bytes result);
+    event JobCancelled(uint256 indexed jobId, address indexed client);
+    event JobDelisted(uint256 indexed jobId, address indexed client);
+    event JobDisputed(uint256 indexed jobId);
+    event JobFinalized(uint256 indexed jobId, address indexed client, address indexed worker);
+    event DisputeModuleUpdated(address disputeModule);
+    event ModulesUpdated(
+        address validationModule,
+        address stakeManager,
+        address reputationEngine,
+        address disputeModule,
+        address certificateNFT,
+        address taxPolicy
+    );
+    event RootNodeUpdated(bytes32 newRootNode);
+    event MerkleRootUpdated(bytes32 newMerkleRoot);
     event ValidatorRewardPctUpdated(uint256 pct);
     event MaxJobRewardUpdated(uint96 amount);
     event MaxJobDurationUpdated(uint40 duration);
 
-    constructor() Ownable(msg.sender) {}
-
+    /// @notice Updates validator reward percentage
+    /// @param pct Percentage of escrow sent to validators
     function setValidatorRewardPct(uint256 pct) external onlyOwner {
         require(pct <= 100, "pct too high");
         validatorRewardPct = pct;
         emit ValidatorRewardPctUpdated(pct);
     }
 
+    constructor() Ownable(msg.sender) {}
+
+    /// @notice Sets module contract addresses
+    /// @param _validation Address of validation module
+    /// @param _stake Address of stake manager
+    /// @param _reputation Address of reputation engine
+    /// @param _dispute Address of dispute module
+    /// @param _certificate Address of certificate NFT
+    /// @param _tax Address of tax policy module
+    function setModules(
+        address _validation,
+        address _stake,
+        address _reputation,
+        address _dispute,
+        address _certificate,
+        address _tax
+    ) external onlyOwner {
+        validationModule = IValidationModule(_validation);
+        stakeManager = IStakeManager(_stake);
+        reputationEngine = IReputationEngine(_reputation);
+        disputeModule = IDisputeModule(_dispute);
+        certificateNFT = ICertificateNFT(_certificate);
+        taxPolicy = ITaxPolicy(_tax);
+        emit ModulesUpdated(_validation, _stake, _reputation, _dispute, _certificate, _tax);
+    }
+
+    /// @notice Updates the dispute module address
+    function setDisputeModule(address _dispute) external onlyOwner {
+        disputeModule = IDisputeModule(_dispute);
+        emit DisputeModuleUpdated(_dispute);
+    }
+
+    /// @notice Updates the root nodes for agents and clubs
+    /// @param agentNode ENS root node for agents
+    /// @param clubNode ENS root node for clubs
+    function setRootNodes(bytes32 agentNode, bytes32 clubNode) external onlyOwner {
+        agentRootNode = agentNode;
+        clubRootNode = clubNode;
+        emit RootNodeUpdated(agentNode);
+        emit RootNodeUpdated(clubNode);
+    }
+
+    /// @notice Updates the Merkle roots for agents and validators
+    /// @param agentRoot Merkle root for agents
+    /// @param validatorRoot Merkle root for validators
+    function setMerkleRoots(bytes32 agentRoot, bytes32 validatorRoot) external onlyOwner {
+        agentMerkleRoot = agentRoot;
+        validatorMerkleRoot = validatorRoot;
+        emit MerkleRootUpdated(agentRoot);
+        emit MerkleRootUpdated(validatorRoot);
+    }
+
+    /// @notice Adds an address to the additional agents allowlist
+    /// @param agent Address to add
+    function addAdditionalAgent(address agent) external onlyOwner {
+        additionalAgents[agent] = true;
+    }
+
+    /// @notice Removes an address from the additional agents allowlist
+    /// @param agent Address to remove
+    function removeAdditionalAgent(address agent) external onlyOwner {
+        delete additionalAgents[agent];
+    }
+
+    /// @notice Adds an address to the additional validators allowlist
+    /// @param validator Address to add
+    function addAdditionalValidator(address validator) external onlyOwner {
+        additionalValidators[validator] = true;
+    }
+
+    /// @notice Removes an address from the additional validators allowlist
+    /// @param validator Address to remove
+    function removeAdditionalValidator(address validator) external onlyOwner {
+        delete additionalValidators[validator];
+    }
+
+    /// @notice Sets the maximum job reward
+    /// @param amount Maximum reward allowed per job
     function setMaxJobReward(uint96 amount) external onlyOwner {
         maxJobReward = amount;
         emit MaxJobRewardUpdated(amount);
     }
 
+    /// @notice Sets the maximum job duration in seconds
+    /// @param duration Maximum allowed duration from now
     function setMaxJobDuration(uint40 duration) external onlyOwner {
         maxJobDuration = duration;
         emit MaxJobDurationUpdated(duration);
     }
+
+    /// @notice Creates a new job and locks client stake
+    /// @param reward Payment amount locked in the stake manager
+    /// @param deadline Unix timestamp for job deadline
+    /// @return jobId Identifier of the created job
+    function createJob(uint96 reward, uint40 deadline) external returns (uint256 jobId) {
+        require(!reputationEngine.isBlacklisted(msg.sender), "blacklisted");
+        require(taxPolicy.isAcknowledged(msg.sender), "tax");
+        require(reward <= maxJobReward, "reward too high");
+        require(deadline != 0 && deadline <= block.timestamp + maxJobDuration, "invalid deadline");
+        jobId = ++nextJobId;
+        stakeManager.lock(jobId, msg.sender, reward);
+        jobs[jobId] = Job({
+            client: msg.sender,
+            reward: reward,
+            worker: address(0),
+            createdAt: uint40(block.timestamp),
+            deadline: deadline,
+            status: Status.Created
+        });
+        emit JobCreated(jobId, msg.sender, reward, deadline);
+    }
+
+    /// @notice Applies for an open job after identity verification
+    /// @param jobId Identifier of the job
+    /// @param subdomain ENS subdomain used for verification
+    /// @param proof Merkle proof validating agent ownership
+    function applyForJob(
+        uint256 jobId,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external {
+        require(!reputationEngine.isBlacklisted(msg.sender), "blacklisted");
+        require(taxPolicy.isAcknowledged(msg.sender), "tax");
+        require(
+            additionalAgents[msg.sender] ||
+                IdentityLib.verify(msg.sender, subdomain, proof, agentRootNode),
+            "identity"
+        );
+        Job storage job = jobs[jobId];
+        require(job.status == Status.Created, "invalid status");
+        uint256 agentStake = stakeManager.agentStakes(msg.sender);
+        uint256 minStake = stakeManager.minStakeAgent();
+        require(agentStake >= minStake, "stake too low");
+        uint256 duration = job.deadline - job.createdAt;
+        reputationEngine.onApply(msg.sender, job.reward, duration);
+        job.worker = msg.sender;
+        job.status = Status.Applied;
+        emit JobApplied(jobId, msg.sender);
+    }
+
+    /// @notice Cancels a job and refunds the client
+    /// @param jobId Identifier of the job
+    function cancelJob(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.client == msg.sender, "not client");
+        require(job.status == Status.Created, "invalid status");
+        stakeManager.release(jobId, job.client, new address[](0), 0);
+        delete jobs[jobId];
+        emit JobCancelled(jobId, job.client);
+    }
+
+    /// @notice Delists a job by the contract owner
+    /// @param jobId Identifier of the job
+    function delistJob(uint256 jobId) external onlyOwner {
+        Job storage job = jobs[jobId];
+        require(job.status == Status.Created, "invalid status");
+        stakeManager.release(jobId, job.client, new address[](0), 0);
+        delete jobs[jobId];
+        emit JobDelisted(jobId, job.client);
+    }
+
+    /// @notice Submits work for a job, validated by validation module
+    /// @param jobId Identifier of the job
+    /// @param result Submission payload
+    function submit(uint256 jobId, bytes calldata result) external {
+        Job storage job = jobs[jobId];
+        require(job.worker == msg.sender, "not worker");
+        require(job.status == Status.Applied, "invalid status");
+        require(block.timestamp <= job.deadline, "deadline passed");
+        require(validationModule.validate(jobId, result), "validation failed");
+        job.status = Status.Submitted;
+        emit JobSubmitted(jobId, job.client, msg.sender, result);
+    }
+
+    /// @notice Opens a dispute for a submitted job
+    /// @param jobId Identifier of the job
+    function dispute(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.client == msg.sender, "not client");
+        require(job.status == Status.Submitted, "invalid status");
+        require(address(disputeModule) != address(0), "no module");
+        disputeModule.dispute(jobId, job.client, job.worker);
+        emit JobDisputed(jobId);
+    }
+
+    /// @notice Called by dispute module to refund employer when they win a dispute
+    /// @param jobId Identifier of the job
+    function resolveDispute(uint256 jobId) external {
+        require(msg.sender == address(disputeModule), "not module");
+        Job storage job = jobs[jobId];
+        stakeManager.release(jobId, job.client, new address[](0), 0);
+        delete jobs[jobId];
+    }
+
+    /// @notice Finalizes a job and releases payment
+    /// @param jobId Identifier of the job
+    function finalize(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.client == msg.sender, "not client");
+        require(job.status == Status.Submitted, "invalid status");
+        require(validationModule.validationResult(jobId), "validation failed");
+        address[] memory winners = validationModule.getWinningValidators(jobId);
+        stakeManager.release(jobId, job.worker, winners, validatorRewardPct);
+        uint256 duration = block.timestamp - job.createdAt;
+        reputationEngine.onFinalize(job.worker, job.reward, duration, true);
+        if (address(disputeModule) != address(0)) {
+            disputeModule.onFinalize(jobId);
+        }
+        if (address(certificateNFT) != address(0)) {
+            certificateNFT.mint(job.worker, jobId);
+        }
+        job.status = Status.Finalized;
+        emit JobFinalized(jobId, job.client, job.worker);
+    }
 }
+

--- a/tests/contracts/contracts/v2/mocks/MockReputationEngine.sol
+++ b/tests/contracts/contracts/v2/mocks/MockReputationEngine.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract MockReputationEngine {
+    bool private blacklisted;
+
+    event Applied(address indexed user, uint256 reward, uint256 duration);
+
+    function setBlacklisted(bool value) external {
+        blacklisted = value;
+    }
+
+    function onApply(address user, uint256 reward, uint256 duration) external {
+        emit Applied(user, reward, duration);
+    }
+
+    function onFinalize(address, uint256, uint256, bool) external {}
+
+    function isBlacklisted(address) external view returns (bool) {
+        return blacklisted;
+    }
+
+    function reputationOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function meetsThreshold(address) external pure returns (bool) {
+        return true;
+    }
+}

--- a/tests/contracts/contracts/v2/mocks/MockTaxPolicy.sol
+++ b/tests/contracts/contracts/v2/mocks/MockTaxPolicy.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract MockTaxPolicy {
+    bool private acknowledged = true;
+
+    function setAcknowledged(bool value) external {
+        acknowledged = value;
+    }
+
+    function isAcknowledged(address) external view returns (bool) {
+        return acknowledged;
+    }
+}

--- a/tests/contracts/test/jobRegistry.stake.test.js
+++ b/tests/contracts/test/jobRegistry.stake.test.js
@@ -1,0 +1,114 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry agent staking requirements", function () {
+  let owner;
+  let employer;
+  let agent;
+  let jobRegistry;
+  let stakeManager;
+  let reputation;
+  let taxPolicy;
+  let agi;
+  const minStake = ethers.parseUnits("100", 18);
+  const reward = ethers.parseUnits("10", 18);
+  const maxDuration = 7 * 24 * 60 * 60; // 1 week
+
+  beforeEach(async function () {
+    await ethers.provider.send("hardhat_reset", []);
+    [owner, employer, agent] = await ethers.getSigners();
+
+    const MockAGI = await ethers.getContractFactory(
+      "contracts/v2/mocks/MockAGI.sol:MockAGI"
+    );
+    agi = await MockAGI.deploy(18);
+    await agi.waitForDeployment();
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await agi.getAddress(),
+      owner.address
+    );
+    await stakeManager.waitForDeployment();
+
+    const MockReputation = await ethers.getContractFactory(
+      "contracts/v2/mocks/MockReputationEngine.sol:MockReputationEngine"
+    );
+    reputation = await MockReputation.deploy();
+    await reputation.waitForDeployment();
+
+    const MockTaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/mocks/MockTaxPolicy.sol:MockTaxPolicy"
+    );
+    taxPolicy = await MockTaxPolicy.deploy();
+    await taxPolicy.waitForDeployment();
+
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    jobRegistry = await JobRegistry.deploy();
+    await jobRegistry.waitForDeployment();
+
+    await stakeManager.setJobRegistry(await jobRegistry.getAddress());
+    await stakeManager.setMinStakeAgent(minStake);
+
+    await jobRegistry.setModules(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      await reputation.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      await taxPolicy.getAddress()
+    );
+    await jobRegistry.setMaxJobReward(reward);
+    await jobRegistry.setMaxJobDuration(maxDuration);
+
+    await jobRegistry.addAdditionalAgent(agent.address);
+  });
+
+  async function createJob() {
+    const block = await ethers.provider.getBlock("latest");
+    const deadline = block.timestamp + 60 * 60; // 1 hour from now
+
+    await agi.mint(employer.address, reward);
+    await agi
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), reward);
+
+    const tx = await jobRegistry
+      .connect(employer)
+      .createJob(reward, deadline);
+    await tx.wait();
+
+    return await jobRegistry.nextJobId();
+  }
+
+  it("rejects agents without the minimum stake", async function () {
+    const jobId = await createJob();
+
+    await expect(
+      jobRegistry.connect(agent).applyForJob(jobId, "", [])
+    ).to.be.revertedWith("stake too low");
+  });
+
+  it("allows agents meeting the minimum stake to apply", async function () {
+    const jobId = await createJob();
+
+    await agi.mint(agent.address, minStake);
+    await agi
+      .connect(agent)
+      .approve(await stakeManager.getAddress(), minStake);
+    await stakeManager.connect(agent).depositStake(0, minStake);
+
+    await expect(
+      jobRegistry.connect(agent).applyForJob(jobId, "", [])
+    )
+      .to.emit(jobRegistry, "JobApplied")
+      .withArgs(jobId, agent.address);
+
+    const job = await jobRegistry.jobs(jobId);
+    expect(job.worker).to.equal(agent.address);
+  });
+});


### PR DESCRIPTION
## Summary
- require job applicants to meet the StakeManager minimum stake before a JobRegistry application is accepted
- expose the agent stake accessors in the registry interface and supporting test harness contracts
- add Hardhat coverage ensuring under-staked agents are rejected while properly staked agents succeed

## Testing
- npx hardhat test

------
https://chatgpt.com/codex/tasks/task_e_68cae8491144833385adadc608305bac