### PR TITLE
feat: configure slash distribution percentages

### DIFF
--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -4,13 +4,7 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 interface IStakeManager {
-    function slash(
-        address offender,
-        address employer,
-        uint256 amount,
-        uint256 burnPctOverride,
-        uint256 jobId
-    ) external;
+    function slash(address offender, address beneficiary, uint256 amount) external;
 }
 
 interface IJobRegistry {
@@ -109,7 +103,7 @@ contract DisputeModule is Ownable {
         if (employerWins) {
             ( , uint96 reward, , , , ) = IJobRegistry(jobRegistry).jobs(jobId);
             IJobRegistry(jobRegistry).resolveDispute(jobId);
-            stakeManager.slash(d.worker, d.employer, reward, 0, jobId);
+            stakeManager.slash(d.worker, d.employer, reward);
         }
         emit DisputeResolved(jobId, employerWins);
     }

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -5,13 +5,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./IdentityLib.sol";
 
 interface IStakeManager {
-    function slash(
-        address offender,
-        address employer,
-        uint256 amount,
-        uint256 burnPctOverride,
-        uint256 jobId
-    ) external;
+    function slash(address offender, address beneficiary, uint256 amount) external;
     function validatorStakes(address user) external view returns (uint256);
     function minStakeValidator() external view returns (uint256);
 }
@@ -223,7 +217,7 @@ contract ValidationModule is Ownable, IValidationModule {
                     no++;
                 }
             } else {
-                stakeManager.slash(validator, address(0), slashAmount, 10_000, jobId);
+                stakeManager.slash(validator, address(0), slashAmount);
                 reputationEngine.onValidate(validator, agentGain, false);
             }
         }
@@ -236,7 +230,7 @@ contract ValidationModule is Ownable, IValidationModule {
                 if (v.vote == r.result) {
                     reputationEngine.onValidate(validator, agentGain, true);
                 } else {
-                    stakeManager.slash(validator, address(0), slashAmount, 10_000, jobId);
+                    stakeManager.slash(validator, address(0), slashAmount);
                     reputationEngine.onValidate(validator, agentGain, false);
                 }
             }

--- a/tests/contracts/contracts/v2/StakeManager.sol
+++ b/tests/contracts/contracts/v2/StakeManager.sol
@@ -41,6 +41,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
 
     uint256 public feePct; // basis points
     uint256 public burnPct; // basis points
+    uint256 public employerSlashPct; // percentage (0-100)
+    uint256 public treasurySlashPct; // percentage (0-100)
 
     mapping(address => uint256) public agiTypePayoutPct;
     address[] public agiTypes;
@@ -57,12 +59,11 @@ contract StakeManager is Ownable, ReentrancyGuard {
         uint256 burn
     );
     event StakeSlashed(
-        uint256 indexed jobId,
         address indexed offender,
-        address indexed employer,
+        address indexed beneficiary,
         uint256 amount,
-        uint256 compensation,
-        uint256 burned
+        uint256 employerShare,
+        uint256 treasuryShare
     );
     event TreasuryUpdated(address indexed treasury);
     event JobRegistryUpdated(address indexed jobRegistry);
@@ -72,6 +73,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
     event MinStakeValidatorUpdated(uint256 amount);
     event FeePctUpdated(uint256 pct);
     event BurnPctUpdated(uint256 pct);
+    event SlashPctsUpdated(uint256 employerPct, uint256 treasuryPct);
     event AGITypeAdded(address indexed nft, uint256 payoutPct);
     event AGITypeRemoved(address indexed nft);
 
@@ -82,6 +84,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
             IERC20Metadata(_agiToken).decimals() == Constants.AGIALPHA_DECIMALS,
             "wrong decimals"
         );
+        _setSlashPercents(0, 100);
     }
 
     /// @notice Updates the treasury address
@@ -133,6 +136,25 @@ contract StakeManager is Ownable, ReentrancyGuard {
         require(pct <= 10_000, "pct too high");
         burnPct = pct;
         emit BurnPctUpdated(pct);
+    }
+
+    /// @notice Sets the employer slash percentage (treasury receives the remainder)
+    function setEmployerSlashPct(uint256 pct) external onlyOwner {
+        require(pct <= 100, "pct too high");
+        _setSlashPercents(pct, 100 - pct);
+    }
+
+    /// @notice Sets the treasury slash percentage (employer receives the remainder)
+    function setTreasurySlashPct(uint256 pct) external onlyOwner {
+        require(pct <= 100, "pct too high");
+        _setSlashPercents(100 - pct, pct);
+    }
+
+    function _setSlashPercents(uint256 employerPct, uint256 treasuryPct) internal {
+        require(employerPct + treasuryPct == 100, "pct mismatch");
+        employerSlashPct = employerPct;
+        treasurySlashPct = treasuryPct;
+        emit SlashPctsUpdated(employerPct, treasuryPct);
     }
 
     /// @notice Adds an AGI type NFT and its payout percentage
@@ -257,10 +279,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
     /// @notice Slashes a user's stake and compensates an employer
     function slash(
         address offender,
-        address employer,
-        uint256 amount,
-        uint256 burnPctOverride,
-        uint256 jobId
+        address beneficiary,
+        uint256 amount
     ) external onlySlasher nonReentrant {
         uint256 available = validatorStakes[offender];
         if (available >= amount) {
@@ -269,16 +289,15 @@ contract StakeManager is Ownable, ReentrancyGuard {
             require(agentStakes[offender] >= amount, "insufficient");
             agentStakes[offender] -= amount;
         }
-        uint256 pct = burnPctOverride > 0 ? burnPctOverride : burnPct;
-        uint256 burnAmount = (amount * pct) / 10_000;
-        uint256 compensation = amount - burnAmount;
-        if (compensation > 0 && employer != address(0)) {
-            agiToken.safeTransfer(employer, compensation);
+        uint256 employerShare = beneficiary != address(0) ? (amount * employerSlashPct) / 100 : 0;
+        uint256 treasuryShare = amount - employerShare;
+        if (employerShare > 0) {
+            agiToken.safeTransfer(beneficiary, employerShare);
         }
-        if (burnAmount > 0) {
-            IERC20Burnable(address(agiToken)).burn(burnAmount);
+        if (treasuryShare > 0) {
+            agiToken.safeTransfer(treasury, treasuryShare);
         }
-        emit StakeSlashed(jobId, offender, employer, amount, compensation, burnAmount);
+        emit StakeSlashed(offender, beneficiary, amount, employerShare, treasuryShare);
     }
 }
 

--- a/tests/contracts/test/stakeManager.events.test.js
+++ b/tests/contracts/test/stakeManager.events.test.js
@@ -1,6 +1,8 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
+const ROLE_VALIDATOR = 2;
+
 async function deployStakeManager() {
   const Mock = await ethers.getContractFactory(
     "contracts/v2/mocks/MockAGI.sol:MockAGI"
@@ -17,12 +19,12 @@ async function deployStakeManager() {
 
 describe("StakeManager setters emit events", function () {
   let owner, addr1, addr2, addr3, addr4;
-  let stake;
+  let stake, agi;
 
   beforeEach(async function () {
     await ethers.provider.send("hardhat_reset", []);
     [owner, addr1, addr2, addr3, addr4] = await ethers.getSigners();
-    ({ stake } = await deployStakeManager());
+    ({ stake, agi } = await deployStakeManager());
   });
 
   it("emits TreasuryUpdated", async function () {
@@ -73,6 +75,18 @@ describe("StakeManager setters emit events", function () {
       .withArgs(200);
   });
 
+  it("emits SlashPctsUpdated when setting employer pct", async function () {
+    await expect(stake.setEmployerSlashPct(40))
+      .to.emit(stake, "SlashPctsUpdated")
+      .withArgs(40, 60);
+  });
+
+  it("emits SlashPctsUpdated when setting treasury pct", async function () {
+    await expect(stake.setTreasurySlashPct(55))
+      .to.emit(stake, "SlashPctsUpdated")
+      .withArgs(45, 55);
+  });
+
   it("emits AGITypeAdded", async function () {
     await expect(stake.addAGIType(addr2.address, 500))
       .to.emit(stake, "AGITypeAdded")
@@ -84,6 +98,69 @@ describe("StakeManager setters emit events", function () {
     await expect(stake.removeAGIType(addr2.address))
       .to.emit(stake, "AGITypeRemoved")
       .withArgs(addr2.address);
+  });
+});
+
+describe("StakeManager slash distribution", function () {
+  let owner, validator, beneficiary, treasury, extra;
+  let stake, agi;
+  const depositAmount = ethers.parseUnits("100", 18);
+
+  beforeEach(async function () {
+    await ethers.provider.send("hardhat_reset", []);
+    [owner, validator, beneficiary, treasury, extra] = await ethers.getSigners();
+    ({ stake, agi } = await deployStakeManager());
+    await stake.setTreasury(treasury.address);
+    await stake.setSlasher(owner.address);
+    await agi.mint(validator.address, depositAmount);
+    await agi
+      .connect(validator)
+      .approve(await stake.getAddress(), depositAmount);
+    await stake
+      .connect(validator)
+      .depositStake(ROLE_VALIDATOR, depositAmount);
+  });
+
+  it("routes the full slash to the treasury by default", async function () {
+    const slashAmount = ethers.parseUnits("40", 18);
+    await expect(
+      stake.slash(validator.address, beneficiary.address, slashAmount)
+    )
+      .to.emit(stake, "StakeSlashed")
+      .withArgs(validator.address, beneficiary.address, slashAmount, 0n, slashAmount);
+    expect(await agi.balanceOf(beneficiary.address)).to.equal(0n);
+    expect(await agi.balanceOf(treasury.address)).to.equal(slashAmount);
+  });
+
+  it("respects the configured employer slash pct", async function () {
+    await stake.setEmployerSlashPct(25);
+    const slashAmount = ethers.parseUnits("20", 18);
+    const employerShare = (slashAmount * 25n) / 100n;
+    const treasuryShare = slashAmount - employerShare;
+    await expect(
+      stake.slash(validator.address, beneficiary.address, slashAmount)
+    )
+      .to.emit(stake, "StakeSlashed")
+      .withArgs(
+        validator.address,
+        beneficiary.address,
+        slashAmount,
+        employerShare,
+        treasuryShare
+      );
+    expect(await agi.balanceOf(beneficiary.address)).to.equal(employerShare);
+    expect(await agi.balanceOf(treasury.address)).to.equal(treasuryShare);
+  });
+
+  it("sends the entire amount to the treasury when no beneficiary", async function () {
+    await stake.setEmployerSlashPct(30);
+    const slashAmount = ethers.parseUnits("10", 18);
+    await expect(
+      stake.slash(validator.address, ethers.ZeroAddress, slashAmount)
+    )
+      .to.emit(stake, "StakeSlashed")
+      .withArgs(validator.address, ethers.ZeroAddress, slashAmount, 0n, slashAmount);
+    expect(await agi.balanceOf(treasury.address)).to.equal(slashAmount);
   });
 });
 


### PR DESCRIPTION
## Summary
- add configurable employer/treasury slash percentages and emit updates
- route stake slashes according to the configured shares and simplify the event payload
- refresh hardhat tests to cover the new distribution scenarios

## Testing
- npm test (tests/contracts)


------
https://chatgpt.com/codex/tasks/task_e_68caee81313883339b7f959b4d7a930a