### PR TITLE
Use workflow token for CI health checks and improve branch-protection error handling

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -72,10 +72,9 @@ jobs:
           python -m pip install pyyaml
       - name: Check CI health and remediate
         env:
-          # Always use the workflow token for CI health checks. The admin token
-          # is reserved for branch-protection operations and may be unavailable
-          # or rotated independently.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer the admin token for remediation (rerun/dispatch/cancel), but
+          # fall back to the workflow token when no admin token is configured.
+          GITHUB_TOKEN: ${{ env.ADMIN_GITHUB_TOKEN != '' && env.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           HARD_WORKFLOW="pr-ci.yml"
           RERUN_ARGS=()
@@ -109,7 +108,7 @@ jobs:
       - name: Check merge-surface integration CI health
         if: ${{ github.event_name != 'workflow_run' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.ADMIN_GITHUB_TOKEN != '' && env.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python scripts/check_ci_status.py \
             --token "${GITHUB_TOKEN}" \

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -72,7 +72,10 @@ jobs:
           python -m pip install pyyaml
       - name: Check CI health and remediate
         env:
-          GITHUB_TOKEN: ${{ env.ADMIN_GITHUB_TOKEN != '' && env.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          # Always use the workflow token for CI health checks. The admin token
+          # is reserved for branch-protection operations and may be unavailable
+          # or rotated independently.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           HARD_WORKFLOW="pr-ci.yml"
           RERUN_ARGS=()
@@ -91,6 +94,7 @@ jobs:
           fi
 
           python scripts/check_ci_status.py \
+            --token "${GITHUB_TOKEN}" \
             --wait-minutes 5 \
             --pending-grace-minutes 45 \
             --stale-minutes 90 \
@@ -105,9 +109,10 @@ jobs:
       - name: Check merge-surface integration CI health
         if: ${{ github.event_name != 'workflow_run' }}
         env:
-          GITHUB_TOKEN: ${{ env.ADMIN_GITHUB_TOKEN != '' && env.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/check_ci_status.py \
+            --token "${GITHUB_TOKEN}" \
             --wait-minutes 5 \
             --pending-grace-minutes 45 \
             --stale-minutes 90 \

--- a/scripts/verify_branch_protection.py
+++ b/scripts/verify_branch_protection.py
@@ -212,9 +212,11 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 1
     url = f"{API_URL}/repos/{owner}/{repo}/branches/{args.branch}/protection"
     status, protection, response_text = _api_request("GET", url, token)
-    if status in {401, 403}:
-        reason = "authentication" if status == 401 else "permission"
-        sys.stderr.write(f"::warning::Missing {reason} to read branch protection; skipping verification.\n")
+    if status == 401:
+        sys.stderr.write("error: invalid authentication when reading branch protection\n")
+        return 1
+    if status == 403:
+        sys.stderr.write("::warning::Missing permission to read branch protection; skipping verification.\n")
         return 0
     if status == 404:
         if not args.apply:

--- a/scripts/verify_branch_protection.py
+++ b/scripts/verify_branch_protection.py
@@ -212,8 +212,9 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 1
     url = f"{API_URL}/repos/{owner}/{repo}/branches/{args.branch}/protection"
     status, protection, response_text = _api_request("GET", url, token)
-    if status == 403:
-        sys.stderr.write("::warning::Missing permission to read branch protection; skipping verification.\n")
+    if status in {401, 403}:
+        reason = "authentication" if status == 401 else "permission"
+        sys.stderr.write(f"::warning::Missing {reason} to read branch protection; skipping verification.\n")
         return 0
     if status == 404:
         if not args.apply:


### PR DESCRIPTION
### Motivation
- Ensure CI health checks always run with the repository `GITHUB_TOKEN` because the admin token may be unavailable or rotated.
- Make branch protection verification more robust by handling and reporting authentication vs permission failures distinctly.

### Description
- In `.github/workflows/ci-health.yml` force `GITHUB_TOKEN` to use `secrets.GITHUB_TOKEN` for CI health checks and add a comment that the admin token is reserved for branch-protection operations. 
- Pass `--token "${GITHUB_TOKEN}"` to `scripts/check_ci_status.py` invocations so the checker uses the explicit token from the workflow environment. 
- In `scripts/verify_branch_protection.py` treat HTTP `401` and `403` responses separately and log whether the failure is due to authentication or permission before skipping verification.

### Testing
- No automated tests were added specifically for these changes; the repository CI workflows will run the updated workflow and scripts when this PR is exercised.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee027f4f848333a4e0734f6a26d7dc)