### PR TITLE
[alpha_factory] Fix missing alpha_agi_insight_v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- The demo page `docs/demos/alpha_agi_insight_v1.md` referenced a mirrored preview asset that was missing, causing the `verify-gallery-assets` pre-commit hook to fail and preventing full CI/local lint checks from passing.

### Description
- Add `docs/alpha_agi_insight_v1/assets/preview.svg` containing the demo preview tile.
- Install Node.js `22.17.1` via `nvm` and run `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` to satisfy the `eslint-insight-browser` pre-commit hook prerequisites.
- Run `pre-commit run --all-files` and commit the new asset (`fix: add missing insight demo preview asset`).

### Testing
- Ran `pre-commit run --all-files` after adding the asset and installing Node/npm deps, and all hooks passed including `verify-gallery-assets` and `eslint-insight-browser` (passed).
- Ran `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml` which resulted in `2 passed, 1 skipped` and produced `coverage.xml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1915624ec8333a399245365758d93)