### PR TITLE
[alpha_factory] Fix missing alpha_agi_insight_v1 preview asset mirror

### DIFF
--- a/docs/alpha_agi_insight_v1/assets/preview.svg
+++ b/docs/alpha_agi_insight_v1/assets/preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Alpha AGI Insight preview</title>
+  <desc id="desc">Gradient preview tile for the Alpha AGI Insight demo page.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1147"/>
+      <stop offset="50%" stop-color="#6d28d9"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="#ffffff" font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="256" font-size="72" font-weight="700">α‑AGI Insight v1</text>
+    <text x="72" y="328" font-size="38" opacity="0.9">Beyond Human Foresight</text>
+    <text x="72" y="396" font-size="30" opacity="0.75">Meta-agentic forecasting demo</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Restore the missing demo preview mirror so the `verify-gallery-assets` CI/pre-commit hook no longer fails for `docs/demos/alpha_agi_insight_v1.md`.

### Description
- Add `docs/alpha_agi_insight_v1/assets/preview.svg` by mirroring the existing demo preview asset and commit the new file to satisfy gallery asset verification.

### Testing
- Ran `pre-commit run verify-gallery-assets --all-files` and `pre-commit run --files docs/demos/alpha_agi_insight_v1.md docs/alpha_agi_insight_v1/assets/preview.svg`, both passed; `pre-commit run --all-files` passed all hooks except `eslint-insight-browser` which failed in this environment due to Node.js `22.17.1` not being active (requires `nvm use`); `pytest -q` was also executed with no related failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c6ee62f08333be2f985f6dafa955)