### PR TITLE
[alpha_factory] Restore missing Insight v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- The docs gallery check was failing because the Insight v1 demo markdown referenced a preview asset that was missing from `docs/alpha_agi_insight_v1/assets`, so the preview must be restored and kept in sync with the canonical source.

### Description
- Added `docs/alpha_agi_insight_v1/assets/preview.svg`, mirroring the canonical preview in `docs/alpha_factory_v1/demos/alpha_agi_insight_v1/assets/preview.svg` so the demo preview path and the preview sync contract are satisfied.

### Testing
- Ran the repository hooks with `pre-commit run --all-files` after installing `pre-commit==4.2.0`, using `nvm use 22.17.1` and running `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1`, and all pre-commit checks (including the gallery asset verifier and ESLint for the Insight Browser) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26e7228088333bcdddd9c21038b65)