### PR TITLE
[alpha_factory] harden Ruff lint scope to exclude .git refs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ line-length = 120
 target-version = "py311"
 exclude = [
     ".cache",
+    ".git",
     # exclude all demo directories except MuZero planning
     "alpha_factory_v1/demos/aiga_meta_evolution/*",
     "alpha_factory_v1/demos/alpha_agi_business_2_v1/*",

--- a/tests/test_ci_ruff_scope_contract.py
+++ b/tests/test_ci_ruff_scope_contract.py
@@ -20,3 +20,10 @@ def test_pr_ci_ruff_step_uses_target_script() -> None:
     assert "name: Ruff check" in workflow
     assert "run: python scripts/ruff_targets.py --run" in workflow
     assert "run: python -m ruff check ." not in workflow
+
+
+def test_ruff_exclude_contains_git_metadata() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert "exclude = [" in pyproject
+    assert '".git"' in pyproject


### PR DESCRIPTION
### Motivation
- Prevent Ruff from accidentally linting Git metadata (for example `.git/refs/...` files that may end in `.py`) which produced false syntax/F821 failures in the lint matrix and break the merge-surface CI.

### Description
- Add `".git"` to the `exclude` list under `[tool.ruff]` in `pyproject.toml` and add a regression test `test_ruff_exclude_contains_git_metadata` to `tests/test_ci_ruff_scope_contract.py` to assert the config-level guard exists, while keeping the explicit CI contract (`python scripts/ruff_targets.py --run`) unchanged.

### Testing
- Reproduced the original failure locally with `python -m ruff check .` (shows `.git/refs/...` F821 errors) and verified `python scripts/ruff_targets.py --run` succeeds and no longer includes `.git` paths; `pytest tests/test_ruff_targets.py tests/test_ci_ruff_scope_contract.py` passed (7 tests).
- Attempted `pre-commit run --all-files` and full `pytest`/`mypy` runs but encountered pre-existing repo baseline failures (missing preview asset, Node requirement, and a large mypy backlog) which are unrelated to this fix and left to separate follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfe2edb4c8333af249c09440f9c07)