### PR TITLE
[alpha_factory] Stabilize CI Health token usage and auth fallback

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -72,7 +72,10 @@ jobs:
           python -m pip install pyyaml
       - name: Check CI health and remediate
         env:
-          GITHUB_TOKEN: ${{ env.ADMIN_GITHUB_TOKEN != '' && env.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          # Always use the workflow token for CI health checks. The admin token
+          # is reserved for branch-protection operations and may be unavailable
+          # or rotated independently.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           HARD_WORKFLOW="pr-ci.yml"
           RERUN_ARGS=()
@@ -105,7 +108,7 @@ jobs:
       - name: Check merge-surface integration CI health
         if: ${{ github.event_name != 'workflow_run' }}
         env:
-          GITHUB_TOKEN: ${{ env.ADMIN_GITHUB_TOKEN != '' && env.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/check_ci_status.py \
             --wait-minutes 5 \

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -94,6 +94,7 @@ jobs:
           fi
 
           python scripts/check_ci_status.py \
+            --token "${GITHUB_TOKEN}" \
             --wait-minutes 5 \
             --pending-grace-minutes 45 \
             --stale-minutes 90 \
@@ -111,6 +112,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/check_ci_status.py \
+            --token "${GITHUB_TOKEN}" \
             --wait-minutes 5 \
             --pending-grace-minutes 45 \
             --stale-minutes 90 \

--- a/scripts/verify_branch_protection.py
+++ b/scripts/verify_branch_protection.py
@@ -212,8 +212,9 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 1
     url = f"{API_URL}/repos/{owner}/{repo}/branches/{args.branch}/protection"
     status, protection, response_text = _api_request("GET", url, token)
-    if status == 403:
-        sys.stderr.write("::warning::Missing permission to read branch protection; skipping verification.\n")
+    if status in {401, 403}:
+        reason = "authentication" if status == 401 else "permission"
+        sys.stderr.write(f"::warning::Missing {reason} to read branch protection; skipping verification.\n")
         return 0
     if status == 404:
         if not args.apply:


### PR DESCRIPTION
### Motivation
- Scheduled CI Health runs were failing when an admin PAT (ADMIN_GITHUB_TOKEN) was unavailable or expired because the watchdog preferred that token for general Actions API checks. 
- The branch-protection verifier should skip verification on missing or invalid auth instead of failing the watchdog to avoid noisy false negatives.

### Description
- Change CI watchdog steps in `.github/workflows/ci-health.yml` to use the workflow token (`secrets.GITHUB_TOKEN`) for general CI health checks and remediation dispatches, reserving `ADMIN_GITHUB_TOKEN` for branch-protection operations. 
- Harden `scripts/verify_branch_protection.py` so HTTP `401` (authentication) and `403` (permission) responses are treated as warning/skip conditions with a clearer message instead of an error.

### Testing
- Attempted `pre-commit run --files .github/workflows/ci-health.yml scripts/verify_branch_protection.py` but the `pre-commit` binary was not available in the environment so hooks were not executed (environment limitation). 
- Successfully ran `python -m py_compile scripts/verify_branch_protection.py` which passed without syntax errors. 
- Validated `.github/workflows/ci-health.yml` by parsing with `yaml.safe_load` which succeeded. 
- Executed `python scripts/verify_branch_protection.py --owner MontrealAI --repo AGI-Alpha-Agent-v0 --branch main` which printed the expected warning when no token was provided and exited with status 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee027f4f848333a4e0734f6a26d7dc)