### PR TITLE
[alpha_factory] Make world-model demo torch-optional and fix docs assets/CSP

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/__init__.py
@@ -34,11 +34,18 @@ from typing import Final, List
 
 # Re-export the runnable demo components
 try:  # optional heavy deps (numpy, torch, etc.)
-    from .alpha_asi_world_model_demo import CFG, Orchestrator, app, _main as _demo_cli  # noqa: F401
+    from .alpha_asi_world_model_demo import (  # noqa: F401
+        CFG,
+        TORCH_AVAILABLE,
+        Orchestrator,
+        _main as _demo_cli,
+        app,
+    )
 
-    _DEPS_AVAILABLE = True
+    _DEPS_AVAILABLE = bool(TORCH_AVAILABLE)
 except Exception:  # pragma: no cover - missing optional deps
     CFG = Orchestrator = app = _demo_cli = None  # type: ignore
+    TORCH_AVAILABLE = False
     _DEPS_AVAILABLE = False
 
 __all__: Final[List[str]] = [

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -56,6 +56,8 @@ except ImportError:  # pragma: no cover - optional dependency path
     F = None  # type: ignore[assignment]
     optim = None  # type: ignore[assignment]
 
+TORCH_AVAILABLE = torch is not None
+
 try:
     import yaml  # soft‑dep; config file
 except ImportError:

--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -42,13 +42,19 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
-from torch import optim
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+    from torch import optim
+except ImportError:  # pragma: no cover - optional dependency path
+    torch = None  # type: ignore[assignment]
+    nn = None  # type: ignore[assignment]
+    F = None  # type: ignore[assignment]
+    optim = None  # type: ignore[assignment]
 
 try:
     import yaml  # soft‑dep; config file
@@ -71,7 +77,8 @@ LOG = logging.getLogger("alpha_asi_demo")
 _SEED = int(os.getenv("ALPHA_ASI_SEED", "42"))
 random.seed(_SEED)
 np.random.seed(_SEED)
-torch.manual_seed(_SEED)
+if torch is not None:
+    torch.manual_seed(_SEED)
 
 
 def _set_seed(val: int) -> None:
@@ -79,7 +86,8 @@ def _set_seed(val: int) -> None:
     _SEED = val
     random.seed(val)
     np.random.seed(val)
-    torch.manual_seed(val)
+    if torch is not None:
+        torch.manual_seed(val)
 
 
 # =============================================================================
@@ -96,7 +104,7 @@ class Config:
     ui_tick: int = 100
     max_steps: int = 200_000
     mcts_simulations: int = 16
-    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    device: str = "cuda" if torch is not None and torch.cuda.is_available() else "cpu"
     log_json: bool = False
     host: str = "127.0.0.1"
     port: int = 7860
@@ -153,7 +161,7 @@ def _load_cfg() -> Config:
             setattr(cfg, k, val)
     # map 'auto' → 'cuda' if available else 'cpu'
     if isinstance(cfg.device, str) and cfg.device.lower() == "auto":
-        cfg.device = "cuda" if torch.cuda.is_available() else "cpu"
+        cfg.device = "cuda" if torch is not None and torch.cuda.is_available() else "cpu"
     try:
         seed = int(seed_raw)
     except Exception:  # pragma: no cover - rarely triggered
@@ -321,72 +329,83 @@ while len(AGENTS) < 5:
 # =============================================================================
 # 4.  MuZeroTiny with lightweight MCTS
 # =============================================================================
-class Repr(nn.Module):
-    def __init__(self, input_dim: int, hidden: int):
-        super().__init__()
-        self.l = nn.Linear(input_dim, hidden)
+if torch is not None:
 
-    def forward(self, x):
-        return torch.tanh(self.l(x))
+    class Repr(nn.Module):
+        def __init__(self, input_dim: int, hidden: int):
+            super().__init__()
+            self.l = nn.Linear(input_dim, hidden)
 
-
-class Dyn(nn.Module):
-    def __init__(self, hidden: int, act_dim: int):
-        super().__init__()
-        self.r = nn.Linear(hidden + act_dim, 1)
-        self.h = nn.Linear(hidden + act_dim, hidden)
-
-    def forward(self, h, a):
-        x = torch.cat([h, a], -1)
-        return self.r(x), torch.tanh(self.h(x))
+        def forward(self, x):
+            return torch.tanh(self.l(x))
 
 
-class Pred(nn.Module):
-    def __init__(self, hidden: int, act_dim: int):
-        super().__init__()
-        self.v = nn.Linear(hidden, 1)
-        self.p = nn.Linear(hidden, act_dim)
+    class Dyn(nn.Module):
+        def __init__(self, hidden: int, act_dim: int):
+            super().__init__()
+            self.r = nn.Linear(hidden + act_dim, 1)
+            self.h = nn.Linear(hidden + act_dim, hidden)
 
-    def forward(self, h):
-        return self.v(h), torch.log_softmax(self.p(h), -1)
-
-
-class MuZeroTiny(nn.Module):
-    def __init__(self, obs_dim: int, act_dim: int):
-        super().__init__()
-        self.repr = Repr(obs_dim, CFG.hidden)
-        self.dyn = Dyn(CFG.hidden, act_dim)
-        self.pred = Pred(CFG.hidden, act_dim)
-
-    def initial(self, obs):
-        h = self.repr(obs)
-        v, p = self.pred(h)
-        return h, v, p
-
-    def recurrent(self, h, a_onehot):
-        r, h2 = self.dyn(h, a_onehot)
-        v, p = self.pred(h2)
-        return h2, r, v, p
+        def forward(self, h, a):
+            x = torch.cat([h, a], -1)
+            return self.r(x), torch.tanh(self.h(x))
 
 
-# -------------------------------- MCTS ---------------------------------------
-def mcts_policy(net: MuZeroTiny, obs: np.ndarray, simulations: int = 16) -> int:
-    """Very small UCB‑based MCTS on top of MuZeroTiny."""
-    act_dim = 4
-    with torch.no_grad():
-        h, v0, p0 = net.initial(torch.tensor(obs, device=CFG.device, dtype=torch.float32))
-    N = np.zeros(act_dim)
-    W = np.zeros(act_dim)
-    P = p0.exp().cpu().numpy()
-    for _ in range(simulations):
-        a = np.argmax(P * (np.sqrt(N.sum() + 1e-8) / (1 + N)))
-        a_one = F.one_hot(torch.tensor(a), num_classes=act_dim).float().to(CFG.device)
-        h2, r, v, p = net.recurrent(h, a_one)
-        q = (r + v).item()
-        N[a] += 1
-        W[a] += q
-    best = int(np.argmax(W / (N + 1e-8)))
-    return best
+    class Pred(nn.Module):
+        def __init__(self, hidden: int, act_dim: int):
+            super().__init__()
+            self.v = nn.Linear(hidden, 1)
+            self.p = nn.Linear(hidden, act_dim)
+
+        def forward(self, h):
+            return self.v(h), torch.log_softmax(self.p(h), -1)
+
+
+    class MuZeroTiny(nn.Module):
+        def __init__(self, obs_dim: int, act_dim: int):
+            super().__init__()
+            self.repr = Repr(obs_dim, CFG.hidden)
+            self.dyn = Dyn(CFG.hidden, act_dim)
+            self.pred = Pred(CFG.hidden, act_dim)
+
+        def initial(self, obs):
+            h = self.repr(obs)
+            v, p = self.pred(h)
+            return h, v, p
+
+        def recurrent(self, h, a_onehot):
+            r, h2 = self.dyn(h, a_onehot)
+            v, p = self.pred(h2)
+            return h2, r, v, p
+
+
+    # -------------------------------- MCTS -----------------------------------
+    def mcts_policy(net: MuZeroTiny, obs: np.ndarray, simulations: int = 16) -> int:
+        """Very small UCB‑based MCTS on top of MuZeroTiny."""
+        act_dim = 4
+        with torch.no_grad():
+            h, v0, p0 = net.initial(torch.tensor(obs, device=CFG.device, dtype=torch.float32))
+        N = np.zeros(act_dim)
+        W = np.zeros(act_dim)
+        P = p0.exp().cpu().numpy()
+        for _ in range(simulations):
+            a = np.argmax(P * (np.sqrt(N.sum() + 1e-8) / (1 + N)))
+            a_one = F.one_hot(torch.tensor(a), num_classes=act_dim).float().to(CFG.device)
+            h2, r, v, p = net.recurrent(h, a_one)
+            q = (r + v).item()
+            N[a] += 1
+            W[a] += q
+        best = int(np.argmax(W / (N + 1e-8)))
+        return best
+else:
+
+    class MuZeroTiny:  # pragma: no cover - only used when torch missing
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise RuntimeError("PyTorch is required for MuZeroTiny. Install torch to enable learner/orchestrator features.")
+
+
+    def mcts_policy(*_: Any, **__: Any) -> int:  # pragma: no cover - only used when torch missing
+        raise RuntimeError("PyTorch is required for MCTS policy evaluation.")
 
 
 # =============================================================================
@@ -468,6 +487,8 @@ class Learner:
 
     def __init__(self, env: MiniWorld):
         """Initialize the learner for ``env``."""
+        if torch is None or optim is None or F is None:
+            raise RuntimeError("PyTorch is required for Learner. Install torch to run the world model training loop.")
         self.net = MuZeroTiny(env.size**2, 4).to(CFG.device)
         self.opt = optim.Adam(self.net.parameters(), CFG.lr)
         self.buffer: List[Tuple[np.ndarray, float]] = []

--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL' 'sha384-ZyC8yQymFcqurObG/g60q83ZQe/44BrGEAB/AGYXfYxN+8Yq8GJJiA30z+zLP2Nr'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">
@@ -84,5 +84,6 @@
 
     <script type="module" src="insight.bundle.js" integrity="sha384-Mb1VRv2DyAqBUMvCGGI6/e90gepYQ9/zjE2rAa8wRVbmwPWSFsW3zIMomuaVkHeh" crossorigin="anonymous"></script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
+  <script>if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./service-worker.js'); }</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure the world-model demo can be imported in environments where `torch` is not installed so unit tests and CI can run without heavy ML deps.  
- Fix documentation gallery contract and service-worker checks by providing the mirrored preview asset and ensuring the docs register the service worker.  
- Keep CSP integrity checks passing by adding the missing inline script hash for the updated `index.html`.

### Description
- Make PyTorch an optional dependency in `alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py` by wrapping `torch` imports in a try/except and falling back to `None` for `torch`, `nn`, `F`, and `optim`.  
- Guard seed initialization and device selection with `if torch is not None` and only define the `MuZeroTiny`/MCTS classes when `torch` is available, providing explanatory runtime errors for training paths (`Learner`) when `torch` is missing.  
- Add explicit runtime checks so the code only raises errors when learners/MuZero features are actually instantiated, preserving other demo/test functionality in torch-free environments.  
- Update `docs/alpha_agi_insight_v1/index.html` to register `service-worker.js` and include the corresponding CSP hash for the added inline script.  
- Add the mirrored preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` required by gallery contract tests.

### Testing
- Ran the focused tests `pytest -q tests/test_docs_service_worker_present.py tests/test_verify_gallery_assets.py tests/test_world_model_open_endedness.py tests/test_world_model_reload.py` and they passed (`9` and `10` tests passed in separate runs).  
- Ran `pytest -q tests/security/test_csp.py` together with the focused docs/world-model tests and the run passed (`10 passed`).  
- Ran the full test suite with `pytest -q` in this environment and the suite completed successfully (`871 passed, 109 skipped, 5 xfailed`, warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7ef9758c83338f48b2e560a0e1c0)