### PR TITLE
[alpha_factory] Add missing Alpha AGI Insight v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>


### PR DESCRIPTION
### Motivation
- The gallery asset verification was failing because the mirrored preview asset for the Insight v1 demo was missing, so CI and the demos could not validate the preview reference.

### Description
- Add the missing preview file `docs/alpha_agi_insight_v1/assets/preview.svg` containing the same SVG content as the source preview in the demo assets so the gallery contract is satisfied.

### Testing
- Ran `python scripts/verify_gallery_assets.py` and it completed successfully.
- Ran `pytest -q tests/test_verify_gallery_assets.py::test_repo_contract_includes_insight_preview_asset` and it passed.
- Ran `pytest -q tests/test_memeplex_ts.py::test_meme_mining tests/test_selfheal_entrypoint.py::test_selfheal_live_endpoint tests/test_sw_integrity.py::test_service_worker_integrity tests/test_workbox_integrity.py::test_workbox_hash_mismatch` which resulted in 2 passed and 2 skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94df19944833381e0ae586257f463)