### PR TITLE
[alpha_factory] Fix insight bundle script contract and add regression guard

### DIFF
--- a/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
+++ b/alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "preinstall": "node -e \"const m=parseInt(process.versions.node); if(m<22){console.error('Node.js 22+ is required. Current version: '+process.versions.node); process.exit(1);} \"",
     "lint": "eslint --config eslint.config.js src --ext .js,.ts",
+    "build:docs-insight": "node build.js",
     "build": "node build.js",
     "fetch-assets": "node -e \"console.log('Using PYODIDE_BASE_URL:', process.env.PYODIDE_BASE_URL)\" && python ../../../../scripts/fetch_assets.py",
     "build:dist": "npm run build && cd dist && cp sw.js service-worker.js && zip -r ../insight_browser.zip index.html insight.bundle.js service-worker.js style.css insight_browser_quickstart.pdf d3.exports.js && zip -r ../insight_browser.zip assets && rm service-worker.js",

--- a/tests/test_insight_build_script_selection.py
+++ b/tests/test_insight_build_script_selection.py
@@ -10,7 +10,13 @@ from scripts.select_insight_build_script import select_build_script
 
 def test_select_build_script_uses_real_insight_package_contract() -> None:
     package_json = Path("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json")
-    assert select_build_script(package_json) == "build"
+    assert select_build_script(package_json) == "build:docs-insight"
+
+
+def test_docs_build_alias_matches_primary_build_command() -> None:
+    package_json = Path("alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json")
+    scripts = json.loads(package_json.read_text(encoding="utf-8"))["scripts"]
+    assert scripts["build:docs-insight"] == scripts["build"]
 
 
 def test_select_build_script_prefers_docs_alias_when_present(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The `build-insight-bundle` workflow preferred the `build:docs-insight` npm script but the Insight Browser package only exposed `build`, causing `npm ERR! Missing script: "build:docs-insight"` in CI; this makes the workflow contract untruthful and brittle.
- Make the bundle detection contract truthful and add a small regression guard so the workflow helper cannot silently select a non-existent script again.

### Description
- Added a truthful `build:docs-insight` npm script alias in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1/package.json` that maps to the existing `node build.js` implementation so `npm run build:docs-insight` is valid. 
- Hardened tests by updating `tests/test_insight_build_script_selection.py` to assert the repository package resolves to `build:docs-insight` and added an assertion that `build:docs-insight` and `build` remain equivalent commands.

### Testing
- Ran targeted unit tests covering the script-selection and workflow contract: `pytest tests/test_insight_build_script_selection.py tests/test_build_insight_bundle_workflow_contract.py`, which passed (`6 passed`).
- Exercised Repo-Healer-related suites used by this change: `pytest tests/repo_healer_v1/test_ci_bundle.py tests/repo_healer_v1/test_validators.py tests/test_ci_health_workflow_policy.py tests/test_repo_healer_workflow_runtime_contract.py`, which passed (`29 passed` across those suites); also ran `ruff check .` (no issues for changed files).
- Notes: local `npm ci`/`npm run build:docs-insight` could not be fully executed in this environment because the checkout enforces `node >= 22` and the local Node is v20; this is an environment mismatch rather than a change regression and the workflow runner uses Node 22 as configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcde65ecc8833396eca98920ed9c27)