### PR TITLE
[alpha_factory] Restore missing mirrored preview asset for Insight v1 docs

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Fix the documentation validation failure caused by a missing/mismatched demo preview used by the gallery mirror checks so CI `verify-gallery-assets` passes.

### Description
- Add the missing mirrored preview file at `docs/alpha_agi_insight_v1/assets/preview.svg`, synced with the canonical demo preview used by the docs checks.
- Ensure the Insight Browser dev dependencies are available by installing Node.js `22.17.1` and running `npm ci` in the browser demo to satisfy the `eslint-insight-browser` pre-commit hook.

### Testing
- Ran `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1`, which completed successfully.
- Ran `pre-commit run --all-files`, and the full hook suite (including `verify-gallery-assets`) passed.
- Ran the `eslint-insight-browser` pre-commit hook explicitly and it passed after the `npm ci` step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5635540c833381d2c3c7f74f0c66)