### PR TITLE
[alpha_factory] Fix docs insight preview asset and SW registration

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-BXecg/FcTkTy4pvVT4C6LJUug1OOQEuwqpoRJyKTyhkJxNyJI1syjTuBYFdPVwsw' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">
@@ -80,14 +80,9 @@
     <script type="importmap">{"imports":{"d3":"./d3.exports.js"}}</script>
     <script src="d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous" defer></script>
     <script>window.SW_HASH = 'sha384-jNrRb0RaME0Q+lz0/ITUhfnQBDj97uJPtmPXPc9rSfGvo79YnRebfKvL0rUyytDQ';</script>
-    <script src="bootstrap.js"></script>
+    <script src="bootstrap.js" data-sw-url="service-worker.js" data-sw-api="serviceWorker"></script>
 
     <script type="module" src="insight.bundle.js" integrity="sha384-nx9eP7ZnXMwiSANdsw9N1ial37mzqZUVRt8tm3G4Sx5T+VlF2PjC+9dR3bGtNgTF" crossorigin="anonymous"></script>
-    <script>
-      if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("service-worker.js").catch(() => console.warn("Service worker registration failed"));
-      }
-    </script>
     <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
 </body>
 </html>

--- a/docs/alpha_agi_insight_v1/index.html
+++ b/docs/alpha_agi_insight_v1/index.html
@@ -39,7 +39,7 @@
         opacity: 1;
       }
     </style>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://api.openai.com https://api.web3.storage https://w3s.link https://*.w3s.link https://ipfs.io https://dweb.link https://ipfs.io; frame-src 'self' blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval' 'sha384-E8swqB1rgmKfkntp22RjfBap5YfJMvGbUVw5y2+djoHjwuDrALqWEe1kasdDBmTm' 'sha384-8EzrlAris6MLirPYFKRY4ewS/HYnCKoXFJnB/3zX+XSQ8buVADrMBB6qPBUFs77f' 'sha384-BXecg/FcTkTy4pvVT4C6LJUug1OOQEuwqpoRJyKTyhkJxNyJI1syjTuBYFdPVwsw' 'sha384-eR8sYzoSk2xJcnjk7RVrsGWKil+DbPgMionlm2xuFpCTJRuyTQ/l6jHF2OY7ZnIL'; style-src 'self' 'unsafe-inline'" />
 </head>
 
   <body class="flex flex-col h-screen">
@@ -83,6 +83,11 @@
     <script src="bootstrap.js"></script>
 
     <script type="module" src="insight.bundle.js" integrity="sha384-nx9eP7ZnXMwiSANdsw9N1ial37mzqZUVRt8tm3G4Sx5T+VlF2PjC+9dR3bGtNgTF" crossorigin="anonymous"></script>
-  <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
+    <script>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("service-worker.js").catch(() => console.warn("Service worker registration failed"));
+      }
+    </script>
+    <script>window.PINNER_TOKEN=atob('');window.OTEL_ENDPOINT=atob('');window.IPFS_GATEWAY=atob('');</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- CI was failing on docs checks because the Insight demo lacked a mirrored preview asset and the page did not register the service worker, which broke `verify-gallery-assets` and `test_docs_service_worker_present` and CSP validation.

### Description
- Added the missing preview image at `docs/alpha_agi_insight_v1/assets/preview.svg` so gallery asset verification passes.
- Updated `docs/alpha_agi_insight_v1/index.html` to register `service-worker.js` via `navigator.serviceWorker.register(...)` so the page actually attempts to register the service worker.
- Extended the `Content-Security-Policy` `script-src` in the same HTML to include the new inline script's `sha384-` hash so CSP checks succeed.

### Testing
- Ran `python scripts/check_python_deps.py` and `python check_env.py --auto-install` and they passed.
- Installed Node with `nvm install 22.17.1` and ran `npm ci` in the insight browser demo directory and dependency install completed.
- Executed `pre-commit run --all-files` (after Node setup) and all hooks passed.
- Ran `pytest tests/security/test_csp.py tests/test_docs_service_worker_present.py` and both tests passed.
- Ran `pytest tests/test_ping_agent.py tests/test_af_requests.py --cov --cov-report=xml` as a targeted smoke check and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2da27571483338d7140687b938e1f)