### PR TITLE
[alpha_factory] Restore missing alpha_agi_insight_v1 preview asset mirror

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Restore the missing mirrored preview asset so the docs gallery preview contract and related pre-commit/CI checks succeed.

### Description
- Add `docs/alpha_agi_insight_v1/assets/preview.svg` (mirrors `docs/alpha_factory_v1/demos/alpha_agi_insight_v1/assets/preview.svg`) to re-establish the required preview asset.

### Testing
- Ran `pytest -q tests/test_verify_gallery_assets.py` which passed (`5 passed`).
- Ran `pytest -q tests/test_sw_integrity.py tests/test_workbox_integrity.py` which completed but the tests were skipped in this environment due to missing Node.js 22+/Playwright prerequisites (`2 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3f16fe688333b5d911688d0e232b)