### PR TITLE
[alpha_factory] Restore missing Alpha AGI Insight demo preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- The docs gallery validation (`verify-gallery-assets`) was failing because the mirrored preview asset referenced by `docs/demos/alpha_agi_insight_v1.md` was missing. 
- The repository's lint hooks for the Insight Browser require Node.js and local npm deps, so installing those prerequisites was necessary to let `eslint-insight-browser` run successfully.

### Description
- Added the missing preview asset at `docs/alpha_agi_insight_v1/assets/preview.svg` so the demo page preview is present.
- Installed `pre-commit==4.2.0` locally to ensure the repo hooks can be executed in this environment.
- Installed Node.js `22.17.1` via `nvm` and ran `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` to satisfy the Insight Browser lint hook dependencies.
- No runtime source code changes were made beyond adding the preview asset and preparing local tooling.

### Testing
- Ran `python scripts/check_python_deps.py` and it passed.
- Ran `python check_env.py --auto-install` and it completed successfully.
- Ran `pre-commit run --all-files` after tooling installation and all hooks passed (including `verify-gallery-assets` and `eslint-insight-browser`).
- Ran `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml` which produced `2 passed, 1 skipped` and wrote `coverage.xml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a0e2c7148333b675978f31c1c275)