### PR TITLE
[alpha_factory] Fix missing Insight v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- The Insight v1 demo referenced a preview image that was missing, which caused the `verify-gallery-assets` pre-commit hook to fail and blocked lint/CI checks.

### Description
- Add the mirrored preview SVG at `docs/alpha_agi_insight_v1/assets/preview.svg` and install Node.js `22.17.1` then run `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` so the ESLint pre-commit hook can execute.

### Testing
- Ran `pre-commit run --all-files` (passed) and `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` (succeeded), which resolved the `verify-gallery-assets` and `eslint-insight-browser` hook failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12b14041c8333bcb46f9d48d1ade8)