### PR TITLE
Add existence assertions and minor refactors in service worker integrity tests

### DIFF
--- a/tests/test_sw_integrity.py
+++ b/tests/test_sw_integrity.py
@@ -14,8 +14,12 @@ def sha384(path: Path) -> str:
 
 
 def test_service_worker_integrity(insight_dist: Path) -> None:
-    html = (insight_dist / "index.html").read_text()
+    index_file = insight_dist / "index.html"
+    sw_file = insight_dist / "service-worker.js"
+    assert index_file.is_file(), "Missing Insight dist index.html"
+    assert sw_file.is_file(), "Missing Insight service-worker.js"
+    html = index_file.read_text()
     match = re.search(r"SW_HASH\s*=\s*['\"](sha384-[^'\"]+)['\"]", html)
     assert match, "SW_HASH missing"
-    expected = sha384(insight_dist / "service-worker.js")
+    expected = sha384(sw_file)
     assert match.group(1) == expected

--- a/tests/test_workbox_integrity.py
+++ b/tests/test_workbox_integrity.py
@@ -22,6 +22,8 @@ def _start_server(directory: Path):
 
 
 def test_workbox_hash_mismatch(tmp_path: Path, insight_dist: Path) -> None:
+    assert (insight_dist / "index.html").is_file(), "Missing Insight dist index.html"
+    assert (insight_dist / "service-worker.js").is_file(), "Missing Insight service-worker.js"
     dist = tmp_path / "dist"
     shutil.copytree(insight_dist, dist)
     sw_file = dist / "service-worker.js"


### PR DESCRIPTION
### Motivation

- Make the integrity tests fail with clearer diagnostics when build artifacts are missing and clean up variable usage for readability.

### Description

- In `tests/test_sw_integrity.py` add `index_file` and `sw_file` variables and assert that `index.html` and `service-worker.js` exist before reading them. 
- Use the `sw_file` variable when computing the expected SHA-384 hash instead of reconstructing the path inline. 
- In `tests/test_workbox_integrity.py` add assertions that `index.html` and `service-worker.js` are present in `insight_dist` before copying the tree and proceed with the existing hash-mismatch mutation logic.

### Testing

- Ran `pytest tests/test_sw_integrity.py::test_service_worker_integrity` which completed successfully. 
- Ran `pytest tests/test_workbox_integrity.py::test_workbox_hash_mismatch` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da525a44488333b77bb08529e732d1)