### PR TITLE
[alpha_factory] Ignore sandboxed worker errors in demo readiness checks

### DIFF
--- a/scripts/verify_demo_pages.py
+++ b/scripts/verify_demo_pages.py
@@ -140,6 +140,9 @@ def _is_ignorable_insight_page_error(message: str) -> bool:
     ignorable_markers = (
         "service worker is disabled because the context is sandboxed",
         "failed to execute 'postmessage' on 'domwindow'",
+        "failed to construct 'worker': script at 'blob:",
+        "cannot be accessed from origin 'null'",
+        "sandbox_worker_host.js",
     )
     if any(marker in msg for marker in ignorable_markers):
         return True


### PR DESCRIPTION
### Motivation
- CI and local sandboxed contexts produce expected ServiceWorker/Worker security errors (blob Workers with origin `null` and `sandbox_worker_host.js` messages) that cause false negatives for the Insight demo readiness check, so these known noise messages should be treated as ignorable.

### Description
- Added additional ignorable markers to `scripts/verify_demo_pages.py::_is_ignorable_insight_page_error` to cover "failed to construct 'Worker'" blob-origin errors and `sandbox_worker_host.js` messages while preserving the stricter Insight contract in `_insight_contract_ok`.

### Testing
- `python -m py_compile scripts/verify_demo_pages.py` succeeded.
- An end-to-end run of `python scripts/verify_demo_pages.py` could not complete here because the Playwright Chromium executable is not installed in this environment, so the full readiness verification was not executed (install browsers via `python -m playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e016de5938833386126fd6ca622622)