### PR TITLE
[alpha_factory] Fix insight docs asset and service worker regressions

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL' 'sha384-sRlerd9kn2E9yd2JpFkJTVDAJWYCunvdXlfGrTj+pgkw7RhlTrmdHPoZXs5aWwVB'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">
@@ -83,6 +83,11 @@
     <script src="bootstrap.js"></script>
 
     <script type="module" src="insight.bundle.js" integrity="sha384-nx9eP7ZnXMwiSANdsw9N1ial37mzqZUVRt8tm3G4Sx5T+VlF2PjC+9dR3bGtNgTF" crossorigin="anonymous"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('service-worker.js').catch(() => console.warn('Service worker registration failed'));
+      }
+    </script>
   <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Restore the docs gallery and security contracts that were failing CI by ensuring the Insight demo page exposes the mirrored preview asset and registers its service worker. 
- Ensure the page's Content-Security-Policy includes the hash for the new inline service-worker registration so CSP validation passes.

### Description
- Added the mirrored preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` required by gallery contract tests. 
- Restored service-worker registration by injecting an inline registration snippet into `docs/alpha_agi_insight_v1/index.html`. 
- Updated the CSP `script-src` meta in `docs/alpha_agi_insight_v1/index.html` to include the new inline script's `sha384` hash.

### Testing
- Ran `python -m pytest -q tests/test_docs_service_worker_present.py tests/test_verify_gallery_assets.py` and the suite passed. 
- Ran `python -m pytest -q tests/security/test_csp.py tests/test_docs_service_worker_present.py tests/test_verify_gallery_assets.py` and the suite passed. 
- A full `python -m pytest -q` run initially surfaced the failing docs/CSP checks before the fixes, and targeted suites were rerun after fixes to confirm resolution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15e8ab7b08333accf612bf7c4fe73)