### PR TITLE
[alpha_factory] Fix replay UI for multi-experiment logs

### DIFF
--- a/docs/assets/pyodide_demo.js
+++ b/docs/assets/pyodide_demo.js
@@ -25,17 +25,21 @@ export async function loadRuntime() {
   return await mod.loadPyodide({indexURL: CDN_BASE});
 }
 
-export function setupPyodideDemo(chart, logEl, defaultData) {
+export function setupPyodideDemo(chart, logEl, experiments, onExperimentRendered) {
+  const knownExperiments = Array.isArray(experiments) && experiments.length > 0
+    ? experiments
+    : [{id: 'default', payload: {steps: [], values: [], logs: []}}];
+
   function showMessage(msg) {
     if (logEl) {
       logEl.textContent += `${msg}\n`;
     }
   }
 
-  function render(data) {
-    const steps = data.steps || [];
-    const values = data.values || [];
-    const logs = data.logs || [];
+  function render(payload, activeId) {
+    const steps = payload?.steps || [];
+    const values = payload?.values || [];
+    const logs = payload?.logs || [];
     chart.data.labels = [];
     chart.data.datasets[0].data = [];
     if (logEl) logEl.textContent = '';
@@ -45,9 +49,19 @@ export function setupPyodideDemo(chart, logEl, defaultData) {
       chart.update();
       if (logEl && logs[idx]) logEl.textContent += logs[idx] + '\n';
     });
+    onExperimentRendered?.(activeId);
   }
 
-  render(defaultData);
+  const defaultExperiment = knownExperiments[0];
+  render(defaultExperiment.payload, defaultExperiment.id);
+
+  window.addEventListener('experiment-change', (event) => {
+    const activeId = event.detail?.id;
+    const selected = knownExperiments.find((entry) => entry.id === activeId);
+    if (selected) {
+      render(selected.payload, selected.id);
+    }
+  });
 
   let pyodide;
   const offlineBtn = document.getElementById('offline-mode');
@@ -64,7 +78,7 @@ values = [random.random() for _ in steps]
 logs = [f"offline step {i}" for i in steps]
 json.dumps({"steps": steps, "values": values, "logs": logs})`;
     const result = await pyodide.runPythonAsync(code);
-    render(JSON.parse(result));
+    render(JSON.parse(result), 'offline-runtime');
     showMessage('Offline simulation complete.');
   }
 
@@ -100,7 +114,7 @@ json.dumps({"steps": steps, "values": values, "logs": logs})`;
       } catch (e) {
         console.error('OpenAI response parse error', e);
       }
-      render(parsed);
+      render(parsed, 'openai-response');
       showMessage('OpenAI response received.');
     } catch (err) {
       console.error('OpenAI request failed', err);

--- a/docs/assets/replay_chart.js
+++ b/docs/assets/replay_chart.js
@@ -4,10 +4,65 @@
 /* eslint-disable no-undef */
 import {setupPyodideDemo} from './pyodide_demo.js';
 
+function normalizeExperiments(data) {
+  if (!data || typeof data !== 'object') {
+    return [{id: 'default', payload: {steps: [], values: [], logs: []}}];
+  }
+
+  if (Array.isArray(data.experiments)) {
+    return data.experiments.map((experiment, idx) => {
+      if (experiment && typeof experiment === 'object' && !Array.isArray(experiment)) {
+        const id = experiment.id || experiment.name || `experiment-${idx + 1}`;
+        return {id, payload: experiment};
+      }
+      return {id: `experiment-${idx + 1}`, payload: {steps: [], values: [], logs: []}};
+    });
+  }
+
+  if (data.experiments && typeof data.experiments === 'object') {
+    return Object.entries(data.experiments).map(([id, payload]) => ({id, payload}));
+  }
+
+  if (data.runs && typeof data.runs === 'object') {
+    return Object.entries(data.runs).map(([id, payload]) => ({id, payload}));
+  }
+
+  return [{id: data.id || 'default', payload: data}];
+}
+
+function ensureExperimentTabs(experiments, onSelect) {
+  if (experiments.length <= 1) {
+    return;
+  }
+
+  const host = document.getElementById('experiment-tabs') || (() => {
+    const el = document.createElement('div');
+    el.id = 'experiment-tabs';
+    el.setAttribute('role', 'tablist');
+    const chart = document.getElementById('chart');
+    chart?.parentNode?.insertBefore(el, chart);
+    return el;
+  })();
+
+  host.textContent = '';
+
+  experiments.forEach((experiment, idx) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = experiment.id;
+    btn.dataset.expId = experiment.id;
+    btn.setAttribute('role', 'tab');
+    btn.setAttribute('aria-selected', idx === 0 ? 'true' : 'false');
+    btn.addEventListener('click', () => onSelect(experiment.id));
+    host.appendChild(btn);
+  });
+}
+
 export async function replayChart({logsUrl, chartId = 'chart', logElId = 'logs-panel', label = 'Demo Metric', color = 'blue'}) {
   try {
     const res = await fetch(logsUrl);
     const data = await res.json();
+    const experiments = normalizeExperiments(data);
     const ctx = document.getElementById(chartId);
     if (!ctx) return;
     const chart = new Chart(ctx, {
@@ -16,7 +71,13 @@ export async function replayChart({logsUrl, chartId = 'chart', logElId = 'logs-p
       options: { animation: false, responsive: true, maintainAspectRatio: false }
     });
     const logEl = document.getElementById(logElId);
-    setupPyodideDemo(chart, logEl, data);
+    setupPyodideDemo(chart, logEl, experiments, (activeId) => {
+      const tabButtons = document.querySelectorAll('#experiment-tabs [role="tab"]');
+      tabButtons.forEach((btn) => {
+        btn.setAttribute('aria-selected', btn.dataset.expId === activeId ? 'true' : 'false');
+      });
+    });
+    ensureExperimentTabs(experiments, (id) => window.dispatchEvent(new CustomEvent('experiment-change', {detail: {id}})));
   } catch (err) {
     console.error('replay failed', err);
   }


### PR DESCRIPTION
### Motivation
- Make the demo replay UI robust so past and future experiment log formats are shown correctly and multiple runs are selectable without manual HTML edits.

### Description
- Add `normalizeExperiments` in `docs/assets/replay_chart.js` to accept `experiments[]`, `experiments{}`, `runs{}` and legacy single-run payloads.
- Add dynamic tab rendering via `ensureExperimentTabs` and wire tab clicks to an `experiment-change` event so the chart/logs switch to the selected run.
- Refactor the demo renderer signature in `docs/assets/pyodide_demo.js` to accept an experiments collection and an optional `onExperimentRendered` callback and to render offline/online runs with explicit active IDs.
- Update callers to use the normalized experiments and update tab `aria-selected` state when the active experiment changes.

### Testing
- Ran `node --check docs/assets/replay_chart.js` which succeeded.
- Ran `node --check docs/assets/pyodide_demo.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b02aa6988333812657cc2930bafd)