### PR TITLE
[alpha_factory] Fix pre-commit failures across demos and docs

### DIFF
--- a/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
+++ b/alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py
@@ -45,6 +45,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+
 try:
     import torch
     import torch.nn as nn
@@ -341,7 +342,6 @@ if torch is not None:
         def forward(self, x):
             return torch.tanh(self.l(x))
 
-
     class Dyn(nn.Module):
         def __init__(self, hidden: int, act_dim: int):
             super().__init__()
@@ -352,7 +352,6 @@ if torch is not None:
             x = torch.cat([h, a], -1)
             return self.r(x), torch.tanh(self.h(x))
 
-
     class Pred(nn.Module):
         def __init__(self, hidden: int, act_dim: int):
             super().__init__()
@@ -361,7 +360,6 @@ if torch is not None:
 
         def forward(self, h):
             return self.v(h), torch.log_softmax(self.p(h), -1)
-
 
     class MuZeroTiny(nn.Module):
         def __init__(self, obs_dim: int, act_dim: int):
@@ -379,7 +377,6 @@ if torch is not None:
             r, h2 = self.dyn(h, a_onehot)
             v, p = self.pred(h2)
             return h2, r, v, p
-
 
     # -------------------------------- MCTS -----------------------------------
     def mcts_policy(net: MuZeroTiny, obs: np.ndarray, simulations: int = 16) -> int:
@@ -399,12 +396,14 @@ if torch is not None:
             W[a] += q
         best = int(np.argmax(W / (N + 1e-8)))
         return best
+
 else:
 
     class MuZeroTiny:  # pragma: no cover - only used when torch missing
         def __init__(self, *_: Any, **__: Any) -> None:
-            raise RuntimeError("PyTorch is required for MuZeroTiny. Install torch to enable learner/orchestrator features.")
-
+            raise RuntimeError(
+                "PyTorch is required for MuZeroTiny. Install torch to enable learner/orchestrator features."
+            )
 
     def mcts_policy(*_: Any, **__: Any) -> int:  # pragma: no cover - only used when torch missing
         raise RuntimeError("PyTorch is required for MCTS policy evaluation.")

--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Restore repository validation by addressing pre-commit hook failures caused by a missing mirrored demo preview asset and formatting issues, and ensure the Insight Browser lint hook can run by providing the required Node environment.

### Description
- Added the missing mirrored preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` to satisfy the gallery asset validator.
- Applied Black formatting changes to `alpha_factory_v1/demos/alpha_asi_world_model/alpha_asi_world_model_demo.py` to resolve the `black` pre-commit hook (whitespace and wrapped string formatting fixes).
- Installed Node.js 22.17.1 and installed the Insight Browser dependencies in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` so the `eslint-insight-browser` hook can run.

### Testing
- Ran `pip install pre-commit==4.2.0` to install the pre-commit tool and then executed `pre-commit run --all-files`, which initially reported missing assets and Node version errors before the fixes.
- Ran `n 22.17.1` and `npm ci` in the Insight Browser directory to satisfy the ESLint hook, and `npm ci` completed successfully.
- Re-ran `pre-commit run --all-files` after the changes and Node/npm installation, and all pre-commit hooks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deaae4ef748333b61710381e4c98ca)