### PR TITLE
[alpha_factory] Restore missing alpha_agi_insight_v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Restore the mirrored gallery preview referenced by `docs/demos/alpha_agi_insight_v1.md` so the `verify-gallery-assets` check and docs pipeline no longer fail.

### Description
- Add the placeholder SVG at `docs/alpha_agi_insight_v1/assets/preview.svg` containing a minimal preview image used by the docs gallery.

### Testing
- Executed `python scripts/verify_gallery_assets.py` (passed) and `pytest -q tests/test_workbox_integrity.py` (1 skipped, exit 0); `pre-commit` was not available in this runtime so hooks were not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f352588c8333a34bd18703c9ed4f)