### PR TITLE
[alpha_factory] Fix missing Insight v1 docs preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#0b1020"/>
+  <circle cx="8" cy="8" r="4.2" fill="#22d3ee" opacity="0.25"/>
+  <text x="8" y="11.5" text-anchor="middle" font-size="8" fill="#e2e8f0">AI</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Restore the missing demo preview asset so the docs page's `![preview](...)` reference resolves and the `verify-gallery-assets` pre-commit hook no longer fails.

### Description
- Add the missing preview SVG at `docs/alpha_agi_insight_v1/assets/preview.svg` to mirror the demo gallery asset; no runtime or Python code was modified.

### Testing
- Ran `python check_env.py --auto-install` which completed successfully.
- Installed and switched to Node.js `22.17.1` with `nvm install`/`nvm use` and ran `npm ci` in the Insight Browser demo, which completed successfully.
- Ran `pre-commit run --all-files` and all hooks passed, including the previously failing `verify-gallery-assets` and `eslint-insight-browser` hooks.
- Executed `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml` which finished with `2 passed, 1 skipped` and coverage XML written.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafab953808333b9a60599564d3d5e)