### PR TITLE
[alpha_factory] Fix orchestrator stub resolution and insight docs asset checks

### DIFF
--- a/alpha_factory_v1/backend/agent_manager.py
+++ b/alpha_factory_v1/backend/agent_manager.py
@@ -21,10 +21,12 @@ class AgentManager:
 
     @staticmethod
     def _resolve_list_agents():
+        agents_mod = sys.modules.get("backend.agents")
+        if agents_mod is not None and not hasattr(agents_mod, "__path__") and hasattr(agents_mod, "list_agents"):
+            return agents_mod.list_agents
         registry_mod = sys.modules.get("backend.agents.registry")
         if registry_mod is not None and hasattr(registry_mod, "list_agents"):
             return registry_mod.list_agents
-        agents_mod = sys.modules.get("backend.agents")
         if agents_mod is not None and hasattr(agents_mod, "list_agents"):
             return agents_mod.list_agents
         from backend.agents.registry import list_agents

--- a/alpha_factory_v1/backend/agent_runner.py
+++ b/alpha_factory_v1/backend/agent_runner.py
@@ -158,10 +158,12 @@ class AgentRunner:
 
     @staticmethod
     def _resolve_get_agent():
+        agents_mod = sys.modules.get("backend.agents")
+        if agents_mod is not None and not hasattr(agents_mod, "__path__") and hasattr(agents_mod, "get_agent"):
+            return agents_mod.get_agent
         registry_mod = sys.modules.get("backend.agents.registry")
         if registry_mod is not None and hasattr(registry_mod, "get_agent"):
             return registry_mod.get_agent
-        agents_mod = sys.modules.get("backend.agents")
         if agents_mod is not None and hasattr(agents_mod, "get_agent"):
             return agents_mod.get_agent
         from backend.agents.registry import get_agent

--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL' 'sha384-1d7Yo06RaZ86Qc529bSDQ1QIwZL4mtFFyNQQxCkXNxyrwr/p9E8GXMEcW+CI7c8A'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">
@@ -84,5 +84,13 @@
 
     <script type="module" src="insight.bundle.js" integrity="sha384-Mb1VRv2DyAqBUMvCGGI6/e90gepYQ9/zjE2rAa8wRVbmwPWSFsW3zIMomuaVkHeh" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
+
+<script>
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("./service-worker.js").catch(() => {
+    console.warn("Service worker registration failed");
+  });
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Tests failed in CI because orchestrator tests that inject non-package `backend.agents` stubs were being ignored by the agent resolver and real registry-backed agents (requiring optional deps like `faiss‑cpu`) were being instantiated instead.
- Gallery/Docs validation tests failed because the Insight demo was missing its mirrored preview asset and the built HTML lacked a service worker registration inline snippet (and its CSP hash).

### Description
- Prefer explicitly monkeypatched non-package `backend.agents` modules when resolving agents by updating `_resolve_list_agents` in `alpha_factory_v1/backend/agent_manager.py` and `_resolve_get_agent` in `alpha_factory_v1/backend/agent_runner.py` so test stubs injected into `sys.modules` are honored first in test contexts.
- Add the missing mirrored preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` to satisfy gallery preview-contract checks.
- Insert a small service worker registration inline script into `docs/alpha_agi_insight_v1/index.html` and extend the `script-src` CSP allowlist with the corresponding inline script `sha384` hash so CSP validation passes.

### Testing
- Installed missing test deps with `python check_env.py --auto-install` which completed successfully and made `requests_mock` and other test helpers available.
- Verified the originally failing suites with `pytest -q tests/test_docs_service_worker_present.py tests/test_verify_gallery_assets.py tests/test_orchestrator_lifecycle.py`, which passed after the changes.
- Ran the broader validation set `pytest -q tests/security/test_csp.py tests/test_backend_orchestrator_dev.py tests/test_orchestrator_lifecycle.py tests/test_docs_service_worker_present.py tests/test_verify_gallery_assets.py` and all selected tests passed (10 passed, 8 warnings).
- Note: a full `pytest -q` run earlier surfaced the issues fixed by this change, and `pre-commit` could not be run in the run environment because the `pre-commit` command was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd44fa75808333ab54d73e0f1ee1dc)