### PR TITLE
[alpha_factory] Fix Insight page error filtering and preserve configured db backend

### DIFF
--- a/alpha_factory_v1/core/utils/config.py
+++ b/alpha_factory_v1/core/utils/config.py
@@ -137,8 +137,6 @@ class Settings(SettingsBase):
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - exercised in tests
         super().__init__(**data)
-        if "ledger_path" in data and "db_type" not in data:
-            self.db_type = "sqlite"
         raw = os.getenv("AGI_ISLAND_BACKENDS")
         if raw and not data.get("island_backends"):
             mapping = {}

--- a/scripts/verify_demo_pages.py
+++ b/scripts/verify_demo_pages.py
@@ -131,10 +131,7 @@ def _is_ready(demo: Path, state: dict[str, object]) -> tuple[bool, str]:
 
 def _is_ignorable_insight_page_error(message: str) -> bool:
     msg = message.lower()
-    return (
-        "service worker is disabled because the context is sandboxed" in msg
-        or "target origin provided" in msg and "does not match the recipient window" in msg
-    )
+    return "service worker is disabled because the context is sandboxed" in msg
 
 def _insight_contract_ok(
     page_errors: list[str],

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -47,3 +47,9 @@ def test_settings_respects_forced_offline(monkeypatch: pytest.MonkeyPatch) -> No
     settings = cfg.Settings()
     assert settings.openai_api_key == "present"
     assert settings.offline
+
+
+def test_settings_preserve_env_db_type_with_explicit_ledger_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGI_INSIGHT_DB", "postgres")
+    settings = cfg.Settings(ledger_path="./ledger/custom.db")
+    assert settings.db_type == "postgres"

--- a/tests/test_verify_demo_pages.py
+++ b/tests/test_verify_demo_pages.py
@@ -80,6 +80,15 @@ def test_insight_contract_requires_clean_runtime() -> None:
     assert _insight_contract_ok([], ["missing.js"], [], []) == (False, "missing-local-assets")
     assert _insight_contract_ok([], [], ["x -> 404"], []) == (False, "http-error-responses")
     assert _insight_contract_ok(["TypeError"], [], [], []) == (False, "page-errors")
+    assert (
+        _insight_contract_ok(
+            ["Failed to execute 'postMessage': The target origin provided does not match the recipient window's origin"],
+            [],
+            [],
+            [],
+        )
+        == (False, "page-errors")
+    )
 
 
 def test_missing_required_assets_detects_insight_contract_files(tmp_path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent masking real runtime errors in the Insight demo verifier by not ignoring genuine `postMessage` origin mismatch errors. 
- Avoid silently overriding an explicitly configured ledger backend (e.g. `AGI_INSIGHT_DB=postgres`) when callers provide a custom `ledger_path`.

### Description
- Tighten the demo error filter in `scripts/verify_demo_pages.py` so only the known sandboxed service worker warning is ignored and `postMessage` origin mismatch messages are treated as failures. 
- Remove the unconditional `db_type = "sqlite"` assignment from `alpha_factory_v1/core/utils/config.py` so environment-provided `AGI_INSIGHT_DB` is preserved even when `ledger_path` is passed. 
- Add regression tests: a `postMessage` origin-mismatch case in `tests/test_verify_demo_pages.py` and a `AGI_INSIGHT_DB=postgres` check with an explicit `ledger_path` in `tests/test_config_utils.py`.

### Testing
- Ran `pytest -q tests/test_verify_demo_pages.py tests/test_config_utils.py` and observed all tests pass (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d980fa55988333a3d9b03bef4cdc67)