### PR TITLE
[alpha_factory] Fix missing alpha_agi_insight_v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#0b1020"/>
+  <circle cx="8" cy="8" r="4.2" fill="#22d3ee" opacity="0.25"/>
+  <text x="8" y="11.5" text-anchor="middle" font-size="8" fill="#e2e8f0">AI</text>
+</svg>


### PR DESCRIPTION
### Motivation
- The docs gallery verification failed because `docs/demos/alpha_agi_insight_v1.md` referenced a mirrored preview asset that was missing, causing the `verify-gallery-assets` pre-commit hook to fail.

### Description
- Add the missing mirrored preview SVG at `docs/alpha_agi_insight_v1/assets/preview.svg` (simple SVG preview) to restore the docs gallery asset mirror.
- To validate hooks in this environment, installed and used `pre-commit==4.2.0`, installed Node.js `22.17.1` via `nvm`, and ran `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` so the Insight Browser lint hook could run.

### Testing
- Ran `pre-commit run --all-files` and all hooks passed after the fix.
- Ran `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml` which completed successfully (2 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad88c5680833386266c658ff1b230)