### PR TITLE
[alpha_factory] Fix Insight sandbox worker CSP/origin regressions

### DIFF
--- a/alpha_factory_v1/core/interface/web_client/dist/sandbox_worker_host.html
+++ b/alpha_factory_v1/core/interface/web_client/dist/sandbox_worker_host.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sandbox Worker Host</title>
+  </head>
+  <body>
+    <script src="sandbox_worker_host.js"></script>
+  </body>
+</html>

--- a/alpha_factory_v1/core/interface/web_client/dist/sandbox_worker_host.js
+++ b/alpha_factory_v1/core/interface/web_client/dist/sandbox_worker_host.js
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+let worker;
+
+window.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+
+  if (data.type === 'start') {
+    if (worker) {
+      worker.terminate();
+    }
+    worker = new Worker(data.url, { type: 'module' });
+    worker.onmessage = (messageEvent) => {
+      parent.postMessage(messageEvent.data, '*');
+    };
+    return;
+  }
+
+  if (worker) {
+    worker.postMessage(data);
+  }
+});

--- a/alpha_factory_v1/core/interface/web_client/public/sandbox_worker_host.html
+++ b/alpha_factory_v1/core/interface/web_client/public/sandbox_worker_host.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sandbox Worker Host</title>
+  </head>
+  <body>
+    <script src="sandbox_worker_host.js"></script>
+  </body>
+</html>

--- a/alpha_factory_v1/core/interface/web_client/public/sandbox_worker_host.js
+++ b/alpha_factory_v1/core/interface/web_client/public/sandbox_worker_host.js
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+let worker;
+
+window.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+
+  if (data.type === 'start') {
+    if (worker) {
+      worker.terminate();
+    }
+    worker = new Worker(data.url, { type: 'module' });
+    worker.onmessage = (messageEvent) => {
+      parent.postMessage(messageEvent.data, '*');
+    };
+    return;
+  }
+
+  if (worker) {
+    worker.postMessage(data);
+  }
+});

--- a/alpha_factory_v1/core/interface/web_client/src/utils/sandbox.ts
+++ b/alpha_factory_v1/core/interface/web_client/src/utils/sandbox.ts
@@ -7,36 +7,20 @@
  */
 export async function createSandboxWorker(url: string | URL): Promise<Worker> {
   return new Promise((resolve) => {
-    const workerBlob = new Blob([
-      `import \"${url.toString()}\";`,
-    ], { type: 'text/javascript' });
+    const workerBlob = new Blob([`import "${url.toString()}";`], { type: "text/javascript" });
     const workerUrl = URL.createObjectURL(workerBlob);
-
-    const html = `\
-<script>
-let w;
-window.addEventListener('message',e=>{
-  if(e.data.type==='start'){
-    w=new Worker(e.data.url,{type:'module'});
-    w.onmessage=d=>parent.postMessage(d.data,location.origin);
-  }else if(w){
-    w.postMessage(e.data);
-  }
-});
-<\/script>`;
 
     const iframe = document.createElement('iframe');
     // allow only script execution in the sandboxed iframe
     (iframe as any).sandbox = 'allow-scripts';
     iframe.style.display = 'none';
-    iframe.src = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+    iframe.src = new URL("./sandbox_worker_host.html", window.location.href).toString();
     document.body.appendChild(iframe);
 
     const worker: any = {
-      postMessage: (m: any) => iframe.contentWindow!.postMessage(m, location.origin),
+      postMessage: (m: any) => iframe.contentWindow!.postMessage(m, "*"),
       terminate() {
         iframe.remove();
-        URL.revokeObjectURL(iframe.src);
         URL.revokeObjectURL(workerUrl);
         window.removeEventListener('message', handler);
       },
@@ -44,14 +28,14 @@ window.addEventListener('message',e=>{
     };
 
     const handler = (e: MessageEvent) => {
-      if (e.source === iframe.contentWindow && e.origin === location.origin && worker.onmessage) {
+      if (e.source === iframe.contentWindow && worker.onmessage) {
         worker.onmessage(e);
       }
     };
     window.addEventListener('message', handler);
 
     iframe.onload = () => {
-      iframe.contentWindow!.postMessage({ type: 'start', url: workerUrl }, location.origin);
+      iframe.contentWindow!.postMessage({ type: 'start', url: workerUrl }, "*");
       resolve(worker as unknown as Worker);
     };
   });

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-Xk9S+uMmV2IBLoszp8N1kKkD8mN7MYR3pw81gSi6PrAo9KZi41x4nlXQoDWMpGtp' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">
@@ -79,7 +79,7 @@
     </footer>
     <script type="importmap">{"imports":{"d3":"./d3.exports.js"}}</script>
     <script src="d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous" defer></script>
-    <script>window.SW_HASH = 'sha384-jNrRb0RaME0Q+lz0/ITUhfnQBDj97uJPtmPXPc9rSfGvo79YnRebfKvL0rUyytDQ';</script>
+    <script>window.SW_HASH = 'sha384-kQo+PZJcRiSq81DoHg7dyh+D8v/XRPNke0/dvpo2pT968hYeKRy2hfcZk4KYSIh5';</script>
     <script src="bootstrap.js"></script>
 
     <script type="module" src="insight.bundle.js" integrity="sha384-nx9eP7ZnXMwiSANdsw9N1ial37mzqZUVRt8tm3G4Sx5T+VlF2PjC+9dR3bGtNgTF" crossorigin="anonymous"></script>

--- a/scripts/ensure_insight_sw_hash.py
+++ b/scripts/ensure_insight_sw_hash.py
@@ -11,11 +11,33 @@ from pathlib import Path
 
 DEFAULT_DIR = Path("docs/alpha_agi_insight_v1")
 SW_HASH_RE = re.compile(r"SW_HASH\s*=\s*['\"]sha384-[^'\"]+['\"]")
+CSP_META_RE = re.compile(r'(<meta[^>]*http-equiv=["\']Content-Security-Policy["\'][^>]*content=")([^"]+)(")', re.IGNORECASE)
+SCRIPT_SRC_RE = re.compile(r"script-src\s+([^;]+)")
+INLINE_SCRIPT_RE = re.compile(r"<script(?![^>]*src)[^>]*>([\s\S]*?)</script>", re.IGNORECASE)
 
 
 def _hash(path: Path) -> str:
     digest = hashlib.sha384(path.read_bytes()).digest()
     return "sha384-" + base64.b64encode(digest).decode()
+
+
+def _hash_snippet(snippet: str) -> str:
+    digest = hashlib.sha384(snippet.encode()).digest()
+    return "'sha384-" + base64.b64encode(digest).decode() + "'"
+
+
+def _refresh_csp_script_hashes(html: str) -> str:
+    meta_match = CSP_META_RE.search(html)
+    if not meta_match:
+        return html
+    policy = meta_match.group(2)
+    script_match = SCRIPT_SRC_RE.search(policy)
+    if not script_match:
+        return html
+    hashes = " ".join(_hash_snippet(snippet) for snippet in INLINE_SCRIPT_RE.findall(html))
+    replacement = f"script-src 'self' 'wasm-unsafe-eval' {hashes}"
+    updated_policy = SCRIPT_SRC_RE.sub(replacement, policy, count=1)
+    return html[: meta_match.start(2)] + updated_policy + html[meta_match.end(2) :]
 
 
 def ensure_sw_hash(directory: Path) -> bool:
@@ -32,10 +54,17 @@ def ensure_sw_hash(directory: Path) -> bool:
     if not SW_HASH_RE.search(html):
         raise ValueError("SW_HASH not found in index.html")
     updated = SW_HASH_RE.sub(f"SW_HASH = 'sha384-{new_hash.split('sha384-', 1)[1]}'", html, count=1)
+    changed = False
     if updated != html:
         index_html.write_text(updated, encoding="utf-8")
-        return True
-    return False
+        changed = True
+
+    # Keep CSP inline script hashes in sync while preserving other CSP directives.
+    recsp = _refresh_csp_script_hashes(updated)
+    if recsp != updated:
+        index_html.write_text(recsp, encoding="utf-8")
+        changed = True
+    return changed
 
 
 def main() -> int:


### PR DESCRIPTION
### Motivation
- The Insight demo was failing in CI/browser smoke tests because inline scripts and their CSP hashes drifted and sandboxed iframe messaging used a strict target origin, producing repeated CSP inline-script refusals and `postMessage` origin-mismatch warnings.
- The intent is to stop generating inline iframe HTML (which forces CSP hash churn) and to keep the CSP `script-src` hashes in sync when the SW hash is updated so the demo can run offline and pass the stricter Insight readiness contracts.

### Description
- Replace the previous inline/blob iframe approach in the shared web-client helper and load the static `sandbox_worker_host.html` instead, and use `postMessage(..., "*")` for sandbox host communication to avoid `origin: null` target mismatches (`alpha_factory_v1/core/interface/web_client/src/utils/sandbox.ts`).
- Make `scripts/ensure_insight_sw_hash.py` update the inline `SW_HASH` value and then refresh only the CSP `script-src` inline-hash list (preserving other CSP directives) so inline script hashes remain correct after updates (`scripts/ensure_insight_sw_hash.py`).
- Re-synced the published Insight demo HTML to the new `service-worker` hash and updated inline-script hashes so the CSP meta and `SW_HASH` are consistent (`docs/alpha_agi_insight_v1/index.html`).

### Testing
- Ran `pytest tests/security/test_csp.py tests/test_verify_demo_pages.py tests/test_sw_integrity.py` and the suite completed with `14 passed, 1 skipped`.
- Executed the SW-hash sync helper via `python scripts/ensure_insight_sw_hash.py docs/alpha_agi_insight_v1`, which updated the CSP/script hashes and the demo HTML as expected.
- Attempted the Playwright-based smoke test `python scripts/verify_demo_pages.py` but it could not run in this environment because the Playwright Chromium browsers were not installed (`playwright install` required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def7c3f310833380395e591ff4bad6)