### PR TITLE
[alpha_factory] Fix missing mirrored preview asset for Insight demo

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- The docs gallery validation (`verify-gallery-assets`) failed because the Insight demo expected a mirrored preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` which was missing, causing pre-commit checks to fail.

### Description
- Add the missing SVG preview file `docs/alpha_agi_insight_v1/assets/preview.svg` (a mirrored preview tile for the Insight demo) so the gallery checks can locate the asset.

### Testing
- Ran `python scripts/check_python_deps.py`, `python check_env.py --auto-install`, `PATH=/tmp/node-v22.17.1/bin:$PATH npm ci` (in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1`) and `PATH=/tmp/node-v22.17.1/bin:$PATH pre-commit run --all-files`; all checks and hooks (including `verify-gallery-assets` and `eslint-insight-browser`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de60f225bc83339712226bca7cdf71)