### PR TITLE
[alpha_factory] Add missing Insight v1 preview asset

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Fix the CI `verify-gallery-assets` failure caused by a missing preview referenced from `docs/demos/alpha_agi_insight_v1.md` and allow the Insight Browser ESLint hook to run locally (requires Node.js v22.17.1).

### Description
- Add the mirrored preview image at `docs/alpha_agi_insight_v1/assets/preview.svg` used by the docs gallery validator.

### Testing
- Ran `python scripts/check_python_deps.py` which passed.
- Ran `python check_env.py --auto-install` which completed successfully.
- Ran `npm ci` in `alpha_factory_v1/demos/alpha_agi_insight_v1/insight_browser_v1` to install Insight Browser deps.
- Ran `pre-commit run --all-files` (with Node.js `22.17.1` active) and all hooks passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15e97a61483338913854cdeb73a40)