### PR TITLE
[alpha_factory] Fix missing alpha_agi_insight_v1 preview mirror asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#0b1020"/>
+  <circle cx="8" cy="8" r="4.2" fill="#22d3ee" opacity="0.25"/>
+  <text x="8" y="11.5" text-anchor="middle" font-size="8" fill="#e2e8f0">AI</text>
+</svg>


### PR DESCRIPTION
### Motivation
- The docs gallery verification failed because the Insight v1 demo page referenced a mirrored preview asset that did not exist, causing pre-commit hooks to fail.

### Description
- Add `docs/alpha_agi_insight_v1/assets/preview.svg` as the mirrored gallery preview asset used by `docs/demos/alpha_agi_insight_v1.md`.
- Provide the expected SVG preview so the gallery verifier no longer reports a missing asset.
- Use Node.js `22.17.1` and install the Insight Browser dependencies so the ESLint pre-commit hook can run successfully.

### Testing
- Ran `python scripts/check_python_deps.py` and it passed.
- Ran `pre-commit run --all-files` after installing Node.js and browser dependencies and all hooks passed.
- Installed Insight Browser dependencies with `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` and ESLint passed.
- Executed `pytest --maxfail=1` and the test suite completed with `922 passed, 95 skipped, 5 xfailed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae8185ca88333a58a286383fef51f)