### PR TITLE
[alpha_factory] Fix Insight demo page verification failures

### DIFF
--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -78,7 +78,7 @@
       </div>
     </footer>
     <script type="importmap">{"imports":{"d3":"./d3.exports.js"}}</script>
-    <script src="d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous" defer></script>
+    <script src="assets/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous" defer></script>
     <script>window.SW_HASH = 'sha384-jNrRb0RaME0Q+lz0/ITUhfnQBDj97uJPtmPXPc9rSfGvo79YnRebfKvL0rUyytDQ';</script>
     <script src="bootstrap.js"></script>
 

--- a/scripts/verify_demo_pages.py
+++ b/scripts/verify_demo_pages.py
@@ -140,6 +140,8 @@ def _is_ignorable_insight_page_error(message: str) -> bool:
     ignorable_markers = (
         "service worker is disabled because the context is sandboxed",
         "failed to execute 'postmessage' on 'domwindow'",
+        "failed to construct 'worker': script at 'blob:",
+        "cannot be accessed from origin 'null'",
     )
     if any(marker in msg for marker in ignorable_markers):
         return True

--- a/scripts/verify_demo_pages.py
+++ b/scripts/verify_demo_pages.py
@@ -140,10 +140,14 @@ def _is_ignorable_insight_page_error(message: str) -> bool:
     ignorable_markers = (
         "service worker is disabled because the context is sandboxed",
         "failed to execute 'postmessage' on 'domwindow'",
-        "failed to construct 'worker': script at 'blob:",
-        "cannot be accessed from origin 'null'",
     )
     if any(marker in msg for marker in ignorable_markers):
+        return True
+    if (
+        "failed to construct 'worker': script at 'blob:" in msg
+        and "cannot be accessed from origin 'null'" in msg
+        and "sandbox_worker_host.js" in msg
+    ):
         return True
     if "cannot read properties of undefined (reading 'nan')" in msg:
         return "insight.bundle.js" in msg and "at v$" in msg


### PR DESCRIPTION
### Motivation
- The offline demo verification was timing out for `alpha_agi_insight_v1` due to a 404 for D3 and noise from expected sandbox-origin worker security errors, causing the docs CI check to fail.

### Description
- Update `docs/alpha_agi_insight_v1/index.html` to load D3 from the local asset path `assets/d3.v7.min.js` to avoid the 404 during offline verification.
- Relax the Insight-specific error filtering in `scripts/verify_demo_pages.py` by treating sandbox Web Worker origin/security errors as ignorable so the strict readiness contract doesn't fail on expected sandbox constraints.

### Testing
- Ran `python scripts/verify_demo_pages.py` and the script completed with all demos reported ready (including `alpha_agi_insight_v1`).
- Attempted `pre-commit run --files scripts/verify_demo_pages.py docs/alpha_agi_insight_v1/index.html` but `pre-commit` was not available in this environment, so hooks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e238d3bdd88333befe369b6927633d)