### PR TITLE
[alpha_factory] Fix gallery preview asset check and Black formatting

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/scripts/verify_demo_pages.py
+++ b/scripts/verify_demo_pages.py
@@ -127,11 +127,10 @@ def _is_ready(demo: Path, state: dict[str, object]) -> tuple[bool, str]:
     return False, ""
 
 
-
-
 def _is_ignorable_insight_page_error(message: str) -> bool:
     msg = message.lower()
     return "service worker is disabled because the context is sandboxed" in msg
+
 
 def _insight_contract_ok(
     page_errors: list[str],

--- a/tests/test_verify_demo_pages.py
+++ b/tests/test_verify_demo_pages.py
@@ -80,15 +80,12 @@ def test_insight_contract_requires_clean_runtime() -> None:
     assert _insight_contract_ok([], ["missing.js"], [], []) == (False, "missing-local-assets")
     assert _insight_contract_ok([], [], ["x -> 404"], []) == (False, "http-error-responses")
     assert _insight_contract_ok(["TypeError"], [], [], []) == (False, "page-errors")
-    assert (
-        _insight_contract_ok(
-            ["Failed to execute 'postMessage': The target origin provided does not match the recipient window's origin"],
-            [],
-            [],
-            [],
-        )
-        == (False, "page-errors")
-    )
+    assert _insight_contract_ok(
+        ["Failed to execute 'postMessage': The target origin provided does not match the recipient window's origin"],
+        [],
+        [],
+        [],
+    ) == (False, "page-errors")
 
 
 def test_missing_required_assets_detects_insight_contract_files(tmp_path) -> None:


### PR DESCRIPTION
### Motivation
- Resolve CI failures caused by a missing mirrored demo preview asset and Black formatting drift that broke formatting checks. 
- Ensure the docs demo verification and demo readiness scripts adhere to repository formatting and asset expectations so gallery checks pass.

### Description
- Added the missing mirrored preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` containing a simple SVG placeholder. 
- Reformatted `scripts/verify_demo_pages.py` with `black` to normalize whitespace and style only. 
- Reformatted `tests/test_verify_demo_pages.py` with `black` to keep the tests compliant with CI formatting rules.

### Testing
- Ran `python -m black --check tests/test_verify_demo_pages.py scripts/verify_demo_pages.py` which passed after reformatting. 
- Ran `python scripts/verify_gallery_assets.py` to validate demo preview assets, which completed without errors. 
- Ran `python -m pytest tests/test_verify_gallery_assets.py tests/test_verify_demo_pages.py` which returned `17 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9892e57208333b86f4137cd394fa2)