### PR TITLE
[alpha_factory] Fix AIGA Gradio loop safety and Insight CSP connect-src

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -22,7 +22,7 @@ additive hardening to satisfy enterprise infosec & regulator audits.
 """
 from __future__ import annotations
 
-import os, asyncio, signal, logging, time, json, math, tempfile, threading
+import os, asyncio, logging, time, json, math, tempfile, threading
 from pathlib import Path
 from typing import Any, Dict
 
@@ -385,7 +385,7 @@ async def best_alpha():
 # ---------------------------------------------------------------------------
 # GRADIO DASHBOARD -----------------------------------------------------------
 # ---------------------------------------------------------------------------
-async def _launch_gradio() -> None:  # noqa: D401
+def _launch_gradio(api_loop: asyncio.AbstractEventLoop) -> None:  # noqa: D401
     if gr is None:
         log.info("Gradio dashboard disabled (package not installed)")
         return
@@ -395,38 +395,46 @@ async def _launch_gradio() -> None:  # noqa: D401
         log_md = gr.Markdown()
 
         def on_step(g=5):
-            asyncio.run(service.evolve(g))
+            asyncio.run_coroutine_threadsafe(service.evolve(g), api_loop).result()
             return service.history_plot(), service.latest_log()
 
         gr.Button("Evolve 5 Generations").click(on_step, [], [plot, log_md])
     ui.launch(server_name="0.0.0.0", server_port=GRADIO_PORT, share=False)
 
 
-# ---------------------------------------------------------------------------
-# SIGNAL HANDLERS ------------------------------------------------------------
-# ---------------------------------------------------------------------------
-async def _graceful_exit(*_):
-    log.info("SIGTERM received – persisting state …")
+_gradio_thread: threading.Thread | None = None
+
+
+@app.on_event("startup")
+async def _start_gradio_dashboard() -> None:
+    """Launch Gradio once and bridge callbacks to FastAPI's event loop."""
+    global _gradio_thread
+    if gr is None:
+        log.info("Skipping Gradio startup")
+        return
+    if _gradio_thread and _gradio_thread.is_alive():
+        return
+
+    api_loop = asyncio.get_running_loop()
+    _gradio_thread = threading.Thread(
+        target=lambda: _launch_gradio(api_loop),
+        daemon=True,
+        name="aiga-gradio",
+    )
+    _gradio_thread.start()
+
+
+@app.on_event("shutdown")
+async def _checkpoint_on_shutdown() -> None:
+    """Persist state before FastAPI shuts down."""
+    log.info("Shutdown received – persisting state …")
     await service.checkpoint()
-    loop = asyncio.get_event_loop()
-    loop.stop()
 
 
 # ---------------------------------------------------------------------------
 # MAIN -----------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(_graceful_exit(s)))
-
-    # Start Gradio in a daemon thread so uvicorn can own the main event loop.
-    if gr is not None:
-        threading.Thread(target=lambda: asyncio.run(_launch_gradio()), daemon=True).start()
-    else:
-        log.info("Skipping Gradio startup")
-
     # register with agent mesh (optional)
     if AgentRuntime:
         AgentRuntime.register(SERVICE_NAME, f"http://localhost:{API_PORT}")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -395,14 +395,25 @@ def _launch_gradio(api_loop: asyncio.AbstractEventLoop) -> None:  # noqa: D401
         log_md = gr.Markdown()
 
         def on_step(g=5):
+            if api_loop.is_closed():
+                log.warning("Skipping evolve request because API event loop is closed")
+                return service.history_plot(), service.latest_log()
             asyncio.run_coroutine_threadsafe(service.evolve(g), api_loop).result()
             return service.history_plot(), service.latest_log()
 
         gr.Button("Evolve 5 Generations").click(on_step, [], [plot, log_md])
-    ui.launch(server_name="0.0.0.0", server_port=GRADIO_PORT, share=False)
+    ui.launch(
+        server_name="0.0.0.0",
+        server_port=GRADIO_PORT,
+        share=False,
+        prevent_thread_lock=True,
+    )
+    _gradio_stop_event.wait()
+    ui.close()
 
 
 _gradio_thread: threading.Thread | None = None
+_gradio_stop_event = threading.Event()
 
 
 @app.on_event("startup")
@@ -415,6 +426,7 @@ async def _start_gradio_dashboard() -> None:
     if _gradio_thread and _gradio_thread.is_alive():
         return
 
+    _gradio_stop_event.clear()
     api_loop = asyncio.get_running_loop()
     _gradio_thread = threading.Thread(
         target=lambda: _launch_gradio(api_loop),
@@ -427,6 +439,11 @@ async def _start_gradio_dashboard() -> None:
 @app.on_event("shutdown")
 async def _checkpoint_on_shutdown() -> None:
     """Persist state before FastAPI shuts down."""
+    global _gradio_thread
+    _gradio_stop_event.set()
+    if _gradio_thread and _gradio_thread.is_alive():
+        _gradio_thread.join(timeout=5)
+    _gradio_thread = None
     log.info("Shutdown received – persisting state …")
     await service.checkpoint()
 

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -328,10 +328,11 @@ async function bundle() {
         stdio: "inherit",
     });
     let outHtml = html;
-    const cspBase =
-        "default-src 'self'; connect-src 'self' https://api.openai.com; frame-src 'self' blob:; worker-src 'self' blob:" +
-        (ipfsOrigin ? ` ${ipfsOrigin}` : "") +
-        (otelOrigin ? ` ${otelOrigin}` : "");
+    const connectSrc =
+        ["'self'", "https://api.openai.com", ipfsOrigin, otelOrigin]
+            .filter(Boolean)
+            .join(" ");
+    const cspBase = `default-src 'self'; connect-src ${connectSrc}; frame-src 'self' blob:; worker-src 'self' blob:`;
     const envScript = injectEnv(process.env);
     await copyAssets(manifest, repoRoot, OUT_DIR, assetRoot);
     if (fsSync.existsSync(d3ExportsPath)) {


### PR DESCRIPTION
### Motivation
- Prevent cross-event-loop deadlocks in the AIGA demo by ensuring Gradio callbacks run on FastAPI's event loop instead of creating a second loop.
- Restore intended network access for optional IPFS/OTEL endpoints by appending those origins to `connect-src` in the Insight Browser CSP instead of `worker-src`.

### Description
- Reworked Gradio startup in `alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py` to launch Gradio from a daemon thread started on FastAPI `startup` and pass `api_loop` into `_launch_gradio` so callbacks can schedule work onto the API loop.
- Replaced direct `asyncio.run(service.evolve(...))` in Gradio callbacks with `asyncio.run_coroutine_threadsafe(service.evolve(...), api_loop).result()` to avoid cross-loop `asyncio.Lock` contention.
- Added `@app.on_event("startup")` to start the Gradio thread and `@app.on_event("shutdown")` to persist state via `service.checkpoint()` instead of manually manipulating signal handlers and loops.
- Fixed CSP generation in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js` by building a `connectSrc` list including `ipfsOrigin` and `otelOrigin` and embedding it into `connect-src`, leaving `worker-src` unchanged.

### Testing
- Ran `python -m py_compile alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py`, which succeeded. 
- Ran `node --check alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9211ce05c8333966fda3bead5ac18)