### PR TITLE
Gradio: single-worker startup with file lock and proper shutdown; tighten frontend CSP generation

### DIFF
--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -22,7 +22,7 @@ additive hardening to satisfy enterprise infosec & regulator audits.
 """
 from __future__ import annotations
 
-import os, asyncio, signal, logging, time, json, math, tempfile, threading
+import os, asyncio, logging, time, json, math, tempfile, threading, fcntl
 from pathlib import Path
 from typing import Any, Dict
 
@@ -385,7 +385,8 @@ async def best_alpha():
 # ---------------------------------------------------------------------------
 # GRADIO DASHBOARD -----------------------------------------------------------
 # ---------------------------------------------------------------------------
-async def _launch_gradio() -> None:  # noqa: D401
+def _launch_gradio(api_loop: asyncio.AbstractEventLoop) -> None:  # noqa: D401
+    global _gradio_ui
     if gr is None:
         log.info("Gradio dashboard disabled (package not installed)")
         return
@@ -395,38 +396,79 @@ async def _launch_gradio() -> None:  # noqa: D401
         log_md = gr.Markdown()
 
         def on_step(g=5):
-            asyncio.run(service.evolve(g))
+            asyncio.run_coroutine_threadsafe(service.evolve(g), api_loop).result()
             return service.history_plot(), service.latest_log()
 
         gr.Button("Evolve 5 Generations").click(on_step, [], [plot, log_md])
+    _gradio_ui = ui
     ui.launch(server_name="0.0.0.0", server_port=GRADIO_PORT, share=False)
 
 
-# ---------------------------------------------------------------------------
-# SIGNAL HANDLERS ------------------------------------------------------------
-# ---------------------------------------------------------------------------
-async def _graceful_exit(*_):
-    log.info("SIGTERM received – persisting state …")
+_gradio_thread: threading.Thread | None = None
+_gradio_ui: Any | None = None
+_gradio_lock_file: Any | None = None
+
+
+@app.on_event("startup")
+async def _start_gradio_dashboard() -> None:
+    """Launch Gradio once and bridge callbacks to FastAPI's event loop."""
+    global _gradio_thread, _gradio_lock_file
+    if gr is None:
+        log.info("Skipping Gradio startup")
+        return
+    if _gradio_thread and not _gradio_thread.is_alive():
+        _gradio_thread = None
+    if _gradio_thread and _gradio_thread.is_alive():
+        return
+
+    if _gradio_lock_file is None:
+        lock_path = Path(tempfile.gettempdir()) / "aiga-gradio.lock"
+        lock_file = lock_path.open("w", encoding="utf-8")
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            log.info("Skipping Gradio startup in this worker (lock already held): %s", lock_path)
+            lock_file.close()
+            return
+        _gradio_lock_file = lock_file
+
+    api_loop = asyncio.get_running_loop()
+    _gradio_thread = threading.Thread(
+        target=lambda: _launch_gradio(api_loop),
+        daemon=True,
+        name="aiga-gradio",
+    )
+    _gradio_thread.start()
+
+
+@app.on_event("shutdown")
+async def _checkpoint_on_shutdown() -> None:
+    """Persist state and stop Gradio before FastAPI shuts down."""
+    global _gradio_thread, _gradio_ui, _gradio_lock_file
+    log.info("Shutdown received – persisting state …")
     await service.checkpoint()
-    loop = asyncio.get_event_loop()
-    loop.stop()
+    if _gradio_ui is not None:
+        try:
+            _gradio_ui.close()
+        except Exception:
+            log.exception("Failed to close Gradio UI cleanly")
+    if _gradio_thread and _gradio_thread.is_alive():
+        _gradio_thread.join(timeout=5)
+    if _gradio_lock_file is not None:
+        try:
+            fcntl.flock(_gradio_lock_file.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            log.exception("Failed to release Gradio startup lock cleanly")
+        _gradio_lock_file.close()
+        _gradio_lock_file = None
+    _gradio_thread = None
+    _gradio_ui = None
 
 
 # ---------------------------------------------------------------------------
 # MAIN -----------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(_graceful_exit(s)))
-
-    # Start Gradio in a daemon thread so uvicorn can own the main event loop.
-    if gr is not None:
-        threading.Thread(target=lambda: asyncio.run(_launch_gradio()), daemon=True).start()
-    else:
-        log.info("Skipping Gradio startup")
-
     # register with agent mesh (optional)
     if AgentRuntime:
         AgentRuntime.register(SERVICE_NAME, f"http://localhost:{API_PORT}")

--- a/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
+++ b/alpha_factory_v1/demos/aiga_meta_evolution/agent_aiga_entrypoint.py
@@ -22,9 +22,14 @@ additive hardening to satisfy enterprise infosec & regulator audits.
 """
 from __future__ import annotations
 
-import os, asyncio, logging, time, json, math, tempfile, threading, fcntl
+import os, asyncio, logging, time, json, math, tempfile, threading
 from pathlib import Path
 from typing import Any, Dict
+
+if os.name != "nt":
+    import fcntl
+else:
+    fcntl = None  # type: ignore[assignment]
 
 import uvicorn
 from fastapi import FastAPI, BackgroundTasks, HTTPException
@@ -421,7 +426,7 @@ async def _start_gradio_dashboard() -> None:
     if _gradio_thread and _gradio_thread.is_alive():
         return
 
-    if _gradio_lock_file is None:
+    if _gradio_lock_file is None and fcntl is not None:
         lock_path = Path(tempfile.gettempdir()) / "aiga-gradio.lock"
         lock_file = lock_path.open("w", encoding="utf-8")
         try:
@@ -431,6 +436,8 @@ async def _start_gradio_dashboard() -> None:
             lock_file.close()
             return
         _gradio_lock_file = lock_file
+    elif _gradio_lock_file is None:
+        log.warning("fcntl unavailable on this platform; starting Gradio without inter-process lock")
 
     api_loop = asyncio.get_running_loop()
     _gradio_thread = threading.Thread(
@@ -454,7 +461,7 @@ async def _checkpoint_on_shutdown() -> None:
             log.exception("Failed to close Gradio UI cleanly")
     if _gradio_thread and _gradio_thread.is_alive():
         _gradio_thread.join(timeout=5)
-    if _gradio_lock_file is not None:
+    if _gradio_lock_file is not None and fcntl is not None:
         try:
             fcntl.flock(_gradio_lock_file.fileno(), fcntl.LOCK_UN)
         except OSError:

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -328,10 +328,11 @@ async function bundle() {
         stdio: "inherit",
     });
     let outHtml = html;
-    const cspBase =
-        "default-src 'self'; connect-src 'self' https://api.openai.com; frame-src 'self' blob:; worker-src 'self' blob:" +
-        (ipfsOrigin ? ` ${ipfsOrigin}` : "") +
-        (otelOrigin ? ` ${otelOrigin}` : "");
+    const connectSrc =
+        ["'self'", "https://api.openai.com", ipfsOrigin, otelOrigin]
+            .filter(Boolean)
+            .join(" ");
+    const cspBase = `default-src 'self'; connect-src ${connectSrc}; frame-src 'self' blob:; worker-src 'self' blob:`;
     const envScript = injectEnv(process.env);
     await copyAssets(manifest, repoRoot, OUT_DIR, assetRoot);
     if (fsSync.existsSync(d3ExportsPath)) {


### PR DESCRIPTION
### Motivation

- Prevent multiple Gradio dashboards from being launched in multi-worker deployments and ensure clean startup/shutdown tied to FastAPI lifecycle.
- Make Content-Security-Policy generation more robust by only including defined origins and avoiding manual string concatenation.

### Description

- Add `fcntl`-based file locking and thread management to ensure only one Gradio instance is started per host, and bridge Gradio callbacks into FastAPI's event loop using `asyncio.run_coroutine_threadsafe`.
- Replace the previous async Gradio launcher with a startup event handler that spawns a daemon thread and a shutdown handler that checkpoints state, closes the UI, joins the thread, and releases the lock file.
- Remove ad-hoc signal handler / main-thread Gradio startup logic and consolidate lifecycle management under FastAPI events; ensure `service.checkpoint()` runs on shutdown.
- Refactor frontend build CSP generation in `build.js` to construct `connect-src` from an array of origins filtered for truthy values and then join them, producing a safer `cspBase` string.

### Testing

- Ran the frontend build (`npm run build` / `node build.js`) which completed and produced the bundled assets successfully.
- Ran the Python test suite via `pytest` and all tests passed.
- Executed lint/static checks (`flake8` and `mypy`), reporting no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9211ce05c8333966fda3bead5ac18)