### PR TITLE
[alpha_factory] Fix Insight demo CSP backend connectivity

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js
@@ -329,7 +329,14 @@ async function bundle() {
     });
     let outHtml = html;
     const connectSrc =
-        ["'self'", "https://api.openai.com", ipfsOrigin, otelOrigin]
+        [
+            "'self'",
+            "https://api.openai.com",
+            "https://api.web3.storage",
+            "https://ipfs.io",
+            ipfsOrigin,
+            otelOrigin,
+        ]
             .filter(Boolean)
             .join(" ");
     const cspBase = `default-src 'self'; connect-src ${connectSrc}; frame-src 'self' blob:; worker-src 'self' blob:`;

--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py
@@ -387,7 +387,8 @@ if otel_origin:
     p = urlparse(otel_origin)
     otel_origin = f"{p.scheme}://{p.netloc}"
 csp_base = (
-    "default-src 'self'; connect-src 'self' https://api.openai.com; " "frame-src 'self' blob:; worker-src 'self' blob:"
+    "default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://ipfs.io; "
+    "frame-src 'self' blob:; worker-src 'self' blob:"
 )
 if ipfs_origin:
     csp_base += f" {ipfs_origin}"

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">


### PR DESCRIPTION
### Motivation
- The Insight browser page restricted `connect-src` to only `'self'` and `https://api.openai.com`, which blocks intentional runtime calls to pin/share backends and IPFS/telemetry origins and causes features like pin/share and telemetry to fail when `PINNER_TOKEN`, `IPFS_GATEWAY` or `OTEL_ENDPOINT` are configured.

### Description
- Expanded the JS build pipeline `connect-src` allowlist to include `https://api.web3.storage` and `https://ipfs.io` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/build.js` so built pages allow Web3.Storage and the default IPFS gateway by default.
- Mirrored the same CSP expansion in the Python manual build path in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py` so both build flows produce consistent headers.
- Updated the committed demo HTML at `docs/alpha_agi_insight_v1/index.html` to use the expanded `connect-src` immediately for the docs site.
- Left the demo verifier's ignore list unchanged so generic `Cannot read properties of undefined (reading 'NaN')` errors are not suppressed by the verifier.

### Testing
- Compiled Python sources with `python -m compileall scripts/verify_demo_pages.py alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/manual_build.py` which succeeded.
- Ran a code search `rg -n "connect-src|api.web3.storage|https://ipfs.io|cannot read properties of undefined \(reading 'nan'\)"` to verify the updated CSP strings are present in `build.js`, `manual_build.py`, and `docs/alpha_agi_insight_v1/index.html` which returned the expected matches.
- Attempted `pytest -q alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/tests/test_closing_tags.py` which failed in this environment due to an import error for the test plugin (`tests.conftest` is not importable), so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc63b8d16483338d30bbffa7da2ca2)