### PR TITLE
[alpha_factory] Fix docs service worker and mirrored preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL' 'sha384-sRlerd9kn2E9yd2JpFkJTVDAJWYCunvdXlfGrTj+pgkw7RhlTrmdHPoZXs5aWwVB'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">
@@ -81,6 +81,12 @@
     <script src="d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous" defer></script>
     <script>window.SW_HASH = 'sha384-jNrRb0RaME0Q+lz0/ITUhfnQBDj97uJPtmPXPc9rSfGvo79YnRebfKvL0rUyytDQ';</script>
     <script src="bootstrap.js"></script>
+
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('service-worker.js').catch(() => console.warn('Service worker registration failed'));
+      }
+    </script>
 
     <script type="module" src="insight.bundle.js" integrity="sha384-Mb1VRv2DyAqBUMvCGGI6/e90gepYQ9/zjE2rAa8wRVbmwPWSFsW3zIMomuaVkHeh" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -175,7 +175,7 @@
   </script>
   <script>
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('assets/service-worker.js').catch(() => console.warn('Service worker registration failed'));
+      navigator.serviceWorker.register('service-worker.js').catch(() => console.warn('Service worker registration failed'));
     }
   </script>
 </body>

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -1,0 +1,223 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* eslint-env serviceworker */
+const CACHE = 'v6387cdd6';
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE)
+      .then(async (cache) => {
+        const assets = [
+          'assets/pyodide/pyodide.js',
+          'assets/pyodide/pyodide.asm.wasm',
+          'assets/pyodide/pyodide-lock.json',
+          '../TERMS_AND_CONDITIONS/assets/preview.svg',
+          '../aiga_meta_evolution/assets/bridge_overview.svg',
+          '../aiga_meta_evolution/assets/logs.json',
+          '../aiga_meta_evolution/assets/preview.svg',
+          '../aiga_meta_evolution/assets/script.js',
+          '../aiga_meta_evolution/assets/style.css',
+          '../alpha_agi_business_2_v1/assets/logs.json',
+          '../alpha_agi_business_2_v1/assets/preview.svg',
+          '../alpha_agi_business_2_v1/assets/script.js',
+          '../alpha_agi_business_2_v1/assets/style.css',
+          '../alpha_agi_business_3_v1/assets/logs.json',
+          '../alpha_agi_business_3_v1/assets/preview.svg',
+          '../alpha_agi_business_3_v1/assets/script.js',
+          '../alpha_agi_business_3_v1/assets/style.css',
+          '../alpha_agi_business_v1/assets/logs.json',
+          '../alpha_agi_business_v1/assets/preview.svg',
+          '../alpha_agi_business_v1/assets/script.js',
+          '../alpha_agi_business_v1/assets/style.css',
+          '../alpha_agi_insight_v0/assets/logs.json',
+          '../alpha_agi_insight_v0/assets/preview.svg',
+          '../alpha_agi_insight_v0/assets/script.js',
+          '../alpha_agi_insight_v0/assets/style.css',
+          '../alpha_agi_insight_v1/assets/logs.json',
+          '../alpha_agi_insight_v1/assets/preview.svg',
+          '../alpha_agi_insight_v1/assets/script.js',
+          '../alpha_agi_insight_v1/assets/style.css',
+          '../alpha_agi_marketplace_v1/assets/logs.json',
+          '../alpha_agi_marketplace_v1/assets/preview.svg',
+          '../alpha_agi_marketplace_v1/assets/script.js',
+          '../alpha_agi_marketplace_v1/assets/style.css',
+          '../alpha_asi_world_model/assets/logs.json',
+          '../alpha_asi_world_model/assets/preview.svg',
+          '../alpha_asi_world_model/assets/script.js',
+          '../alpha_asi_world_model/assets/style.css',
+          '../alpha_super_planner_v1/assets/preview.svg',
+          '../cross_industry_alpha_factory/assets/logs.json',
+          '../cross_industry_alpha_factory/assets/preview.svg',
+          '../cross_industry_alpha_factory/assets/script.js',
+          '../cross_industry_alpha_factory/assets/style.css',
+          '../demos/assets/readme_preview.svg',
+          '../era_of_experience/assets/logs.json',
+          '../era_of_experience/assets/preview.svg',
+          '../era_of_experience/assets/script.js',
+          '../era_of_experience/assets/style.css',
+          '../finance_alpha/assets/logs.json',
+          '../finance_alpha/assets/preview.svg',
+          '../finance_alpha/assets/script.js',
+          '../finance_alpha/assets/style.css',
+          '../gpt2_small_cli/assets/preview.svg',
+          '../macro_sentinel/assets/logs.json',
+          '../macro_sentinel/assets/preview.svg',
+          '../macro_sentinel/assets/script.js',
+          '../macro_sentinel/assets/style.css',
+          '../meta_agentic_agi/assets/logo.svg',
+          '../meta_agentic_agi/assets/logs.json',
+          '../meta_agentic_agi/assets/preview.svg',
+          '../meta_agentic_agi/assets/script.js',
+          '../meta_agentic_agi/assets/style.css',
+          '../meta_agentic_agi/assets/theme-dark.css',
+          '../meta_agentic_agi/assets/theme-light.css',
+          '../meta_agentic_agi_v2/assets/logo.svg',
+          '../meta_agentic_agi_v2/assets/logs.json',
+          '../meta_agentic_agi_v2/assets/preview.svg',
+          '../meta_agentic_agi_v2/assets/script.js',
+          '../meta_agentic_agi_v2/assets/style.css',
+          '../meta_agentic_agi_v2/assets/theme-dark.css',
+          '../meta_agentic_agi_v2/assets/theme-light.css',
+          '../meta_agentic_agi_v3/assets/logo.svg',
+          '../meta_agentic_agi_v3/assets/logs.json',
+          '../meta_agentic_agi_v3/assets/preview.svg',
+          '../meta_agentic_agi_v3/assets/script.js',
+          '../meta_agentic_agi_v3/assets/style.css',
+          '../meta_agentic_agi_v3/assets/theme-dark.css',
+          '../meta_agentic_agi_v3/assets/theme-light.css',
+          '../meta_agentic_tree_search_v0/assets/logs.json',
+          '../meta_agentic_tree_search_v0/assets/preview.svg',
+          '../meta_agentic_tree_search_v0/assets/script.js',
+          '../meta_agentic_tree_search_v0/assets/style.css',
+          '../muzero_planning/assets/logs.json',
+          '../muzero_planning/assets/preview.svg',
+          '../muzero_planning/assets/script.js',
+          '../muzero_planning/assets/style.css',
+          '../muzeromctsllmagent_v0/assets/logs.json',
+          '../muzeromctsllmagent_v0/assets/preview.svg',
+          '../muzeromctsllmagent_v0/assets/script.js',
+          '../muzeromctsllmagent_v0/assets/style.css',
+          '../omni_factory_demo/assets/logs.json',
+          '../omni_factory_demo/assets/preview.svg',
+          '../omni_factory_demo/assets/script.js',
+          '../omni_factory_demo/assets/style.css',
+          '../self_healing_repo/assets/logs.json',
+          '../self_healing_repo/assets/preview.svg',
+          '../self_healing_repo/assets/script.js',
+          '../self_healing_repo/assets/style.css',
+          '../solving_agi_governance/assets/logs.json',
+          '../solving_agi_governance/assets/preview.svg',
+          '../solving_agi_governance/assets/script.js',
+          '../solving_agi_governance/assets/style.css',
+          '../sovereign_agentic_agialpha_agent_v0/assets/logs.json',
+          '../sovereign_agentic_agialpha_agent_v0/assets/preview.svg',
+          '../sovereign_agentic_agialpha_agent_v0/assets/script.js',
+          '../sovereign_agentic_agialpha_agent_v0/assets/style.css',
+          '../utils/assets/logs.json',
+          '../utils/assets/preview.svg',
+          '../utils/assets/script.js',
+          '../utils/assets/style.css',
+          '../aiga_meta_evolution/index.html',
+          '../alpha_agi_business_2_v1/index.html',
+          '../alpha_agi_business_3_v1/index.html',
+          '../alpha_agi_business_v1/index.html',
+          '../alpha_agi_insight_v0/index.html',
+          '../alpha_agi_insight_v1/index.html',
+          '../alpha_agi_marketplace_v1/index.html',
+          '../alpha_asi_world_model/index.html',
+          '../alpha_factory_v1/demos/aiga_meta_evolution/index.html',
+          '../alpha_factory_v1/demos/alpha_agi_business_2_v1/index.html',
+          '../alpha_factory_v1/demos/alpha_agi_business_3_v1/index.html',
+          '../alpha_factory_v1/demos/alpha_agi_business_v1/index.html',
+          '../alpha_factory_v1/demos/alpha_agi_insight_v0/index.html',
+          '../alpha_factory_v1/demos/alpha_agi_insight_v1/index.html',
+          '../alpha_factory_v1/demos/alpha_agi_marketplace_v1/index.html',
+          '../alpha_factory_v1/demos/alpha_asi_world_model/index.html',
+          '../alpha_factory_v1/demos/cross_industry_alpha_factory/index.html',
+          '../alpha_factory_v1/demos/era_of_experience/index.html',
+          '../alpha_factory_v1/demos/finance_alpha/index.html',
+          '../alpha_factory_v1/demos/index.html',
+          '../alpha_factory_v1/demos/macro_sentinel/index.html',
+          '../alpha_factory_v1/demos/meta_agentic_agi/index.html',
+          '../alpha_factory_v1/demos/meta_agentic_agi_v2/index.html',
+          '../alpha_factory_v1/demos/meta_agentic_agi_v3/index.html',
+          '../alpha_factory_v1/demos/meta_agentic_tree_search_v0/index.html',
+          '../alpha_factory_v1/demos/muzero_planning/index.html',
+          '../alpha_factory_v1/demos/muzeromctsllmagent_v0/index.html',
+          '../alpha_factory_v1/demos/omni_factory_demo/index.html',
+          '../alpha_factory_v1/demos/self_healing_repo/index.html',
+          '../alpha_factory_v1/demos/solving_agi_governance/index.html',
+          '../alpha_factory_v1/demos/sovereign_agentic_agialpha_agent_v0/index.html',
+          '../alpha_factory_v1/index.html',
+          '../cross_industry_alpha_factory/index.html',
+          '../demos/index.html',
+          '../era_of_experience/index.html',
+          '../finance_alpha/index.html',
+          '../index.html',
+          '../macro_sentinel/index.html',
+          '../meta_agentic_agi/index.html',
+          '../meta_agentic_agi_v2/index.html',
+          '../meta_agentic_agi_v3/index.html',
+          '../meta_agentic_tree_search_v0/index.html',
+          '../muzero_planning/index.html',
+          '../muzeromctsllmagent_v0/index.html',
+          '../omni_factory_demo/index.html',
+          '../self_healing_repo/index.html',
+          '../solving_agi_governance/index.html',
+          '../sovereign_agentic_agialpha_agent_v0/index.html',
+          '../utils/index.html',
+        ];
+        await cache.addAll(assets);
+      })
+      .catch(() => undefined),
+  );
+  self.skipWaiting();
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names.map((name) => (name !== CACHE ? caches.delete(name) : undefined)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) {
+    event.respondWith(
+      caches.open(CACHE).then(async (cache) => {
+        try {
+          const resp = await fetch(event.request);
+          if (resp.ok) {
+            cache.put(event.request, resp.clone());
+          }
+          return resp;
+        } catch (err) {
+          const cached =
+            (await cache.match(event.request)) ||
+            (await cache.match(`pyodide/${url.pathname.split('/').pop()}`));
+          return cached || Promise.reject(err);
+        }
+      }),
+    );
+    return;
+  }
+  event.respondWith(
+    caches.open(CACHE).then((cache) =>
+      cache.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request)
+            .then((resp) => {
+              if (resp.ok) {
+                cache.put(event.request, resp.clone());
+              }
+              return resp;
+            })
+            .catch(() => cached),
+      ),
+    ),
+  );
+});


### PR DESCRIPTION
### Motivation
- Tests and runtime checks were failing because the docs site was missing the mirrored Insight preview asset and the service worker was not registered where tests expect it. 
- The Content Security Policy did not include the hash for the new inline service-worker registration snippet, causing CSP validation failures. 

### Description
- Restored the mirrored preview at `docs/alpha_agi_insight_v1/assets/preview.svg` so gallery preview contract checks succeed. 
- Added `docs/service-worker.js` (service worker implementation) to the docs root so the site can register a top-level service worker. 
- Updated `docs/alpha_agi_insight_v1/index.html` to include an explicit service worker registration snippet and added the corresponding CSP hash. 
- Updated `docs/index.html` to register `service-worker.js` from the docs root path expected by the tests. 

### Testing
- `pre-commit run --all-files` could not be executed in this environment because `pre-commit` was not installed (hook attempted and failed). 
- Fixed a test collection error by installing `requests-mock` and verified `python -m pytest -q tests/test_docs_service_worker_present.py tests/test_verify_gallery_assets.py` passed. 
- Verified `python -m pytest -q tests/security/test_csp.py tests/test_docs_service_worker_present.py tests/test_verify_gallery_assets.py` passed. 
- Ran the full suite with `python -m pytest -q` and observed all tests passing locally (`903 passed, 103 skipped, 5 xfailed` as reported in the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddaffecd1c833398713bf825156987)