### PR TITLE
[alpha_factory] Add missing Insight v1 demo preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- The demo gallery verification was failing because the mirrored preview image for the Alpha AGI Insight v1 demo was missing, causing `pre-commit` CI checks to fail.

### Description
- Add `docs/alpha_agi_insight_v1/assets/preview.svg`, a mirrored preview image for the `alpha_agi_insight_v1` demo page.
- Provide the SVG gradient tile used by the demo gallery so `docs/demos/alpha_agi_insight_v1.md` has a matching preview asset.
- Validate frontend linting requirements by using Node `22.17.1` and running `npm ci` in the demo frontend directory to ensure the `eslint-insight-browser` hook can run.
- Install `pre-commit==4.2.0` in the environment to run repository hooks during validation.

### Testing
- Ran `pre-commit run --all-files`, which completed successfully and all hooks passed, including `verify-gallery-assets` and `eslint-insight-browser`.
- Ran `source ~/.nvm/nvm.sh && nvm install 22.17.1 && nvm use 22.17.1` and `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5a24c6b88333ada1208c72060483)