### PR TITLE
[alpha_factory] Clarify check_env required vs optional warnings

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -510,11 +510,14 @@ def main(argv: Optional[List[str]] = None) -> int:
         missing_required.append("google_adk")
     missing = missing_required + missing_optional
     if missing:
-        print("WARNING: Missing packages:", ", ".join(missing))
-        for pkg in missing_optional:
-            hint = OPTIONAL_HINTS.get(pkg)
-            if hint:
-                print("  -", hint)
+        if missing_required:
+            print("WARNING: Missing required packages:", ", ".join(missing_required))
+        if missing_optional:
+            print("INFO: Optional integrations unavailable:", ", ".join(missing_optional))
+            for pkg in missing_optional:
+                hint = OPTIONAL_HINTS.get(pkg)
+                if hint:
+                    print("  -", hint)
         if not google_adk_attr_ok:
             hint = OPTIONAL_HINTS.get("google_adk")
             if hint:


### PR DESCRIPTION
### Motivation
- Improve the clarity of `check_env.py` output by separating missing required dependencies from optional integrations so optional packages are not presented as hard failures.
- Reduce confusion when running environment checks in restricted or minimal setups where optional extras (e.g., `gymnasium`) may be intentionally absent.

### Description
- Changed the messaging in `check_env.py` to print `WARNING: Missing required packages: ...` for required packages and `INFO: Optional integrations unavailable: ...` for optional packages.
- Retained and preserved the existing `--auto-install` behavior so automatic installation continues to target only missing required packages.
- Kept printing of optional hints from `OPTIONAL_HINTS` to guide users on how to install non-critical integrations.

### Testing
- Ran `python check_env.py --auto-install` and verified it completed successfully.
- Ran `ruff check check_env.py` and the linter passed with no issues.
- Ran `pytest tests/test_business_bridge_offline.py tests/test_aiga_offline_setup.py -q` and the tests succeeded (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f0fac20083339033914c21695df5)