### PR TITLE
[alpha_factory] Pin CI baseline installer to pip <26

### DIFF
--- a/scripts/ci_install_python_baseline.sh
+++ b/scripts/ci_install_python_baseline.sh
@@ -25,7 +25,12 @@ while (($#)); do
     shift
 done
 
-python -m pip install --upgrade pip
+#
+# NOTE: keep CI on the latest stable pip 25.x for now. pip 26 introduced
+# resolver/lockfile regressions that can break matrix jobs before lint/test
+# steps run, so we explicitly constrain the installer until the lock pipeline
+# is validated against pip 26.
+python -m pip install --upgrade "pip<26"
 pip install -r requirements.lock
 pip install -r requirements-dev.lock
 


### PR DESCRIPTION
### Motivation
- Pin the CI bootstrap `pip` installer to `<26` to avoid pip 26 resolver/lockfile regressions that caused matrix jobs to fail before lint/test/doc steps and to preserve deterministic installs from lockfiles.

### Description
- Change `scripts/ci_install_python_baseline.sh` to run `python -m pip install --upgrade "pip<26"` and add an inline note explaining the temporary pin.

### Testing
- Verified with `bash -n scripts/ci_install_python_baseline.sh`, `python scripts/ruff_targets.py --run`, `pytest -q tests/test_ruff_targets.py` (4 passed), and `pytest -q tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml` (2 passed, 1 skipped); all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8679caf1483338abf6563e8d98718)