### PR TITLE
[alpha_factory] Fix Ruff target contract to avoid linting Git metadata

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -49,7 +49,7 @@ jobs:
           pip install -r requirements.lock
           pip install -r requirements-dev.lock
       - name: Ruff check
-        run: python -m ruff check .
+        run: python scripts/ruff_targets.py --run
 
   smoke:
     name: "Smoke tests"

--- a/alpha_factory_v1/demos/self_healing_repo/repo_healer_v1/ci_bundle.py
+++ b/alpha_factory_v1/demos/self_healing_repo/repo_healer_v1/ci_bundle.py
@@ -122,7 +122,7 @@ def _collect_junit_signals(junit_path: pathlib.Path) -> list[FailureSignal]:
 
 def _default_reproduction_command(validator: ValidatorClass, candidate_files: list[str]) -> list[str]:
     if validator == ValidatorClass.RUFF:
-        return ["ruff", "check", "."]
+        return [sys.executable, "scripts/ruff_targets.py", "--run"]
     if validator == ValidatorClass.MYPY:
         return ["mypy", "--config-file", "mypy.ini"]
     if validator == ValidatorClass.IMPORT:

--- a/alpha_factory_v1/demos/self_healing_repo/repo_healer_v1/validators.py
+++ b/alpha_factory_v1/demos/self_healing_repo/repo_healer_v1/validators.py
@@ -47,7 +47,7 @@ DEFAULT_SMOKE_TARGETED = [
 
 REGISTRY: dict[ValidatorClass, ValidatorPlan] = {
     ValidatorClass.RUFF: ValidatorPlan(
-        targeted=["ruff", "check", "."],
+        targeted=[PYTHON, "scripts/ruff_targets.py", "--run"],
         broader=[PYTHON, "-m", "pytest", "-m", "smoke", "tests/test_ping_agent.py", "tests/test_af_requests.py", "-q"],
     ),
     ValidatorClass.MYPY: ValidatorPlan(

--- a/scripts/ruff_targets.py
+++ b/scripts/ruff_targets.py
@@ -25,19 +25,25 @@ METADATA_PATH_PARTS: frozenset[str] = frozenset(
 
 def _repo_root() -> Path:
     """Return the current Git repository root path."""
-    result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return Path.cwd()
     return Path(result.stdout.strip())
 
 
 def list_tracked_python_files(repo_root: Path) -> list[str]:
     """Return tracked Python-related files for Ruff relative to ``repo_root``."""
     command = ["git", "-C", str(repo_root), "ls-files", "--cached", "-z", "--", *PYTHON_FILE_GLOBS]
-    result = subprocess.run(command, check=True, capture_output=True)
+    try:
+        result = subprocess.run(command, check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        return _walk_python_files(repo_root)
 
     entries = [item for item in result.stdout.decode("utf-8").split("\x00") if item]
     filtered = sorted({entry for entry in entries if _is_lintable_path(entry)})
@@ -48,6 +54,20 @@ def _is_lintable_path(relative_path: str) -> bool:
     """Return whether ``relative_path`` should be included in Ruff scope."""
     path = Path(relative_path)
     return not any(part in METADATA_PATH_PARTS for part in path.parts)
+
+
+def _walk_python_files(repo_root: Path) -> list[str]:
+    """Return Python files from filesystem walk when Git metadata is unavailable."""
+    discovered: set[str] = set()
+    for pattern in PYTHON_FILE_GLOBS:
+        for path in repo_root.rglob(pattern):
+            try:
+                rel = path.relative_to(repo_root).as_posix()
+            except ValueError:
+                continue
+            if _is_lintable_path(rel):
+                discovered.add(rel)
+    return sorted(discovered)
 
 
 def run_ruff(repo_root: Path, targets: list[str], batch_size: int) -> int:

--- a/tests/repo_healer_v1/test_ci_bundle.py
+++ b/tests/repo_healer_v1/test_ci_bundle.py
@@ -570,7 +570,7 @@ def test_build_bundle_sets_reproduction_and_risk_tier(tmp_path: Path, monkeypatc
     monkeypatch.setattr(ci_bundle, "_api_get", fake_api_get)
     bundle = build_failure_bundle(event_path, repository="org/repo", token="token")
 
-    assert bundle.reproduction_command == ["ruff", "check", "."]
+    assert bundle.reproduction_command == [ci_bundle.sys.executable, "scripts/ruff_targets.py", "--run"]
     assert bundle.risk_tier == "tier1"
 
 

--- a/tests/repo_healer_v1/test_triage_engine.py
+++ b/tests/repo_healer_v1/test_triage_engine.py
@@ -209,3 +209,11 @@ def test_mypy_validator_plan_matches_ci_scope() -> None:
 
     plan = get_plan(ValidatorClass.MYPY)
     assert plan.targeted == ["mypy", "--config-file", "mypy.ini"]
+
+
+def test_ruff_validator_plan_matches_ci_scope() -> None:
+    from alpha_factory_v1.demos.self_healing_repo.repo_healer_v1 import validators
+    from alpha_factory_v1.demos.self_healing_repo.repo_healer_v1.validators import get_plan
+
+    plan = get_plan(ValidatorClass.RUFF)
+    assert plan.targeted == [validators.PYTHON, "scripts/ruff_targets.py", "--run"]

--- a/tests/test_ci_ruff_scope_contract.py
+++ b/tests/test_ci_ruff_scope_contract.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guards for explicit Ruff target selection in CI workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_integration_ci_ruff_step_uses_target_script() -> None:
+    workflow = Path('.github/workflows/ci.yml').read_text(encoding='utf-8')
+
+    assert 'name: Ruff lint' in workflow
+    assert 'run: python scripts/ruff_targets.py --run' in workflow
+    assert 'name: Ruff lint\n        run: python -m ruff check .' not in workflow
+
+
+def test_pr_ci_ruff_step_uses_target_script() -> None:
+    workflow = Path('.github/workflows/pr-ci.yml').read_text(encoding='utf-8')
+
+    assert 'name: Ruff check' in workflow
+    assert 'run: python scripts/ruff_targets.py --run' in workflow
+    assert 'run: python -m ruff check .' not in workflow

--- a/tests/test_ruff_targets.py
+++ b/tests/test_ruff_targets.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from scripts.ruff_targets import list_tracked_python_files
+from scripts.ruff_targets import _repo_root, list_tracked_python_files
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -57,3 +57,36 @@ def test_list_tracked_python_files_filters_metadata_paths(monkeypatch: Any, tmp_
 
     assert "--cached" in captured["cmd"]
     assert targets == ["docs/readme.pyi", "src/good.py"]
+
+
+def test_list_tracked_python_files_falls_back_without_git_index(monkeypatch: Any, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pkg").mkdir()
+    (repo / "pkg" / "ok.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / ".git" / "refs").mkdir(parents=True)
+    (repo / ".git" / "refs" / "bad.py").write_text("deadbeef\n", encoding="utf-8")
+
+    def fake_run(cmd: list[str], check: bool, capture_output: bool) -> SimpleNamespace:
+        raise subprocess.CalledProcessError(returncode=128, cmd=cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    targets = list_tracked_python_files(repo)
+
+    assert targets == ["pkg/ok.py"]
+
+
+def test_repo_root_falls_back_to_cwd_when_git_unavailable(monkeypatch: Any, tmp_path: Path) -> None:
+    original_cwd = Path.cwd()
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        raise subprocess.CalledProcessError(returncode=128, cmd=["git", "rev-parse"])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    try:
+        import os
+
+        os.chdir(tmp_path)
+        assert _repo_root() == tmp_path
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
### Motivation
- The CI Ruff step was recursively linting `.` which allowed Git refs such as `.git/refs/remotes/...` (sometimes named like `*.py`) to be parsed by Ruff and produce spurious F821 / SyntaxError failures. This is a target‑selection bug, not repository code errors.
- The fix must make the lint target set explicit and regression‑protected so Git metadata cannot re-enter Ruff's scope.

### Description
- Replace the PR CI Ruff invocation from `python -m ruff check .` to the tracked-file runner `python scripts/ruff_targets.py --run` so the step lints only Git‑tracked Python files. (`.github/workflows/pr-ci.yml`).
- Align Repo‑Healer reproduction/validator commands to call the same tracked-target script instead of `ruff check .` (updated `ci_bundle.py` and `validators.py`).
- Add tests that lock the new contract: `tests/test_ci_ruff_scope_contract.py` asserts the workflows use `scripts/ruff_targets.py --run`, and added/updated unit tests in `tests/repo_healer_v1` to expect the new reproduction command; existing `tests/test_ruff_targets.py` continues to assert index-based enumeration and `.git` filtering behavior.

### Testing
- Ran targeted unit tests: `pytest tests/test_ci_ruff_scope_contract.py tests/test_ruff_targets.py tests/repo_healer_v1/test_ci_bundle.py tests/repo_healer_v1/test_triage_engine.py -q` and they all passed (`39 passed`).
- Verified the new runtime invocation locally for both interpreters via `PYENV_VERSION=3.11.14 pyenv exec python scripts/ruff_targets.py --run` and `PYENV_VERSION=3.12.12 pyenv exec python scripts/ruff_targets.py --run`, both returned success and no `.git/refs/...` lint output.
- Ran `pre-commit run --all-files` and saw existing unrelated repo hooks fail (missing gallery preview asset + Node version for Insight ESLint); these are pre-existing and outside this change.
- Ran a full `pytest` run to check broader impact; the suite completed but surfaced a pre-existing unrelated failure `tests/test_verify_gallery_assets.py::test_repo_contract_includes_insight_preview_asset` and existing `mypy` debt remains (unrelated to the Ruff target contract fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d819494ec4833396c1d8322e6b1c7a)