### PR TITLE
[alpha_factory] Fix Insight gallery preview asset contract

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#222"/>
+  <text x="8" y="12" text-anchor="middle" font-size="12" fill="#fff">α</text>
+</svg>

--- a/tests/test_verify_gallery_assets.py
+++ b/tests/test_verify_gallery_assets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from scripts.verify_gallery_assets import (
+    PREVIEW_RE,
     collect_missing_preview_assets,
     collect_preview_sync_contract_violations,
 )
@@ -82,3 +83,15 @@ def test_collect_preview_sync_contract_violations_reports_missing_mirror(tmp_pat
     assert collect_preview_sync_contract_violations(repo) == [
         "missing mirrored preview: docs/alpha_agi_insight_v1/assets/preview.svg"
     ]
+
+
+def test_insight_demo_markdown_points_to_mirrored_preview_asset() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    demo_md = repo / "docs" / "demos" / "alpha_agi_insight_v1.md"
+    match = PREVIEW_RE.search(demo_md.read_text(encoding="utf-8"))
+    assert match is not None
+    preview_ref = match.group(1).split("#", 1)[0]
+    assert preview_ref == "../alpha_agi_insight_v1/assets/preview.svg"
+    preview_target = (demo_md.parent / preview_ref).resolve()
+    assert preview_target == (repo / "docs" / "alpha_agi_insight_v1" / "assets" / "preview.svg").resolve()
+    assert preview_target.is_file()


### PR DESCRIPTION
### Motivation
- The `verify-gallery-assets` pre-commit hook was failing because the mirrored preview asset expected by the gallery/docs was missing, causing multiple merge-surface jobs to fail on the same contract. 
- Restore the single source-of-truth required by the hook and add a regression guard to prevent recurrence.

### Description
- Restored the missing mirrored preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` so links from `docs/demos/alpha_agi_insight_v1.md` resolve correctly. 
- Added a focused regression test `test_insight_demo_markdown_points_to_mirrored_preview_asset` in `tests/test_verify_gallery_assets.py` that asserts the demo markdown references the expected mirrored path and that the file exists. 
- No workflow, CI policy, or Repo‑Healer changes were made; this is a targeted content + test fix that preserves existing CI enforcement.

### Testing
- Reproduced the original hook failure with `python scripts/verify_gallery_assets.py` before the fix (reported the missing mirrored preview) and verified it passes after restoring the file. 
- Ran `pre-commit run verify-gallery-assets --all-files` and observed it passed. 
- Ran the new/targeted unit tests with `pytest -q tests/test_verify_gallery_assets.py` and they passed (`6 passed`). 
- Ran docs build and local checks used by CI: `SKIP=eslint-insight-browser git ls-files -z 'docs/**' | xargs -0 pre-commit run --files` (passed) and `mkdocs build --strict` (passed in this environment after installing doc deps). 
- Executed targeted lint/type commands used in the CI matrix (`python scripts/ruff_targets.py --run` and `mypy` under the CI Python targets) to verify no regression in the lint/type stage related to this change; these targeted runs passed for the relevant invocation scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0d9001a883338a163b31ab71f44f)