### PR TITLE
[alpha_factory] Fix missing alpha_agi_insight_v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- The pre-commit `verify-gallery-assets` hook failed because the docs demo `docs/demos/alpha_agi_insight_v1.md` referenced a preview image that was not mirrored under `docs/alpha_agi_insight_v1/assets/preview.svg`, so the gallery build and lint pipeline could not pass.

### Description
- Add the missing mirrored preview SVG at `docs/alpha_agi_insight_v1/assets/preview.svg` (copied from `alpha_factory_v1/demos/alpha_agi_insight_v1/assets/preview.svg`) so the demo's preview reference resolves.

### Testing
- Ran `python scripts/check_python_deps.py` which passed, `python check_env.py --auto-install` which passed, installed `pre-commit==4.2.0` which succeeded, installed and used Node `22.17.1` and ran `npm ci` in the insight browser which succeeded, and executed `pre-commit run --all-files` which completed with all hooks passing (including `verify-gallery-assets` and `eslint-insight-browser`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6abb19b4833389c33d4440c02739)