### PR TITLE
Bridge Gradio to FastAPI lifecycle, add safe shutdown, and fix CSP connect-src assembly

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -22,7 +22,7 @@ additive hardening to satisfy enterprise infosec & regulator audits.
 """
 from __future__ import annotations
 
-import os, asyncio, signal, logging, time, json, math, tempfile, threading
+import os, asyncio, logging, time, json, math, tempfile, threading
 from pathlib import Path
 from typing import Any, Dict
 
@@ -385,7 +385,8 @@ async def best_alpha():
 # ---------------------------------------------------------------------------
 # GRADIO DASHBOARD -----------------------------------------------------------
 # ---------------------------------------------------------------------------
-async def _launch_gradio() -> None:  # noqa: D401
+def _launch_gradio(api_loop: asyncio.AbstractEventLoop) -> None:  # noqa: D401
+    global _gradio_ui
     if gr is None:
         log.info("Gradio dashboard disabled (package not installed)")
         return
@@ -395,38 +396,60 @@ async def _launch_gradio() -> None:  # noqa: D401
         log_md = gr.Markdown()
 
         def on_step(g=5):
-            asyncio.run(service.evolve(g))
+            asyncio.run_coroutine_threadsafe(service.evolve(g), api_loop).result()
             return service.history_plot(), service.latest_log()
 
         gr.Button("Evolve 5 Generations").click(on_step, [], [plot, log_md])
+    _gradio_ui = ui
     ui.launch(server_name="0.0.0.0", server_port=GRADIO_PORT, share=False)
 
 
-# ---------------------------------------------------------------------------
-# SIGNAL HANDLERS ------------------------------------------------------------
-# ---------------------------------------------------------------------------
-async def _graceful_exit(*_):
-    log.info("SIGTERM received – persisting state …")
+_gradio_thread: threading.Thread | None = None
+_gradio_ui: Any | None = None
+
+
+@app.on_event("startup")
+async def _start_gradio_dashboard() -> None:
+    """Launch Gradio once and bridge callbacks to FastAPI's event loop."""
+    global _gradio_thread
+    if gr is None:
+        log.info("Skipping Gradio startup")
+        return
+    if _gradio_thread and not _gradio_thread.is_alive():
+        _gradio_thread = None
+    if _gradio_thread and _gradio_thread.is_alive():
+        return
+
+    api_loop = asyncio.get_running_loop()
+    _gradio_thread = threading.Thread(
+        target=lambda: _launch_gradio(api_loop),
+        daemon=True,
+        name="aiga-gradio",
+    )
+    _gradio_thread.start()
+
+
+@app.on_event("shutdown")
+async def _checkpoint_on_shutdown() -> None:
+    """Persist state and stop Gradio before FastAPI shuts down."""
+    global _gradio_thread, _gradio_ui
+    log.info("Shutdown received – persisting state …")
     await service.checkpoint()
-    loop = asyncio.get_event_loop()
-    loop.stop()
+    if _gradio_ui is not None:
+        try:
+            _gradio_ui.close()
+        except Exception:
+            log.exception("Failed to close Gradio UI cleanly")
+    if _gradio_thread and _gradio_thread.is_alive():
+        _gradio_thread.join(timeout=5)
+    _gradio_thread = None
+    _gradio_ui = None
 
 
 # ---------------------------------------------------------------------------
 # MAIN -----------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(_graceful_exit(s)))
-
-    # Start Gradio in a daemon thread so uvicorn can own the main event loop.
-    if gr is not None:
-        threading.Thread(target=lambda: asyncio.run(_launch_gradio()), daemon=True).start()
-    else:
-        log.info("Skipping Gradio startup")
-
     # register with agent mesh (optional)
     if AgentRuntime:
         AgentRuntime.register(SERVICE_NAME, f"http://localhost:{API_PORT}")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -85,6 +85,11 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     gr = None  # type: ignore[assignment]
 
+try:
+    import fcntl
+except Exception:  # pragma: no cover - Windows fallback
+    fcntl = None  # type: ignore[assignment]
+
 try:  # optional JWT auth
     import jwt  # type: ignore
 except Exception:  # pragma: no cover - optional
@@ -406,6 +411,26 @@ def _launch_gradio(api_loop: asyncio.AbstractEventLoop) -> None:  # noqa: D401
 
 _gradio_thread: threading.Thread | None = None
 _gradio_ui: Any | None = None
+_gradio_lock_handle: Any | None = None
+
+
+def _acquire_gradio_process_lock() -> bool:
+    """Allow only one process to launch the Gradio dashboard for this port."""
+    global _gradio_lock_handle
+    if fcntl is None:
+        return True
+    if _gradio_lock_handle is not None:
+        return True
+
+    lock_path = Path(tempfile.gettempdir()) / f"aiga-gradio-{GRADIO_PORT}.lock"
+    lock_handle = open(lock_path, "w", encoding="utf-8")
+    try:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        lock_handle.close()
+        return False
+    _gradio_lock_handle = lock_handle
+    return True
 
 
 @app.on_event("startup")
@@ -414,6 +439,9 @@ async def _start_gradio_dashboard() -> None:
     global _gradio_thread
     if gr is None:
         log.info("Skipping Gradio startup")
+        return
+    if not _acquire_gradio_process_lock():
+        log.info("Skipping Gradio startup in this worker (dashboard already owned by another process)")
         return
     if _gradio_thread and not _gradio_thread.is_alive():
         _gradio_thread = None
@@ -432,7 +460,7 @@ async def _start_gradio_dashboard() -> None:
 @app.on_event("shutdown")
 async def _checkpoint_on_shutdown() -> None:
     """Persist state and stop Gradio before FastAPI shuts down."""
-    global _gradio_thread, _gradio_ui
+    global _gradio_thread, _gradio_ui, _gradio_lock_handle
     log.info("Shutdown received – persisting state …")
     await service.checkpoint()
     if _gradio_ui is not None:
@@ -444,6 +472,11 @@ async def _checkpoint_on_shutdown() -> None:
         _gradio_thread.join(timeout=5)
     _gradio_thread = None
     _gradio_ui = None
+    if _gradio_lock_handle is not None:
+        if fcntl is not None:
+            fcntl.flock(_gradio_lock_handle.fileno(), fcntl.LOCK_UN)
+        _gradio_lock_handle.close()
+        _gradio_lock_handle = None
 
 
 # ---------------------------------------------------------------------------

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -328,10 +328,11 @@ async function bundle() {
         stdio: "inherit",
     });
     let outHtml = html;
-    const cspBase =
-        "default-src 'self'; connect-src 'self' https://api.openai.com; frame-src 'self' blob:; worker-src 'self' blob:" +
-        (ipfsOrigin ? ` ${ipfsOrigin}` : "") +
-        (otelOrigin ? ` ${otelOrigin}` : "");
+    const connectSrc =
+        ["'self'", "https://api.openai.com", ipfsOrigin, otelOrigin]
+            .filter(Boolean)
+            .join(" ");
+    const cspBase = `default-src 'self'; connect-src ${connectSrc}; frame-src 'self' blob:; worker-src 'self' blob:`;
     const envScript = injectEnv(process.env);
     await copyAssets(manifest, repoRoot, OUT_DIR, assetRoot);
     if (fsSync.existsSync(d3ExportsPath)) {


### PR DESCRIPTION
### Motivation
- Improve reliability of the Gradio dashboard by running it as a daemon thread tied to FastAPI startup/shutdown instead of ad-hoc event loop and signal handlers.
- Ensure clean checkpointing and UI teardown on application shutdown to avoid dangling threads and corrupted state.
- Harden frontend Content Security Policy generation to safely include optional origins without producing malformed directives.

### Description
- Replace ad-hoc event loop manipulation and signal handlers with `@app.on_event("startup")` and `@app.on_event("shutdown")` handlers that launch Gradio in a daemon thread and persist state on shutdown.
- Change `_launch_gradio` to accept the FastAPI event loop and use `asyncio.run_coroutine_threadsafe(service.evolve(g), api_loop).result()` to bridge Gradio callbacks to the main loop, and expose `_gradio_ui` for controlled teardown.
- Introduce `_gradio_thread` and `_gradio_ui` globals and add logic to close the Gradio UI and join the thread with a timeout during shutdown, plus error logging on close failure.
- Simplify and harden the frontend CSP generation in `build.js` by assembling `connect-src` from a filtered array of origins and injecting it into `cspBase` to avoid malformed directives.

### Testing
- Ran the backend automated test suite with `pytest`, and all tests passed.
- Executed the frontend build script (`node insight_browser_v1/build.js`) to produce the bundle and assets, and the build completed successfully.
- Verified that the FastAPI app starts and stops without leaving Gradio threads running by exercising the startup/shutdown lifecycle in an automated integration run, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9211ce05c8333966fda3bead5ac18)