### PR TITLE
[alpha_factory] Add missing Insight demo preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#0b1020"/>
+  <circle cx="8" cy="8" r="4.2" fill="#22d3ee" opacity="0.25"/>
+  <text x="8" y="11.5" text-anchor="middle" font-size="8" fill="#e2e8f0">AI</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Fix the `verify-gallery-assets` pre-commit failure caused by a missing mirrored preview referenced by `docs/demos/alpha_agi_insight_v1.md`.

### Description
- Add the missing preview file `docs/alpha_agi_insight_v1/assets/preview.svg`, a lightweight SVG used by the demo gallery.

### Testing
- Ran `pre-commit run --all-files` after selecting Node.js `22.17.1` with `nvm use 22.17.1`, and all hooks passed including the Insight Browser ESLint check.
- Ran `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml` and the suite completed with all tests passing (2 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad88c5680833386266c658ff1b230)